### PR TITLE
Wire full cross-module AliasRegistry into codegen call sites (BT-2932)

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -762,6 +762,13 @@ pub fn write_core_erlang_with_bindings(
             .with_class_superclass_index(hierarchy.class_superclass_index.clone())
             .with_source_path_opt(source_path)
             .with_class_hierarchy(hierarchy.pre_loaded_classes.clone())
+            // BT-2932: thread cross-module type aliases through to codegen so
+            // an alias-typed annotation referencing a `type Name = ...` from
+            // another module in the same compilation unit resolves to a
+            // `user_type` reference in generated `-spec`/`-type` attributes
+            // instead of falling through to `any()` — mirrors
+            // `pre_loaded_classes` immediately above.
+            .with_pre_loaded_aliases(hierarchy.pre_loaded_aliases.clone())
             .with_native_type_registry(native_type_registry)
             // ADR 0098 Phase 3: bake the producing-toolchain identity into __beamtalk_meta.
             .with_provenance(
@@ -991,10 +998,18 @@ pub(crate) fn compile_source_with_bindings(
     let embed_source_path = Some(embed_source_path.as_str());
     // Build a codegen-specific hierarchy with cross-file classes (filtered to
     // exclude the current file's classes, which are added by codegen itself).
+    // BT-2932: `pre_loaded_aliases` is *not* filtered the way `cross_file_classes`
+    // is — it already includes the current file's own aliases (see
+    // `ClassHierarchyContext::pre_loaded_aliases`'s doc), and codegen's merge
+    // (`AliasRegistry::from_module_declarations_with_pre_loaded`) lets the
+    // module's own declaration take precedence over its duplicate pre-loaded
+    // entry, mirroring how semantic analysis's `AnalysisContext::pre_loaded_aliases`
+    // already handles the same list.
     let codegen_hierarchy = ClassHierarchyContext {
         class_module_index: ctx.hierarchy.class_module_index.clone(),
         class_superclass_index: ctx.hierarchy.class_superclass_index.clone(),
         pre_loaded_classes: cross_file_classes,
+        pre_loaded_aliases: ctx.hierarchy.pre_loaded_aliases.clone(),
         ..ClassHierarchyContext::default()
     };
     write_core_erlang_with_bindings(

--- a/crates/beamtalk-cli/src/commands/build.rs
+++ b/crates/beamtalk-cli/src/commands/build.rs
@@ -3422,6 +3422,85 @@ mod tests {
         );
     }
 
+    /// BT-2932: cross-module `AliasRegistry` wiring into codegen — the
+    /// codegen counterpart of `test_cross_file_alias_resolution_no_false_type_mismatch`
+    /// above. File A declares `type Direction = ...`; file B has no alias
+    /// declarations of its own, only a method parameter explicitly
+    /// annotated `:: Direction`. Before this issue, `compile_file`'s codegen
+    /// call (`write_core_erlang_with_bindings` → `CodegenOptions`) only ever
+    /// built `AliasRegistry::from_module_declarations(module)` — B's own
+    /// (empty) `type_aliases` — so this parameter's generated `-spec` fell
+    /// through to `any()` even though semantic analysis (BT-2928) already
+    /// resolved the reference correctly. With `pre_loaded_aliases` threaded
+    /// through (`ClassHierarchyContext::pre_loaded_aliases` →
+    /// `codegen_hierarchy` → `CodegenOptions::with_pre_loaded_aliases`), B's
+    /// generated `.core` file must contain a `user_type` reference to the
+    /// alias declared in A, plus the matching named `-type` declaration (an
+    /// `erlc` compile error otherwise).
+    #[test]
+    fn test_cross_file_alias_reference_emits_user_type_in_generated_core_erlang() {
+        let temp = TempDir::new().unwrap();
+        let project_path = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let src_path = project_path.join("src");
+        fs::create_dir_all(&src_path).unwrap();
+
+        write_test_file(
+            &src_path.join("a.bt"),
+            "type Direction = #north | #south | #east | #west\n\
+             Value subclass: A\n  heading -> Direction => #north\n",
+        );
+        write_test_file(
+            &src_path.join("b.bt"),
+            "Object subclass: B\n  useDirection: d :: Direction => d\n",
+        );
+
+        let build_dir = project_path.join("_build/dev/ebin");
+        fs::create_dir_all(&build_dir).unwrap();
+
+        let source_files = vec![src_path.join("a.bt"), src_path.join("b.bt")];
+        let (
+            class_module_index,
+            class_superclass_index,
+            all_class_infos,
+            _extensions,
+            _cached_asts,
+        ) = build_class_module_index(&source_files, Some(&src_path), "test_pkg").unwrap();
+        let all_alias_infos = collect_project_alias_infos(&source_files, "test_pkg");
+
+        let core_file = build_dir.join("bt@test_pkg@b.core");
+        let options = default_options();
+        compile_file(
+            &src_path.join("b.bt"),
+            "bt@test_pkg@b",
+            &core_file,
+            &options,
+            &CompileContext {
+                hierarchy: ClassHierarchyContext {
+                    class_module_index,
+                    class_superclass_index,
+                    pre_loaded_classes: all_class_infos,
+                    pre_loaded_aliases: all_alias_infos,
+                    ..ClassHierarchyContext::default()
+                },
+                ..CompileContext::default()
+            },
+            None,
+        )
+        .expect("Cross-file alias-typed parameter should compile without errors");
+
+        let core_src = fs::read_to_string(&core_file).unwrap();
+        assert!(
+            core_src.contains("{'user_type', 0, 'direction', []}"),
+            "parameter typed with a cross-file alias should emit a user_type reference in the \
+             generated Core Erlang. Got:\n{core_src}"
+        );
+        assert!(
+            core_src.contains("'direction'"),
+            "module must declare the matching named -type for the cross-file alias. \
+             Got:\n{core_src}"
+        );
+    }
+
     #[test]
     fn test_clean_stale_artifacts_removes_orphaned_beam() {
         let temp = TempDir::new().unwrap();

--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -1160,7 +1160,7 @@ fn handle_compile_expression(request: &Map) -> Term {
         &source,
         &known_vars,
         pre_class_hierarchy.clone(),
-        pre_loaded_aliases,
+        pre_loaded_aliases.clone(),
     ) {
         Ok(r) => r,
         Err(resp) => return resp,
@@ -1180,6 +1180,7 @@ fn handle_compile_expression(request: &Map) -> Term {
             &class_superclass_index,
             class_module_index,
             pre_class_hierarchy,
+            pre_loaded_aliases,
             module_name_override.as_deref(),
         );
     }
@@ -1370,6 +1371,7 @@ fn handle_inline_class_definition(
     class_superclass_index: &std::collections::HashMap<String, String>,
     class_module_index: std::collections::HashMap<String, String>,
     pre_class_hierarchy: Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
+    pre_loaded_aliases: Vec<beamtalk_core::semantic_analysis::AliasInfo>,
     module_name_override: Option<&str>,
 ) -> Term {
     let mut module = module;
@@ -1437,7 +1439,8 @@ fn handle_inline_class_definition(
             .with_source(source)
             .with_class_superclass_index(class_superclass_index.clone())
             .with_class_module_index(class_module_index)
-            .with_class_hierarchy(pre_class_hierarchy),
+            .with_class_hierarchy(pre_class_hierarchy)
+            .with_pre_loaded_aliases(pre_loaded_aliases),
     ) {
         Ok(code) => class_definition_ok_response(
             &code,
@@ -1573,7 +1576,7 @@ fn handle_compile(request: &Map) -> Term {
             parse_diagnostics,
             &[],
             pre_class_hierarchy.clone(),
-            pre_loaded_aliases,
+            pre_loaded_aliases.clone(),
             diagnostics_overrides(),
         );
 
@@ -1711,6 +1714,7 @@ fn handle_compile(request: &Map) -> Term {
             .with_class_module_index(class_module_index)
             .with_class_superclass_index(class_superclass_index)
             .with_class_hierarchy(pre_class_hierarchy)
+            .with_pre_loaded_aliases(pre_loaded_aliases)
             .with_source_path_opt(source_path.as_deref()),
     ) {
         Ok(code) => compile_ok_response(
@@ -1887,7 +1891,7 @@ fn handle_compile_method(request: &Map) -> Term {
             merged_parse_diags,
             &[],
             pre_class_hierarchy.clone(),
-            pre_loaded_aliases,
+            pre_loaded_aliases.clone(),
             diagnostics_overrides(),
         );
     let options = beamtalk_core::CompilerOptions {
@@ -1943,6 +1947,7 @@ fn handle_compile_method(request: &Map) -> Term {
             .with_class_module_index(class_module_index)
             .with_class_superclass_index(class_superclass_index)
             .with_class_hierarchy(pre_class_hierarchy)
+            .with_pre_loaded_aliases(pre_loaded_aliases)
             .with_source_path_opt(source_path.as_deref()),
     ) {
         Ok(code) => compile_method_ok_response(

--- a/crates/beamtalk-core/src/codegen/core_erlang/actor_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/actor_codegen.rs
@@ -18,7 +18,6 @@ use super::util::ClassIdentity;
 use super::{CodeGenContext, CoreErlangGenerator, Result};
 use crate::ast::{MethodKind, Module};
 use crate::docvec;
-use crate::semantic_analysis::alias_registry::AliasRegistry;
 
 impl CoreErlangGenerator {
     /// Generates a full actor module with `gen_server` behaviour.
@@ -125,19 +124,19 @@ impl CoreErlangGenerator {
         let mut docs: Vec<Document<'static>> = Vec::new();
 
         // BT-586: Generate spec attributes from type annotations
-        // BT-2909: build the alias registry once from this module's own
-        // `type_aliases` so alias-named annotations resolve to `user_type`
-        // references (ADR 0108) instead of falling through to `any()`.
-        // Cross-module aliases (an annotation referencing an alias exported
-        // by a dependency, ADR 0108) are not resolved here — only this
-        // module's own declarations — so they still fall through to `any()`.
-        // TODO(BT-2932): thread the full seeded registry through instead of
-        // reconstructing a module-local one.
-        let alias_registry = AliasRegistry::from_module_declarations(module);
+        // BT-2909/BT-2932: use the generator's cross-module-aware alias
+        // registry (this module's own `type_aliases` merged with any
+        // pre-loaded aliases from other modules in the same compilation
+        // unit — see `CoreErlangGenerator::alias_registry`'s doc) so an
+        // alias-named annotation resolves to a `user_type` reference (ADR
+        // 0108) instead of falling through to `any()`, regardless of which
+        // module declared the alias.
         let spec_attrs = module
             .classes
             .first()
-            .map(|class| spec_codegen::generate_class_specs(class, false, Some(&alias_registry)))
+            .map(|class| {
+                spec_codegen::generate_class_specs(class, false, Some(&self.alias_registry))
+            })
             .unwrap_or_default();
         let spec_suffix: Document<'static> = spec_codegen::format_spec_attributes(&spec_attrs)
             .map_or(Document::Nil, |s| docvec![",\n     ", s]);
@@ -146,7 +145,7 @@ impl CoreErlangGenerator {
         // module attribute list (an `erlc` compile error otherwise) — empty
         // for a module with no `type_aliases`, so this is a no-op change for
         // the common case.
-        let alias_type_attrs = spec_codegen::generate_alias_type_attrs(&alias_registry);
+        let alias_type_attrs = spec_codegen::generate_alias_type_attrs(&self.alias_registry);
         let alias_type_suffix: Document<'static> =
             spec_codegen::format_alias_type_attributes(&alias_type_attrs)
                 .map_or(Document::Nil, |s| docvec![",\n     ", s]);

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/native_facade.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/native_facade.rs
@@ -15,7 +15,6 @@ use super::super::spec_codegen;
 use super::super::{CodeGenContext, CoreErlangGenerator, Result};
 use crate::ast::{MethodDefinition, MethodKind, Module};
 use crate::docvec;
-use crate::semantic_analysis::alias_registry::AliasRegistry;
 use crate::unparse::unparse_method_display_signature;
 
 impl CoreErlangGenerator {
@@ -43,19 +42,19 @@ impl CoreErlangGenerator {
         let class_method_export_doc = Self::build_class_method_export_doc(module);
 
         // BT-586: Generate spec attributes from type annotations
-        // BT-2909: build the alias registry once from this module's own
-        // `type_aliases` so alias-named annotations resolve to `user_type`
-        // references (ADR 0108) instead of falling through to `any()`.
-        // Cross-module aliases (an annotation referencing an alias exported
-        // by a dependency, ADR 0108) are not resolved here — only this
-        // module's own declarations — so they still fall through to `any()`.
-        // TODO(BT-2932): thread the full seeded registry through instead of
-        // reconstructing a module-local one.
-        let alias_registry = AliasRegistry::from_module_declarations(module);
+        // BT-2909/BT-2932: use the generator's cross-module-aware alias
+        // registry (this module's own `type_aliases` merged with any
+        // pre-loaded aliases from other modules in the same compilation
+        // unit — see `CoreErlangGenerator::alias_registry`'s doc) so an
+        // alias-named annotation resolves to a `user_type` reference (ADR
+        // 0108) instead of falling through to `any()`, regardless of which
+        // module declared the alias.
         let spec_attrs = module
             .classes
             .first()
-            .map(|class| spec_codegen::generate_class_specs(class, false, Some(&alias_registry)))
+            .map(|class| {
+                spec_codegen::generate_class_specs(class, false, Some(&self.alias_registry))
+            })
             .unwrap_or_default();
         let spec_suffix: Document<'static> = spec_codegen::format_spec_attributes(&spec_attrs)
             .map_or(Document::Nil, |s| docvec![",\n     ", s]);
@@ -64,7 +63,7 @@ impl CoreErlangGenerator {
         // module attribute list (an `erlc` compile error otherwise) — empty
         // for a module with no `type_aliases`, so this is a no-op change for
         // the common case.
-        let alias_type_attrs = spec_codegen::generate_alias_type_attrs(&alias_registry);
+        let alias_type_attrs = spec_codegen::generate_alias_type_attrs(&self.alias_registry);
         let alias_type_suffix: Document<'static> =
             spec_codegen::format_alias_type_attributes(&alias_type_attrs)
                 .map_or(Document::Nil, |s| docvec![",\n     ", s]);

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -361,6 +361,15 @@ pub struct CodegenOptions {
     /// `List` written back to `method_return_types` before codegen.
     native_type_registry:
         Option<std::sync::Arc<crate::semantic_analysis::type_checker::NativeTypeRegistry>>,
+    /// BT-2932: type alias declarations (`type Name = ...`) from other
+    /// modules in the same compilation unit — the codegen counterpart of
+    /// `AnalysisContext`/`ClassHierarchyContext`'s `pre_loaded_aliases`
+    /// (BT-2928). Merged with this module's own `module.type_aliases` via
+    /// `AliasRegistry::from_module_declarations_with_pre_loaded` so a
+    /// cross-module alias reference resolves to a `user_type` reference in
+    /// generated `-spec`/`-type` attributes instead of falling through to
+    /// `any()`.
+    pre_loaded_aliases: Vec<crate::semantic_analysis::alias_registry::AliasInfo>,
 }
 
 impl CodegenOptions {
@@ -380,6 +389,7 @@ impl CodegenOptions {
             beamtalk_version: None,
             otp_release: None,
             native_type_registry: None,
+            pre_loaded_aliases: Vec::new(),
         }
     }
 
@@ -494,6 +504,20 @@ impl CodegenOptions {
         >,
     ) -> Self {
         self.native_type_registry = registry;
+        self
+    }
+
+    /// BT-2932: sets pre-loaded type alias declarations from other modules
+    /// in the same compilation unit, so `generate_module` can resolve a
+    /// cross-module alias reference to a `user_type` reference in generated
+    /// `-spec`/`-type` attributes instead of falling through to `any()`.
+    /// Mirrors [`Self::with_class_hierarchy`]'s pre-loaded-metadata shape.
+    #[must_use]
+    pub fn with_pre_loaded_aliases(
+        mut self,
+        aliases: Vec<crate::semantic_analysis::alias_registry::AliasInfo>,
+    ) -> Self {
+        self.pre_loaded_aliases = aliases;
         self
     }
 }
@@ -623,6 +647,17 @@ pub fn generate_module_with_warnings(
     // so codegen generates auto-slot methods (withX: setters).
     crate::semantic_analysis::apply_class_kind_writeback(&mut module_with_writeback, &hierarchy);
     let module = &module_with_writeback;
+
+    // BT-2932: build the alias registry once, merging this module's own
+    // `type_aliases` with any pre-loaded aliases from other modules in the
+    // same compilation unit, so a cross-module alias reference resolves to
+    // a `user_type` reference instead of falling through to `any()` in
+    // generated `-spec`/`-type` attributes.
+    generator.alias_registry =
+        crate::semantic_analysis::alias_registry::AliasRegistry::from_module_declarations_with_pre_loaded(
+            module,
+            &options.pre_loaded_aliases,
+        );
 
     // ADR 0065 / BT-1457: Set Server subclass flag for handle_info codegen dispatch.
     if let Some(class) = module.classes.first() {
@@ -1344,6 +1379,22 @@ pub(crate) struct CoreErlangGenerator {
     /// ADR 0098 Phase 3: producing compound OTP version (`<release>-<erts>`),
     /// baked into `__beamtalk_meta`. Supplied by the CLI; `None` omits the key.
     otp_release: Option<EcoString>,
+    /// BT-2932: cross-module-aware alias registry for this generation —
+    /// this module's own `type_aliases` merged with any pre-loaded aliases
+    /// from other modules in the same compilation unit
+    /// (`CodegenOptions::pre_loaded_aliases`). Populated by
+    /// `generate_module_with_warnings` before codegen begins; consumed by
+    /// the `generate_class_specs`/`generate_method_spec`/
+    /// `generate_type_alias`/`generate_alias_type_attrs` call sites in
+    /// `actor_codegen.rs`, `value_type_codegen.rs`, `supervisor_codegen.rs`,
+    /// and `gen_server/native_facade.rs` so an alias-typed annotation
+    /// resolves to a `user_type` reference regardless of which module
+    /// declared the alias. Empty (not `None`) when the module has no
+    /// `type_aliases` and no pre-loaded aliases were supplied — mirrors
+    /// `AliasRegistry::from_module_declarations`'s empty-registry default,
+    /// so every downstream `Some(&self.alias_registry)` call site is a
+    /// no-op for the common case.
+    pub(super) alias_registry: crate::semantic_analysis::alias_registry::AliasRegistry,
 }
 
 impl CoreErlangGenerator {
@@ -1386,6 +1437,7 @@ impl CoreErlangGenerator {
             class_hierarchy: None,
             beamtalk_version: None,
             otp_release: None,
+            alias_registry: crate::semantic_analysis::alias_registry::AliasRegistry::new(),
         }
     }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/spec_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/spec_codegen.rs
@@ -565,6 +565,19 @@ fn generate_alias_type_attr(
 /// must declare the corresponding named `-type` in the same module attribute
 /// list, since a reference to an undeclared type is an `erlc` compile error,
 /// not just a Dialyzer warning.
+///
+/// Emits a `-type` for every name in `aliases` (BT-2932), not only the ones
+/// this module's own specs actually reference — since (BT-2932) `aliases` is
+/// the full pre-loaded registry seeded from every source file in the
+/// compilation unit, a module using one cross-module alias still declares
+/// `-type` attributes for all of them. This is correctness-safe (extra
+/// `-type` declarations are valid metadata, and the registry is
+/// self-consistent, so no undeclared-type `erlc` error results) but grows
+/// each compiled module's attribute list with the full project's alias
+/// count rather than just what it uses. Tracking which names are actually
+/// touched during `generate_class_specs`/`generate_method_spec` and scoping
+/// emission to those would need a second pass or accumulator — deferred
+/// until this proves costly at real project scale.
 pub fn generate_alias_type_attrs(aliases: &AliasRegistry) -> Vec<Document<'static>> {
     let mut names: Vec<&EcoString> = aliases.alias_names().collect();
     names.sort_unstable();

--- a/crates/beamtalk-core/src/codegen/core_erlang/supervisor_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/supervisor_codegen.rs
@@ -28,7 +28,6 @@ use super::util::ClassIdentity;
 use super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result, spec_codegen};
 use crate::ast::{MethodKind, Module, SupervisorKind};
 use crate::docvec;
-use crate::semantic_analysis::alias_registry::AliasRegistry;
 
 impl CoreErlangGenerator {
     /// Generates an OTP supervisor module for `Supervisor subclass:` or
@@ -90,16 +89,15 @@ impl CoreErlangGenerator {
         let beamtalk_class_attr = super::util::beamtalk_class_attribute(&module.classes);
         let file_attr = self.file_attr();
         let source_path_attr = self.source_path_attr();
-        // BT-2909: build the alias registry once from this module's own
-        // `type_aliases` so alias-named annotations resolve to `user_type`
-        // references (ADR 0108) instead of falling through to `any()`.
-        // Cross-module aliases (an annotation referencing an alias exported
-        // by a dependency, ADR 0108) are not resolved here — only this
-        // module's own declarations — so they still fall through to `any()`.
-        // TODO(BT-2932): thread the full seeded registry through instead of
-        // reconstructing a module-local one.
-        let alias_registry = AliasRegistry::from_module_declarations(module);
-        let spec_attrs = spec_codegen::generate_class_specs(class, true, Some(&alias_registry));
+        // BT-2909/BT-2932: use the generator's cross-module-aware alias
+        // registry (this module's own `type_aliases` merged with any
+        // pre-loaded aliases from other modules in the same compilation
+        // unit — see `CoreErlangGenerator::alias_registry`'s doc) so an
+        // alias-named annotation resolves to a `user_type` reference (ADR
+        // 0108) instead of falling through to `any()`, regardless of which
+        // module declared the alias.
+        let spec_attrs =
+            spec_codegen::generate_class_specs(class, true, Some(&self.alias_registry));
         let spec_suffix: Document<'static> = spec_codegen::format_spec_attributes(&spec_attrs)
             .map_or(Document::Nil, |s| docvec![",\n     ", s]);
         // BT-2909: every class module that could contain a `user_type`
@@ -107,7 +105,7 @@ impl CoreErlangGenerator {
         // module attribute list (an `erlc` compile error otherwise) — empty
         // for a module with no `type_aliases`, so this is a no-op change for
         // the common case.
-        let alias_type_attrs = spec_codegen::generate_alias_type_attrs(&alias_registry);
+        let alias_type_attrs = spec_codegen::generate_alias_type_attrs(&self.alias_registry);
         let alias_type_suffix: Document<'static> =
             spec_codegen::format_alias_type_attributes(&alias_type_attrs)
                 .map_or(Document::Nil, |s| docvec![",\n     ", s]);
@@ -185,16 +183,15 @@ impl CoreErlangGenerator {
         let beamtalk_class_attr = super::util::beamtalk_class_attribute(&module.classes);
         let file_attr = self.file_attr();
         let source_path_attr = self.source_path_attr();
-        // BT-2909: build the alias registry once from this module's own
-        // `type_aliases` so alias-named annotations resolve to `user_type`
-        // references (ADR 0108) instead of falling through to `any()`.
-        // Cross-module aliases (an annotation referencing an alias exported
-        // by a dependency, ADR 0108) are not resolved here — only this
-        // module's own declarations — so they still fall through to `any()`.
-        // TODO(BT-2932): thread the full seeded registry through instead of
-        // reconstructing a module-local one.
-        let alias_registry = AliasRegistry::from_module_declarations(module);
-        let spec_attrs = spec_codegen::generate_class_specs(class, true, Some(&alias_registry));
+        // BT-2909/BT-2932: use the generator's cross-module-aware alias
+        // registry (this module's own `type_aliases` merged with any
+        // pre-loaded aliases from other modules in the same compilation
+        // unit — see `CoreErlangGenerator::alias_registry`'s doc) so an
+        // alias-named annotation resolves to a `user_type` reference (ADR
+        // 0108) instead of falling through to `any()`, regardless of which
+        // module declared the alias.
+        let spec_attrs =
+            spec_codegen::generate_class_specs(class, true, Some(&self.alias_registry));
         let spec_suffix: Document<'static> = spec_codegen::format_spec_attributes(&spec_attrs)
             .map_or(Document::Nil, |s| docvec![",\n     ", s]);
         // BT-2909: every class module that could contain a `user_type`
@@ -202,7 +199,7 @@ impl CoreErlangGenerator {
         // module attribute list (an `erlc` compile error otherwise) — empty
         // for a module with no `type_aliases`, so this is a no-op change for
         // the common case.
-        let alias_type_attrs = spec_codegen::generate_alias_type_attrs(&alias_registry);
+        let alias_type_attrs = spec_codegen::generate_alias_type_attrs(&self.alias_registry);
         let alias_type_suffix: Document<'static> =
             spec_codegen::format_alias_type_attributes(&alias_type_attrs)
                 .map_or(Document::Nil, |s| docvec![",\n     ", s]);

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -3190,6 +3190,51 @@ Value subclass: Child
 }
 
 #[test]
+fn test_value_subclass_cross_module_alias_reference_emits_user_type() {
+    // BT-2932: same wiring check as
+    // `test_value_subclass_field_alias_emits_user_type_and_named_type`
+    // above, but the alias is declared in a *different* compiled module —
+    // threaded in via `CodegenOptions::with_pre_loaded_aliases`, mirroring
+    // how the CLI build pipeline populates it from
+    // `ClassHierarchyContext::pre_loaded_aliases` — instead of this
+    // module's own `type_aliases`.
+    let alias_src = "type RestartStrategy = #temporary | #transient | #permanent";
+    let alias_tokens = crate::source_analysis::lex_with_eof(alias_src);
+    let (alias_module, alias_diags) = crate::source_analysis::parse(alias_tokens);
+    assert!(
+        alias_diags.is_empty(),
+        "alias-declaring module parse should succeed: {alias_diags:?}"
+    );
+    let pre_loaded_aliases =
+        crate::semantic_analysis::AliasRegistry::extract_alias_infos(&alias_module);
+
+    // No `type RestartStrategy = ...` in this module — only a `state:`
+    // field referencing the name declared elsewhere.
+    let src = "
+Value subclass: Child
+  state: strategy :: RestartStrategy = #temporary
+";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, diags) = crate::source_analysis::parse(tokens);
+    assert!(diags.is_empty(), "parse should succeed: {diags:?}");
+    let code = generate_module(
+        &module,
+        CodegenOptions::new("bt@child_cross_module").with_pre_loaded_aliases(pre_loaded_aliases),
+    )
+    .expect("codegen should succeed");
+
+    assert!(
+        code.contains("{'user_type', 0, 'restart_strategy', []}"),
+        "state field typed with a cross-module alias should emit a user_type reference. \
+         Got:\n{code}"
+    );
+    assert!(
+        code.contains("'export_type' = [{'t', 0}]"),
+        "Value subclass's own -type t() alias (BT-1156) must be unaffected. Got:\n{code}"
+    );
+}
+
+#[test]
 fn test_module_without_type_aliases_is_unaffected_by_alias_wiring() {
     // BT-2909 acceptance criterion: confirm generated Core Erlang for
     // message dispatch/field access is unaffected for modules with no
@@ -3210,6 +3255,90 @@ Actor subclass: Counter
     assert!(
         !code.contains("user_type"),
         "a module with no type_aliases must never emit a user_type reference. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_cross_module_alias_reference_emits_user_type_via_pre_loaded_aliases() {
+    // BT-2932: an alias declared in one compiled module — simulated here by
+    // extracting `AliasInfo`s from a standalone `type X = ...` module via
+    // `AliasRegistry::extract_alias_infos`, the same mechanism the CLI build
+    // pipeline uses to populate `ClassHierarchyContext::pre_loaded_aliases`
+    // — and referenced in a method annotation in a *different* module must
+    // still emit a `user_type` reference. Before this issue,
+    // `actor_codegen.rs`'s `generate_class_specs` call site only ever saw
+    // `AliasRegistry::from_module_declarations(module)` — the referencing
+    // module's own (here, empty) `type_aliases` — so this exact case fell
+    // through to `any()` (see the negative-control test below).
+    let alias_src = "type RestartStrategy = #temporary | #transient | #permanent";
+    let alias_tokens = crate::source_analysis::lex_with_eof(alias_src);
+    let (alias_module, alias_diags) = crate::source_analysis::parse(alias_tokens);
+    assert!(
+        alias_diags.is_empty(),
+        "alias-declaring module parse should succeed: {alias_diags:?}"
+    );
+    let pre_loaded_aliases =
+        crate::semantic_analysis::AliasRegistry::extract_alias_infos(&alias_module);
+    assert_eq!(
+        pre_loaded_aliases.len(),
+        1,
+        "sanity: exactly one pre-loaded alias extracted"
+    );
+
+    // The consuming module declares no `type RestartStrategy = ...` of its
+    // own — only a method annotation referencing the name declared in the
+    // other (pre-loaded) module.
+    let src = "
+Actor subclass: Supervisor
+  class defaultStrategy: policy :: RestartStrategy => policy
+";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, diags) = crate::source_analysis::parse(tokens);
+    assert!(diags.is_empty(), "parse should succeed: {diags:?}");
+
+    let code = generate_module(
+        &module,
+        CodegenOptions::new("bt@supervisor_cross_module")
+            .with_pre_loaded_aliases(pre_loaded_aliases),
+    )
+    .expect("codegen should succeed");
+
+    assert!(
+        code.contains("{'user_type', 0, 'restart_strategy', []}"),
+        "class method param typed with a cross-module alias should emit a user_type reference. \
+         Got:\n{code}"
+    );
+    assert!(
+        code.contains("'restart_strategy'"),
+        "module must declare the matching named -type for the cross-module alias. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_cross_module_alias_reference_without_pre_loaded_aliases_falls_back_to_any() {
+    // BT-2932 negative control: the same module, compiled without
+    // `with_pre_loaded_aliases`, reproduces the pre-fix gap this issue
+    // closes — since the module has no local `type_aliases` of its own,
+    // `RestartStrategy` is an unresolved name and the annotation falls
+    // through to `any()` rather than a spurious `user_type` reference.
+    let src = "
+Actor subclass: Supervisor
+  class defaultStrategy: policy :: RestartStrategy => policy
+";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, diags) = crate::source_analysis::parse(tokens);
+    assert!(diags.is_empty(), "parse should succeed: {diags:?}");
+
+    let code = generate_module(
+        &module,
+        CodegenOptions::new("bt@supervisor_cross_module_neg"),
+    )
+    .expect("codegen should succeed");
+
+    assert!(
+        !code.contains("user_type"),
+        "without pre-loaded aliases, an unresolved cross-module alias name must fall back to \
+         any(), not user_type. Got:\n{code}"
     );
 }
 
@@ -4003,6 +4132,53 @@ fn test_native_facade_class_method_alias_param_emits_user_type_and_named_type() 
     assert!(
         code.contains("'restart_strategy'"),
         "module must declare the matching named -type for the alias. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_native_facade_cross_module_alias_reference_emits_user_type() {
+    // BT-2932: same wiring check as
+    // `test_native_facade_class_method_alias_param_emits_user_type_and_named_type`
+    // above, but the alias is declared in a *different* compiled module —
+    // threaded in via `CodegenOptions::with_pre_loaded_aliases` — instead of
+    // this module's own `type_aliases`.
+    let strategy_alias = TypeAliasDefinition {
+        name: Identifier::new("RestartStrategy", Span::new(0, 0)),
+        annotation: TypeAnnotation::union(
+            vec![
+                TypeAnnotation::singleton("temporary", Span::new(0, 0)),
+                TypeAnnotation::singleton("transient", Span::new(0, 0)),
+                TypeAnnotation::singleton("permanent", Span::new(0, 0)),
+            ],
+            Span::new(0, 0),
+        ),
+        is_internal: false,
+        comments: CommentAttachment::default(),
+        doc_comment: None,
+        span: Span::new(0, 0),
+    };
+    let pre_loaded_aliases =
+        vec![crate::semantic_analysis::alias_registry::AliasInfo::from_definition(&strategy_alias)];
+
+    // No `type_aliases` of its own — the module only references the name.
+    let mut module = make_native_actor_with_class_methods();
+    module.classes[0].class_methods[0].parameters[0].type_annotation =
+        Some(TypeAnnotation::simple("RestartStrategy", Span::new(0, 0)));
+
+    let code = generate_module(
+        &module,
+        CodegenOptions::new("bt@test_rich_cross_module")
+            .with_pre_loaded_aliases(pre_loaded_aliases),
+    )
+    .expect("codegen should succeed");
+    assert!(
+        code.contains("{'user_type', 0, 'restart_strategy', []}"),
+        "class method param typed with a cross-module alias should emit a user_type reference. \
+         Got:\n{code}"
+    );
+    assert!(
+        code.contains("'restart_strategy'"),
+        "module must declare the matching named -type for the cross-module alias. Got:\n{code}"
     );
 }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -3315,6 +3315,42 @@ Actor subclass: Supervisor
 }
 
 #[test]
+fn test_cross_module_alias_reference_compiles_through_erlc() {
+    // BT-2932 (review follow-up): the sibling same-module case is guarded
+    // through erlc by `test_alias_annotated_actor_module_compiles_through_erlc`
+    // (BT-2909) — this exercises the cross-module case (alias declared in
+    // one module, referenced via `pre_loaded_aliases` from another) the same
+    // way, so a `-type`/`user_type` pairing bug here would fail to compile
+    // rather than only fail a string assertion.
+    let alias_src = "type RestartStrategy = #temporary | #transient | #permanent";
+    let alias_tokens = crate::source_analysis::lex_with_eof(alias_src);
+    let (alias_module, alias_diags) = crate::source_analysis::parse(alias_tokens);
+    assert!(
+        alias_diags.is_empty(),
+        "alias-declaring module parse should succeed: {alias_diags:?}"
+    );
+    let pre_loaded_aliases =
+        crate::semantic_analysis::AliasRegistry::extract_alias_infos(&alias_module);
+
+    let src = "
+Actor subclass: Supervisor
+  class defaultStrategy: policy :: RestartStrategy => policy
+";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, diags) = crate::source_analysis::parse(tokens);
+    assert!(diags.is_empty(), "parse should succeed: {diags:?}");
+
+    let code = generate_module(
+        &module,
+        CodegenOptions::new("bt_cross_module_alias_erlc_check")
+            .with_pre_loaded_aliases(pre_loaded_aliases),
+    )
+    .expect("codegen should succeed");
+
+    crate::test_helpers::assert_compiles_through_erlc("bt_cross_module_alias_erlc_check", &code);
+}
+
+#[test]
 fn test_cross_module_alias_reference_without_pre_loaded_aliases_falls_back_to_any() {
     // BT-2932 negative control: the same module, compiled without
     // `with_pre_loaded_aliases`, reproduces the pre-fix gap this issue

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/supervisor.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/supervisor.rs
@@ -427,3 +427,199 @@ fn test_static_supervisor_class_method_alias_param_emits_user_type_and_named_typ
         "module must declare the matching named -type for the alias. Got:\n{code}"
     );
 }
+
+#[test]
+fn test_static_supervisor_cross_module_alias_reference_emits_user_type() {
+    // BT-2932: same wiring check as
+    // `test_static_supervisor_class_method_alias_param_emits_user_type_and_named_type`
+    // above, but the alias is declared in a *different* module — passed via
+    // `CodegenOptions::with_pre_loaded_aliases` instead of this module's own
+    // `type_aliases` — the cross-module case `supervisor_codegen.rs`'s
+    // `generate_static_supervisor` couldn't resolve before this issue, since
+    // it only ever built `AliasRegistry::from_module_declarations(module)`.
+    let strategy_alias = TypeAliasDefinition {
+        name: Identifier::new("RestartStrategy", Span::new(0, 0)),
+        annotation: TypeAnnotation::union(
+            vec![
+                TypeAnnotation::singleton("temporary", Span::new(0, 0)),
+                TypeAnnotation::singleton("transient", Span::new(0, 0)),
+                TypeAnnotation::singleton("permanent", Span::new(0, 0)),
+            ],
+            Span::new(0, 0),
+        ),
+        is_internal: false,
+        comments: CommentAttachment::default(),
+        doc_comment: None,
+        span: Span::new(0, 0),
+    };
+    let pre_loaded_aliases =
+        vec![crate::semantic_analysis::alias_registry::AliasInfo::from_definition(&strategy_alias)];
+    let strategy_method = MethodDefinition {
+        selector: MessageSelector::Keyword(vec![KeywordPart::new(
+            "defaultStrategy:",
+            Span::new(0, 0),
+        )]),
+        parameters: vec![ParameterDefinition::with_type(
+            Identifier::new("policy", Span::new(0, 0)),
+            TypeAnnotation::simple("RestartStrategy", Span::new(0, 0)),
+        )],
+        body: vec![bare(Expression::Identifier(Identifier::new(
+            "policy",
+            Span::new(0, 0),
+        )))],
+        kind: MethodKind::Primary,
+        return_type: None,
+        is_sealed: false,
+        is_internal: false,
+        is_class_method: false,
+        span: Span::new(0, 0),
+        doc_comment: None,
+        expect: None,
+        comments: CommentAttachment::default(),
+    };
+    let class = ClassDefinition {
+        name: Identifier::new("WebApp", Span::new(0, 0)),
+        superclass: Some(Identifier::new("Supervisor", Span::new(0, 0))),
+        superclass_package: None,
+        class_kind: ClassKind::Object,
+        is_abstract: false,
+        is_sealed: false,
+        is_typed: false,
+        is_internal: false,
+        supervisor_kind: Some(SupervisorKind::Static),
+        state: vec![],
+        methods: vec![],
+        class_methods: vec![strategy_method],
+        class_variables: vec![],
+        type_params: vec![],
+        superclass_type_args: vec![],
+        comments: CommentAttachment::default(),
+        doc_comment: None,
+        backing_module: None,
+        handle_scope: None,
+        span: Span::new(0, 0),
+    };
+    // No `type_aliases` of its own — the module only references the name.
+    let module = Module {
+        classes: vec![class],
+        method_definitions: vec![],
+        protocols: Vec::new(),
+        type_aliases: Vec::new(),
+        expressions: vec![],
+        span: Span::new(0, 0),
+        file_leading_comments: vec![],
+        file_trailing_comments: vec![],
+    };
+    let code = generate_module(
+        &module,
+        CodegenOptions::new("bt@webapp_cross_module").with_pre_loaded_aliases(pre_loaded_aliases),
+    )
+    .expect("codegen should succeed");
+    assert!(
+        code.contains("{'user_type', 0, 'restart_strategy', []}"),
+        "class method param typed with a cross-module alias should emit a user_type reference. \
+         Got:\n{code}"
+    );
+    assert!(
+        code.contains("'restart_strategy'"),
+        "module must declare the matching named -type for the cross-module alias. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_dynamic_supervisor_cross_module_alias_reference_emits_user_type() {
+    // BT-2932: same wiring check as
+    // `test_static_supervisor_cross_module_alias_reference_emits_user_type`
+    // above, but for `supervisor_codegen.rs`'s *second* call site,
+    // `generate_dynamic_supervisor` (`DynamicSupervisor subclass:`) — the
+    // two call sites are separate copies of the same
+    // `AliasRegistry`-consuming code, so both need coverage.
+    let strategy_alias = TypeAliasDefinition {
+        name: Identifier::new("RestartStrategy", Span::new(0, 0)),
+        annotation: TypeAnnotation::union(
+            vec![
+                TypeAnnotation::singleton("temporary", Span::new(0, 0)),
+                TypeAnnotation::singleton("transient", Span::new(0, 0)),
+                TypeAnnotation::singleton("permanent", Span::new(0, 0)),
+            ],
+            Span::new(0, 0),
+        ),
+        is_internal: false,
+        comments: CommentAttachment::default(),
+        doc_comment: None,
+        span: Span::new(0, 0),
+    };
+    let pre_loaded_aliases =
+        vec![crate::semantic_analysis::alias_registry::AliasInfo::from_definition(&strategy_alias)];
+    let strategy_method = MethodDefinition {
+        selector: MessageSelector::Keyword(vec![KeywordPart::new(
+            "defaultStrategy:",
+            Span::new(0, 0),
+        )]),
+        parameters: vec![ParameterDefinition::with_type(
+            Identifier::new("policy", Span::new(0, 0)),
+            TypeAnnotation::simple("RestartStrategy", Span::new(0, 0)),
+        )],
+        body: vec![bare(Expression::Identifier(Identifier::new(
+            "policy",
+            Span::new(0, 0),
+        )))],
+        kind: MethodKind::Primary,
+        return_type: None,
+        is_sealed: false,
+        is_internal: false,
+        is_class_method: false,
+        span: Span::new(0, 0),
+        doc_comment: None,
+        expect: None,
+        comments: CommentAttachment::default(),
+    };
+    let class = ClassDefinition {
+        name: Identifier::new("WorkerPool", Span::new(0, 0)),
+        superclass: Some(Identifier::new("DynamicSupervisor", Span::new(0, 0))),
+        superclass_package: None,
+        class_kind: ClassKind::Object,
+        is_abstract: false,
+        is_sealed: false,
+        is_typed: false,
+        is_internal: false,
+        supervisor_kind: Some(SupervisorKind::Dynamic),
+        state: vec![],
+        methods: vec![],
+        class_methods: vec![strategy_method],
+        class_variables: vec![],
+        type_params: vec![],
+        superclass_type_args: vec![],
+        comments: CommentAttachment::default(),
+        doc_comment: None,
+        backing_module: None,
+        handle_scope: None,
+        span: Span::new(0, 0),
+    };
+    // No `type_aliases` of its own — the module only references the name.
+    let module = Module {
+        classes: vec![class],
+        method_definitions: vec![],
+        protocols: Vec::new(),
+        type_aliases: Vec::new(),
+        expressions: vec![],
+        span: Span::new(0, 0),
+        file_leading_comments: vec![],
+        file_trailing_comments: vec![],
+    };
+    let code = generate_module(
+        &module,
+        CodegenOptions::new("bt@workerpool_cross_module")
+            .with_pre_loaded_aliases(pre_loaded_aliases),
+    )
+    .expect("codegen should succeed");
+    assert!(
+        code.contains("{'user_type', 0, 'restart_strategy', []}"),
+        "class method param typed with a cross-module alias should emit a user_type reference. \
+         Got:\n{code}"
+    );
+    assert!(
+        code.contains("'restart_strategy'"),
+        "module must declare the matching named -type for the cross-module alias. Got:\n{code}"
+    );
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -21,7 +21,6 @@ use crate::ast::{
     Module, WellKnownSelector,
 };
 use crate::docvec;
-use crate::semantic_analysis::alias_registry::AliasRegistry;
 
 /// Classification of how a value-type method body expression should be handled
 /// for Self-threading.  Produced by [`CoreErlangGenerator::classify_vt_body_expr`]
@@ -424,25 +423,26 @@ impl CoreErlangGenerator {
         class: &ClassDefinition,
         exports: Document<'static>,
     ) -> Document<'static> {
-        // BT-2909: build the alias registry once from this module's own
-        // `type_aliases` so alias-named annotations resolve to `user_type`
-        // references (ADR 0108) instead of falling through to `any()`.
-        // Cross-module aliases (an annotation referencing an alias exported
-        // by a dependency, ADR 0108) are not resolved here — only this
-        // module's own declarations — so they still fall through to `any()`.
-        // TODO(BT-2932): thread the full seeded registry through instead of
-        // reconstructing a module-local one.
-        let alias_registry = AliasRegistry::from_module_declarations(module);
-
         // BT-586: Generate spec attributes from type annotations
-        let spec_attrs = spec_codegen::generate_class_specs(class, true, Some(&alias_registry));
+        // BT-2909/BT-2932: use the generator's cross-module-aware alias
+        // registry (this module's own `type_aliases` merged with any
+        // pre-loaded aliases from other modules in the same compilation
+        // unit — see `CoreErlangGenerator::alias_registry`'s doc) so an
+        // alias-named annotation resolves to a `user_type` reference (ADR
+        // 0108) instead of falling through to `any()`, regardless of which
+        // module declared the alias.
+        let spec_attrs =
+            spec_codegen::generate_class_specs(class, true, Some(&self.alias_registry));
         let spec_suffix: Document<'static> = spec_codegen::format_spec_attributes(&spec_attrs)
             .map_or(Document::Nil, |s| docvec![",\n     ", s]);
 
         // BT-1156: Generate -type t() alias for Value classes with state: declarations.
         let class_name_for_type = self.class_name();
-        let type_alias_opt =
-            spec_codegen::generate_type_alias(class, &class_name_for_type, Some(&alias_registry));
+        let type_alias_opt = spec_codegen::generate_type_alias(
+            class,
+            &class_name_for_type,
+            Some(&self.alias_registry),
+        );
         let export_type_suffix: Document<'static> = if type_alias_opt.is_some() {
             Document::Str(",\n     'export_type' = [{'t', 0}]")
         } else {
@@ -456,7 +456,7 @@ impl CoreErlangGenerator {
         // module attribute list (an `erlc` compile error otherwise) — empty
         // for a module with no `type_aliases`, so this is a no-op change for
         // the common case.
-        let alias_type_attrs = spec_codegen::generate_alias_type_attrs(&alias_registry);
+        let alias_type_attrs = spec_codegen::generate_alias_type_attrs(&self.alias_registry);
         let alias_type_suffix: Document<'static> =
             spec_codegen::format_alias_type_attributes(&alias_type_attrs)
                 .map_or(Document::Nil, |s| docvec![",\n     ", s]);

--- a/crates/beamtalk-core/src/semantic_analysis/alias_registry.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/alias_registry.rs
@@ -371,6 +371,45 @@ impl AliasRegistry {
         }
     }
 
+    /// Builds an alias registry from a module's own declarations, extended
+    /// with pre-loaded aliases from other modules in the same compilation
+    /// unit (ADR 0108, BT-2932) — the **codegen**-only counterpart of
+    /// [`Self::add_pre_loaded`].
+    ///
+    /// Like [`Self::from_module_declarations`], this constructor runs no
+    /// validation (no namespace-collision, duplicate-name, or
+    /// package-boundary `internal`-visibility checks): by the time a module
+    /// reaches codegen, semantic analysis has already run
+    /// [`Self::register_module`] and [`Self::add_pre_loaded`] against the
+    /// full package (which *do* run those checks), so any name that
+    /// survived to codegen is already known-good — codegen only needs the
+    /// name → annotation map to resolve [`TypeAnnotation::Simple`]
+    /// references to `user_type` forms (see
+    /// `codegen::core_erlang::spec_codegen::type_annotation_to_spec`).
+    ///
+    /// A pre-loaded alias never overrides a same-named module-local
+    /// declaration — mirrors `add_pre_loaded`'s `entry(..).or_insert(..)`
+    /// "first (module-local) definition wins" behaviour. This matters
+    /// because callers (e.g. `ClassHierarchyContext::pre_loaded_aliases`)
+    /// typically populate `pre_loaded_aliases` from *every* source file in
+    /// the compilation unit, including the one currently being compiled —
+    /// so the module's own duplicate entry in that list is a silent no-op
+    /// rather than something the caller needs to filter out first.
+    #[must_use]
+    pub fn from_module_declarations_with_pre_loaded(
+        module: &Module,
+        pre_loaded_aliases: &[AliasInfo],
+    ) -> Self {
+        let mut registry = Self::from_module_declarations(module);
+        for info in pre_loaded_aliases {
+            registry
+                .aliases
+                .entry(info.name.clone())
+                .or_insert_with(|| info.clone());
+        }
+        registry
+    }
+
     /// Extract `AliasInfo` entries from a parsed module without registering them.
     ///
     /// BT-2898: Mirrors `ProtocolRegistry::extract_protocol_infos` /


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2932

Follow-up to [BT-2909](https://linear.app/beamtalk/issue/BT-2909) (PR #3040), raised during that PR's review. The four module-level codegen drivers BT-2909 wired — `actor_codegen.rs`, `value_type_codegen.rs`, `supervisor_codegen.rs` (×2 call sites), `gen_server/native_facade.rs` — each built their own throwaway `AliasRegistry` via `AliasRegistry::from_module_declarations(module)`, which only sees the current module's own `type_aliases`. Semantic analysis, by contrast, uses the full `AliasRegistry` seeded across module boundaries (mirroring `ProtocolRegistry::add_pre_loaded`, ADR 0108), so a cross-module alias reference type-checks correctly today but fell through to `any()` in generated Dialyzer `-spec`/`-type` attributes instead of the precise `{user_type, 0, ..., []}` reference. No runtime effect (`-spec` attributes are Dialyzer/FFI-documentation metadata only), but it undercut BT-2909's stated goal of FFI-precise generated specs.

## Key changes

- `AliasRegistry::from_module_declarations_with_pre_loaded` — new codegen-only constructor that merges a module's own `type_aliases` with pre-loaded cross-module aliases, no extra validation (semantic analysis has already validated them by the time codegen runs).
- `CodegenOptions::with_pre_loaded_aliases` + `CoreErlangGenerator::alias_registry` — thread the merged registry once per generation, mirroring the existing `with_class_hierarchy`/`pre_class_hierarchy` shape.
- All five codegen call sites (`actor_codegen.rs`, `value_type_codegen.rs`, `supervisor_codegen.rs` ×2, `gen_server/native_facade.rs`) now consume `self.alias_registry` instead of reconstructing a module-local registry.
- `beam_compiler.rs`'s `write_core_erlang_with_bindings`/`compile_source_with_bindings` thread `ClassHierarchyContext::pre_loaded_aliases` into codegen, mirroring how `pre_loaded_classes` already flows through the same pipeline.
- New tests: codegen-level cross-module tests for all five call sites (positive + a negative control confirming the pre-fix `any()` fallback without pre-loaded aliases), plus a CLI-pipeline-level integration test compiling two real files (`a.bt` declares the alias, `b.bt` references it) and asserting the generated `.core` file contains the `user_type` reference.

## Test plan

- [x] `just build && just clippy && just fmt-check` — clean
- [x] `just test` — Rust (5189 tests), stdlib, BUnit, Erlang runtime unit tests all green
- [x] `just ci-changed` — build/lint/test/dialyzer/spec-validation/corpus/surface-drift all green
- [x] New cross-module tests pass; existing single-module `from_module_declarations`-based tests unaffected
- [x] Confirmed no change to generated Core Erlang for message dispatch/field access (spec-attribute-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz


---
_Generated by [Claude Code](https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz)_