### PR TITLE
Shrink target/ dir: tune debug profile, consolidate beamtalk-cli test binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,13 @@ resolver = "2"
 members = ["crates/*", "crates/beamtalk-examples/build-corpus", "test-package-compiler"]
 exclude = ["fuzz"]
 
+[profile.dev]
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+
+[profile.release]
+strip = "debuginfo"
+
 [workspace.package]
 # Keep in sync with VERSION file at repo root
 version = "0.4.0"

--- a/crates/beamtalk-cli/Cargo.toml
+++ b/crates/beamtalk-cli/Cargo.toml
@@ -64,6 +64,10 @@ criterion.workspace = true
 assert_cmd = "2"
 predicates = "3"
 
+[[test]]
+name = "cli"
+path = "tests/cli/main.rs"
+
 [[bench]]
 name = "build_bench"
 harness = false

--- a/crates/beamtalk-cli/Cargo.toml
+++ b/crates/beamtalk-cli/Cargo.toml
@@ -64,10 +64,6 @@ criterion.workspace = true
 assert_cmd = "2"
 predicates = "3"
 
-[[test]]
-name = "cli"
-path = "tests/cli/main.rs"
-
 [[bench]]
 name = "build_bench"
 harness = false

--- a/crates/beamtalk-cli/tests/cli/cli_build.rs
+++ b/crates/beamtalk-cli/tests/cli/cli_build.rs
@@ -6,7 +6,7 @@
 //! Verifies exit code, the `_build/` artefact set produced by a successful
 //! build, and error output when sources fail to parse.
 
-mod cli_common;
+use crate::cli_common;
 
 use predicates::prelude::*;
 use predicates::str::contains;

--- a/crates/beamtalk-cli/tests/cli/cli_doc.rs
+++ b/crates/beamtalk-cli/tests/cli/cli_doc.rs
@@ -3,7 +3,7 @@
 
 //! Subprocess tests for `beamtalk doc` and `beamtalk test-docs` (BT-2084).
 
-mod cli_common;
+use crate::cli_common;
 
 use predicates::str::contains;
 

--- a/crates/beamtalk-cli/tests/cli/cli_doctor.rs
+++ b/crates/beamtalk-cli/tests/cli/cli_doctor.rs
@@ -8,7 +8,7 @@
 //! * a synthesized broken runtime directory (error path) — stdlib/runtime
 //!   checks fail and the command exits non-zero with actionable output.
 
-mod cli_common;
+use crate::cli_common;
 
 use predicates::prelude::*;
 use predicates::str::contains;

--- a/crates/beamtalk-cli/tests/cli/cli_fmt.rs
+++ b/crates/beamtalk-cli/tests/cli/cli_fmt.rs
@@ -5,7 +5,7 @@
 //!
 //! Verifies in-place rewriting, unified diff output, and exit codes.
 
-mod cli_common;
+use crate::cli_common;
 
 use predicates::prelude::*;
 use predicates::str::contains;

--- a/crates/beamtalk-cli/tests/cli/cli_lint.rs
+++ b/crates/beamtalk-cli/tests/cli/cli_lint.rs
@@ -7,7 +7,7 @@
 //! happy- and error-path cases. Uses `assert_cmd` against the built
 //! `beamtalk` binary and a hermetic fixture project per test.
 
-mod cli_common;
+use crate::cli_common;
 
 use predicates::prelude::*;
 use predicates::str::contains;

--- a/crates/beamtalk-cli/tests/cli/cli_new.rs
+++ b/crates/beamtalk-cli/tests/cli/cli_new.rs
@@ -3,7 +3,7 @@
 
 //! Subprocess tests for `beamtalk new` (BT-2084).
 
-mod cli_common;
+use crate::cli_common;
 
 use predicates::str::contains;
 

--- a/crates/beamtalk-cli/tests/cli/cli_run.rs
+++ b/crates/beamtalk-cli/tests/cli/cli_run.rs
@@ -6,7 +6,7 @@
 //! Covers the script-mode entry-point invocation. Service mode (`run .`)
 //! requires a running BEAM workspace and is exercised by the e2e tests.
 
-mod cli_common;
+use crate::cli_common;
 
 use predicates::prelude::*;
 use predicates::str::contains;

--- a/crates/beamtalk-cli/tests/cli/cli_test.rs
+++ b/crates/beamtalk-cli/tests/cli/cli_test.rs
@@ -6,7 +6,7 @@
 //! Verifies exit code mapping (pass = 0, fail = nonzero) and the text
 //! summary format. Uses a hermetic fixture project per test.
 
-mod cli_common;
+use crate::cli_common;
 
 use predicates::prelude::*;
 use predicates::str::contains;

--- a/crates/beamtalk-cli/tests/cli/cli_transcript.rs
+++ b/crates/beamtalk-cli/tests/cli/cli_transcript.rs
@@ -9,7 +9,7 @@
 //! workspace name that doesn't exist. Streaming behaviour is covered by
 //! e2e tests against a live workspace.
 
-mod cli_common;
+use crate::cli_common;
 
 use predicates::prelude::*;
 use predicates::str::contains;

--- a/crates/beamtalk-cli/tests/cli/gen_native.rs
+++ b/crates/beamtalk-cli/tests/cli/gen_native.rs
@@ -9,7 +9,7 @@
 //! Tests are `#[ignore]` because they require the beamtalk binary.
 //! Run with: `cargo test --test gen_native -- --ignored`
 
-mod cli_common;
+use crate::cli_common;
 
 use std::process::Command;
 

--- a/crates/beamtalk-cli/tests/cli/gen_native.rs
+++ b/crates/beamtalk-cli/tests/cli/gen_native.rs
@@ -7,7 +7,7 @@
 //! `.bt` source with `native:` to skeleton `.erl` `gen_server` file.
 //!
 //! Tests are `#[ignore]` because they require the beamtalk binary.
-//! Run with: `cargo test --test gen_native -- --ignored`
+//! Run with: `cargo test --test cli gen_native:: -- --ignored`
 
 use crate::cli_common;
 

--- a/crates/beamtalk-cli/tests/cli/main.rs
+++ b/crates/beamtalk-cli/tests/cli/main.rs
@@ -8,8 +8,8 @@
 //! was the dominant contributor to `target/debug` size.
 //!
 //! `repl_protocol.rs` and `spec_validation.rs` stay as their own binaries:
-//! both are invoked by name elsewhere (`cargo test --test repl_protocol`,
-//! `--test spec_validation`) in the Justfile and docs.
+//! `repl_protocol` is invoked by name in the Justfile; `spec_validation`
+//! is referenced in `docs/development/common-tasks.md`.
 //!
 //! Unlike before, these modules' tests now run as threads of one process
 //! rather than as separate processes, so a test must never mutate

--- a/crates/beamtalk-cli/tests/cli/main.rs
+++ b/crates/beamtalk-cli/tests/cli/main.rs
@@ -4,12 +4,18 @@
 //! Single integration-test binary for the `beamtalk-cli` subprocess test
 //! suite (BT-2823). Consolidating what used to be 11 separate `tests/*.rs`
 //! binaries into modules of one binary avoids re-linking the full
-//! dependency graph (clap, miette, assert_cmd, ...) once per file, which
+//! dependency graph (clap, miette, `assert_cmd`, ...) once per file, which
 //! was the dominant contributor to `target/debug` size.
 //!
 //! `repl_protocol.rs` and `spec_validation.rs` stay as their own binaries:
 //! both are invoked by name elsewhere (`cargo test --test repl_protocol`,
 //! `--test spec_validation`) in the Justfile and docs.
+//!
+//! Unlike before, these modules' tests now run as threads of one process
+//! rather than as separate processes, so a test must never mutate
+//! process-global state (`std::env::set_var`, `std::env::set_current_dir`)
+//! directly — use `Command::env`/`Command::current_dir` on the child
+//! `beamtalk` process instead, as every existing test here already does.
 
 #[path = "../cli_common/mod.rs"]
 mod cli_common;

--- a/crates/beamtalk-cli/tests/cli/main.rs
+++ b/crates/beamtalk-cli/tests/cli/main.rs
@@ -1,0 +1,27 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Single integration-test binary for the `beamtalk-cli` subprocess test
+//! suite (BT-2823). Consolidating what used to be 11 separate `tests/*.rs`
+//! binaries into modules of one binary avoids re-linking the full
+//! dependency graph (clap, miette, assert_cmd, ...) once per file, which
+//! was the dominant contributor to `target/debug` size.
+//!
+//! `repl_protocol.rs` and `spec_validation.rs` stay as their own binaries:
+//! both are invoked by name elsewhere (`cargo test --test repl_protocol`,
+//! `--test spec_validation`) in the Justfile and docs.
+
+#[path = "../cli_common/mod.rs"]
+mod cli_common;
+
+mod cli_build;
+mod cli_doc;
+mod cli_doctor;
+mod cli_fmt;
+mod cli_lint;
+mod cli_new;
+mod cli_run;
+mod cli_test;
+mod cli_transcript;
+mod gen_native;
+mod native_type_extraction;

--- a/crates/beamtalk-cli/tests/cli/native_type_extraction.rs
+++ b/crates/beamtalk-cli/tests/cli/native_type_extraction.rs
@@ -13,7 +13,7 @@
 //! reference collapsed to `Dynamic` — degrading `{ok, T} | {error, E}` to a
 //! bare `Result` instead of the parameterized `Result(T, E)`.
 
-mod cli_common;
+use crate::cli_common;
 
 #[test]
 fn native_sibling_type_reference_resolves_after_build() {


### PR DESCRIPTION
## Summary

- Add `[profile.dev]` / `[profile.release]` tuning to the workspace `Cargo.toml`: `debug = "line-tables-only"` + `split-debuginfo = "unpacked"` for dev, `strip = "debuginfo"` for release. No behavior change — pure debug-info trimming.
- Consolidate 11 of the 13 integration test files under `crates/beamtalk-cli/tests/` (each previously its own test binary, statically re-linking the full dependency graph — clap, miette, assert_cmd, ...) into a single `cli` test binary at `tests/cli/main.rs` + submodules. `repl_protocol.rs` and `spec_validation.rs` stay separate since both are invoked by name elsewhere (`cargo test --test repl_protocol` / `--test spec_validation` in the Justfile and docs) and `repl_protocol.rs` is also matched by path in the Justfile's changed-file CI gating.
- Follow-up fixes from code review: dropped a redundant `[[test]]` Cargo.toml stanza (Cargo already auto-discovers `tests/<name>/main.rs`), fixed a stale doc comment in `gen_native.rs` pointing at the old per-file `--test` invocation, fixed a clippy `doc_markdown` warning, and documented that the merged modules now share one process instead of 11 (so tests must avoid mutating process-global env/cwd state directly).

## Measurements

Clean, isolated `rm -rf target && cargo build --all-targets [--release]` (matching `just build` exactly), 4 CPUs:

| | Before | After |
|---|---|---|
| **Total `target/`** | 6.4G | 4.2–4.4G |
| `target/debug` | 5.5G | 3.4–3.6G |
| `target/debug/deps` | 2.8G | 1.6–1.7G |
| `target/release` | 884M | 884M (unchanged — release already had no debug info by default) |

The `[profile.dev]` change accounts for the bulk of the reduction (~2.2G). The test-binary consolidation's measured effect was smaller than expected (~100-200M) — most of the size in `target/debug/deps` turned out to be shared, already-cached dependency rlibs rather than duplicated per test binary; the real savings from consolidation are the ~10 duplicate final linked test executables it removes (each ~15-20M), not a re-link of the whole dependency graph.

## Known pre-existing issue (out of scope)

While verifying the moved `gen_native.rs` tests still run under their new invocation (`cargo test --test cli gen_native:: -- --ignored`), they fail — but this is pre-existing and unrelated to this PR: the `beamtalk gen-native` subcommand was renamed to `beamtalk generate` at some point and these `#[ignore]`d tests were never updated. They don't run in normal CI (ignored), so nothing here regresses; flagging separately rather than fixing as part of this PR.

## Test plan

- [x] Clean `cargo build --all-targets` + `--release` succeeds
- [x] `cargo test --test cli -p beamtalk-cli`: 39 passed, 6 ignored, 0 failed
- [x] `cargo test --test spec_validation` / `--test repl_protocol` still build and run correctly as standalone binaries
- [x] `cargo clippy -p beamtalk-cli --tests`: clean
- [x] Reviewed via 4 independent finder agents (line-by-line, removed-behavior, cross-file reference, reuse/simplification/efficiency/altitude/conventions) + fixes applied for everything confirmed


---
_Generated by [Claude Code](https://claude.ai/code/session_01E6HLdLpU8sbTp3igbd81D7)_