### PR TITLE
Wire pre_loaded_protocols/pre_loaded_aliases into build/lint CLI pipeline (BT-2910)

### DIFF
--- a/crates/beamtalk-cli/src/commands/build.rs
+++ b/crates/beamtalk-cli/src/commands/build.rs
@@ -518,29 +518,28 @@ fn build_class_index(
         check_stdlib_reservations(&dep_registry)?;
     }
 
-    // BT-2928 / BT-2910: Same-package cross-file type-alias resolution,
-    // merged with dependency-exported aliases. Only runs for manifest-based
-    // package builds (matching `pre_loaded_classes`'s existing scope) — a
-    // manifest-less directory/single-file build has no package boundary and
-    // keeps today's same-file-only alias resolution.
-    let all_alias_infos = match pkg_manifest {
-        Some(pkg) => collect_all_alias_infos(&[
-            &collect_project_alias_infos(&env.source_files, &pkg.name),
-            &dep_alias_infos,
-        ]),
-        None => Vec::new(),
-    };
-
-    // BT-2910: Same-package cross-file protocol resolution (didn't exist at
-    // all before this — real `build` always passed `Vec::new()`), merged
-    // with dependency-exported protocols. Scoped to manifest-based package
-    // builds like the alias/class collections above.
-    let all_protocol_infos = match pkg_manifest {
-        Some(_) => collect_all_protocol_infos(&[
-            &collect_project_protocol_infos(&env.source_files),
-            &dep_protocol_infos,
-        ]),
-        None => Vec::new(),
+    // BT-2928 / BT-2910: Same-package cross-file protocol and type-alias
+    // resolution, merged with dependency-exported protocols/aliases. Only
+    // runs for manifest-based package builds (matching `pre_loaded_classes`'s
+    // existing scope) — a manifest-less directory/single-file build has no
+    // package boundary and keeps today's same-file-only resolution.
+    //
+    // Protocols and aliases are extracted together in one uncached scan
+    // (`collect_project_protocol_and_alias_infos`) rather than two separate
+    // ones — a build review finding: scanning the project source set twice
+    // here, on top of `build_class_module_index`'s own (incrementally
+    // cached) scan for classes, was doing up to three full parses of every
+    // file per build.
+    let (all_protocol_infos, all_alias_infos) = match pkg_manifest {
+        Some(pkg) => {
+            let (source_protocol_infos, source_alias_infos) =
+                collect_project_protocol_and_alias_infos(&env.source_files, &pkg.name);
+            (
+                collect_all_protocol_infos(&[&source_protocol_infos, &dep_protocol_infos]),
+                collect_all_alias_infos(&[&source_alias_infos, &dep_alias_infos]),
+            )
+        }
+        None => (Vec::new(), Vec::new()),
     };
 
     Ok(ClassIndexResult {
@@ -1707,23 +1706,7 @@ pub(crate) fn collect_project_alias_infos(
     source_files: &[Utf8PathBuf],
     pkg_name: &str,
 ) -> Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo> {
-    let mut all_aliases = Vec::new();
-    for file in source_files {
-        let Ok(source) = fs::read_to_string(file) else {
-            continue;
-        };
-        let tokens = beamtalk_core::source_analysis::lex_with_eof(&source);
-        let (module, _diagnostics) = beamtalk_core::source_analysis::parse(tokens);
-        let mut infos =
-            beamtalk_core::semantic_analysis::alias_registry::AliasRegistry::extract_alias_infos(
-                &module,
-            );
-        for info in &mut infos {
-            info.package = Some(pkg_name.into());
-        }
-        all_aliases.extend(infos);
-    }
-    all_aliases
+    collect_project_protocol_and_alias_infos(source_files, pkg_name).1
 }
 
 /// Merge alias infos from multiple sources (same-package cross-file +
@@ -1754,23 +1737,69 @@ pub(crate) fn collect_all_alias_infos(
 /// Parse errors on an individual file are non-fatal here: that file simply
 /// contributes no protocols to the merged set, and the same parse error is
 /// already reported through the normal Pass 1 diagnostics path.
+///
+/// `build_class_index`'s production path calls
+/// `collect_project_protocol_and_alias_infos` directly to extract both kinds
+/// in one scan; this standalone single-purpose wrapper is kept for tests
+/// that only care about protocols (mirrors `collect_project_alias_infos`,
+/// which stays in production use via `compile_dependency_with_context`).
+#[allow(dead_code)] // Used by tests; production path uses the combined extractor above
 pub(crate) fn collect_project_protocol_infos(
     source_files: &[Utf8PathBuf],
 ) -> Vec<beamtalk_core::semantic_analysis::protocol_registry::ProtocolInfo> {
+    collect_project_protocol_and_alias_infos(source_files, "").0
+}
+
+/// Extracts both protocol and type-alias declarations from every project
+/// source file in a single lex/parse pass per file (BT-2910 review finding).
+///
+/// `collect_project_protocol_infos`/`collect_project_alias_infos` used to
+/// each independently re-parse the full project source set, meaning a
+/// manifest-based build did up to three full scans of every source file:
+/// once (incrementally cached) in `build_class_module_index` for classes,
+/// then two more *uncached* scans here for protocols and aliases. This
+/// combines those last two into one uncached scan, mirroring how
+/// `build_dep_class_index` already extracts both kinds from a single pass
+/// over its cached ASTs. The class-index scan stays separate — it's
+/// incrementally cached and produces different data
+/// (`class_module_index`/`class_superclass_index`), not a natural fit for
+/// this merge.
+///
+/// `pkg_name` is only used to stamp `AliasInfo.package`; pass `""` when only
+/// the protocol half of the result is needed (see
+/// `collect_project_protocol_infos`, which never stamps a package anyway).
+fn collect_project_protocol_and_alias_infos(
+    source_files: &[Utf8PathBuf],
+    pkg_name: &str,
+) -> (
+    Vec<beamtalk_core::semantic_analysis::protocol_registry::ProtocolInfo>,
+    Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo>,
+) {
     let mut all_protocols = Vec::new();
+    let mut all_aliases = Vec::new();
     for file in source_files {
         let Ok(source) = fs::read_to_string(file) else {
             continue;
         };
         let tokens = beamtalk_core::source_analysis::lex_with_eof(&source);
         let (module, _diagnostics) = beamtalk_core::source_analysis::parse(tokens);
+
         all_protocols.extend(
             beamtalk_core::semantic_analysis::protocol_registry::ProtocolRegistry::extract_protocol_infos(
                 &module,
             ),
         );
+
+        let mut infos =
+            beamtalk_core::semantic_analysis::alias_registry::AliasRegistry::extract_alias_infos(
+                &module,
+            );
+        for info in &mut infos {
+            info.package = Some(pkg_name.into());
+        }
+        all_aliases.extend(infos);
     }
-    all_protocols
+    (all_protocols, all_aliases)
 }
 
 /// Merge protocol infos from multiple sources (same-package cross-file +

--- a/crates/beamtalk-cli/src/commands/build.rs
+++ b/crates/beamtalk-cli/src/commands/build.rs
@@ -389,7 +389,17 @@ struct ClassIndexResult {
     /// during Pass 2. See `collect_project_alias_infos`'s doc for why this
     /// is a plain full scan rather than threaded through the incremental
     /// Pass 1 cache the way `all_class_infos` is.
+    ///
+    /// BT-2910: Merged with dependency-exported alias infos
+    /// (`ResolvedDependency.alias_infos`), so cross-package aliases (e.g.
+    /// stdlib's `JsonValue`) resolve the same way cross-package classes do.
     all_alias_infos: Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo>,
+    /// BT-2910: Unified collection of all `ProtocolInfo` from same-package
+    /// cross-file protocol definitions and dependency-exported protocols,
+    /// mirroring `all_alias_infos`/`all_class_infos`. Protocols have no
+    /// `internal` modifier at the AST level, so every declared protocol
+    /// project-wide (and every dependency's) is included unconditionally.
+    all_protocol_infos: Vec<beamtalk_core::semantic_analysis::protocol_registry::ProtocolInfo>,
     /// Project-wide standalone extension index from Pass 1 (BT-2795).
     extension_index: beamtalk_core::compilation::extension_index::ExtensionIndex,
     /// Dependency registry for cross-package collision detection.
@@ -477,9 +487,12 @@ fn build_class_index(
     let dep_registry =
         beamtalk_core::semantic_analysis::build_dependency_registry_with_graph(&dep_infos);
 
-    // Collect dependency ClassInfo separately, then merge with source ClassInfo
-    // via collect_all_class_infos (BT-1733).
+    // Collect dependency ClassInfo/ProtocolInfo/AliasInfo separately, then
+    // merge with source-side infos via the collect_all_* helpers (BT-1733,
+    // BT-2910).
     let mut dep_class_infos = Vec::new();
+    let mut dep_protocol_infos = Vec::new();
+    let mut dep_alias_infos = Vec::new();
     for dep in &dep_ctx.resolved_deps {
         for (class_name, module_name) in &dep.class_module_index {
             debug!(
@@ -491,6 +504,8 @@ fn build_class_index(
             class_module_index.insert(class_name.clone(), module_name.clone());
         }
         dep_class_infos.extend(dep.class_infos.clone());
+        dep_protocol_infos.extend(dep.protocol_infos.clone());
+        dep_alias_infos.extend(dep.alias_infos.clone());
     }
 
     // BT-1733: Single unified collection of all ClassInfo from all sources.
@@ -503,14 +518,28 @@ fn build_class_index(
         check_stdlib_reservations(&dep_registry)?;
     }
 
-    // BT-2928: Same-package cross-file type-alias resolution. Only runs for
-    // manifest-based package builds (matching `pre_loaded_classes`'s existing
-    // scope) — a manifest-less directory/single-file build has no package
-    // boundary and keeps today's same-file-only alias resolution. Dependency
-    // (cross-package) alias export is deferred — see the BT-2928 follow-up
-    // filed for `dependency_classes.rs`.
+    // BT-2928 / BT-2910: Same-package cross-file type-alias resolution,
+    // merged with dependency-exported aliases. Only runs for manifest-based
+    // package builds (matching `pre_loaded_classes`'s existing scope) — a
+    // manifest-less directory/single-file build has no package boundary and
+    // keeps today's same-file-only alias resolution.
     let all_alias_infos = match pkg_manifest {
-        Some(pkg) => collect_project_alias_infos(&env.source_files, &pkg.name),
+        Some(pkg) => collect_all_alias_infos(&[
+            &collect_project_alias_infos(&env.source_files, &pkg.name),
+            &dep_alias_infos,
+        ]),
+        None => Vec::new(),
+    };
+
+    // BT-2910: Same-package cross-file protocol resolution (didn't exist at
+    // all before this — real `build` always passed `Vec::new()`), merged
+    // with dependency-exported protocols. Scoped to manifest-based package
+    // builds like the alias/class collections above.
+    let all_protocol_infos = match pkg_manifest {
+        Some(_) => collect_all_protocol_infos(&[
+            &collect_project_protocol_infos(&env.source_files),
+            &dep_protocol_infos,
+        ]),
         None => Vec::new(),
     };
 
@@ -519,6 +548,7 @@ fn build_class_index(
         class_superclass_index,
         all_class_infos,
         all_alias_infos,
+        all_protocol_infos,
         extension_index,
         dep_registry,
         cached_asts,
@@ -795,7 +825,7 @@ fn execute_build_passes(
             class_module_index: index.class_module_index.clone(),
             class_superclass_index: index.class_superclass_index.clone(),
             pre_loaded_classes: index.all_class_infos.clone(),
-            pre_loaded_protocols: Vec::new(),
+            pre_loaded_protocols: index.all_protocol_infos.clone(),
             pre_loaded_aliases: index.all_alias_infos.clone(),
             extension_index: index.extension_index.clone(),
         },
@@ -1694,6 +1724,67 @@ pub(crate) fn collect_project_alias_infos(
         all_aliases.extend(infos);
     }
     all_aliases
+}
+
+/// Merge alias infos from multiple sources (same-package cross-file +
+/// dependency-exported) into one collection, mirroring `collect_all_class_infos`
+/// (BT-2910). A plain concatenation — collision diagnostics are handled by
+/// `AliasRegistry::add_pre_loaded`, not here.
+pub(crate) fn collect_all_alias_infos(
+    sources: &[&[beamtalk_core::semantic_analysis::alias_registry::AliasInfo]],
+) -> Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo> {
+    let total_len: usize = sources.iter().map(|s| s.len()).sum();
+    let mut result = Vec::with_capacity(total_len);
+    for source in sources {
+        result.extend_from_slice(source);
+    }
+    result
+}
+
+/// Extracts protocol declarations (`Protocol define: Name ...`) from every
+/// project source file, for same-package cross-file protocol resolution
+/// during Pass 2 (BT-2910).
+///
+/// Mirrors `collect_project_alias_infos`: a plain, uncached full scan rather
+/// than threaded through the incremental Pass 1 cache. Unlike `AliasInfo`,
+/// `ProtocolInfo` carries no `package` field to stamp — protocols have no
+/// `internal` modifier at the AST level, so every declared protocol is
+/// exported project-wide.
+///
+/// Parse errors on an individual file are non-fatal here: that file simply
+/// contributes no protocols to the merged set, and the same parse error is
+/// already reported through the normal Pass 1 diagnostics path.
+pub(crate) fn collect_project_protocol_infos(
+    source_files: &[Utf8PathBuf],
+) -> Vec<beamtalk_core::semantic_analysis::protocol_registry::ProtocolInfo> {
+    let mut all_protocols = Vec::new();
+    for file in source_files {
+        let Ok(source) = fs::read_to_string(file) else {
+            continue;
+        };
+        let tokens = beamtalk_core::source_analysis::lex_with_eof(&source);
+        let (module, _diagnostics) = beamtalk_core::source_analysis::parse(tokens);
+        all_protocols.extend(
+            beamtalk_core::semantic_analysis::protocol_registry::ProtocolRegistry::extract_protocol_infos(
+                &module,
+            ),
+        );
+    }
+    all_protocols
+}
+
+/// Merge protocol infos from multiple sources (same-package cross-file +
+/// dependency-exported) into one collection, mirroring `collect_all_class_infos`
+/// / `collect_all_alias_infos` (BT-2910).
+pub(crate) fn collect_all_protocol_infos(
+    sources: &[&[beamtalk_core::semantic_analysis::protocol_registry::ProtocolInfo]],
+) -> Vec<beamtalk_core::semantic_analysis::protocol_registry::ProtocolInfo> {
+    let total_len: usize = sources.iter().map(|s| s.len()).sum();
+    let mut result = Vec::with_capacity(total_len);
+    for source in sources {
+        result.extend_from_slice(source);
+    }
+    result
 }
 
 // ── BT-1730: Class module header generation ─────────────────────────────────
@@ -3422,6 +3513,114 @@ mod tests {
         );
     }
 
+    /// BT-2910: `collect_project_protocol_infos`/`collect_all_protocol_infos`
+    /// and `collect_all_alias_infos` are the merge helpers `build_class_index`
+    /// uses to combine same-package cross-file protocol/alias metadata with
+    /// a dependency's exported protocol/alias metadata (`ResolvedDependency`).
+    /// This test exercises that merge directly — mirroring
+    /// `test_cross_file_alias_resolution_no_false_type_mismatch`'s pattern
+    /// for aliases, but for a *dependency-sourced* protocol and alias rather
+    /// than a same-package cross-file one — and confirms the merged sets,
+    /// once threaded through `pre_loaded_protocols`/`pre_loaded_aliases`,
+    /// let a consumer file resolve a protocol name and an alias-typed
+    /// annotation it never declares itself.
+    #[test]
+    fn dependency_protocol_and_alias_infos_merge_and_resolve() {
+        use beamtalk_core::semantic_analysis::alias_registry::AliasInfo;
+        use beamtalk_core::semantic_analysis::protocol_registry::ProtocolInfo;
+
+        let temp = TempDir::new().unwrap();
+        let project_path = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let src_path = project_path.join("src");
+        fs::create_dir_all(&src_path).unwrap();
+
+        // Consumer file: no protocol/alias declarations of its own, only a
+        // reference to a dependency-only protocol name and a parameter
+        // annotated with a dependency-only alias.
+        write_test_file(
+            &src_path.join("consumer.bt"),
+            "Object subclass: Consumer\n  \
+             useStatus: s :: Status => s\n  \
+             greetableInfo => Greetable requiredMethods\n",
+        );
+
+        let build_dir = project_path.join("_build/dev/ebin");
+        fs::create_dir_all(&build_dir).unwrap();
+
+        let source_files = vec![src_path.join("consumer.bt")];
+        let (class_module_index, class_superclass_index, all_class_infos, _extensions, _cached) =
+            build_class_module_index(&source_files, Some(&src_path), "test_pkg").unwrap();
+
+        // Same-package cross-file collections are empty here (single file,
+        // no protocol/alias declarations) — this test's focus is the
+        // dependency-sourced side of the merge.
+        let source_protocol_infos = collect_project_protocol_infos(&source_files);
+        let source_alias_infos = collect_project_alias_infos(&source_files, "test_pkg");
+        assert!(source_protocol_infos.is_empty());
+        assert!(source_alias_infos.is_empty());
+
+        // Simulate a resolved dependency exporting a `Greetable` protocol and
+        // a public `Status` alias (`ResolvedDependency.protocol_infos` /
+        // `.alias_infos`, as populated by `build_dep_class_index`).
+        let dep_protocol_infos = vec![ProtocolInfo {
+            name: "Greetable".into(),
+            type_params: vec![],
+            type_param_bounds: vec![],
+            extending: None,
+            methods: vec![],
+            class_methods: vec![],
+            span: beamtalk_core::source_analysis::Span::default(),
+        }];
+        let dep_alias_infos = vec![AliasInfo {
+            name: "Status".into(),
+            annotation: beamtalk_core::ast::TypeAnnotation::Simple(
+                beamtalk_core::ast::Identifier {
+                    name: "Symbol".into(),
+                    span: beamtalk_core::source_analysis::Span::default(),
+                },
+            ),
+            is_internal: false,
+            package: Some("dep_types".into()),
+            span: beamtalk_core::source_analysis::Span::default(),
+        }];
+
+        let all_protocol_infos =
+            collect_all_protocol_infos(&[&source_protocol_infos, &dep_protocol_infos]);
+        let all_alias_infos = collect_all_alias_infos(&[&source_alias_infos, &dep_alias_infos]);
+        assert_eq!(all_protocol_infos.len(), 1);
+        assert_eq!(all_alias_infos.len(), 1);
+
+        let core_file = build_dir.join("bt@test_pkg@consumer.core");
+        let options = default_options();
+        let diagnostics = compile_file(
+            &src_path.join("consumer.bt"),
+            "bt@test_pkg@consumer",
+            &core_file,
+            &options,
+            &CompileContext {
+                hierarchy: ClassHierarchyContext {
+                    class_module_index,
+                    class_superclass_index,
+                    pre_loaded_classes: all_class_infos,
+                    pre_loaded_protocols: all_protocol_infos,
+                    pre_loaded_aliases: all_alias_infos,
+                    ..ClassHierarchyContext::default()
+                },
+                ..CompileContext::default()
+            },
+            None,
+        )
+        .expect("Compiling with dependency-merged protocol/alias infos should succeed");
+
+        assert!(core_file.exists());
+        assert!(
+            diagnostics.iter().all(|d| d.category
+                != Some(beamtalk_core::source_analysis::DiagnosticCategory::UnresolvedClass)),
+            "Dependency-sourced Greetable/Status must not be reported unresolved \
+             once merged into pre_loaded_protocols/pre_loaded_aliases, got: {diagnostics:?}"
+        );
+    }
+
     /// BT-2932: cross-module `AliasRegistry` wiring into codegen — the
     /// codegen counterpart of `test_cross_file_alias_resolution_no_false_type_mismatch`
     /// above. File A declares `type Direction = ...`; file B has no alias
@@ -3969,6 +4168,8 @@ mod tests {
             ebin_path: dep_root.join("ebin"),
             class_module_index: HashMap::new(),
             class_infos: Vec::new(),
+            protocol_infos: Vec::new(),
+            alias_infos: Vec::new(),
             is_direct: true,
             via_chain: Vec::new(),
         }];
@@ -4030,6 +4231,8 @@ mod tests {
                 ebin_path: first_root.join("ebin"),
                 class_module_index: HashMap::new(),
                 class_infos: Vec::new(),
+                protocol_infos: Vec::new(),
+                alias_infos: Vec::new(),
                 is_direct: true,
                 via_chain: Vec::new(),
             },
@@ -4039,6 +4242,8 @@ mod tests {
                 ebin_path: second_root.join("ebin"),
                 class_module_index: HashMap::new(),
                 class_infos: Vec::new(),
+                protocol_infos: Vec::new(),
+                alias_infos: Vec::new(),
                 is_direct: true,
                 via_chain: Vec::new(),
             },
@@ -4097,6 +4302,8 @@ mod tests {
             ebin_path: dep_root.join("ebin"),
             class_module_index: HashMap::new(),
             class_infos: Vec::new(),
+            protocol_infos: Vec::new(),
+            alias_infos: Vec::new(),
             is_direct: true,
             via_chain: Vec::new(),
         }];
@@ -4547,6 +4754,8 @@ mod tests {
             ebin_path: Utf8PathBuf::from_path_buf(root.join(name).join("ebin")).unwrap(),
             class_module_index: std::collections::HashMap::new(),
             class_infos: Vec::new(),
+            protocol_infos: Vec::new(),
+            alias_infos: Vec::new(),
             is_direct: true,
             via_chain: Vec::new(),
         }

--- a/crates/beamtalk-cli/src/commands/deps/mod.rs
+++ b/crates/beamtalk-cli/src/commands/deps/mod.rs
@@ -254,8 +254,9 @@ fn collect_fresh_deps(
     for dep in &all_deps {
         let ebin_path = layout.dep_ebin_dir(&dep.name);
 
-        // Rebuild class module index from source files (fast — no compilation)
-        let (class_module_index, class_infos) = path::build_dep_class_index(&dep.root, &dep.name)?;
+        // Rebuild class/protocol/alias indexes from source files (fast — no compilation)
+        let (class_module_index, class_infos, protocol_infos, alias_infos) =
+            path::build_dep_class_index(&dep.root, &dep.name)?;
 
         debug!(
             dep = %dep.name,
@@ -270,6 +271,8 @@ fn collect_fresh_deps(
             ebin_path,
             class_module_index,
             class_infos,
+            protocol_infos,
+            alias_infos,
             is_direct: dep.is_direct,
             via_chain: dep.via_chain.clone(),
         });
@@ -1095,6 +1098,8 @@ mod tests {
             ebin_path: layout.dep_ebin_dir("utils"),
             class_module_index: HashMap::default(),
             class_infos: Vec::new(),
+            protocol_infos: Vec::new(),
+            alias_infos: Vec::new(),
             is_direct: true,
             via_chain: Vec::new(),
         }];
@@ -1125,6 +1130,8 @@ mod tests {
                 ebin_path: layout.dep_ebin_dir("a"),
                 class_module_index: HashMap::default(),
                 class_infos: Vec::new(),
+                protocol_infos: Vec::new(),
+                alias_infos: Vec::new(),
                 is_direct: true,
                 via_chain: Vec::new(),
             },
@@ -1134,6 +1141,8 @@ mod tests {
                 ebin_path: layout.dep_ebin_dir("b"),
                 class_module_index: HashMap::default(),
                 class_infos: Vec::new(),
+                protocol_infos: Vec::new(),
+                alias_infos: Vec::new(),
                 is_direct: true,
                 via_chain: Vec::new(),
             },

--- a/crates/beamtalk-cli/src/commands/deps/path.rs
+++ b/crates/beamtalk-cli/src/commands/deps/path.rs
@@ -40,6 +40,22 @@ pub struct ResolvedDependency {
     /// class references (superclass chains, method signatures, etc.).
     /// Empty when metadata is unavailable (e.g., compiled-only dependencies).
     pub class_infos: Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
+    /// Full protocol metadata from the dependency's source files (BT-2910).
+    ///
+    /// Lets a consumer's `extending:`/conformance checks resolve protocol
+    /// names exported by this dependency. Protocols have no `internal`
+    /// modifier at the AST level, so every declared protocol is exported —
+    /// unlike `alias_infos`, there is no seeding-boundary filter to apply.
+    pub protocol_infos: Vec<beamtalk_core::semantic_analysis::protocol_registry::ProtocolInfo>,
+    /// Full type-alias metadata from the dependency's source files (BT-2910),
+    /// each stamped with `.package = Some(name)`.
+    ///
+    /// Lets a consumer's `:: Alias` annotations resolve type aliases exported
+    /// by this dependency. `AliasRegistry::add_pre_loaded`'s existing
+    /// seeding-boundary filter uses the stamped `package` to exclude this
+    /// dependency's `internal type` declarations while still seeding its
+    /// public aliases (ADR 0108 Phase 5).
+    pub alias_infos: Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo>,
     /// Whether this is a direct dependency of the root package (ADR 0070 Phase 3).
     /// `false` means it is a transitive dependency.
     pub is_direct: bool,
@@ -226,14 +242,17 @@ fn resolve_single_path_dep(
 
     info!(dep = %name, ebin = %ebin_path, "Resolved path dependency");
 
+    let (_, class_infos, protocol_infos, alias_infos) =
+        build_dep_class_index(&dep_root, name).unwrap_or_default();
+
     resolved.push(ResolvedDependency {
         name: name.to_string(),
         root: dep_root.clone(),
         ebin_path,
         class_module_index: dep_class_module_index,
-        class_infos: build_dep_class_index(&dep_root, name)
-            .map(|(_, infos)| infos)
-            .unwrap_or_default(),
+        class_infos,
+        protocol_infos,
+        alias_infos,
         is_direct: true, // Legacy path — all treated as direct
         via_chain: Vec::new(),
     });
@@ -316,14 +335,17 @@ pub(crate) fn compile_dependency_at(
     let (ebin_path, class_module_index) =
         compile_dependency_with_context(project_root, dep_root, dep_name, options, prior_deps)?;
 
+    let (_, class_infos, protocol_infos, alias_infos) =
+        build_dep_class_index(dep_root, dep_name).unwrap_or_default();
+
     Ok(ResolvedDependency {
         name: dep_name.to_string(),
         root: dep_root.to_path_buf(),
         ebin_path,
         class_module_index,
-        class_infos: build_dep_class_index(dep_root, dep_name)
-            .map(|(_, infos)| infos)
-            .unwrap_or_default(),
+        class_infos,
+        protocol_infos,
+        alias_infos,
         is_direct: false, // Caller sets this based on graph knowledge
         via_chain: Vec::new(),
     })
@@ -610,14 +632,23 @@ fn generate_dependency_app_file(
 
 /// Build a class module index for a dependency without compiling.
 ///
-/// Scans the dependency's source files and extracts class-to-module mappings.
-/// This is the fast path used when deps are fresh and don't need recompilation.
+/// Scans the dependency's source files and extracts class-to-module mappings,
+/// plus (BT-2910) protocol and type-alias metadata for cross-package
+/// `extending:`/`:: Alias` resolution. This is the fast path used when deps
+/// are fresh and don't need recompilation.
+///
+/// Protocol and alias extraction reuses `build_class_module_index`'s cached,
+/// already-parsed ASTs rather than re-lexing/re-parsing the dependency's
+/// source files a second and third time.
+#[allow(clippy::type_complexity)] // 4-tuple mirrors ResolvedDependency's own fields; a type alias wouldn't clarify
 pub(crate) fn build_dep_class_index(
     dep_root: &Utf8Path,
     dep_name: &str,
 ) -> Result<(
     HashMap<String, String>,
     Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
+    Vec<beamtalk_core::semantic_analysis::protocol_registry::ProtocolInfo>,
+    Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo>,
 )> {
     let src_dir = dep_root.join("src");
     let search_dir = if src_dir.exists() {
@@ -628,7 +659,7 @@ pub(crate) fn build_dep_class_index(
 
     let source_files = crate::commands::build::collect_source_files_from_dir(&search_dir)?;
     if source_files.is_empty() {
-        return Ok((HashMap::new(), Vec::new()));
+        return Ok((HashMap::new(), Vec::new(), Vec::new(), Vec::new()));
     }
 
     let source_root = if src_dir.exists() {
@@ -637,14 +668,38 @@ pub(crate) fn build_dep_class_index(
         None
     };
 
-    let (class_module_index, _, class_infos, _, _) =
+    let (class_module_index, _, class_infos, _, cached_asts) =
         crate::commands::build::build_class_module_index(
             &source_files,
             source_root.as_deref(),
             dep_name,
         )?;
 
-    Ok((class_module_index, class_infos))
+    // BT-2910: Extract protocol/alias infos from the already-parsed modules,
+    // iterating in a stable (sorted-by-path) order for deterministic output.
+    let mut sorted_files: Vec<&Utf8PathBuf> = cached_asts.keys().collect();
+    sorted_files.sort();
+
+    let mut protocol_infos = Vec::new();
+    let mut alias_infos = Vec::new();
+    for file in sorted_files {
+        let module = &cached_asts[file].module;
+        protocol_infos.extend(
+            beamtalk_core::semantic_analysis::protocol_registry::ProtocolRegistry::extract_protocol_infos(
+                module,
+            ),
+        );
+        let mut infos =
+            beamtalk_core::semantic_analysis::alias_registry::AliasRegistry::extract_alias_infos(
+                module,
+            );
+        for info in &mut infos {
+            info.package = Some(dep_name.into());
+        }
+        alias_infos.extend(infos);
+    }
+
+    Ok((class_module_index, class_infos, protocol_infos, alias_infos))
 }
 
 #[cfg(test)]
@@ -1007,6 +1062,78 @@ dep_utils = { path = "dep_utils" }"#,
         assert!(
             !beam_files.is_empty(),
             "dep ebin should contain .beam files"
+        );
+    }
+
+    /// BT-2910: `build_dep_class_index` must extract a dependency's protocol
+    /// and type-alias declarations alongside its classes, so that a
+    /// consumer's cross-package `extending:`/`:: Alias` resolution can be
+    /// wired from `ResolvedDependency.protocol_infos`/`alias_infos`.
+    ///
+    /// Each `AliasInfo` (public and `internal`) must be stamped with
+    /// `.package = Some(dep_name)` — `AliasRegistry::add_pre_loaded`'s
+    /// seeding-boundary filter (ADR 0108 Phase 5) relies on that stamp to
+    /// exclude a dependency's `internal type` while still seeding its public
+    /// aliases. Extraction itself does not filter `internal` aliases out —
+    /// that exclusion happens downstream at seeding time.
+    #[test]
+    fn build_dep_class_index_extracts_protocols_and_aliases() {
+        let temp = TempDir::new().unwrap();
+        let dep_dir = temp.path().join("dep_types");
+        fs::create_dir_all(&dep_dir).unwrap();
+        write_manifest(&dep_dir, "dep_types", "0.1.0", "");
+        write_source(
+            &dep_dir,
+            "types.bt",
+            "type Status = #ok | #error\n\
+             internal type Secret = Integer\n\n\
+             Protocol define: Greetable\n  \
+             greet -> String\n",
+        );
+
+        let dep_root = Utf8PathBuf::from_path_buf(dep_dir).unwrap();
+        let (class_module_index, _class_infos, protocol_infos, alias_infos) =
+            build_dep_class_index(&dep_root, "dep_types").unwrap();
+
+        assert!(
+            class_module_index.is_empty(),
+            "fixture declares no classes: {class_module_index:?}"
+        );
+
+        assert_eq!(
+            protocol_infos.len(),
+            1,
+            "should extract the Greetable protocol: {protocol_infos:?}"
+        );
+        assert_eq!(protocol_infos[0].name.as_str(), "Greetable");
+
+        assert_eq!(
+            alias_infos.len(),
+            2,
+            "should extract both Status and Secret aliases: {alias_infos:?}"
+        );
+        let status = alias_infos
+            .iter()
+            .find(|a| a.name.as_str() == "Status")
+            .expect("Status alias should be extracted");
+        assert!(!status.is_internal, "Status is a public alias");
+        assert_eq!(
+            status.package.as_deref(),
+            Some("dep_types"),
+            "alias must be stamped with the dependency's package name"
+        );
+
+        let secret = alias_infos
+            .iter()
+            .find(|a| a.name.as_str() == "Secret")
+            .expect(
+                "Secret alias should be extracted (filtering happens at seeding, not extraction)",
+            );
+        assert!(secret.is_internal, "Secret is declared `internal type`");
+        assert_eq!(
+            secret.package.as_deref(),
+            Some("dep_types"),
+            "internal alias must still be stamped so add_pre_loaded can filter it"
         );
     }
 }

--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -36,11 +36,13 @@ use tracing::warn;
 /// project so that cross-file type/DNU diagnostics match what `build` emits.
 /// Without this, `@expect type` / `@expect all` annotations that suppress real
 /// diagnostics during build would be reported as stale by lint.
-#[allow(clippy::too_many_arguments)] // BT-2920 added `current_package`; each param is load-bearing context
+#[allow(clippy::too_many_arguments)] // BT-2910 added pre_loaded_protocols/pre_loaded_aliases; each param is load-bearing context
 fn collect_diagnostics(
     module: &beamtalk_core::ast::Module,
     parse_diags: Vec<beamtalk_core::source_analysis::Diagnostic>,
     cross_file_classes: Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
+    pre_loaded_protocols: Vec<beamtalk_core::semantic_analysis::protocol_registry::ProtocolInfo>,
+    pre_loaded_aliases: Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo>,
     native_type_registry: Option<
         std::sync::Arc<beamtalk_core::semantic_analysis::type_checker::NativeTypeRegistry>,
     >,
@@ -81,13 +83,16 @@ fn collect_diagnostics(
         current_package: current_package.map(str::to_string),
         ..Default::default()
     };
-    let analysis_result = beamtalk_core::semantic_analysis::analyse_with_natives_and_extensions(
-        module,
-        &options,
-        cross_file_classes,
-        native_type_registry,
-        cross_file_extensions,
-    );
+    let analysis_result =
+        beamtalk_core::semantic_analysis::analyse_with_natives_and_protocols_and_aliases(
+            module,
+            &options,
+            cross_file_classes,
+            pre_loaded_protocols,
+            pre_loaded_aliases,
+            native_type_registry,
+            cross_file_extensions,
+        );
     lint_diags.extend(
         analysis_result
             .diagnostics
@@ -154,17 +159,28 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
     // Resolved before extraction so cross-file `ClassInfo` can be
     // package-stamped too (see `parse_and_extract_class_infos`'s
     // `stamp_package_on_infos` call).
-    let (mut all_class_infos, extension_index, parsed_files) = parse_and_extract_class_infos(
+    let (
+        mut all_class_infos,
+        extension_index,
+        mut all_protocol_infos,
+        mut all_alias_infos,
+        parsed_files,
+    ) = parse_and_extract_class_infos(
         &source_files,
         package_root.as_deref(),
         current_package.as_deref(),
     )?;
 
-    // Merge dependency class metadata so lint sees the same class hierarchy
-    // as build. Without this, @expect annotations that suppress real cross-package
-    // diagnostics would be reported as stale.
+    // Merge dependency class/protocol/alias metadata so lint sees the same
+    // cross-package picture as build. Without this, @expect annotations that
+    // suppress real cross-package diagnostics would be reported as stale.
     if let Some(ref project_root) = package_root {
-        merge_dependency_class_infos(project_root, &mut all_class_infos);
+        merge_dependency_infos(
+            project_root,
+            &mut all_class_infos,
+            &mut all_protocol_infos,
+            &mut all_alias_infos,
+        );
     }
 
     // BT-2134 / BT-2851: Populate the FFI type registry via the same
@@ -209,6 +225,8 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
             &module,
             parse_diags,
             cross_file_classes,
+            all_protocol_infos.clone(),
+            all_alias_infos.clone(),
             native_type_registry.clone(),
             knowledge_scope,
             &extension_index,
@@ -457,6 +475,7 @@ type ParsedLintFile = (
     Vec<beamtalk_core::source_analysis::Diagnostic>,
 );
 
+#[allow(clippy::type_complexity)] // Mirrors the pre-existing 3-tuple return; BT-2910 adds two sibling collections
 fn parse_and_extract_class_infos(
     source_files: &[Utf8PathBuf],
     package_root: Option<&Utf8Path>,
@@ -464,6 +483,8 @@ fn parse_and_extract_class_infos(
 ) -> Result<(
     Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
     beamtalk_core::compilation::extension_index::ExtensionIndex,
+    Vec<beamtalk_core::semantic_analysis::protocol_registry::ProtocolInfo>,
+    Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo>,
     Vec<ParsedLintFile>,
 )> {
     let extraction_files = match package_root {
@@ -481,6 +502,12 @@ fn parse_and_extract_class_infos(
         .collect();
     let mut all_class_infos = Vec::new();
     let mut extension_index = beamtalk_core::compilation::extension_index::ExtensionIndex::new();
+    // BT-2910: Same-package cross-file protocol/alias metadata — `beamtalk
+    // lint` previously collected neither (protocols not at all; aliases only
+    // via BT-2928 in `build`), so `:: Alias` and `extending:` diagnostics
+    // could disagree between `build` and `lint`.
+    let mut all_protocol_infos = Vec::new();
+    let mut all_alias_infos = Vec::new();
     let mut parsed_files: Vec<ParsedLintFile> = Vec::new();
 
     for file in &extraction_files {
@@ -519,12 +546,40 @@ fn parse_and_extract_class_infos(
         // way they do during build.
         extension_index.add_module(&module, file.as_std_path());
 
+        // BT-2910: Extract protocol/alias infos from the already-parsed
+        // module — no second parse pass, mirroring the class_infos handling
+        // just above. Aliases are stamped with `current_package` the same
+        // way `build`'s `collect_project_alias_infos` stamps them, so
+        // `AliasRegistry::add_pre_loaded`'s seeding-boundary filter can tell
+        // a same-package alias apart from a dependency's `internal` one.
+        all_protocol_infos.extend(
+            beamtalk_core::semantic_analysis::protocol_registry::ProtocolRegistry::extract_protocol_infos(
+                &module,
+            ),
+        );
+        let mut alias_infos =
+            beamtalk_core::semantic_analysis::alias_registry::AliasRegistry::extract_alias_infos(
+                &module,
+            );
+        if let Some(pkg) = current_package {
+            for info in &mut alias_infos {
+                info.package = Some(pkg.into());
+            }
+        }
+        all_alias_infos.extend(alias_infos);
+
         if source_file_set.contains(&canonicalize_or_clone(file)) {
             parsed_files.push((file.clone(), source, module, parse_diags));
         }
     }
 
-    Ok((all_class_infos, extension_index, parsed_files))
+    Ok((
+        all_class_infos,
+        extension_index,
+        all_protocol_infos,
+        all_alias_infos,
+        parsed_files,
+    ))
 }
 
 /// Walk ancestors from the given path to find the package root (containing `beamtalk.toml`).
@@ -542,33 +597,42 @@ pub(crate) fn find_package_root(start: &Utf8Path) -> Option<Utf8PathBuf> {
     package::find_package_root(start.as_std_path()).and_then(|p| Utf8PathBuf::from_path_buf(p).ok())
 }
 
-/// Resolve dependency classes and merge them into the class info list.
+/// Resolve dependency classes/protocols/aliases and merge them into the
+/// respective info lists.
 ///
 /// Best-effort: if dependency resolution fails (e.g. network error for a git
-/// dep), lint continues without dep classes rather than failing entirely.
+/// dep), lint continues without dep metadata rather than failing entirely.
 ///
 /// BT-2920 (review S1): `has_package_dependencies` (BT-2794) used to be
 /// computed here from its own re-parse of `beamtalk.toml`, independently of
 /// `run_lint`'s `current_package` resolution — two reads of the same file
 /// with inconsistent error handling. `run_lint` now parses the manifest once
 /// and derives both from that single read; this function's only remaining
-/// job is the dependency-class side effect on `all_class_infos`.
-fn merge_dependency_class_infos(
+/// job is the dependency-metadata side effect on the three `all_*` lists.
+///
+/// BT-2910: Renamed from `merge_dependency_class_infos` — now also merges
+/// `dep.protocol_infos`/`dep.alias_infos`, giving `beamtalk lint` the same
+/// cross-package protocol/alias resolution `beamtalk build` has.
+fn merge_dependency_infos(
     project_root: &Utf8Path,
     all_class_infos: &mut Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
+    all_protocol_infos: &mut Vec<beamtalk_core::semantic_analysis::protocol_registry::ProtocolInfo>,
+    all_alias_infos: &mut Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo>,
 ) {
     let options = beamtalk_core::CompilerOptions::default();
     match super::deps::ensure_deps_resolved(project_root, &options) {
         Ok(resolved_deps) => {
             for dep in &resolved_deps {
                 all_class_infos.extend(dep.class_infos.clone());
+                all_protocol_infos.extend(dep.protocol_infos.clone());
+                all_alias_infos.extend(dep.alias_infos.clone());
             }
         }
         Err(e) => {
             warn!(
                 error = %e,
                 "Failed to resolve dependencies for lint; \
-                 dependency classes may not be available"
+                 dependency classes/protocols/aliases may not be available"
             );
         }
     }
@@ -642,6 +706,8 @@ fn collect_lint_diagnostics(source: &str) -> Vec<beamtalk_core::source_analysis:
     collect_diagnostics(
         &module,
         parse_diags,
+        vec![],
+        vec![],
         vec![],
         None,
         beamtalk_core::semantic_analysis::KnowledgeScope::default(),
@@ -737,6 +803,8 @@ mod tests {
             &module,
             parse_diags,
             cross_file_classes,
+            vec![],
+            vec![],
             None,
             beamtalk_core::semantic_analysis::KnowledgeScope::default(),
             &beamtalk_core::compilation::extension_index::ExtensionIndex::new(),
@@ -937,6 +1005,8 @@ mod tests {
             &module,
             parse_diags,
             cross_file_classes,
+            vec![],
+            vec![],
             None,
             beamtalk_core::semantic_analysis::KnowledgeScope::default(),
             &beamtalk_core::compilation::extension_index::ExtensionIndex::new(),
@@ -954,6 +1024,172 @@ mod tests {
         assert!(
             unresolved.is_empty(),
             "test/ file should resolve src/ classes, got unresolved: {unresolved:?}"
+        );
+    }
+
+    /// BT-2910 (acceptance criterion): `beamtalk lint` must resolve a
+    /// dependency's exported protocol and public type alias — mirroring what
+    /// `beamtalk build` already does via `ResolvedDependency.protocol_infos`/
+    /// `.alias_infos` — while a dependency's `internal type` stays excluded.
+    ///
+    /// Sets up a two-package path-dependency fixture on disk: `producer`
+    /// exports a public `Status` alias, an `internal` `Secret` alias, and a
+    /// `Greetable` protocol; `consumer` depends on `producer` (path dep) and
+    /// references all three names without declaring any of them itself.
+    ///
+    /// `producer`'s ebin/provenance stamp is faked (mirroring
+    /// `commands::deps::mod::tests::create_dep_ebin_with_beam`) so
+    /// `ensure_deps_resolved`'s "deps are fresh" fast path
+    /// (`collect_fresh_deps` → `build_dep_class_index`, pure parsing, no
+    /// `erlc`) is used instead of a real compile — keeping this test fast
+    /// and runnable without an Erlang toolchain.
+    #[test]
+    #[allow(clippy::too_many_lines)] // Two-package fixture setup + assertions; splitting would obscure the flow
+    fn lint_resolves_dependency_protocol_and_public_alias_but_not_internal_alias() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+
+        // Producer package: public Status alias, internal Secret alias,
+        // Greetable protocol.
+        let producer_dir = root.join("producer");
+        std::fs::create_dir_all(producer_dir.join("src")).unwrap();
+        std::fs::write(
+            producer_dir.join("beamtalk.toml"),
+            "[package]\nname = \"producer\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            producer_dir.join("src").join("types.bt"),
+            "type Status = #ok | #error\n\
+             internal type Secret = Integer\n\n\
+             Protocol define: Greetable\n  \
+             greet -> String\n",
+        )
+        .unwrap();
+
+        // Consumer package: depends on producer, references Status,
+        // Greetable, and Secret without declaring any of them.
+        let consumer_dir = root.join("consumer");
+        std::fs::create_dir_all(consumer_dir.join("src")).unwrap();
+        std::fs::write(
+            consumer_dir.join("beamtalk.toml"),
+            "[package]\nname = \"consumer\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nproducer = { path = \"../producer\" }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            consumer_dir.join("src").join("consumer.bt"),
+            "Object subclass: Consumer\n  \
+             useStatus: s :: Status => s\n  \
+             useSecret: s :: Secret => s\n  \
+             greetableInfo => Greetable requiredMethods\n",
+        )
+        .unwrap();
+
+        let consumer_root = camino::Utf8PathBuf::from_path_buf(consumer_dir.clone()).unwrap();
+
+        // Fake the producer's compiled state, *relative to the consumer's
+        // own `_build/deps/producer/`* (`ensure_deps_resolved` is called
+        // with `consumer_root`, so that's where it looks for freshness) —
+        // so `ensure_deps_resolved` takes the fresh/no-recompile fast path
+        // (`collect_fresh_deps` → `build_dep_class_index`) instead of a real
+        // `erlc` compile, keeping this test fast and toolchain-independent.
+        let layout = crate::commands::build_layout::BuildLayout::new(&consumer_root);
+        let ebin_dir = layout.dep_ebin_dir("producer");
+        std::fs::create_dir_all(&ebin_dir).unwrap();
+        std::fs::write(ebin_dir.join("bt@producer@types.beam"), b"BEAM").unwrap();
+        crate::commands::build_stamp::write_stamp(
+            &layout.dep_stamp_path("producer"),
+            crate::commands::build_stamp::current_otp_version(),
+        );
+        let consumer_file = consumer_root.join("src").join("consumer.bt");
+        let source_files = vec![consumer_file.clone()];
+
+        // Mirrors `run_lint`'s own orchestration: extract same-package
+        // protocol/alias infos, then merge in the resolved dependency's.
+        let (
+            mut all_class_infos,
+            extension_index,
+            mut all_protocol_infos,
+            mut all_alias_infos,
+            parsed_files,
+        ) = parse_and_extract_class_infos(&source_files, Some(&consumer_root), Some("consumer"))
+            .unwrap();
+        merge_dependency_infos(
+            &consumer_root,
+            &mut all_class_infos,
+            &mut all_protocol_infos,
+            &mut all_alias_infos,
+        );
+
+        assert!(
+            all_protocol_infos.iter().any(|p| p.name == "Greetable"),
+            "producer's Greetable protocol should be merged in: {all_protocol_infos:?}"
+        );
+        assert!(
+            all_alias_infos
+                .iter()
+                .any(|a| a.name == "Status" && !a.is_internal),
+            "producer's public Status alias should be merged in: {all_alias_infos:?}"
+        );
+        // The internal Secret alias is *not* filtered out at this merge
+        // stage (`merge_dependency_infos`/`ResolvedDependency.alias_infos`
+        // carry every declaration, filtered or not) — the seeding-boundary
+        // exclusion happens downstream, inside `AliasRegistry::add_pre_loaded`
+        // when `collect_diagnostics` calls `analyse_with_natives_and_protocols_and_aliases`
+        // below. That exclusion logic itself is already covered by
+        // `add_pre_loaded_never_seeds_internal_alias_from_different_package`
+        // in `alias_registry.rs` (BT-2898); what this test proves is that the
+        // wiring correctly delivers `is_internal`/`package` all the way from
+        // `producer`'s source to `consumer`'s lint pass so that exclusion can
+        // actually engage.
+        let secret = all_alias_infos
+            .iter()
+            .find(|a| a.name == "Secret")
+            .expect("producer's Secret alias should be merged in (unfiltered at this stage)");
+        assert!(secret.is_internal, "Secret must be flagged internal");
+        assert_eq!(
+            secret.package.as_deref(),
+            Some("producer"),
+            "Secret must be stamped with producer's package name so the \
+             seeding-boundary check can tell it apart from consumer's own package"
+        );
+
+        let (file, _source, module, parse_diags) = parsed_files
+            .into_iter()
+            .find(|(f, ..)| *f == consumer_file)
+            .expect("consumer.bt should be among the parsed files");
+        assert_eq!(file, consumer_file);
+
+        let diags = collect_diagnostics(
+            &module,
+            parse_diags,
+            vec![], // no same-package cross-file classes
+            all_protocol_infos,
+            all_alias_infos,
+            None,
+            beamtalk_core::semantic_analysis::KnowledgeScope::ProjectComplete,
+            &extension_index,
+            true, // has_package_dependencies
+            Some("consumer"),
+        );
+
+        let unresolved_names: Vec<String> = diags
+            .iter()
+            .filter(|d| {
+                d.category
+                    == Some(beamtalk_core::source_analysis::DiagnosticCategory::UnresolvedClass)
+            })
+            .map(|d| d.message.to_string())
+            .collect();
+
+        assert!(
+            !unresolved_names.iter().any(|m| m.contains("Status")),
+            "dependency-exported Status alias should resolve, unresolved: {unresolved_names:?}"
+        );
+        assert!(
+            !unresolved_names.iter().any(|m| m.contains("Greetable")),
+            "dependency-exported Greetable protocol should resolve, unresolved: {unresolved_names:?}"
         );
     }
 
@@ -1044,6 +1280,8 @@ mod tests {
             &module,
             parse_diags,
             vec![],
+            vec![],
+            vec![],
             None,
             beamtalk_core::semantic_analysis::KnowledgeScope::default(),
             &beamtalk_core::compilation::extension_index::ExtensionIndex::new(),
@@ -1091,6 +1329,8 @@ mod tests {
         let diags = collect_diagnostics(
             &module,
             parse_diags,
+            vec![],
+            vec![],
             vec![],
             Some(std::sync::Arc::new(registry)),
             beamtalk_core::semantic_analysis::KnowledgeScope::default(),
@@ -1153,6 +1393,8 @@ mod tests {
         let diags = collect_diagnostics(
             &module,
             parse_diags,
+            vec![],
+            vec![],
             vec![],
             Some(std::sync::Arc::new(registry)),
             beamtalk_core::semantic_analysis::KnowledgeScope::default(),

--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -1155,6 +1155,49 @@ mod tests {
              seeding-boundary check can tell it apart from consumer's own package"
         );
 
+        // Directly exercise the seeding step `collect_diagnostics` performs
+        // internally (`AliasRegistry::add_pre_loaded`, via
+        // `analyse_with_natives_and_protocols_and_aliases`), rather than
+        // trying to observe the exclusion through a lint diagnostic: a `::
+        // Secret` annotation on its own produces no diagnostic either way —
+        // `check_unresolved_type_aliases` (structural_validators.rs) is
+        // deliberately scoped to near-miss *typos* of already-registered
+        // alias names, not general annotation-existence checking (per its
+        // own doc comment, "no general annotation-existence checker exists
+        // yet"), so an unregistered `Secret` is silently accepted in
+        // annotation position regardless of whether the wiring below is
+        // correct. This directly proves what actually matters: the
+        // `is_internal`/`package` data this test's earlier assertions
+        // confirmed reaches `all_alias_infos` correctly is exactly what lets
+        // `add_pre_loaded`'s own seeding-boundary filter (already unit-tested
+        // in `alias_registry.rs`'s
+        // `add_pre_loaded_never_seeds_internal_alias_from_different_package`)
+        // actually exclude `Secret` while still seeding `Status`.
+        let hierarchy =
+            beamtalk_core::semantic_analysis::class_hierarchy::ClassHierarchy::with_builtins();
+        let protocol_registry =
+            beamtalk_core::semantic_analysis::protocol_registry::ProtocolRegistry::new();
+        let mut alias_registry =
+            beamtalk_core::semantic_analysis::alias_registry::AliasRegistry::new();
+        let seeding_diags = alias_registry.add_pre_loaded(
+            all_alias_infos.clone(),
+            &hierarchy,
+            &protocol_registry,
+            Some("consumer"),
+        );
+        assert!(
+            seeding_diags.is_empty(),
+            "seeding should not produce collision diagnostics: {seeding_diags:?}"
+        );
+        assert!(
+            alias_registry.has_alias("Status"),
+            "producer's public Status alias must be seeded into consumer's alias table"
+        );
+        assert!(
+            !alias_registry.has_alias("Secret"),
+            "producer's internal Secret alias must NOT be seeded into consumer's alias table"
+        );
+
         let (file, _source, module, parse_diags) = parsed_files
             .into_iter()
             .find(|(f, ..)| *f == consumer_file)


### PR DESCRIPTION
## Summary

Closes the gap where `ProtocolRegistry::add_pre_loaded`/`extract_protocol_infos` (BT-2006) and `AliasRegistry::add_pre_loaded`/`extract_alias_infos` (BT-2898) were real, unit-tested semantic-analysis machinery but never wired into the *real* `beamtalk build`/`beamtalk lint` cross-package dependency-resolution pipeline.

Linear issue: https://linear.app/beamtalk/issue/BT-2910

Scoped to the design spec's steps 1-3 (the `ResolvedDependency` seam plus `build.rs`/`lint.rs` wiring), as recommended in the issue. LSP protocol wiring and the LSP alias-leak gap are tracked separately as explicit follow-ups (see below).

## Key changes

- **`ResolvedDependency`** (`crates/beamtalk-cli/src/commands/deps/path.rs`) gains `protocol_infos`/`alias_infos` fields, populated by `build_dep_class_index` from the dependency's already-parsed ASTs (reuses `build_class_module_index`'s cached `Module`s — no extra lex/parse pass). Each `AliasInfo` is stamped with `.package = Some(dep_name)` so `AliasRegistry::add_pre_loaded`'s existing seeding-boundary filter (ADR 0108 Phase 5) can correctly exclude a dependency's `internal type` while still seeding its public aliases.
- **`beamtalk build`**: `build_class_index` now merges same-package cross-file protocol infos (new `collect_project_protocol_infos`, didn't exist before) and dependency-exported protocol/alias infos (new `collect_all_alias_infos`/`collect_all_protocol_infos` merge helpers) into `ClassIndexResult`. `execute_build_passes` no longer passes `pre_loaded_protocols: Vec::new()` unconditionally.
- **`beamtalk lint`**: previously had *zero* alias wiring and *zero* protocol wiring, even same-package. `parse_and_extract_class_infos` now also extracts protocol/alias infos; `merge_dependency_class_infos` (renamed `merge_dependency_infos`) now merges dependency protocol/alias data too; `collect_diagnostics` switches from `analyse_with_natives_and_extensions` to the already-existing `analyse_with_natives_and_protocols_and_aliases`.

## Tests added

- `commands::deps::path::tests::build_dep_class_index_extracts_protocols_and_aliases` — extraction-level: a dependency's public alias, `internal` alias, and protocol are all extracted, with aliases correctly package-stamped.
- `commands::build::tests::dependency_protocol_and_alias_infos_merge_and_resolve` — merge-level: the new `collect_all_*` helpers correctly combine same-package + dependency-sourced protocol/alias infos, and the merged set resolves via `compile_file`.
- `commands::lint::tests::lint_resolves_dependency_protocol_and_public_alias_but_not_internal_alias` — end-to-end: a two-package path-dependency fixture proves `beamtalk lint` resolves a producer's public alias and protocol for a consumer package, while the producer's `internal` alias is correctly excluded from what gets seeded. Runs via the same "fresh ebin" fast path `ensure_deps_resolved` already uses, so it's fast and doesn't require `erlc`.

## Follow-ups filed (out of scope for this PR, per the design spec)

- BT-2950 — LSP protocol wiring (`pre_loaded_protocols` never populated on the LSP surface at all)
- BT-2951 — LSP alias `cross_file_alias_infos_for` has no package-boundary filtering (pre-existing gap, not a regression from this PR)

## Test plan

- [x] `cargo test -p beamtalk-cli --bin beamtalk` — 855 passed, 1 pre-existing unrelated failure (`epmd` public-interface test, confirmed failing on `main` too — environment-specific, not caused by this change)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `just build && just lint && just test && just check-corpus && just check-surface-drift` — all green (stdlib: 223/223, BUnit: 2774/2776 passing/0 failed, runtime: 5382+1588 tests/0 failures)
- [x] Pre-push hook (full lint suite) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)