### PR TITLE
fix: preserve leading comments on protocol method signatures (BT-2930)

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -2033,10 +2033,12 @@ impl Parser {
             && !self.is_at_type_alias_definition()
             && !self.is_at_standalone_method_definition()
         {
-            // BT-1618: Collect doc comment *before* checking for `class` prefix,
-            // because the doc comment is leading trivia on the `class` token and
-            // would be lost when we advance past it.
+            // BT-1618/BT-2930: Collect the doc comment and any non-doc leading
+            // comments *before* checking for `class` prefix, because both are
+            // leading trivia on the `class` token and would be lost when we
+            // advance past it.
             let doc_comment = self.collect_doc_comment();
+            let comments = self.collect_comment_attachment();
 
             // BT-1611: Detect `class` prefix for class method signatures.
             // Use the same lookahead as class definition parsing: `class` followed
@@ -2050,7 +2052,8 @@ impl Parser {
                 self.advance(); // consume `class`
             }
 
-            if let Some(sig) = self.parse_protocol_method_signature_with_doc(doc_comment) {
+            if let Some(sig) = self.parse_protocol_method_signature_with_doc(doc_comment, comments)
+            {
                 if is_class_method {
                     class_signatures.push(sig);
                 } else {
@@ -2072,9 +2075,11 @@ impl Parser {
     ///
     /// Returns `None` if the current position doesn't look like a method signature.
     ///
-    /// If `pre_doc` is `Some`, it is used as the doc comment (already collected
-    /// by the caller before consuming a `class` prefix). Otherwise, collects
-    /// the doc comment from the current token's leading trivia.
+    /// `pre_doc` and `pre_comments` are the doc comment and non-doc leading
+    /// comments, respectively, already collected by the caller before
+    /// consuming an optional `class` prefix — both live in the `class`
+    /// token's leading trivia and would be lost once the parser advances
+    /// past it (BT-1618, BT-2930).
     ///
     /// Syntax:
     /// - Unary: `asString -> String`
@@ -2083,10 +2088,11 @@ impl Parser {
     fn parse_protocol_method_signature_with_doc(
         &mut self,
         pre_doc: Option<String>,
+        pre_comments: CommentAttachment,
     ) -> Option<ProtocolMethodSignature> {
         let start = self.current_token().span();
         let doc_comment = pre_doc.or_else(|| self.collect_doc_comment());
-        let comments = self.collect_comment_attachment();
+        let comments = pre_comments;
 
         // Determine what kind of signature this is
         let (selector, parameters) = match self.current_kind() {

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -756,6 +756,16 @@ fn unparse_protocol_method_signature(
 ) -> Document<'static> {
     let mut docs: Vec<Document<'static>> = Vec::new();
 
+    // Non-doc leading comments
+    docs.extend(unparse_comment_attachment_leading(&sig.comments));
+
+    // Blank line between a preserved, earlier `///` block that broke away
+    // from a different declaration (BT-2924) and this signature's own doc
+    // comment — see `leading_ends_with_orphaned_doc_comment`.
+    if leading_ends_with_orphaned_doc_comment(&sig.comments) {
+        docs.push(line());
+    }
+
     // Doc comment
     if let Some(doc) = &sig.doc_comment {
         for line_text in doc.lines() {
@@ -3613,6 +3623,71 @@ mod tests {
             "Protocol define: Displayable\n",
             "  /// Convert to display string.\n",
             "  asString -> String\n",
+        );
+        assert_identity(source);
+    }
+
+    // --- BT-2930 regression: leading `//`/`/* */` comments on protocol
+    // method signatures must survive a `beamtalk fmt` round-trip. ---
+
+    #[test]
+    fn protocol_instance_method_leading_comment_round_trip() {
+        // Exact repro from BT-2930: an ordinary leading `//` comment (no doc
+        // comment) directly above an instance-side signature was silently
+        // dropped because `unparse_protocol_method_signature` never called
+        // `unparse_comment_attachment_leading`.
+        let source = concat!(
+            "Protocol define: Displayable\n",
+            "  // A leading comment.\n",
+            "  asString -> String\n",
+        );
+        assert_identity(source);
+    }
+
+    #[test]
+    fn protocol_instance_method_leading_block_comment_round_trip() {
+        let source = concat!(
+            "Protocol define: Displayable\n",
+            "  /* A leading block comment. */\n",
+            "  asString -> String\n",
+        );
+        assert_identity(source);
+    }
+
+    #[test]
+    fn protocol_instance_method_leading_comment_and_doc_comment_round_trip() {
+        // Leading comments and doc comments must both render, in the right
+        // order (leading comment first, then doc comment, then signature) —
+        // matching every other declaration kind.
+        let source = concat!(
+            "Protocol define: Displayable\n",
+            "  // A leading comment.\n",
+            "  /// Convert to display string.\n",
+            "  asString -> String\n",
+        );
+        assert_identity(source);
+    }
+
+    #[test]
+    fn protocol_class_method_leading_comment_round_trip() {
+        let source = concat!(
+            "Protocol define: Creatable\n",
+            "  // A leading comment.\n",
+            "  class create -> Self\n",
+        );
+        assert_identity(source);
+    }
+
+    #[test]
+    fn protocol_class_method_leading_comment_and_doc_comment_round_trip() {
+        // Verifies interaction with the existing doc-comment-before-`class`-
+        // keyword handling: leading comment, then doc comment, then `class`
+        // on the signature line.
+        let source = concat!(
+            "Protocol define: Parseable\n",
+            "  // A leading comment.\n",
+            "  /// Reconstruct from string.\n",
+            "  class fromString: aString :: String -> Self\n",
         );
         assert_identity(source);
     }


### PR DESCRIPTION
## Summary

Linear issue: https://linear.app/beamtalk/issue/BT-2930

`beamtalk fmt` silently dropped ordinary `//`/`/* */` leading comments attached to protocol method signatures, even though the parser correctly collected them into `ProtocolMethodSignature.comments`. Discovered incidentally while fixing BT-2924.

Two bugs, both in the same area:

- `unparse_protocol_method_signature` (`crates/beamtalk-core/src/unparse/mod.rs`) never emitted `sig.comments.leading` before the doc comment/signature, unlike every other declaration kind's unparse function (`unparse_class_definition`, `unparse_type_alias_definition`, `unparse_protocol_definition`, `unparse_state_declaration_inner`, `unparse_method_definition_inner`).
- For class-side signatures, `parse_protocol_body` (`crates/beamtalk-core/src/source_analysis/parser/declarations.rs`) only pre-collected the *doc* comment before consuming the `class` prefix token (BT-1618). Non-doc leading comments live in the same `class` token's leading trivia and were silently lost once the parser advanced past it. Both are now collected together, before the `class` prefix is consumed.

## Changes

- `unparse_protocol_method_signature` now emits leading comments (matching the pattern used by sibling declaration unparsers, including the BT-2924 orphaned-doc-comment blank-line handling).
- `parse_protocol_body` collects non-doc leading comments alongside the doc comment before checking for/consuming the `class` prefix, and threads them through to `parse_protocol_method_signature_with_doc` as a new `pre_comments` parameter (mirroring the existing `pre_doc` parameter).
- 5 new regression tests in `crates/beamtalk-core/src/unparse/mod.rs`: leading `//` and `/* */` comments on instance- and class-side signatures, with and without a doc comment, verifying ordering (leading comment, then doc comment, then signature) and interaction with the existing `class`-keyword-placement handling.

## Follow-up

While reviewing, found a separate, pre-existing bug in the same area: blank lines *between* protocol method signatures within a `Protocol define:` body are also silently dropped (reproduces even with zero comments involved — a different code path than this fix or BT-2943). Filed as [BT-2946](https://linear.app/beamtalk/issue/BT-2946) — out of scope for this PR.

## Test plan

- [x] `just build`, `just clippy`, `just fmt` clean
- [x] `just test` — all suites green (Rust 5206, stdlib 223, BUnit 2776, runtime 5382+1588)
- [x] `just ci-changed` — build/lint/test/corpus/surface-drift all pass
- [x] `just dialyzer` clean
- [x] Manually verified via `beamtalk fmt` CLI on the exact repro from the issue — comment now preserved, round-trip is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEG6wPAJvSvgYXxwkpamxz)_