### PR TITLE
Unparse: class definition header trailing comment silently dropped (BT-2933)

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -130,7 +130,7 @@ impl Parser {
     pub(super) fn parse_class_definition(&mut self) -> ClassDefinition {
         let start = self.current_token().span();
         let doc_comment = self.collect_doc_comment();
-        let comments = self.collect_comment_attachment();
+        let mut comments = self.collect_comment_attachment();
         let mut is_abstract = false;
         let mut is_sealed = false;
         let mut is_typed = false;
@@ -223,6 +223,12 @@ impl Parser {
         // Parse optional `handleScope: #symbol` clause (ADR 0103). Appears at
         // the head of the class body, like `native:` is a header clause.
         let handle_scope = self.parse_optional_handle_scope();
+
+        // Collect a trailing end-of-line comment on the class header line
+        // (after the last header token — class name, type params, `native:`
+        // module, or `handleScope:` symbol, whichever comes last), mirroring
+        // the identical fix for type alias/protocol declarations (BT-2906).
+        comments.trailing = self.collect_trailing_comment();
 
         // Parse class body (state declarations, instance methods, class methods, class variables)
         let (state, methods, class_methods, class_variables) = self.parse_class_body();

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -3698,6 +3698,19 @@ mod tests {
         assert_identity(source);
     }
 
+    #[test]
+    fn class_header_trailing_comment_with_state_round_trip() {
+        // BT-2933 (review follow-up): the most common real-world class
+        // shape — a header trailing comment plus a `state:` declaration.
+        let source = concat!(
+            "Object subclass: Counter  // counter class\n",
+            "  state: count :: Integer = 0\n",
+            "\n",
+            "  increment => count := count + 1\n",
+        );
+        assert_identity(source);
+    }
+
     // --- BT-2924 regression: `type` alias sandwiched between a class's doc
     // comment and the class itself must not lose the class's doc comment. ---
 

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -3653,6 +3653,51 @@ mod tests {
         assert_identity(source);
     }
 
+    // --- Class definition header trailing comment (BT-2933) ---
+
+    #[test]
+    fn class_header_trailing_comment_round_trip() {
+        // BT-2933: a trailing end-of-line comment on the `subclass:` header
+        // line must round-trip losslessly, mirroring the identical fix for
+        // type alias/protocol declarations (BT-2906). Before the fix,
+        // `parse_class_definition` never populated `comments.trailing`, so
+        // `unparse_class_definition`'s trailing-comment branch was dead code
+        // and the comment was silently dropped.
+        // A class with no `state:` declarations always gets a blank line
+        // before its first method (canonical formatting, unrelated to this
+        // fix), hence the blank line in the expected output below.
+        let source = concat!(
+            "Object subclass: Foo  // header comment\n",
+            "\n",
+            "  x => 1\n",
+        );
+        assert_identity(source);
+    }
+
+    #[test]
+    fn class_header_trailing_comment_with_type_params_round_trip() {
+        // BT-2933: the trailing comment attaches after the last header
+        // token — here, the type parameter list.
+        let source = concat!(
+            "Object subclass: Box(T)  // header comment\n",
+            "\n",
+            "  x => 1\n",
+        );
+        assert_identity(source);
+    }
+
+    #[test]
+    fn class_header_trailing_comment_with_native_round_trip() {
+        // BT-2933: the trailing comment attaches after the `native:` module
+        // name — the last header token when present.
+        let source = concat!(
+            "Object subclass: Foo native: my_module  // header comment\n",
+            "\n",
+            "  x => 1\n",
+        );
+        assert_identity(source);
+    }
+
     // --- BT-2924 regression: `type` alias sandwiched between a class's doc
     // comment and the class itself must not lose the class's doc comment. ---
 


### PR DESCRIPTION
## Summary

Linear issue: https://linear.app/beamtalk/issue/BT-2933

`unparse_class_definition` in `crates/beamtalk-core/src/unparse/mod.rs` already had code to re-emit a trailing comment on the class header (`class.comments.trailing`), but `parse_class_definition` never populated it — so that branch was dead code and a trailing comment on `Object subclass: Foo // comment` was silently dropped.

- `parse_class_definition` now collects the trailing end-of-line comment after the last header token — class name, type params, `native:` module, or `handleScope:` symbol, whichever comes last — into `comments.trailing`, mirroring the identical fix applied to `parse_type_alias_definition`/`parse_protocol_definition` in BT-2906.
- Added regression tests covering the base case plus variants with type params and `native:`.

## Key changes

- `crates/beamtalk-core/src/source_analysis/parser/declarations.rs`: `parse_class_definition` now calls `collect_trailing_comment()` after parsing the header (superclass/name/type params/`native:`/`handleScope:`), before parsing the class body.
- `crates/beamtalk-core/src/unparse/mod.rs`: three new regression tests — `class_header_trailing_comment_round_trip`, `class_header_trailing_comment_with_type_params_round_trip`, `class_header_trailing_comment_with_native_round_trip`.

## Test plan

- [x] `cargo test -p beamtalk-core --lib -- class_header_trailing type_alias_trailing protocol_trailing` — all pass
- [x] `just test` — Rust, stdlib, BUnit, and runtime tests all pass
- [x] `just ci-changed` — full local CI (build/lint/test/check-corpus/check-surface-drift) passes
- [x] Manual CLI verification: `Object subclass: Foo  // header comment\n  x => 1\n` now round-trips the comment through `beamtalk fmt` instead of dropping it

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz)_