### PR TITLE
beamtalk fmt relocates/drops blank lines between top-level declarations (BT-2929)

### DIFF
--- a/crates/beamtalk-core/src/ast/mod.rs
+++ b/crates/beamtalk-core/src/ast/mod.rs
@@ -292,6 +292,11 @@ pub struct CommentAttachment {
 
 impl CommentAttachment {
     /// Returns true if no comments are attached.
+    ///
+    /// Deliberately ignores `leading_blank_line` — a call site gated on
+    /// `is_empty()` will silently discard that field's value. See
+    /// `PendingDeclarationExpect::apply_to` for the one call site where
+    /// this is already known to be harmless.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.leading.is_empty() && self.trailing.is_none()

--- a/crates/beamtalk-core/src/ast/mod.rs
+++ b/crates/beamtalk-core/src/ast/mod.rs
@@ -276,6 +276,18 @@ pub struct CommentAttachment {
     pub leading: Vec<Comment>,
     /// A single end-of-line comment on the same line as this node.
     pub trailing: Option<Comment>,
+    /// Whether a blank line preceded this node in the source, before any
+    /// leading comments (or before the node itself, if it has none).
+    ///
+    /// Mirrors [`ExpressionStatement::preceding_blank_line`] (BT-987), but
+    /// lives here — rather than as a field on each top-level declaration
+    /// type — so that the many existing `CommentAttachment::default()` call
+    /// sites (tests, synthetic AST construction) keep compiling unchanged.
+    /// Populated by [`crate::source_analysis::parser`]'s
+    /// `collect_comment_attachment` and consulted by the module-level
+    /// unparser to preserve the blank line separating top-level class /
+    /// protocol / type-alias declarations (BT-2929).
+    pub leading_blank_line: bool,
 }
 
 impl CommentAttachment {
@@ -909,6 +921,7 @@ mod tests {
         let ca = CommentAttachment {
             leading: vec![Comment::line("a comment", Span::new(0, 11))],
             trailing: None,
+            leading_blank_line: false,
         };
         assert!(!ca.is_empty());
     }
@@ -918,6 +931,7 @@ mod tests {
         let ca = CommentAttachment {
             leading: Vec::new(),
             trailing: Some(Comment::line("trailing", Span::new(10, 20))),
+            leading_blank_line: false,
         };
         assert!(!ca.is_empty());
     }
@@ -927,6 +941,7 @@ mod tests {
         let ca = CommentAttachment {
             leading: vec![Comment::line("leading", Span::new(0, 9))],
             trailing: Some(Comment::line("trailing", Span::new(20, 30))),
+            leading_blank_line: false,
         };
         assert!(!ca.is_empty());
         assert_eq!(ca.leading.len(), 1);
@@ -959,6 +974,7 @@ mod tests {
             comments: CommentAttachment {
                 leading: vec![Comment::line("before", Span::new(0, 8))],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: expr,
             preceding_blank_line: false,

--- a/crates/beamtalk-core/src/ast/mod.rs
+++ b/crates/beamtalk-core/src/ast/mod.rs
@@ -297,9 +297,12 @@ impl CommentAttachment {
     /// Returns true if no comments are attached.
     ///
     /// Deliberately ignores `leading_blank_line` — a call site gated on
-    /// `is_empty()` will silently discard that field's value. See
-    /// `PendingDeclarationExpect::apply_to` for the production call site
-    /// where this is already known to be harmless.
+    /// `is_empty()` will silently discard or overwrite that field's value
+    /// (discard if it drops the whole attachment on the empty branch,
+    /// overwrite if it replaces one attachment with another there). See
+    /// `PendingDeclarationExpect::apply_to` for the production call site —
+    /// an overwrite — where this is already known to be harmless
+    /// (tracked as BT-2944).
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.leading.is_empty() && self.trailing.is_none()

--- a/crates/beamtalk-core/src/ast/mod.rs
+++ b/crates/beamtalk-core/src/ast/mod.rs
@@ -284,9 +284,12 @@ pub struct CommentAttachment {
     /// type — so that the many existing `CommentAttachment::default()` call
     /// sites (tests, synthetic AST construction) keep compiling unchanged.
     /// Populated by [`crate::source_analysis::parser`]'s
-    /// `collect_comment_attachment` and consulted by the module-level
-    /// unparser to preserve the blank line separating top-level class /
-    /// protocol / type-alias declarations (BT-2929).
+    /// `collect_comment_attachment` for every `CommentAttachment` it
+    /// produces — method bodies, state declarations, and expression
+    /// statements included, not only top-level declarations — but
+    /// currently consulted only by the module-level unparser, to preserve
+    /// the blank line separating top-level class / protocol / type-alias
+    /// declarations (BT-2929).
     pub leading_blank_line: bool,
 }
 
@@ -295,8 +298,8 @@ impl CommentAttachment {
     ///
     /// Deliberately ignores `leading_blank_line` — a call site gated on
     /// `is_empty()` will silently discard that field's value. See
-    /// `PendingDeclarationExpect::apply_to` for the one call site where
-    /// this is already known to be harmless.
+    /// `PendingDeclarationExpect::apply_to` for the production call site
+    /// where this is already known to be harmless.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.leading.is_empty() && self.trailing.is_none()

--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -95,8 +95,8 @@ impl PendingDeclarationExpect {
             // value when it's replaced wholesale. Harmless today because no
             // unparser reads `leading_blank_line` on class-member-level
             // `CommentAttachment`s (state/class-var/method) — only on
-            // top-level class/protocol/type-alias declarations. Revisit
-            // this overwrite if that ever changes.
+            // top-level class/protocol/type-alias declarations. Tracked as
+            // BT-2944: revisit this overwrite if that ever changes.
             *comments = self.comments;
         }
     }

--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -86,6 +86,17 @@ impl PendingDeclarationExpect {
             *doc_comment = self.doc_comment;
         }
         if comments.is_empty() {
+            // `CommentAttachment::is_empty()` only looks at `leading`/
+            // `trailing`, so this deliberately ignores `leading_blank_line`
+            // on both sides (BT-2929) — the declaration's own (usually
+            // `false`, since it directly follows `@expect` with no blank
+            // line) `leading_blank_line` is kept when `comments` is
+            // otherwise non-empty, and overwritten by `self.comments`'s
+            // value when it's replaced wholesale. Harmless today because no
+            // unparser reads `leading_blank_line` on class-member-level
+            // `CommentAttachment`s (state/class-var/method) — only on
+            // top-level class/protocol/type-alias declarations. Revisit
+            // this overwrite if that ever changes.
             *comments = self.comments;
         }
     }

--- a/crates/beamtalk-core/src/source_analysis/parser/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/mod.rs
@@ -1007,6 +1007,11 @@ impl Parser {
     /// current token is the same for both calls.
     pub(super) fn collect_comment_attachment(&self) -> CommentAttachment {
         let token_span = self.current_token().span();
+        // Blank line before the *entire* leading block (before any leading
+        // comment, or before the node itself when it has none) — distinct
+        // from `saw_blank_line` below, which tracks blank lines *between*
+        // consecutive leading comments (BT-2929).
+        let leading_blank_line = self.current_token().has_blank_line_before_first_comment();
         let mut leading = Vec::new();
         let mut saw_blank_line = false;
         // Positions (within this token's leading trivia) already captured by
@@ -1081,6 +1086,7 @@ impl Parser {
         CommentAttachment {
             leading,
             trailing: None,
+            leading_blank_line,
         }
     }
 

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -4008,6 +4008,21 @@ mod tests {
     }
 
     #[test]
+    fn multiple_blank_lines_between_top_level_declarations_normalised_to_one() {
+        // BT-2929 (review follow-up): `has_blank_line_before_first_comment`
+        // treats any run of 2+ blank lines as "a blank line preceded this
+        // node" — the unparser always re-emits exactly one, so multiple
+        // blank lines collapse to one on format (standard normalisation),
+        // not a bug. Two blank lines in source...
+        let source = "type Port = Integer\n\n\ntype Timeout = Integer\n";
+        let formatted = format_source(source).expect("format_source must succeed");
+        // ...become one blank line in the formatted output...
+        assert_eq!(formatted, "type Port = Integer\n\ntype Timeout = Integer\n");
+        // ...and that single-blank-line form is stable under a second pass.
+        assert_identity(&formatted);
+    }
+
+    #[test]
     fn blank_line_preserved_across_all_three_declaration_kinds_interleaved() {
         // Full combination: type alias, protocol, and class, each separated
         // by a blank line — every pairwise gap (type-alias/protocol,

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -4015,7 +4015,12 @@ mod tests {
         // predates BT-2929 and is documented in the loop's comment.
         // Confirmed here with an explicit regression test rather than only
         // a code comment.
-        let source = "\ntype Port = Integer\n";
+        //
+        // Two leading newlines are required, not one: a single `\n` is
+        // below `has_blank_line_before_first_comment()`'s `>= 2` threshold,
+        // so it would produce `leading_blank_line: false` and never
+        // actually exercise the `i > 0` guard this test targets.
+        let source = "\n\ntype Port = Integer\n";
         let formatted = format_source(source).expect("format_source must succeed");
         assert_eq!(formatted, "type Port = Integer\n");
     }

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -374,9 +374,9 @@ pub(crate) fn unparse_module_doc(module: &Module) -> Document<'static> {
     for (i, decl) in top_level_decls.into_iter().enumerate() {
         // BT-2929: re-emit the blank line the author placed between this
         // declaration and the previous one. Skipped for the first
-        // declaration — there's nothing before it in this section to
-        // separate from (any file-level leading comments/blank line were
-        // already handled above).
+        // declaration in the section — a blank line there (before the very
+        // first top-level declaration) is dropped, same as pre-existing
+        // behaviour; we only preserve inter-declaration gaps.
         if i > 0 && decl.preceding_blank_line() {
             docs.push(line());
         }

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -4008,6 +4008,19 @@ mod tests {
     }
 
     #[test]
+    fn blank_line_before_first_top_level_declaration_is_dropped() {
+        // BT-2929 (review follow-up): the `i > 0` guard in
+        // `unparse_module_doc`'s loop intentionally does not preserve a
+        // blank line before the very first top-level declaration — this
+        // predates BT-2929 and is documented in the loop's comment.
+        // Confirmed here with an explicit regression test rather than only
+        // a code comment.
+        let source = "\ntype Port = Integer\n";
+        let formatted = format_source(source).expect("format_source must succeed");
+        assert_eq!(formatted, "type Port = Integer\n");
+    }
+
+    #[test]
     fn multiple_blank_lines_between_top_level_declarations_normalised_to_one() {
         // BT-2929 (review follow-up): `has_blank_line_before_first_comment`
         // treats any run of 2+ blank lines as "a blank line preceded this

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -332,6 +332,17 @@ enum TopLevelDecl<'a> {
     TypeAlias(&'a TypeAliasDefinition),
 }
 
+impl TopLevelDecl<'_> {
+    /// Whether a blank line preceded this declaration in the source (BT-2929).
+    fn preceding_blank_line(&self) -> bool {
+        match self {
+            Self::Class(class) => class.comments.leading_blank_line,
+            Self::Protocol(protocol) => protocol.comments.leading_blank_line,
+            Self::TypeAlias(type_alias) => type_alias.comments.leading_blank_line,
+        }
+    }
+}
+
 /// Builds a [`Document`] for a [`Module`].
 #[must_use]
 pub(crate) fn unparse_module_doc(module: &Module) -> Document<'static> {
@@ -360,7 +371,15 @@ pub(crate) fn unparse_module_doc(module: &Module) -> Document<'static> {
         TopLevelDecl::TypeAlias(type_alias) => type_alias.span.start(),
     });
 
-    for decl in top_level_decls {
+    for (i, decl) in top_level_decls.into_iter().enumerate() {
+        // BT-2929: re-emit the blank line the author placed between this
+        // declaration and the previous one. Skipped for the first
+        // declaration — there's nothing before it in this section to
+        // separate from (any file-level leading comments/blank line were
+        // already handled above).
+        if i > 0 && decl.preceding_blank_line() {
+            docs.push(line());
+        }
         match decl {
             TopLevelDecl::Class(class) => docs.push(unparse_class_definition(class)),
             TopLevelDecl::Protocol(protocol) => docs.push(unparse_protocol_definition(protocol)),
@@ -2273,6 +2292,7 @@ mod tests {
             comments: CommentAttachment {
                 leading: vec![Comment::line("This is 42", span())],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Expression::Literal(Literal::Integer(42), span()),
             preceding_blank_line: false,
@@ -2287,6 +2307,7 @@ mod tests {
             comments: CommentAttachment {
                 leading: Vec::new(),
                 trailing: Some(Comment::line("trailing", span())),
+                leading_blank_line: false,
             },
             expression: Expression::Literal(Literal::Integer(1), span()),
             preceding_blank_line: false,
@@ -2301,6 +2322,7 @@ mod tests {
             comments: CommentAttachment {
                 leading: vec![Comment::line("before", span())],
                 trailing: Some(Comment::line("after", span())),
+                leading_blank_line: false,
             },
             expression: Expression::Literal(Literal::Integer(99), span()),
             preceding_blank_line: false,
@@ -2341,6 +2363,7 @@ mod tests {
         method.comments = CommentAttachment {
             leading: vec![Comment::line("Returns the current value", span())],
             trailing: None,
+            leading_blank_line: false,
         };
         let output = unparse_method_definition(&method).to_pretty_string();
         assert_eq!(output, "// Returns the current value\ngetValue => 0");
@@ -2642,6 +2665,7 @@ mod tests {
             comments: CommentAttachment {
                 leading: vec![Comment::line("the result", span())],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Expression::Identifier(Identifier::new("x", span())),
             preceding_blank_line: false,
@@ -2707,6 +2731,7 @@ mod tests {
             comments: CommentAttachment {
                 leading: vec![Comment::line("do the thing", span())],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Expression::Identifier(Identifier::new("x", span())),
             preceding_blank_line: false,
@@ -2730,6 +2755,7 @@ mod tests {
                     Comment::line("second comment", span()),
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Expression::Literal(Literal::Integer(42), span()),
             preceding_blank_line: false,
@@ -3863,6 +3889,67 @@ mod tests {
             formatted, formatted_again,
             "format_source is not idempotent"
         );
+    }
+
+    // --- BT-2929: blank line between top-level declarations ---
+    //
+    // `unparse_module_doc` used to always emit exactly one `line()` after
+    // each top-level declaration, regardless of whether the source had a
+    // blank line there — so the separating blank line was either silently
+    // dropped, or (for a class) looked "relocated" into the class's own
+    // body, since a class unconditionally gets a blank line before its
+    // first method whether or not it has state declarations (an unrelated,
+    // pre-existing formatting rule — see the `Blank line before first
+    // method` comment in `unparse_class_definition`). All three assertions
+    // below use `assert_identity` with sources that are already in that
+    // canonical form, so a regression here fails on the *first* format
+    // pass rather than requiring a second one to notice non-idempotency.
+
+    #[test]
+    fn blank_line_preserved_type_alias_then_class() {
+        // Repro A from BT-2929.
+        assert_identity(concat!(
+            "type Port = Integer\n",
+            "\n",
+            "Object subclass: Foo\n",
+            "\n",
+            "  m => 1\n",
+        ));
+    }
+
+    #[test]
+    fn blank_line_preserved_class_then_class() {
+        // Repro B from BT-2929 — confirms the bug wasn't type-alias-specific.
+        assert_identity(concat!(
+            "Object subclass: A\n",
+            "\n",
+            "  m => 1\n",
+            "\n",
+            "Object subclass: B\n",
+            "\n",
+            "  n => 2\n",
+        ));
+    }
+
+    #[test]
+    fn blank_line_preserved_type_alias_then_type_alias() {
+        // Repro C from BT-2929 — the blank line was dropped outright here
+        // (neither declaration has a body to "absorb" it into).
+        assert_identity(concat!(
+            "type Port = Integer\n",
+            "\n",
+            "type Timeout = Integer\n",
+        ));
+    }
+
+    #[test]
+    fn no_blank_line_between_top_level_declarations_stays_absent() {
+        // The converse of the three tests above: declarations with *no*
+        // blank line between them in the source must not gain one.
+        assert_identity(concat!(
+            "type Port = Integer\n",
+            "type Timeout = Integer\n",
+        ));
     }
 
     #[test]

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -3946,10 +3946,7 @@ mod tests {
     fn no_blank_line_between_top_level_declarations_stays_absent() {
         // The converse of the three tests above: declarations with *no*
         // blank line between them in the source must not gain one.
-        assert_identity(concat!(
-            "type Port = Integer\n",
-            "type Timeout = Integer\n",
-        ));
+        assert_identity(concat!("type Port = Integer\n", "type Timeout = Integer\n",));
     }
 
     #[test]

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -4008,6 +4008,25 @@ mod tests {
     }
 
     #[test]
+    fn blank_line_preserved_across_all_three_declaration_kinds_interleaved() {
+        // Full combination: type alias, protocol, and class, each separated
+        // by a blank line — every pairwise gap (type-alias/protocol,
+        // protocol/class, class/type-alias) must round-trip.
+        assert_identity(concat!(
+            "type Port = Integer\n",
+            "\n",
+            "Protocol define: Startable\n",
+            "  start -> Integer\n",
+            "\n",
+            "Object subclass: Server\n",
+            "\n",
+            "  start => 1\n",
+            "\n",
+            "type Timeout = Integer\n",
+        ));
+    }
+
+    #[test]
     fn state_declaration_preceded_by_orphaned_doc_block_does_not_merge_into_own_doc_comment() {
         // BT-2924 follow-up (found in adversarial review): a `///` block that
         // breaks away from a *different* declaration must not get glued onto

--- a/test-package-compiler/tests/snapshots/compiler_tests__abstract_class_spawn_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__abstract_class_spawn_parser.snap
@@ -41,6 +41,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -74,6 +75,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -115,6 +117,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,
@@ -135,6 +138,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: ClassReference {

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_conditional_field_mutations_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_conditional_field_mutations_parser.snap
@@ -65,6 +65,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -97,6 +98,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -135,6 +137,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -166,6 +169,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -261,6 +265,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -306,6 +311,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -342,6 +348,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -373,6 +380,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -468,6 +476,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -513,6 +522,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -549,6 +559,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -587,6 +598,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -643,6 +655,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -704,6 +717,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -749,6 +763,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -785,6 +800,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -824,6 +840,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -885,6 +902,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -930,6 +948,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -966,6 +985,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -998,6 +1018,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -1029,6 +1050,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Assignment {
                                                         target: Identifier(
@@ -1111,6 +1133,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -1161,6 +1184,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1328,6 +1352,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_parser.snap
@@ -65,6 +65,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -103,6 +104,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -149,6 +151,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -271,6 +274,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -325,6 +329,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -361,6 +366,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -407,6 +413,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -497,6 +504,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -592,6 +600,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -646,6 +655,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -682,6 +692,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -714,6 +725,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -760,6 +772,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Identifier(
                                                         Identifier {
@@ -787,6 +800,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Assignment {
                                                         target: Identifier(
@@ -856,6 +870,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -897,6 +912,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1073,6 +1089,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_list_ops_no_mutation_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_list_ops_no_mutation_parser.snap
@@ -122,6 +122,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -209,6 +210,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -228,6 +230,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -267,6 +270,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -345,6 +349,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -364,6 +369,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -403,6 +409,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -481,6 +488,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -500,6 +508,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -539,6 +548,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -617,6 +627,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -636,6 +647,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -682,6 +694,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -730,6 +743,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: Literal(
                                                             Integer(
@@ -787,6 +801,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -806,6 +821,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -845,6 +861,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -923,6 +940,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -942,6 +960,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -981,6 +1000,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: ListLiteral {
                                                             elements: [
@@ -1056,6 +1076,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1075,6 +1096,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1114,6 +1136,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1192,6 +1215,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1211,6 +1235,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1250,6 +1275,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1328,6 +1354,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1347,6 +1374,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1386,6 +1414,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1464,6 +1493,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1483,6 +1513,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1522,6 +1553,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1600,6 +1632,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1619,6 +1652,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1681,6 +1715,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1759,6 +1794,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1778,6 +1814,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1817,6 +1854,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1895,6 +1933,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1914,6 +1953,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1953,6 +1993,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -2031,6 +2072,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2050,6 +2092,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -2089,6 +2132,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -2167,6 +2211,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2186,6 +2231,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -2225,6 +2271,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -82,6 +83,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -101,6 +103,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Assignment {
                                     target: FieldAccess {
@@ -195,6 +198,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_parser.snap
@@ -104,6 +104,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -136,6 +137,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -155,6 +157,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Assignment {
                                     target: FieldAccess {
@@ -269,6 +272,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_parser.snap
@@ -68,6 +68,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -110,6 +111,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -129,6 +131,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Assignment {
                                     target: FieldAccess {
@@ -208,6 +211,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Return {
                                     value: FieldAccess {
@@ -278,6 +282,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -297,6 +302,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Return {
                                     value: FieldAccess {

--- a/test-package-compiler/tests/snapshots/compiler_tests__annotated_local_vars_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__annotated_local_vars_parser.snap
@@ -65,6 +65,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -84,6 +85,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -129,6 +131,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -179,6 +182,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,
@@ -226,6 +230,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -268,6 +273,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -321,6 +327,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -338,6 +345,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -438,6 +446,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -470,6 +479,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -487,6 +497,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -546,6 +557,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -578,6 +590,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -591,6 +604,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -69,6 +70,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Return {
                                     value: MessageSend {

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -69,6 +70,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Return {
                                     value: MessageSend {

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -69,6 +70,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Return {
                                     value: MessageSend {

--- a/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -112,6 +113,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -165,6 +167,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -218,6 +221,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -271,6 +275,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -324,6 +329,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -387,6 +393,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -450,6 +457,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -513,6 +521,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -576,6 +585,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -639,6 +649,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -702,6 +713,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -765,6 +777,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -828,6 +841,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -891,6 +905,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -973,6 +988,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1057,6 +1073,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1141,6 +1158,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1258,6 +1276,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1292,6 +1311,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1375,6 +1395,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1407,6 +1428,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1439,6 +1461,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1507,6 +1530,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -78,6 +79,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -109,6 +111,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -162,6 +165,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -194,6 +198,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -213,6 +218,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -265,6 +271,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -318,6 +325,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -337,6 +345,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -389,6 +398,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -420,6 +430,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -499,6 +510,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -518,6 +530,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -549,6 +562,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -568,6 +582,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -599,6 +614,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -618,6 +634,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Literal(
                                     Integer(

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -182,6 +183,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -312,6 +314,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -523,6 +526,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -542,6 +546,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Block(
                                     Block {
@@ -551,6 +556,7 @@ Module {
                                                 comments: CommentAttachment {
                                                     leading: [],
                                                     trailing: None,
+                                                    leading_blank_line: false,
                                                 },
                                                 expression: Block(
                                                     Block {
@@ -560,6 +566,7 @@ Module {
                                                                 comments: CommentAttachment {
                                                                     leading: [],
                                                                     trailing: None,
+                                                                    leading_blank_line: false,
                                                                 },
                                                                 expression: Block(
                                                                     Block {
@@ -569,6 +576,7 @@ Module {
                                                                                 comments: CommentAttachment {
                                                                                     leading: [],
                                                                                     trailing: None,
+                                                                                    leading_blank_line: false,
                                                                                 },
                                                                                 expression: Block(
                                                                                     Block {
@@ -578,6 +586,7 @@ Module {
                                                                                                 comments: CommentAttachment {
                                                                                                     leading: [],
                                                                                                     trailing: None,
+                                                                                                    leading_blank_line: false,
                                                                                                 },
                                                                                                 expression: Block(
                                                                                                     Block {
@@ -587,6 +596,7 @@ Module {
                                                                                                                 comments: CommentAttachment {
                                                                                                                     leading: [],
                                                                                                                     trailing: None,
+                                                                                                                    leading_blank_line: false,
                                                                                                                 },
                                                                                                                 expression: Literal(
                                                                                                                     Integer(
@@ -673,6 +683,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -692,6 +703,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Block(
                                     Block {
@@ -709,6 +721,7 @@ Module {
                                                 comments: CommentAttachment {
                                                     leading: [],
                                                     trailing: None,
+                                                    leading_blank_line: false,
                                                 },
                                                 expression: Block(
                                                     Block {
@@ -718,6 +731,7 @@ Module {
                                                                 comments: CommentAttachment {
                                                                     leading: [],
                                                                     trailing: None,
+                                                                    leading_blank_line: false,
                                                                 },
                                                                 expression: Block(
                                                                     Block {
@@ -735,6 +749,7 @@ Module {
                                                                                 comments: CommentAttachment {
                                                                                     leading: [],
                                                                                     trailing: None,
+                                                                                    leading_blank_line: false,
                                                                                 },
                                                                                 expression: Block(
                                                                                     Block {
@@ -744,6 +759,7 @@ Module {
                                                                                                 comments: CommentAttachment {
                                                                                                     leading: [],
                                                                                                     trailing: None,
+                                                                                                    leading_blank_line: false,
                                                                                                 },
                                                                                                 expression: Block(
                                                                                                     Block {
@@ -761,6 +777,7 @@ Module {
                                                                                                                 comments: CommentAttachment {
                                                                                                                     leading: [],
                                                                                                                     trailing: None,
+                                                                                                                    leading_blank_line: false,
                                                                                                                 },
                                                                                                                 expression: MessageSend {
                                                                                                                     receiver: Identifier(
@@ -874,6 +891,7 @@ Module {
                                         },
                                     ],
                                     trailing: None,
+                                    leading_blank_line: true,
                                 },
                                 expression: Assignment {
                                     target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -101,6 +102,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -143,6 +145,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -246,6 +249,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -108,6 +109,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Literal(
                 Integer(
@@ -134,6 +136,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -235,6 +238,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_parser.snap
@@ -68,6 +68,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Identifier(
                 Identifier {
@@ -84,6 +85,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Invalid assignment target",

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -107,6 +108,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Cascade {
                 receiver: MessageSend {
@@ -172,6 +174,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Cascade {
                 receiver: MessageSend {
@@ -339,6 +342,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -462,6 +466,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Cascade {
                 receiver: MessageSend {
@@ -502,6 +507,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -579,6 +585,7 @@ Module {
                                             comments: CommentAttachment {
                                                 leading: [],
                                                 trailing: None,
+                                                leading_blank_line: false,
                                             },
                                             expression: MessageSend {
                                                 receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascades_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascades_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -78,6 +79,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Cascade {
                                     receiver: MessageSend {

--- a/test-package-compiler/tests/snapshots/compiler_tests__character_literals_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__character_literals_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -82,6 +83,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -114,6 +116,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -156,6 +159,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -188,6 +192,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =",

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_definition_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_definition_parser.snap
@@ -55,6 +55,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -74,6 +75,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -159,6 +161,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -176,6 +179,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Return {
                                 value: FieldAccess {
@@ -217,6 +221,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -258,6 +263,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_methods_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_methods_parser.snap
@@ -55,6 +55,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -74,6 +75,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -159,6 +161,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -176,6 +179,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -211,6 +215,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -230,6 +235,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -309,6 +315,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -342,6 +349,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -359,6 +367,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -394,6 +403,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -428,6 +438,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -467,6 +478,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_parser.snap
@@ -69,6 +69,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -129,6 +130,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -171,6 +173,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -213,6 +216,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -265,6 +269,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -320,6 +325,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -339,6 +345,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Literal(
                                     Integer(

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Invalid assignment target",
@@ -73,6 +74,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -87,6 +89,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Invalid assignment target",
@@ -101,6 +104,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -147,6 +151,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -161,6 +166,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Return {
                 value: Identifier(
@@ -183,6 +189,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -197,6 +204,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -211,6 +219,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -225,6 +234,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -239,6 +249,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_parser.snap
@@ -86,6 +86,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -118,6 +119,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Block(
@@ -128,6 +130,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -188,6 +191,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -276,6 +280,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -308,6 +313,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Block(
                 Block {
@@ -317,6 +323,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -342,6 +349,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =",
@@ -356,6 +364,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -385,6 +394,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -473,6 +483,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -505,6 +516,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -537,6 +549,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -569,6 +582,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Block(
@@ -579,6 +593,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -639,6 +654,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -692,6 +708,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -745,6 +762,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -860,6 +878,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -892,6 +911,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Literal(
@@ -923,6 +943,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -1011,6 +1032,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1043,6 +1065,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Literal(
@@ -1098,6 +1121,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -1213,6 +1237,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1289,6 +1314,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1321,6 +1347,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -1360,6 +1387,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -1448,6 +1476,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1480,6 +1509,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1529,6 +1559,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Assignment {
                                             target: Identifier(
@@ -1631,6 +1662,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =",
@@ -1645,6 +1677,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -1674,6 +1707,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Literal(
                                         Integer(
@@ -1706,6 +1740,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found )",
@@ -1720,6 +1755,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -1734,6 +1770,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -1748,6 +1785,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -1762,6 +1800,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -1776,6 +1815,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -1790,6 +1830,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -1804,6 +1845,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -1818,6 +1860,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -1832,6 +1875,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -1846,6 +1890,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -1860,6 +1905,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -1889,6 +1935,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -1921,6 +1968,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: MessageSend {
                                         receiver: Block(
@@ -1931,6 +1979,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1991,6 +2040,7 @@ Module {
                                                             comments: CommentAttachment {
                                                                 leading: [],
                                                                 trailing: None,
+                                                                leading_blank_line: false,
                                                             },
                                                             expression: Assignment {
                                                                 target: Identifier(
@@ -2044,6 +2094,7 @@ Module {
                                                             comments: CommentAttachment {
                                                                 leading: [],
                                                                 trailing: None,
+                                                                leading_blank_line: false,
                                                             },
                                                             expression: Assignment {
                                                                 target: Identifier(
@@ -2113,6 +2164,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -2166,6 +2218,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -2272,6 +2325,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Invalid assignment target",
@@ -2286,6 +2340,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -2300,6 +2355,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -2346,6 +2402,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -2375,6 +2432,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: FieldAccess {
@@ -2470,6 +2528,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Return {
                 value: FieldAccess {
@@ -2505,6 +2564,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -2530,6 +2590,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =>",
@@ -2544,6 +2605,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Invalid assignment target",
@@ -2558,6 +2620,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -2604,6 +2667,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -2618,6 +2682,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Return {
                 value: FieldAccess {
@@ -2653,6 +2718,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Identifier(
                 Identifier {
@@ -2669,6 +2735,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =>",
@@ -2683,6 +2750,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -2697,6 +2765,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -2737,6 +2806,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -2806,6 +2876,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: FieldAccess {
@@ -2851,6 +2922,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Return {
                 value: Identifier(
@@ -2873,6 +2945,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Identifier(
                 Identifier {
@@ -2889,6 +2962,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =>",
@@ -2903,6 +2977,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -2917,6 +2992,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -2963,6 +3039,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -2992,6 +3069,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: FieldAccess {
@@ -3071,6 +3149,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -3153,6 +3232,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Return {
                 value: Identifier(
@@ -3175,6 +3255,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Error {
                 message: "Type annotations on non-identifier assignments are not supported",
@@ -3189,6 +3270,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -3203,6 +3285,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -3217,6 +3300,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -3231,6 +3315,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -3245,6 +3330,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -3259,6 +3345,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -3273,6 +3360,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -3302,6 +3390,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -3355,6 +3444,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -102,6 +103,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -145,6 +147,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -188,6 +191,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_parser.snap
@@ -55,6 +55,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -79,6 +80,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -96,6 +98,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -131,6 +134,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -155,6 +159,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -213,6 +218,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_message_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_message_parser.snap
@@ -41,6 +41,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -92,6 +93,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -109,6 +111,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -141,6 +144,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -192,6 +196,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -242,6 +247,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -89,6 +90,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Literal(
                 Integer(
@@ -115,6 +117,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -145,6 +148,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Identifier(
                 Identifier {
@@ -171,6 +175,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Error {
                 message: "Invalid assignment target",

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -114,6 +115,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -180,6 +182,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -239,6 +242,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Literal(
                 Integer(
@@ -265,6 +269,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -123,6 +124,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__expect_directive_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__expect_directive_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: ExpectDirective {
                 category: Dnu,
@@ -74,6 +75,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Literal(
@@ -111,6 +113,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: ExpectDirective {
                 category: Type,
@@ -126,6 +129,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Literal(
@@ -173,6 +177,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: ExpectDirective {
                 category: Unused,
@@ -188,6 +193,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -230,6 +236,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: ExpectDirective {
                 category: All,
@@ -245,6 +252,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Identifier(
                 Identifier {
@@ -271,6 +279,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: ExpectDirective {
                 category: Dnu,
@@ -286,6 +295,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: ExpectDirective {
                 category: Type,
@@ -301,6 +311,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Literal(

--- a/test-package-compiler/tests/snapshots/compiler_tests__foreign_extension_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__foreign_extension_parser.snap
@@ -26,6 +26,7 @@ Module {
                         comments: CommentAttachment {
                             leading: [],
                             trailing: None,
+                            leading_blank_line: false,
                         },
                         expression: MessageSend {
                             receiver: Identifier(
@@ -115,6 +116,7 @@ Module {
                         },
                     ],
                     trailing: None,
+                    leading_blank_line: false,
                 },
                 doc_comment: None,
                 span: Span {

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_parser.snap
@@ -68,6 +68,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -122,6 +123,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found |",
@@ -136,6 +138,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -150,6 +153,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -164,6 +168,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -178,6 +183,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -192,6 +198,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",
@@ -206,6 +213,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",
@@ -220,6 +228,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",
@@ -234,6 +243,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -291,6 +301,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =>",
@@ -305,6 +316,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found )",
@@ -319,6 +331,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found )",
@@ -333,6 +346,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found )",
@@ -347,6 +361,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found )",
@@ -361,6 +376,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found )",
@@ -375,6 +391,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",
@@ -389,6 +406,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",
@@ -403,6 +421,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -417,6 +436,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -431,6 +451,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -488,6 +509,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =>",
@@ -502,6 +524,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -516,6 +539,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",
@@ -530,6 +554,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -544,6 +569,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -82,6 +83,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -140,6 +142,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -172,6 +175,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -251,6 +255,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -283,6 +288,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -315,6 +321,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -384,6 +391,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -439,6 +447,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -471,6 +480,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -543,6 +553,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -575,6 +586,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -651,6 +663,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -714,6 +727,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -766,6 +780,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__hello_world_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__hello_world_parser.snap
@@ -41,6 +41,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: ClassReference {

--- a/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_parser.snap
@@ -55,6 +55,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -87,6 +88,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -106,6 +108,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -151,6 +154,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -202,6 +206,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -219,6 +224,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -254,6 +260,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -271,6 +278,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -306,6 +314,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -374,6 +383,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__intrinsic_keyword_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__intrinsic_keyword_parser.snap
@@ -41,6 +41,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "blockValue",
@@ -64,6 +65,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -81,6 +83,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "size",
@@ -104,6 +107,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -154,6 +158,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_parser.snap
@@ -55,6 +55,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -74,6 +75,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -153,6 +155,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Super(
@@ -183,6 +186,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -200,6 +204,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -235,6 +240,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -303,6 +309,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__logging_init_counter_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__logging_init_counter_parser.snap
@@ -55,6 +55,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -74,6 +75,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -125,6 +127,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -142,6 +145,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -221,6 +225,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Super(
@@ -251,6 +256,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -268,6 +274,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -303,6 +310,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -398,6 +406,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__map_literals_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__map_literals_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -90,6 +91,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -179,6 +181,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -268,6 +271,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -381,6 +385,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -494,6 +499,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -677,6 +683,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -766,6 +773,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__match_exhaustiveness_missing_arm_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__match_exhaustiveness_missing_arm_parser.snap
@@ -60,6 +60,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Match {
                                 value: Identifier(
@@ -115,6 +116,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -158,6 +160,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         span: Span {
                                             start: 243,
@@ -183,6 +186,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -233,6 +237,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__method_lookup_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__method_lookup_parser.snap
@@ -41,6 +41,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: ClassReference {
@@ -99,6 +100,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -135,6 +137,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -188,6 +191,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -265,6 +269,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -105,6 +106,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: MessageSend {
                                         receiver: Identifier(
@@ -161,6 +163,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: MessageSend {
                                         receiver: Identifier(
@@ -224,6 +227,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -379,6 +383,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -508,6 +513,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -568,6 +574,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: MessageSend {
                                         receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -78,6 +79,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Block(
                                     Block {
@@ -95,6 +97,7 @@ Module {
                                                 comments: CommentAttachment {
                                                     leading: [],
                                                     trailing: None,
+                                                    leading_blank_line: false,
                                                 },
                                                 expression: MessageSend {
                                                     receiver: Identifier(
@@ -156,6 +159,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -199,6 +203,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -270,6 +275,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -289,6 +295,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Block(
                                     Block {
@@ -298,6 +305,7 @@ Module {
                                                 comments: CommentAttachment {
                                                     leading: [],
                                                     trailing: None,
+                                                    leading_blank_line: false,
                                                 },
                                                 expression: Block(
                                                     Block {
@@ -307,6 +315,7 @@ Module {
                                                                 comments: CommentAttachment {
                                                                     leading: [],
                                                                     trailing: None,
+                                                                    leading_blank_line: false,
                                                                 },
                                                                 expression: Literal(
                                                                     Integer(
@@ -366,6 +375,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -393,6 +403,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -420,6 +431,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: MessageSend {
                                                         receiver: Identifier(
@@ -472,6 +484,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -542,6 +555,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -597,6 +611,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -624,6 +639,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -676,6 +692,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: MessageSend {
                                         receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -200,6 +201,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -341,6 +343,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Parenthesized {
@@ -431,6 +434,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__sealed_class_violation_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__sealed_class_violation_parser.snap
@@ -41,6 +41,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -84,6 +85,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -134,6 +136,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__sealed_method_override_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__sealed_method_override_parser.snap
@@ -41,6 +41,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Literal(
                                 Integer(
@@ -63,6 +64,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -113,6 +115,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,
@@ -160,6 +163,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Literal(
                                 Integer(
@@ -182,6 +186,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -195,6 +200,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,
@@ -242,6 +248,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Literal(
                                 Integer(
@@ -264,6 +271,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -277,6 +285,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__set_theoretic_operators_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__set_theoretic_operators_parser.snap
@@ -41,6 +41,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Literal(
                                 Symbol(
@@ -105,6 +106,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -166,6 +168,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -228,6 +231,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -301,6 +305,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Match {
                                 value: Identifier(
@@ -336,6 +341,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         span: Span {
                                             start: 1771,
@@ -365,6 +371,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         span: Span {
                                             start: 1793,
@@ -394,6 +401,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         span: Span {
                                             start: 1817,
@@ -457,6 +465,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -642,6 +651,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,
@@ -675,6 +685,7 @@ Module {
                         comments: CommentAttachment {
                             leading: [],
                             trailing: None,
+                            leading_blank_line: false,
                         },
                         expression: Literal(
                             Symbol(
@@ -784,6 +795,7 @@ Module {
                         },
                     ],
                     trailing: None,
+                    leading_blank_line: false,
                 },
                 doc_comment: None,
                 span: Span {
@@ -816,6 +828,7 @@ Module {
                         comments: CommentAttachment {
                             leading: [],
                             trailing: None,
+                            leading_blank_line: false,
                         },
                         expression: Identifier(
                             Identifier {
@@ -994,6 +1007,7 @@ Module {
                         },
                     ],
                     trailing: None,
+                    leading_blank_line: false,
                 },
                 doc_comment: None,
                 span: Span {

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_dictionary_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_dictionary_parser.snap
@@ -41,6 +41,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "size",
@@ -74,6 +75,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -91,6 +93,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "keys",
@@ -114,6 +117,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -131,6 +135,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "values",
@@ -154,6 +159,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -190,6 +196,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "at:",
@@ -213,6 +220,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -266,6 +274,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "at:ifAbsent:",
@@ -289,6 +298,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -342,6 +352,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "at:put:",
@@ -365,6 +376,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -401,6 +413,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "includesKey:",
@@ -424,6 +437,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -460,6 +474,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "removeKey:",
@@ -493,6 +508,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -529,6 +545,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "merge:",
@@ -552,6 +569,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -588,6 +606,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "keysAndValuesDo:",
@@ -621,6 +640,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -680,6 +700,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_parser.snap
@@ -41,6 +41,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "size",
@@ -74,6 +75,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -91,6 +93,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "isEmpty",
@@ -114,6 +117,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -131,6 +135,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "first",
@@ -154,6 +159,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -171,6 +177,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "rest",
@@ -194,6 +201,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -211,6 +219,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "last",
@@ -234,6 +243,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -270,6 +280,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "at:",
@@ -293,6 +304,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -329,6 +341,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "includes:",
@@ -352,6 +365,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -369,6 +383,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "sort",
@@ -402,6 +417,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -438,6 +454,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "sort:",
@@ -461,6 +478,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -478,6 +496,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "reversed",
@@ -501,6 +520,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -518,6 +538,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "unique",
@@ -541,6 +562,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -577,6 +599,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "detect:",
@@ -610,6 +633,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -663,6 +687,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "detect:ifNone:",
@@ -686,6 +711,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -722,6 +748,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "do:",
@@ -755,6 +782,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -791,6 +819,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "collect:",
@@ -814,6 +843,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -850,6 +880,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "select:",
@@ -873,6 +904,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -909,6 +941,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "reject:",
@@ -932,6 +965,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -985,6 +1019,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "inject:into:",
@@ -1008,6 +1043,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1044,6 +1080,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "take:",
@@ -1077,6 +1114,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1113,6 +1151,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "drop:",
@@ -1136,6 +1175,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1153,6 +1193,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "flatten",
@@ -1176,6 +1217,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1212,6 +1254,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "flatMap:",
@@ -1235,6 +1278,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1271,6 +1315,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "count:",
@@ -1294,6 +1339,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1330,6 +1376,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "anySatisfy:",
@@ -1353,6 +1400,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1389,6 +1437,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "allSatisfy:",
@@ -1412,6 +1461,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1440,6 +1490,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "++",
@@ -1473,6 +1524,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1526,6 +1578,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "from:to:",
@@ -1559,6 +1612,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1595,6 +1649,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -1657,6 +1712,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Assignment {
                                                         target: Identifier(
@@ -1710,6 +1766,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: MessageSend {
                                                         receiver: MessageSend {
@@ -1762,6 +1819,7 @@ Module {
                                                                             comments: CommentAttachment {
                                                                                 leading: [],
                                                                                 trailing: None,
+                                                                                leading_blank_line: false,
                                                                             },
                                                                             expression: Return {
                                                                                 value: Identifier(
@@ -1800,6 +1858,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Identifier(
                                                         Identifier {
@@ -1832,6 +1891,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -1854,6 +1914,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1890,6 +1951,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -1952,6 +2014,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Assignment {
                                                         target: Identifier(
@@ -2005,6 +2068,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: MessageSend {
                                                         receiver: Identifier(
@@ -2066,6 +2130,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Identifier(
                                                         Identifier {
@@ -2098,6 +2163,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -2130,6 +2196,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2166,6 +2233,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "zip:",
@@ -2199,6 +2267,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2235,6 +2304,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "groupBy:",
@@ -2258,6 +2328,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2294,6 +2365,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "partition:",
@@ -2317,6 +2389,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2353,6 +2426,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "takeWhile:",
@@ -2376,6 +2450,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2412,6 +2487,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "dropWhile:",
@@ -2435,6 +2511,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2471,6 +2548,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "intersperse:",
@@ -2494,6 +2572,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2530,6 +2609,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "add:",
@@ -2553,6 +2633,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2603,6 +2684,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_set_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_set_parser.snap
@@ -54,6 +54,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -73,6 +74,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "size",
@@ -106,6 +108,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -123,6 +126,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "isEmpty",
@@ -146,6 +150,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -182,6 +187,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "includes:",
@@ -215,6 +221,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -251,6 +258,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "add:",
@@ -284,6 +292,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -320,6 +329,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "remove:",
@@ -343,6 +353,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -379,6 +390,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "union:",
@@ -412,6 +424,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -448,6 +461,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "intersection:",
@@ -471,6 +485,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -507,6 +522,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "difference:",
@@ -530,6 +546,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -566,6 +583,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "isSubsetOf:",
@@ -599,6 +617,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -616,6 +635,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "asList",
@@ -649,6 +669,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -685,6 +706,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "fromList:",
@@ -708,6 +730,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -744,6 +767,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "do:",
@@ -777,6 +801,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -827,6 +852,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_tuple_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_tuple_parser.snap
@@ -41,6 +41,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "size",
@@ -74,6 +75,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -110,6 +112,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "at:",
@@ -133,6 +136,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -150,6 +154,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "isOk",
@@ -183,6 +188,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -200,6 +206,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "isError",
@@ -223,6 +230,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -240,6 +248,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "unwrap",
@@ -273,6 +282,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -309,6 +319,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "unwrapOr:",
@@ -332,6 +343,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -368,6 +380,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "unwrapOrElse:",
@@ -391,6 +404,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -408,6 +422,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "asString",
@@ -441,6 +456,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -500,6 +516,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__string_operations_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__string_operations_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -82,6 +83,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -114,6 +116,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -219,6 +222,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -272,6 +276,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -325,6 +330,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -378,6 +384,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -431,6 +438,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -494,6 +502,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -537,6 +546,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -590,6 +600,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -622,6 +633,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -675,6 +687,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -707,6 +720,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -750,6 +764,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -803,6 +818,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -864,6 +880,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -935,6 +952,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -996,6 +1014,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1067,6 +1086,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1128,6 +1148,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1199,6 +1220,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1231,6 +1253,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1302,6 +1325,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_parser.snap
@@ -65,6 +65,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -84,6 +85,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -139,6 +141,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -156,6 +159,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -235,6 +239,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -280,6 +285,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -316,6 +322,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -395,6 +402,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -450,6 +458,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -518,6 +527,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_parser.snap
@@ -65,6 +65,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -84,6 +85,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -139,6 +141,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -185,6 +188,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -290,6 +294,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -307,6 +312,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Parenthesized {
@@ -385,6 +391,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: FieldAccess {
                                                         receiver: Identifier(
@@ -425,6 +432,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Identifier(
                                                         Identifier {
@@ -500,6 +508,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -517,6 +526,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -612,6 +622,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -653,6 +664,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_value_type_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_value_type_parser.snap
@@ -65,6 +65,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -107,6 +108,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -126,6 +128,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -181,6 +184,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -198,6 +202,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -243,6 +248,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -289,6 +295,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "distanceTo:",
@@ -332,6 +339,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -349,6 +357,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Primitive {
                                 name: "printString",
@@ -382,6 +391,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -423,6 +433,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_parser.snap
@@ -78,6 +78,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -141,6 +142,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -200,6 +202,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -243,6 +246,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -296,6 +300,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -339,6 +344,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -401,6 +407,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -444,6 +451,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -506,6 +514,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -570,6 +579,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -602,6 +612,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -667,6 +678,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -694,6 +706,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -742,6 +755,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -769,6 +783,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -82,6 +83,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -114,6 +116,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -156,6 +159,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_enumeration_ops_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_enumeration_ops_parser.snap
@@ -60,6 +60,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -92,6 +93,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -138,6 +140,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: Assignment {
                                                         target: Identifier(
@@ -234,6 +237,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -275,6 +279,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -397,6 +402,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_type_multi_expr_method_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_type_multi_expr_method_parser.snap
@@ -60,6 +60,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: ClassReference {
@@ -110,6 +111,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -163,6 +165,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -216,6 +219,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -253,6 +257,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -290,6 +295,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -343,6 +349,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -429,6 +436,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_parser.snap
@@ -60,6 +60,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -97,6 +98,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -177,6 +179,7 @@ Module {
                             },
                         ],
                         trailing: None,
+                        leading_blank_line: true,
                     },
                     doc_comment: None,
                     span: Span {
@@ -263,6 +266,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_parser.snap
@@ -41,6 +41,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -60,6 +61,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -92,6 +94,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Block(
@@ -102,6 +105,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: MessageSend {
                                                         receiver: Identifier(
@@ -162,6 +166,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: Assignment {
                                                             target: Identifier(
@@ -231,6 +236,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -278,6 +284,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -297,6 +304,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -329,6 +337,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Block(
@@ -339,6 +348,7 @@ Module {
                                                     comments: CommentAttachment {
                                                         leading: [],
                                                         trailing: None,
+                                                        leading_blank_line: false,
                                                     },
                                                     expression: MessageSend {
                                                         receiver: Identifier(
@@ -399,6 +409,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: Assignment {
                                                             target: Identifier(
@@ -468,6 +479,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -515,6 +527,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -534,6 +547,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -562,6 +576,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Block(
@@ -572,6 +587,7 @@ Module {
                                                                             comments: CommentAttachment {
                                                                                 leading: [],
                                                                                 trailing: None,
+                                                                                leading_blank_line: false,
                                                                             },
                                                                             expression: MessageSend {
                                                                                 receiver: Identifier(
@@ -632,6 +648,7 @@ Module {
                                                                                 comments: CommentAttachment {
                                                                                     leading: [],
                                                                                     trailing: None,
+                                                                                    leading_blank_line: false,
                                                                                 },
                                                                                 expression: Assignment {
                                                                                     target: Identifier(
@@ -701,6 +718,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: Identifier(
                                                             Identifier {
@@ -760,6 +778,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -807,6 +826,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -826,6 +846,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -854,6 +875,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Block(
@@ -864,6 +886,7 @@ Module {
                                                                             comments: CommentAttachment {
                                                                                 leading: [],
                                                                                 trailing: None,
+                                                                                leading_blank_line: false,
                                                                             },
                                                                             expression: MessageSend {
                                                                                 receiver: Identifier(
@@ -924,6 +947,7 @@ Module {
                                                                                 comments: CommentAttachment {
                                                                                     leading: [],
                                                                                     trailing: None,
+                                                                                    leading_blank_line: false,
                                                                                 },
                                                                                 expression: Assignment {
                                                                                     target: Identifier(
@@ -993,6 +1017,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: Identifier(
                                                             Identifier {
@@ -1052,6 +1077,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -1099,6 +1125,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1118,6 +1145,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -1150,6 +1178,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Literal(
@@ -1181,6 +1210,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: Assignment {
                                                             target: Identifier(
@@ -1250,6 +1280,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -1297,6 +1328,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1316,6 +1348,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -1344,6 +1377,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Literal(
@@ -1375,6 +1409,7 @@ Module {
                                                                                 comments: CommentAttachment {
                                                                                     leading: [],
                                                                                     trailing: None,
+                                                                                    leading_blank_line: false,
                                                                                 },
                                                                                 expression: Assignment {
                                                                                     target: Identifier(
@@ -1444,6 +1479,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: Identifier(
                                                             Identifier {
@@ -1503,6 +1539,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -1550,6 +1587,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1569,6 +1607,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -1601,6 +1640,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Literal(
@@ -1656,6 +1696,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: Assignment {
                                                             target: Identifier(
@@ -1725,6 +1766,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -1772,6 +1814,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1791,6 +1834,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -1819,6 +1863,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: Assignment {
                                                             target: Identifier(
@@ -1851,6 +1896,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1906,6 +1952,7 @@ Module {
                                                                                 comments: CommentAttachment {
                                                                                     leading: [],
                                                                                     trailing: None,
+                                                                                    leading_blank_line: false,
                                                                                 },
                                                                                 expression: Assignment {
                                                                                     target: Identifier(
@@ -1975,6 +2022,7 @@ Module {
                                                         comments: CommentAttachment {
                                                             leading: [],
                                                             trailing: None,
+                                                            leading_blank_line: false,
                                                         },
                                                         expression: Identifier(
                                                             Identifier {
@@ -2034,6 +2082,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Return {
                                     value: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_parser.snap
@@ -59,6 +59,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -122,6 +123,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -185,6 +187,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -248,6 +251,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -290,6 +294,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -332,6 +337,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_parser.snap
@@ -41,6 +41,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: Cascade {
                                 receiver: MessageSend {
@@ -143,6 +144,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -175,6 +177,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_parser.snap
@@ -41,6 +41,7 @@ Module {
                             comments: CommentAttachment {
                                 leading: [],
                                 trailing: None,
+                                leading_blank_line: false,
                             },
                             expression: MessageSend {
                                 receiver: ClassReference {
@@ -97,6 +98,7 @@ Module {
                     comments: CommentAttachment {
                         leading: [],
                         trailing: None,
+                        leading_blank_line: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -129,6 +131,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_mutations_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_mutations_parser.snap
@@ -68,6 +68,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -87,6 +88,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -118,6 +120,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ,",
@@ -132,6 +135,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -146,6 +150,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -160,6 +165,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -174,6 +180,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -188,6 +195,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -202,6 +210,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -216,6 +225,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_search_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_search_parser.snap
@@ -68,6 +68,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -87,6 +88,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -118,6 +120,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ,",
@@ -132,6 +135,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -146,6 +150,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -160,6 +165,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -174,6 +180,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -188,6 +195,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -217,6 +225,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Literal(
                                         Integer(
@@ -259,6 +268,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -291,6 +301,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -340,6 +351,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Assignment {
                                             target: Identifier(
@@ -393,6 +405,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -462,6 +475,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -494,6 +508,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -543,6 +558,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Assignment {
                                             target: Identifier(
@@ -596,6 +612,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -665,6 +682,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -697,6 +715,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -746,6 +765,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Assignment {
                                             target: Identifier(
@@ -799,6 +819,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -868,6 +889,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -900,6 +922,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -956,6 +979,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Assignment {
                                             target: Identifier(
@@ -1009,6 +1033,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1057,6 +1082,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             Integer(

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_simple_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_simple_parser.snap
@@ -77,6 +77,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -96,6 +97,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -127,6 +129,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ,",
@@ -141,6 +144,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -155,6 +159,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -169,6 +174,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -183,6 +189,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -197,6 +204,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -211,6 +219,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -225,6 +234,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -80,6 +81,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -110,6 +112,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -150,6 +153,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -211,6 +215,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -282,6 +287,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -325,6 +331,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -378,6 +385,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -431,6 +439,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -518,6 +527,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -557,6 +567,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -633,6 +644,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -682,6 +694,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -751,6 +764,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -800,6 +814,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -869,6 +884,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -941,6 +957,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1010,6 +1027,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1081,6 +1099,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1111,6 +1130,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ++",
@@ -1125,6 +1145,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -69,6 +70,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -100,6 +102,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -153,6 +156,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -180,6 +184,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -232,6 +237,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -303,6 +309,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -337,6 +344,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -389,6 +397,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -476,6 +485,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -508,6 +518,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Block(
@@ -518,6 +529,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -578,6 +590,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -657,6 +670,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -689,6 +703,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -708,6 +723,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -760,6 +776,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -88,6 +89,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -149,6 +151,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -225,6 +228,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -263,6 +267,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -324,6 +329,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -400,6 +406,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -441,6 +448,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -479,6 +487,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -520,6 +529,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -558,6 +568,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -599,6 +610,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -647,6 +659,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -688,6 +701,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -726,6 +740,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -767,6 +782,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -805,6 +821,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -846,6 +863,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -894,6 +912,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -937,6 +956,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -153,6 +154,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -193,6 +195,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -254,6 +257,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -325,6 +329,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -382,6 +387,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -430,6 +436,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -517,6 +524,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -604,6 +612,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -657,6 +666,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -718,6 +728,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -789,6 +800,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -860,6 +872,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -903,6 +916,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -956,6 +970,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -1002,6 +1017,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -1052,6 +1068,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -1128,6 +1145,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1224,6 +1242,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1293,6 +1312,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1372,6 +1392,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1451,6 +1472,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -103,6 +104,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -156,6 +158,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -209,6 +212,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -282,6 +286,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -314,6 +319,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -377,6 +383,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -430,6 +437,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -483,6 +491,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -515,6 +524,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =",
@@ -529,6 +539,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -543,6 +554,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -557,6 +569,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -571,6 +584,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -69,6 +70,7 @@ Module {
                                 comments: CommentAttachment {
                                     leading: [],
                                     trailing: None,
+                                    leading_blank_line: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -100,6 +102,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ,",
@@ -114,6 +117,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -128,6 +132,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -142,6 +147,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -156,6 +162,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -170,6 +177,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -184,6 +192,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -198,6 +207,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -219,6 +229,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Literal(
                                         Integer(
@@ -251,6 +262,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ,",
@@ -265,6 +277,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_parser.snap
@@ -87,6 +87,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -140,6 +141,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -193,6 +195,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -256,6 +259,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -309,6 +313,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -362,6 +367,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -425,6 +431,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -478,6 +485,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -531,6 +539,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -584,6 +593,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -674,6 +684,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -715,6 +726,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -773,6 +785,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -822,6 +835,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -901,6 +915,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -949,6 +964,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -984,6 +1000,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1053,6 +1070,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1109,6 +1127,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1157,6 +1176,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -1242,6 +1262,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1291,6 +1312,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1360,6 +1382,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1409,6 +1432,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1478,6 +1502,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1527,6 +1552,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Parenthesized {
@@ -1660,6 +1686,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1711,6 +1738,7 @@ Module {
                                                 comments: CommentAttachment {
                                                     leading: [],
                                                     trailing: None,
+                                                    leading_blank_line: false,
                                                 },
                                                 expression: MessageSend {
                                                     receiver: Identifier(
@@ -1815,6 +1843,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1864,6 +1893,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1903,6 +1933,7 @@ Module {
                                                                 comments: CommentAttachment {
                                                                     leading: [],
                                                                     trailing: None,
+                                                                    leading_blank_line: false,
                                                                 },
                                                                 expression: MessageSend {
                                                                     receiver: Identifier(
@@ -1998,6 +2029,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2041,6 +2073,7 @@ Module {
                                                 comments: CommentAttachment {
                                                     leading: [],
                                                     trailing: None,
+                                                    leading_blank_line: false,
                                                 },
                                                 expression: Literal(
                                                     Integer(
@@ -2151,6 +2184,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2203,6 +2237,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -2251,6 +2286,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2303,6 +2339,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -2361,6 +2398,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2420,6 +2458,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -2447,6 +2486,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -2532,6 +2572,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2552,6 +2593,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Literal(
                                         Integer(
@@ -2603,6 +2645,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2631,6 +2674,7 @@ Module {
                                     comments: CommentAttachment {
                                         leading: [],
                                         trailing: None,
+                                        leading_blank_line: false,
                                     },
                                     expression: Identifier(
                                         Identifier {
@@ -2719,6 +2763,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2762,6 +2807,7 @@ Module {
                                                 comments: CommentAttachment {
                                                     leading: [],
                                                     trailing: None,
+                                                    leading_blank_line: false,
                                                 },
                                                 expression: Literal(
                                                     Integer(
@@ -2845,6 +2891,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2886,6 +2933,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Literal(
@@ -3003,6 +3051,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3045,6 +3094,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3104,6 +3154,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -3131,6 +3182,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -3179,6 +3231,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3221,6 +3274,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3270,6 +3324,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -3349,6 +3404,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3397,6 +3453,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -3432,6 +3489,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -3480,6 +3538,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3528,6 +3587,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -3563,6 +3623,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -3648,6 +3709,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3699,6 +3761,7 @@ Module {
                                                 comments: CommentAttachment {
                                                     leading: [],
                                                     trailing: None,
+                                                    leading_blank_line: false,
                                                 },
                                                 expression: MessageSend {
                                                     receiver: Identifier(
@@ -3803,6 +3866,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3846,6 +3910,7 @@ Module {
                                                 comments: CommentAttachment {
                                                     leading: [],
                                                     trailing: None,
+                                                    leading_blank_line: false,
                                                 },
                                                 expression: Literal(
                                                     Integer(
@@ -3946,6 +4011,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3988,6 +4054,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -4037,6 +4104,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: MessageSend {
@@ -4127,6 +4195,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -4169,6 +4238,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -4210,6 +4280,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -4258,6 +4329,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -4300,6 +4372,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -4348,6 +4421,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -4383,6 +4457,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_parser.snap
@@ -87,6 +87,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -140,6 +141,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -220,6 +222,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -261,6 +264,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -309,6 +313,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -358,6 +363,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -427,6 +433,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -475,6 +482,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -510,6 +518,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -558,6 +567,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -614,6 +624,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -641,6 +652,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -716,6 +728,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -759,6 +772,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -802,6 +816,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -865,6 +880,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -955,6 +971,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -998,6 +1015,7 @@ Module {
                                                 comments: CommentAttachment {
                                                     leading: [],
                                                     trailing: None,
+                                                    leading_blank_line: false,
                                                 },
                                                 expression: Literal(
                                                     Integer(
@@ -1081,6 +1099,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1124,6 +1143,7 @@ Module {
                                                 comments: CommentAttachment {
                                                     leading: [],
                                                     trailing: None,
+                                                    leading_blank_line: false,
                                                 },
                                                 expression: Literal(
                                                     String(
@@ -1197,6 +1217,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1238,6 +1259,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1269,6 +1291,7 @@ Module {
                                                                 comments: CommentAttachment {
                                                                     leading: [],
                                                                     trailing: None,
+                                                                    leading_blank_line: false,
                                                                 },
                                                                 expression: Literal(
                                                                     String(
@@ -1343,6 +1366,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1384,6 +1408,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -1469,6 +1494,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1542,6 +1568,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1605,6 +1632,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1668,6 +1696,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1768,6 +1797,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1820,6 +1850,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -1868,6 +1899,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1920,6 +1952,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -1968,6 +2001,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2020,6 +2054,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -2068,6 +2103,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2120,6 +2156,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -2178,6 +2215,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2237,6 +2275,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -2264,6 +2303,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -2349,6 +2389,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2390,6 +2431,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Literal(
@@ -2490,6 +2532,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2539,6 +2582,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -2656,6 +2700,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2699,6 +2744,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2742,6 +2788,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2795,6 +2842,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2836,6 +2884,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -2867,6 +2916,7 @@ Module {
                                                                 comments: CommentAttachment {
                                                                     leading: [],
                                                                     trailing: None,
+                                                                    leading_blank_line: false,
                                                                 },
                                                                 expression: Identifier(
                                                                     Identifier {
@@ -2931,6 +2981,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2973,6 +3024,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3063,6 +3115,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3104,6 +3157,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -3162,6 +3216,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3203,6 +3258,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -3261,6 +3317,7 @@ Module {
                         preceding_blank_line: false,
                     },
                 ),
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3304,6 +3361,7 @@ Module {
                                                 comments: CommentAttachment {
                                                     leading: [],
                                                     trailing: None,
+                                                    leading_blank_line: false,
                                                 },
                                                 expression: Literal(
                                                     Integer(

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -96,6 +97,7 @@ Module {
                                         comments: CommentAttachment {
                                             leading: [],
                                             trailing: None,
+                                            leading_blank_line: false,
                                         },
                                         expression: Literal(
                                             Symbol(
@@ -134,6 +136,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ,",
@@ -148,6 +151,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -162,6 +166,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -176,6 +181,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -190,6 +196,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -204,6 +211,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_parser.snap
@@ -50,6 +50,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -82,6 +83,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -124,6 +126,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -229,6 +232,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -282,6 +286,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -335,6 +340,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -398,6 +404,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -441,6 +448,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -494,6 +502,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -537,6 +546,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -590,6 +600,7 @@ Module {
                     },
                 ],
                 trailing: None,
+                leading_blank_line: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -651,6 +662,7 @@ Module {
             comments: CommentAttachment {
                 leading: [],
                 trailing: None,
+                leading_blank_line: false,
             },
             expression: Assignment {
                 target: Identifier(


### PR DESCRIPTION
## Summary

Linear issue: https://linear.app/beamtalk/issue/BT-2929

`unparse_module_doc` in `crates/beamtalk-core/src/unparse/mod.rs` always emitted exactly one `line()` (single newline) after each top-level class/protocol/type-alias declaration, regardless of whether the source had a blank line there. So the blank line separating two top-level declarations was either silently dropped, or — for a class — looked "relocated" into the class's own body, since a class unconditionally gets a blank line before its first method (an unrelated, pre-existing rule).

- Added `CommentAttachment::leading_blank_line: bool` — whether a blank line preceded a node's leading-comment block (or the node itself, if it has none) in the source. This lives on `CommentAttachment` rather than on `ClassDefinition`/`ProtocolDefinition`/`TypeAliasDefinition` directly, since `CommentAttachment` derives `Default` and is almost always constructed via `::default()`, avoiding the need to touch the ~100 other AST-literal test fixtures across the codebase that construct those three declaration types via raw struct literals.
- `collect_comment_attachment()` in the parser now computes this via the pre-existing `Token::has_blank_line_before_first_comment()` helper (already used for a similar purpose, BT-1016).
- `unparse_module_doc`'s loop over interleaved top-level declarations (BT-2907) now re-emits the blank line when the current declaration's `leading_blank_line` is set (skipped for the first declaration in the section — nothing before it to separate from).
- Regression tests covering the three repro cases from the issue (type-alias-then-class, class-then-class, type-alias-then-type-alias) plus a negative case and a full 3-way interleaving.

## Key changes

- `crates/beamtalk-core/src/ast/mod.rs`: new `CommentAttachment::leading_blank_line` field.
- `crates/beamtalk-core/src/source_analysis/parser/mod.rs`: `collect_comment_attachment()` now populates it.
- `crates/beamtalk-core/src/unparse/mod.rs`: `unparse_module_doc` consults it via a small `TopLevelDecl::preceding_blank_line()` helper; 5 new regression tests.
- `crates/beamtalk-core/src/source_analysis/parser/declarations.rs`: doc comment noting a (currently inert) interaction between `PendingDeclarationExpect::apply_to` and the new field, found during adversarial review.
- 79 insta snapshot files under `test-package-compiler/tests/snapshots/` regenerated (purely additive `leading_blank_line: bool` lines in Debug-derived AST dumps — verified no other content changed).
- ~13 other raw `CommentAttachment { ... }` struct literals in test code updated to include the new field.

## Follow-up filed

- BT-2943: a separate, narrower gap surfaced by adversarial review — blank lines are still dropped at the *boundaries* between `unparse_module_doc`'s three top-level sections (declarations / standalone methods / expressions), not just within the declarations section this PR fixes.

## Test plan

- [x] `cargo test -p beamtalk-core --lib` — 5199 passed, 0 failed
- [x] `cargo test -p test-package-compiler --test compiler_tests` — 398 passed (parser snapshots regenerated)
- [x] `just ci-changed` — full local CI (build/lint/test/check-corpus/check-surface-drift) passes
- [x] Manual CLI verification of all three repro cases from the issue, plus additional class/protocol/type-alias combinations, comment interactions, and multi-blank-line collapsing — all round-trip correctly and idempotently
- [x] Three-pass code review (diff review, system review, adversarial review via a separate agent) — no critical/recommended findings left open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz)_