### PR TITLE
Thread AliasRegistry through resolve_type_name_string's remaining call sites (BT-2936)

### DIFF
--- a/crates/beamtalk-core/src/queries/hover_provider.rs
+++ b/crates/beamtalk-core/src/queries/hover_provider.rs
@@ -124,6 +124,7 @@ pub fn compute_hover(
             hierarchy,
             &type_map,
             native_types,
+            alias_registry,
         ) {
             return Some(hover);
         }
@@ -143,6 +144,7 @@ pub fn compute_hover(
                     hierarchy,
                     &type_map,
                     native_types,
+                    alias_registry,
                 ) {
                     return Some(hover);
                 }
@@ -160,6 +162,7 @@ pub fn compute_hover(
                     hierarchy,
                     &type_map,
                     native_types,
+                    alias_registry,
                 ) {
                     return Some(hover);
                 }
@@ -182,6 +185,7 @@ pub fn compute_hover(
                 hierarchy,
                 &type_map,
                 native_types,
+                alias_registry,
             ) {
                 return Some(hover);
             }
@@ -714,6 +718,7 @@ fn find_hover_in_expr(
     hierarchy: &ClassHierarchy,
     type_map: &TypeMap,
     native_types: Option<&NativeTypeRegistry>,
+    alias_registry: Option<&AliasRegistry>,
 ) -> Option<HoverInfo> {
     let span = expr.span();
     if offset < span.start() || offset >= span.end() {
@@ -737,9 +742,17 @@ fn find_hover_in_expr(
                 };
                 // ADR 0103: annotate reference/handle-typed values with their
                 // sendability tier (the tier's sole v1 consumer).
+                //
+                // `alias_registry` (BT-2936, ADR 0108 follow-up to BT-2928)
+                // is threaded through from `compute_hover` so an alias-typed
+                // `Value` field's hover tier composes through the alias's
+                // expansion instead of falling back to `Tier::Unknown` for
+                // the opaque alias name.
                 if let Some(tier) = inferred.and_then(|ty| {
                     crate::semantic_analysis::type_checker::sendability::hover_tier_label(
-                        ty, hierarchy,
+                        ty,
+                        hierarchy,
+                        alias_registry,
                     )
                 }) {
                     contents.push_str(" — Sendability: ");
@@ -791,11 +804,26 @@ fn find_hover_in_expr(
                 None
             }
         }
-        Expression::Assignment { target, value, .. } => {
-            find_hover_in_expr(target, offset, context, hierarchy, type_map, native_types).or_else(
-                || find_hover_in_expr(value, offset, context, hierarchy, type_map, native_types),
+        Expression::Assignment { target, value, .. } => find_hover_in_expr(
+            target,
+            offset,
+            context,
+            hierarchy,
+            type_map,
+            native_types,
+            alias_registry,
+        )
+        .or_else(|| {
+            find_hover_in_expr(
+                value,
+                offset,
+                context,
+                hierarchy,
+                type_map,
+                native_types,
+                alias_registry,
             )
-        }
+        }),
         Expression::MessageSend {
             receiver,
             selector,
@@ -804,13 +832,27 @@ fn find_hover_in_expr(
             ..
         } => {
             // First check receiver and arguments
-            if let Some(hover) =
-                find_hover_in_expr(receiver, offset, context, hierarchy, type_map, native_types)
-            {
+            if let Some(hover) = find_hover_in_expr(
+                receiver,
+                offset,
+                context,
+                hierarchy,
+                type_map,
+                native_types,
+                alias_registry,
+            ) {
                 return Some(hover);
             }
             if let Some(hover) = arguments.iter().find_map(|arg| {
-                find_hover_in_expr(arg, offset, context, hierarchy, type_map, native_types)
+                find_hover_in_expr(
+                    arg,
+                    offset,
+                    context,
+                    hierarchy,
+                    type_map,
+                    native_types,
+                    alias_registry,
+                )
             }) {
                 return Some(hover);
             }
@@ -871,14 +913,29 @@ fn find_hover_in_expr(
                 hierarchy,
                 type_map,
                 native_types,
+                alias_registry,
             )
         }),
-        Expression::Return { value, .. } => {
-            find_hover_in_expr(value, offset, context, hierarchy, type_map, native_types)
-        }
+        Expression::Return { value, .. } => find_hover_in_expr(
+            value,
+            offset,
+            context,
+            hierarchy,
+            type_map,
+            native_types,
+            alias_registry,
+        ),
         Expression::DestructureAssignment { pattern, value, .. } => {
             find_hover_in_pattern(pattern, offset, type_map).or_else(|| {
-                find_hover_in_expr(value, offset, context, hierarchy, type_map, native_types)
+                find_hover_in_expr(
+                    value,
+                    offset,
+                    context,
+                    hierarchy,
+                    type_map,
+                    native_types,
+                    alias_registry,
+                )
             })
         }
         Expression::Parenthesized { expression, .. } => find_hover_in_expr(
@@ -888,6 +945,7 @@ fn find_hover_in_expr(
             hierarchy,
             type_map,
             native_types,
+            alias_registry,
         ),
         Expression::FieldAccess {
             receiver, field, ..
@@ -927,22 +985,44 @@ fn find_hover_in_expr(
                         .with_documentation("_state variable_".to_string()),
                 )
             } else {
-                find_hover_in_expr(receiver, offset, context, hierarchy, type_map, native_types)
+                find_hover_in_expr(
+                    receiver,
+                    offset,
+                    context,
+                    hierarchy,
+                    type_map,
+                    native_types,
+                    alias_registry,
+                )
             }
         }
         Expression::Cascade {
             receiver, messages, ..
         } => {
-            if let Some(hover) =
-                find_hover_in_expr(receiver, offset, context, hierarchy, type_map, native_types)
-            {
+            if let Some(hover) = find_hover_in_expr(
+                receiver,
+                offset,
+                context,
+                hierarchy,
+                type_map,
+                native_types,
+                alias_registry,
+            ) {
                 return Some(hover);
             }
             // Check each cascaded message
             for msg in messages {
                 // Check arguments first
                 if let Some(hover) = msg.arguments.iter().find_map(|arg| {
-                    find_hover_in_expr(arg, offset, context, hierarchy, type_map, native_types)
+                    find_hover_in_expr(
+                        arg,
+                        offset,
+                        context,
+                        hierarchy,
+                        type_map,
+                        native_types,
+                        alias_registry,
+                    )
                 }) {
                     return Some(hover);
                 }
@@ -973,37 +1053,44 @@ fn find_hover_in_expr(
             }
             None
         }
-        Expression::Match { value, arms, .. } => {
-            find_hover_in_expr(value, offset, context, hierarchy, type_map, native_types).or_else(
-                || {
-                    arms.iter().find_map(|arm| {
-                        find_hover_in_pattern(&arm.pattern, offset, type_map)
-                            .or_else(|| {
-                                arm.guard.as_ref().and_then(|g| {
-                                    find_hover_in_expr(
-                                        g,
-                                        offset,
-                                        context,
-                                        hierarchy,
-                                        type_map,
-                                        native_types,
-                                    )
-                                })
-                            })
-                            .or_else(|| {
-                                find_hover_in_expr(
-                                    &arm.body,
-                                    offset,
-                                    context,
-                                    hierarchy,
-                                    type_map,
-                                    native_types,
-                                )
-                            })
+        Expression::Match { value, arms, .. } => find_hover_in_expr(
+            value,
+            offset,
+            context,
+            hierarchy,
+            type_map,
+            native_types,
+            alias_registry,
+        )
+        .or_else(|| {
+            arms.iter().find_map(|arm| {
+                find_hover_in_pattern(&arm.pattern, offset, type_map)
+                    .or_else(|| {
+                        arm.guard.as_ref().and_then(|g| {
+                            find_hover_in_expr(
+                                g,
+                                offset,
+                                context,
+                                hierarchy,
+                                type_map,
+                                native_types,
+                                alias_registry,
+                            )
+                        })
                     })
-                },
-            )
-        }
+                    .or_else(|| {
+                        find_hover_in_expr(
+                            &arm.body,
+                            offset,
+                            context,
+                            hierarchy,
+                            type_map,
+                            native_types,
+                            alias_registry,
+                        )
+                    })
+            })
+        }),
         Expression::MapLiteral { pairs, span } => {
             if offset >= span.start() && offset < span.end() {
                 // Check if hovering over a specific key or value
@@ -1015,6 +1102,7 @@ fn find_hover_in_expr(
                         hierarchy,
                         type_map,
                         native_types,
+                        alias_registry,
                     ) {
                         return Some(hover);
                     }
@@ -1025,6 +1113,7 @@ fn find_hover_in_expr(
                         hierarchy,
                         type_map,
                         native_types,
+                        alias_registry,
                     ) {
                         return Some(hover);
                     }
@@ -1045,16 +1134,28 @@ fn find_hover_in_expr(
         } => {
             if offset >= span.start() && offset < span.end() {
                 for elem in elements {
-                    if let Some(hover) =
-                        find_hover_in_expr(elem, offset, context, hierarchy, type_map, native_types)
-                    {
+                    if let Some(hover) = find_hover_in_expr(
+                        elem,
+                        offset,
+                        context,
+                        hierarchy,
+                        type_map,
+                        native_types,
+                        alias_registry,
+                    ) {
                         return Some(hover);
                     }
                 }
                 if let Some(t) = tail {
-                    if let Some(hover) =
-                        find_hover_in_expr(t, offset, context, hierarchy, type_map, native_types)
-                    {
+                    if let Some(hover) = find_hover_in_expr(
+                        t,
+                        offset,
+                        context,
+                        hierarchy,
+                        type_map,
+                        native_types,
+                        alias_registry,
+                    ) {
                         return Some(hover);
                     }
                 }
@@ -1069,9 +1170,15 @@ fn find_hover_in_expr(
         Expression::ArrayLiteral { elements, span } => {
             if offset >= span.start() && offset < span.end() {
                 for elem in elements {
-                    if let Some(hover) =
-                        find_hover_in_expr(elem, offset, context, hierarchy, type_map, native_types)
-                    {
+                    if let Some(hover) = find_hover_in_expr(
+                        elem,
+                        offset,
+                        context,
+                        hierarchy,
+                        type_map,
+                        native_types,
+                        alias_registry,
+                    ) {
                         return Some(hover);
                     }
                 }
@@ -1119,6 +1226,7 @@ fn find_hover_in_expr(
                             hierarchy,
                             type_map,
                             native_types,
+                            alias_registry,
                         ) {
                             return Some(info);
                         }
@@ -1604,6 +1712,57 @@ mod tests {
         );
     }
 
+    /// BT-2936: an alias-typed field (`type PortAlias = Port`) composes its
+    /// sendability tier through the alias's expansion when `compute_hover`'s
+    /// `alias_registry` is threaded all the way through to `hover_tier_label`,
+    /// instead of silently omitting the tier line for the opaque alias name.
+    #[test]
+    fn hover_shows_composed_handle_scope_for_alias_typed_value_field() {
+        use crate::semantic_analysis::alias_registry::AliasRegistry;
+        use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
+
+        let src = "type PortAlias = Port\ntyped Value subclass: Wrapper\n  field: p :: PortAlias = nil\n\n\
+                   Object subclass: M\n  run: w :: Wrapper =>\n    w printString\n";
+        let tokens = lex_with_eof(src);
+        let (module, parse_diags) = parse(tokens);
+        assert!(parse_diags.is_empty(), "parse failed: {parse_diags:?}");
+        let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
+        assert!(diags.is_empty(), "unexpected alias diagnostics: {diags:?}");
+
+        // Line 6, col 4 is the `w` use in the body.
+        let hover = compute_hover(
+            &module,
+            src,
+            Position::new(6, 4),
+            &hierarchy,
+            None,
+            Some(&registry),
+        )
+        .expect("hover");
+        assert!(
+            hover
+                .contents
+                .contains("Sendability: HandleScoped(#process)"),
+            "expected composed HandleScoped(#process) tier through the alias, got: {}",
+            hover.contents
+        );
+
+        // Without the registry, the alias name stays opaque and the tier
+        // silently falls back to Unknown (no tier line) — the pre-BT-2936
+        // fallback this test guards against regressing back to.
+        let hover_no_registry =
+            compute_hover(&module, src, Position::new(6, 4), &hierarchy, None, None)
+                .expect("hover");
+        assert!(
+            !hover_no_registry.contents.contains("Sendability:"),
+            "without the registry the tier should stay silent (Unknown), got: {}",
+            hover_no_registry.contents
+        );
+    }
+
     #[test]
     fn hover_omits_tier_for_sendable() {
         let src = "Object subclass: M\n  run: n :: Integer =>\n    n printString\n";
@@ -1742,7 +1901,7 @@ mod tests {
             is_inferred: false,
             span: Span::new(0, 22),
         };
-        let hover = find_hover_in_expr(&expr, 5, &ctx, &hierarchy, &TypeMap::new(), None);
+        let hover = find_hover_in_expr(&expr, 5, &ctx, &hierarchy, &TypeMap::new(), None, None);
         assert!(hover.is_some());
         let hover = hover.unwrap();
         assert!(hover.contents.contains("`@primitive \"erlang_add\"`"));
@@ -1763,7 +1922,7 @@ mod tests {
             is_inferred: false,
             span: Span::new(0, 15),
         };
-        let hover = find_hover_in_expr(&expr, 5, &ctx, &hierarchy, &TypeMap::new(), None);
+        let hover = find_hover_in_expr(&expr, 5, &ctx, &hierarchy, &TypeMap::new(), None, None);
         assert!(hover.is_some());
         let hover = hover.unwrap();
         assert!(hover.contents.contains("`@primitive size`"));

--- a/crates/beamtalk-core/src/semantic_analysis/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/mod.rs
@@ -813,6 +813,7 @@ fn analyse_full(module: &Module, ctx: AnalysisContext<'_>) -> AnalysisResult {
         &result.class_hierarchy,
         analyser.type_map(),
         &analyser.result.block_info,
+        Some(&result.alias_registry),
         &mut result.diagnostics,
     );
     result.diagnostics.extend(analyser.result.diagnostics);

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -17,6 +17,7 @@ use crate::ast::{
     Expression, ExpressionStatement, Literal, MatchArm, MessageSelector, Module, Pattern,
     TypeAnnotation,
 };
+use crate::semantic_analysis::alias_registry::AliasRegistry;
 use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
 use crate::semantic_analysis::string_utils::edit_distance;
 use crate::semantic_analysis::validators::is_concrete_leaf_class;
@@ -1361,6 +1362,7 @@ impl TypeChecker {
                                 &type_args,
                                 parent,
                                 hierarchy,
+                                self.alias_registry.as_ref(),
                             )
                         } else {
                             InferredType::Dynamic(DynamicReason::Unknown)
@@ -1568,8 +1570,22 @@ impl TypeChecker {
         ) {
             Self::detect_narrowing(receiver)
                 .map(|info| self.refine_responds_to_narrowing(info))
-                .map(|info| Self::refine_result_narrowing(info, env, hierarchy))
-                .map(|info| Self::refine_singleton_narrowing(info, env, hierarchy))
+                .map(|info| {
+                    Self::refine_result_narrowing(
+                        info,
+                        env,
+                        hierarchy,
+                        self.alias_registry.as_ref(),
+                    )
+                })
+                .map(|info| {
+                    Self::refine_singleton_narrowing(
+                        info,
+                        env,
+                        hierarchy,
+                        self.alias_registry.as_ref(),
+                    )
+                })
                 .map(|info| self.refine_class_narrowing(info, env, hierarchy, span))
         } else {
             None
@@ -1626,7 +1642,12 @@ impl TypeChecker {
             // like `5 >= local` in `local > 0 and: [5 >= local]` — see the
             // narrowed type too, closing the gap where only receiver
             // positions were narrowed.
-            let current_ty = Self::resolve_narrowing_variable_type(&var_key, env, hierarchy);
+            let current_ty = Self::resolve_narrowing_variable_type(
+                &var_key,
+                env,
+                hierarchy,
+                self.alias_registry.as_ref(),
+            );
             let non_nil_ty = Self::non_nil_type(&current_ty);
             vec![self.infer_block_with_narrowing(
                 arg,
@@ -2648,8 +2669,12 @@ impl TypeChecker {
         }
         // No alias registry threaded here: `ret_ty` comes from the built-in
         // Metaclass/Class/Behaviour/Object/ProtoObject tower, which never
-        // declares an alias-typed return (BT-2928 follow-up covers the
-        // general case; this call site is out of scope for it).
+        // declares an alias-typed return. BT-2936 (the general follow-up
+        // that threaded `alias_registry` through the other deferred call
+        // sites) revisited this one specifically and confirmed it stays
+        // out of scope: the tower's method table is fixed, built-in, and
+        // has no alias-typed entries to expand, so there is nothing for a
+        // registry to do here.
         Some(Self::resolve_type_name_string(ret_ty, None))
     }
 
@@ -3078,11 +3103,13 @@ impl TypeChecker {
         mut info: NarrowingInfo,
         env: &TypeEnv,
         hierarchy: &ClassHierarchy,
+        alias_registry: Option<&AliasRegistry>,
     ) -> NarrowingInfo {
         if !info.is_result_ok_check && !info.is_result_error_check {
             return info;
         }
-        let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
+        let current_ty =
+            Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy, alias_registry);
         let is_result = matches!(
             &current_ty,
             InferredType::Known { class_name, .. }
@@ -3127,11 +3154,13 @@ impl TypeChecker {
         mut info: NarrowingInfo,
         env: &TypeEnv,
         hierarchy: &ClassHierarchy,
+        alias_registry: Option<&AliasRegistry>,
     ) -> NarrowingInfo {
         let Some(eq) = info.singleton_eq.clone() else {
             return info;
         };
-        let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
+        let current_ty =
+            Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy, alias_registry);
 
         let matched = InferredType::known(eq.singleton.as_type_name().clone());
         let provenance = super::TypeProvenance::Inferred(Span::default());
@@ -3188,7 +3217,12 @@ impl TypeChecker {
         let Some(ClassTestInfo { class_name, .. }) = info.class_test.clone() else {
             return info;
         };
-        let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
+        let current_ty = Self::resolve_narrowing_variable_type(
+            &info.variable,
+            env,
+            hierarchy,
+            self.alias_registry.as_ref(),
+        );
         let refined_info = Self::compute_class_narrowing(
             info,
             &current_ty,
@@ -4369,8 +4403,12 @@ impl TypeChecker {
                         arg_types.push(ty);
                     } else if info.is_nil_check {
                         // isNil ifFalse: → variable is non-nil
-                        let current_ty =
-                            Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
+                        let current_ty = Self::resolve_narrowing_variable_type(
+                            &info.variable,
+                            env,
+                            hierarchy,
+                            self.alias_registry.as_ref(),
+                        );
                         let non_nil = Self::non_nil_type(&current_ty);
                         let ty = self.infer_block_with_narrowing(
                             arg,
@@ -4438,8 +4476,12 @@ impl TypeChecker {
                         arg_types.push(ty);
                     } else if info.is_nil_check {
                         // isNil ifTrue: [...] ifFalse: [block] → non-nil in false block
-                        let current_ty =
-                            Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
+                        let current_ty = Self::resolve_narrowing_variable_type(
+                            &info.variable,
+                            env,
+                            hierarchy,
+                            self.alias_registry.as_ref(),
+                        );
                         let non_nil = Self::non_nil_type(&current_ty);
                         let ty = self.infer_block_with_narrowing(
                             false_arg,
@@ -5090,10 +5132,16 @@ impl TypeChecker {
     /// [`EnvKey::SelfField`] (BT-2048 / BT-2062) we prefer a previously
     /// pushed narrowing, falling back to the declared state type resolved
     /// through the class hierarchy when none is present.
+    ///
+    /// `alias_registry` (BT-2936, ADR 0108 follow-up to BT-2928) is threaded
+    /// through so a `self.field isNil ifFalse: [...]` narrowing check on a
+    /// cross-file alias-typed field expands the alias instead of falling
+    /// back to an opaque nominal class.
     fn resolve_narrowing_variable_type(
         var_key: &EnvKey,
         env: &TypeEnv,
         hierarchy: &ClassHierarchy,
+        alias_registry: Option<&AliasRegistry>,
     ) -> InferredType {
         // Regular env lookup first (handles locals and previously-narrowed fields).
         if let Some(ty) = env.get(var_key) {
@@ -5104,14 +5152,7 @@ impl TypeChecker {
         if let EnvKey::SelfField(field_name) = var_key {
             if let Some(InferredType::Known { class_name, .. }) = env.get_local("self") {
                 if let Some(field_type) = hierarchy.state_field_type(&class_name, field_name) {
-                    // No alias registry threaded here — this free function's
-                    // several callers don't have one in scope. A narrowing
-                    // check (e.g. `self.field isNil ifFalse: [...]`) on a
-                    // cross-file alias-typed field falls back to the
-                    // opaque-name behaviour this fixes elsewhere (BT-2928
-                    // follow-up: thread `alias_registry` through the
-                    // narrowing call chain too).
-                    return Self::resolve_type_name_string(&field_type, None);
+                    return Self::resolve_type_name_string(&field_type, alias_registry);
                 }
             }
         }
@@ -5211,7 +5252,12 @@ impl TypeChecker {
             // `compute_class_narrowing` — `expr` (this exact guard) was
             // already fully type-checked by `infer_stmts` above, so the
             // "comparison can never be true" hint already fired once.
-            let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
+            let current_ty = Self::resolve_narrowing_variable_type(
+                &info.variable,
+                env,
+                hierarchy,
+                self.alias_registry.as_ref(),
+            );
             info = Self::compute_class_narrowing(
                 info,
                 &current_ty,
@@ -5240,7 +5286,12 @@ impl TypeChecker {
                     }
                 }
             }
-            let Some(narrowed) = Self::early_return_false_branch_type(&info, env, hierarchy) else {
+            let Some(narrowed) = Self::early_return_false_branch_type(
+                &info,
+                env,
+                hierarchy,
+                self.alias_registry.as_ref(),
+            ) else {
                 return;
             };
             // BT-2050: after this statement, the variable is narrowed.
@@ -5287,11 +5338,17 @@ impl TypeChecker {
         info: &NarrowingInfo,
         env: &TypeEnv,
         hierarchy: &ClassHierarchy,
+        alias_registry: Option<&AliasRegistry>,
     ) -> Option<InferredType> {
         if let Some(ref false_ty) = info.false_type {
             Some(false_ty.clone())
         } else if info.is_nil_check {
-            let current_ty = Self::resolve_narrowing_variable_type(&info.variable, env, hierarchy);
+            let current_ty = Self::resolve_narrowing_variable_type(
+                &info.variable,
+                env,
+                hierarchy,
+                alias_registry,
+            );
             Some(Self::non_nil_type(&current_ty))
         } else {
             None
@@ -6243,6 +6300,55 @@ mod tests {
         assert_eq!(unresolved, InferredType::known("RestartStrategy"));
     }
 
+    /// BT-2936: a `self.field` narrowing lookup (e.g. the `self.field isNil
+    /// ifFalse: [...]` shape [`Self::resolve_narrowing_variable_type`]
+    /// serves) on an alias-typed field expands the alias through the
+    /// threaded `alias_registry`, instead of leaving it an opaque nominal
+    /// class — the deferred half of BT-2928's `resolve_type_name_string`
+    /// fix for the narrowing call chain specifically.
+    #[test]
+    fn resolve_narrowing_variable_type_expands_alias_for_self_field() {
+        use crate::semantic_analysis::alias_registry::AliasRegistry;
+        use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
+
+        let tokens = crate::source_analysis::lex_with_eof(
+            "type RestartStrategy = #permanent | #temporary\n\
+             Object subclass: Supervisor\n  state: strategy :: RestartStrategy = nil\n",
+        );
+        let (module, parse_diags) = crate::source_analysis::parse(tokens);
+        assert!(parse_diags.is_empty(), "parse failed: {parse_diags:?}");
+        let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
+        assert!(diags.is_empty(), "unexpected alias diagnostics: {diags:?}");
+
+        let mut env = TypeEnv::new();
+        env.set_local("self", InferredType::known("Supervisor"));
+        let var_key = EnvKey::self_field("strategy");
+
+        let result = TypeChecker::resolve_narrowing_variable_type(
+            &var_key,
+            &env,
+            &hierarchy,
+            Some(&registry),
+        );
+        match result {
+            InferredType::Union { members, .. } => {
+                assert_eq!(members.len(), 2);
+                assert!(members.contains(&InferredType::known("#permanent")));
+                assert!(members.contains(&InferredType::known("#temporary")));
+            }
+            other => panic!("Expected Union (alias expansion), got {other:?}"),
+        }
+
+        // Without the registry, the field's raw type name stays opaque — the
+        // pre-BT-2936 fallback this test guards against regressing back to.
+        let unresolved =
+            TypeChecker::resolve_narrowing_variable_type(&var_key, &env, &hierarchy, None);
+        assert_eq!(unresolved, InferredType::known("RestartStrategy"));
+    }
+
     // ---- detect_narrowing ----
 
     #[test]
@@ -6481,7 +6587,7 @@ mod tests {
             class_test: None,
         };
         let hierarchy = ClassHierarchy::with_builtins();
-        let refined = TypeChecker::refine_result_narrowing(info, &env, &hierarchy);
+        let refined = TypeChecker::refine_result_narrowing(info, &env, &hierarchy, None);
         assert_eq!(refined.true_type, result_ty);
         assert_eq!(refined.false_type, Some(result_ty));
         assert!(refined.is_result_ok_check);
@@ -6505,7 +6611,7 @@ mod tests {
             class_test: None,
         };
         let hierarchy = ClassHierarchy::with_builtins();
-        let refined = TypeChecker::refine_result_narrowing(info, &env, &hierarchy);
+        let refined = TypeChecker::refine_result_narrowing(info, &env, &hierarchy, None);
         assert!(!refined.is_result_ok_check);
         assert!(!refined.is_result_error_check);
         assert!(refined.false_type.is_none());

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/sendability.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/sendability.rs
@@ -33,6 +33,7 @@ use ecow::EcoString;
 
 use crate::ast::ClassKind;
 use crate::semantic_analysis::ClassHierarchy;
+use crate::semantic_analysis::alias_registry::AliasRegistry;
 
 use super::InferredType;
 
@@ -196,14 +197,29 @@ const MAX_COMPOSE_DEPTH: u8 = 12;
 
 /// Derive the sendability tier of an inferred type. **The single source of
 /// truth** — every boundary check calls this.
+///
+/// `alias_registry` (BT-2936, ADR 0108 follow-up to BT-2928) is threaded
+/// through to the `Value` structural composition below so an alias-typed
+/// field expands to its declared type's tier instead of falling back to
+/// `Tier::Unknown` for the opaque alias name. Pass `None` when no registry
+/// is available, matching this function's pre-BT-2936 behaviour.
 #[must_use]
-pub(crate) fn tier_of(ty: &InferredType, hierarchy: &ClassHierarchy) -> Tier {
-    tier_of_depth(ty, hierarchy, 0)
+pub(crate) fn tier_of(
+    ty: &InferredType,
+    hierarchy: &ClassHierarchy,
+    alias_registry: Option<&AliasRegistry>,
+) -> Tier {
+    tier_of_depth(ty, hierarchy, 0, alias_registry)
 }
 
 // `Never` and `Meta` coincide at `Sendable` but describe distinct cases.
 #[allow(clippy::match_same_arms)]
-fn tier_of_depth(ty: &InferredType, hierarchy: &ClassHierarchy, depth: u8) -> Tier {
+fn tier_of_depth(
+    ty: &InferredType,
+    hierarchy: &ClassHierarchy,
+    depth: u8,
+    alias_registry: Option<&AliasRegistry>,
+) -> Tier {
     if depth >= MAX_COMPOSE_DEPTH {
         return Tier::Sendable;
     }
@@ -218,12 +234,12 @@ fn tier_of_depth(ty: &InferredType, hierarchy: &ClassHierarchy, depth: u8) -> Ti
             class_name,
             type_args,
             ..
-        } => tier_of_known(class_name, type_args, hierarchy, depth),
+        } => tier_of_known(class_name, type_args, hierarchy, depth, alias_registry),
         // A union value may be *any* member — take the weakest so a hazardous
         // member is not masked by a sendable one.
         InferredType::Union { members, .. } => members
             .iter()
-            .map(|m| tier_of_depth(m, hierarchy, depth + 1))
+            .map(|m| tier_of_depth(m, hierarchy, depth + 1, alias_registry))
             .reduce(Tier::join)
             .unwrap_or(Tier::Unknown),
         // An intersection value satisfies *every* member at once, so its
@@ -232,11 +248,13 @@ fn tier_of_depth(ty: &InferredType, hierarchy: &ClassHierarchy, depth: u8) -> Ti
         // safer co-member. Same weakest-wins rule as a union.
         InferredType::Intersection { members, .. } => members
             .iter()
-            .map(|m| tier_of_depth(m, hierarchy, depth + 1))
+            .map(|m| tier_of_depth(m, hierarchy, depth + 1, alias_registry))
             .reduce(Tier::join)
             .unwrap_or(Tier::Unknown),
         // `A \ B` is still an `A`.
-        InferredType::Negation { base, .. } => tier_of_depth(base, hierarchy, depth),
+        InferredType::Negation { base, .. } => {
+            tier_of_depth(base, hierarchy, depth, alias_registry)
+        }
     }
 }
 
@@ -245,6 +263,7 @@ fn tier_of_known(
     type_args: &[InferredType],
     hierarchy: &ClassHierarchy,
     depth: u8,
+    alias_registry: Option<&AliasRegistry>,
 ) -> Tier {
     let name = class_name.as_str();
     // Symbol singletons (`#foo`) are plain atoms.
@@ -282,7 +301,7 @@ fn tier_of_known(
     // Generic composition (ADR 0102 `type_args`): a container is as weak as its
     // weakest element — `List(Port)` (a `Collection` → `Value`) → `HandleScoped`.
     for arg in type_args {
-        tier = tier.join(tier_of_depth(arg, hierarchy, depth + 1));
+        tier = tier.join(tier_of_depth(arg, hierarchy, depth + 1, alias_registry));
     }
 
     // `Value` structural composition: a Value inherits the weakest tier of its
@@ -299,14 +318,14 @@ fn tier_of_known(
                 // be treated as the class name, `resolve_class_kind` would find
                 // no such class, and a generic field would silently drop to
                 // `Unknown` instead of composing its element tier (BT-2770).
+                // BT-2936: `alias_registry` (threaded from the top-level
+                // `tier_of` call) additionally expands an alias-typed field
+                // to its declared type before tiering, instead of treating
+                // the alias name as an unresolved nominal class.
                 Some(field_ty) => {
-                    // No alias registry threaded here (BT-2928 follow-up) —
-                    // this free function's callers don't have one in scope.
-                    // An alias-typed field's sendability tier falls back to
-                    // treating the alias name as an unresolved nominal class
-                    // (`Tier::Unknown`), same as before this fix.
-                    let field_type = super::TypeChecker::resolve_type_name_string(&field_ty, None);
-                    tier_of_depth(&field_type, hierarchy, depth + 1)
+                    let field_type =
+                        super::TypeChecker::resolve_type_name_string(&field_ty, alias_registry);
+                    tier_of_depth(&field_type, hierarchy, depth + 1, alias_registry)
                 }
                 // An untyped field carries no static tier — treat as Unknown.
                 None => Tier::Unknown,
@@ -328,8 +347,12 @@ fn tier_of_known(
 /// default (rendering it on every `Integer` would be noise) and `Unknown`
 /// means the checker has nothing to say.
 #[must_use]
-pub(crate) fn hover_tier_label(ty: &InferredType, hierarchy: &ClassHierarchy) -> Option<String> {
-    match tier_of(ty, hierarchy) {
+pub(crate) fn hover_tier_label(
+    ty: &InferredType,
+    hierarchy: &ClassHierarchy,
+    alias_registry: Option<&AliasRegistry>,
+) -> Option<String> {
+    match tier_of(ty, hierarchy, alias_registry) {
         Tier::SendableRef => Some("SendableRef".to_string()),
         Tier::HandleScoped(scope) => Some(format!("HandleScoped(#{})", scope.as_atom())),
         Tier::Sendable | Tier::Unknown => None,
@@ -351,18 +374,18 @@ mod tests {
     #[test]
     fn builtin_table_tiers() {
         let h = hierarchy();
-        assert_eq!(tier_of(&known("Pid"), &h), Tier::SendableRef);
+        assert_eq!(tier_of(&known("Pid"), &h, None), Tier::SendableRef);
         assert_eq!(
-            tier_of(&known("Port"), &h),
+            tier_of(&known("Port"), &h, None),
             Tier::HandleScoped(HandleScope::Process)
         );
-        assert_eq!(tier_of(&known("Reference"), &h), Tier::Sendable);
+        assert_eq!(tier_of(&known("Reference"), &h, None), Tier::Sendable);
         assert_eq!(
-            tier_of(&known("Subscription"), &h),
+            tier_of(&known("Subscription"), &h, None),
             Tier::HandleScoped(HandleScope::Node)
         );
         assert_eq!(
-            tier_of(&known("FileHandle"), &h),
+            tier_of(&known("FileHandle"), &h, None),
             Tier::HandleScoped(HandleScope::Process)
         );
     }
@@ -371,14 +394,14 @@ mod tests {
     fn primitives_are_sendable() {
         let h = hierarchy();
         for p in ["Integer", "String", "Symbol", "Boolean", "Float"] {
-            assert_eq!(tier_of(&known(p), &h), Tier::Sendable, "{p}");
+            assert_eq!(tier_of(&known(p), &h, None), Tier::Sendable, "{p}");
         }
     }
 
     #[test]
     fn symbol_singleton_is_sendable() {
         let h = hierarchy();
-        assert_eq!(tier_of(&known("#west"), &h), Tier::Sendable);
+        assert_eq!(tier_of(&known("#west"), &h, None), Tier::Sendable);
     }
 
     #[test]
@@ -387,7 +410,8 @@ mod tests {
         assert_eq!(
             tier_of(
                 &InferredType::Dynamic(super::super::DynamicReason::UntypedFfi),
-                &h
+                &h,
+                None
             ),
             Tier::Unknown
         );
@@ -397,27 +421,27 @@ mod tests {
     fn unclassified_object_is_unknown() {
         let h = hierarchy();
         // A bare user Object subclass with no classification is silent.
-        assert_eq!(tier_of(&known("SomeRandomClass"), &h), Tier::Unknown);
+        assert_eq!(tier_of(&known("SomeRandomClass"), &h, None), Tier::Unknown);
     }
 
     #[test]
     fn hover_renders_meaningful_tiers() {
         let h = hierarchy();
         assert_eq!(
-            hover_tier_label(&known("Pid"), &h).as_deref(),
+            hover_tier_label(&known("Pid"), &h, None).as_deref(),
             Some("SendableRef")
         );
         assert_eq!(
-            hover_tier_label(&known("Port"), &h).as_deref(),
+            hover_tier_label(&known("Port"), &h, None).as_deref(),
             Some("HandleScoped(#process)")
         );
         assert_eq!(
-            hover_tier_label(&known("Subscription"), &h).as_deref(),
+            hover_tier_label(&known("Subscription"), &h, None).as_deref(),
             Some("HandleScoped(#node)")
         );
         // Sendable and Unknown are the silent tiers — no hover label.
-        assert_eq!(hover_tier_label(&known("Integer"), &h), None);
-        assert_eq!(hover_tier_label(&known("SomeRandomClass"), &h), None);
+        assert_eq!(hover_tier_label(&known("Integer"), &h, None), None);
+        assert_eq!(hover_tier_label(&known("SomeRandomClass"), &h, None), None);
     }
 
     #[test]
@@ -427,12 +451,12 @@ mod tests {
         // Port makes the whole collection HandleScoped(#process).
         let list_of_port = InferredType::known_with_args("List", vec![known("Port")]);
         assert_eq!(
-            tier_of(&list_of_port, &h),
+            tier_of(&list_of_port, &h, None),
             Tier::HandleScoped(HandleScope::Process)
         );
         // List(Integer) stays Sendable.
         let list_of_int = InferredType::known_with_args("List", vec![known("Integer")]);
-        assert_eq!(tier_of(&list_of_int, &h), Tier::Sendable);
+        assert_eq!(tier_of(&list_of_int, &h, None), Tier::Sendable);
     }
 
     #[test]
@@ -441,7 +465,10 @@ mod tests {
         // Dictionary(String, Port) → HandleScoped via its value type arg.
         let dict =
             InferredType::known_with_args("Dictionary", vec![known("String"), known("Port")]);
-        assert_eq!(tier_of(&dict, &h), Tier::HandleScoped(HandleScope::Process));
+        assert_eq!(
+            tier_of(&dict, &h, None),
+            Tier::HandleScoped(HandleScope::Process)
+        );
     }
 
     #[test]
@@ -453,7 +480,7 @@ mod tests {
         let (module, _) = crate::source_analysis::parse(tokens);
         let h = ClassHierarchy::build(&module).0.unwrap();
         assert_eq!(
-            tier_of(&known("PortBox"), &h),
+            tier_of(&known("PortBox"), &h, None),
             Tier::HandleScoped(HandleScope::Process)
         );
     }
@@ -467,7 +494,7 @@ mod tests {
         );
         let (module, _) = crate::source_analysis::parse(tokens);
         let h = ClassHierarchy::build(&module).0.unwrap();
-        assert_eq!(tier_of(&known("MyActor"), &h), Tier::SendableRef);
+        assert_eq!(tier_of(&known("MyActor"), &h, None), Tier::SendableRef);
     }
 
     #[test]
@@ -480,7 +507,7 @@ mod tests {
             provenance: super::super::TypeProvenance::Extracted,
         };
         assert_eq!(
-            tier_of(&intersection, &h),
+            tier_of(&intersection, &h, None),
             Tier::HandleScoped(HandleScope::Process)
         );
     }
@@ -494,7 +521,7 @@ mod tests {
         let (module, _) = crate::source_analysis::parse(tokens);
         let h = ClassHierarchy::build(&module).0.unwrap();
         assert_eq!(
-            tier_of(&known("Wrapper"), &h),
+            tier_of(&known("Wrapper"), &h, None),
             Tier::HandleScoped(HandleScope::Process)
         );
     }
@@ -511,7 +538,7 @@ mod tests {
         let (module, _) = crate::source_analysis::parse(tokens);
         let h = ClassHierarchy::build(&module).0.unwrap();
         assert_eq!(
-            tier_of(&known("Wrapper"), &h),
+            tier_of(&known("Wrapper"), &h, None),
             Tier::HandleScoped(HandleScope::Process)
         );
     }
@@ -525,7 +552,7 @@ mod tests {
         );
         let (module, _) = crate::source_analysis::parse(tokens);
         let h = ClassHierarchy::build(&module).0.unwrap();
-        assert_eq!(tier_of(&known("IntBox"), &h), Tier::Sendable);
+        assert_eq!(tier_of(&known("IntBox"), &h, None), Tier::Sendable);
     }
 
     #[test]
@@ -538,9 +565,39 @@ mod tests {
         let (module, _) = crate::source_analysis::parse(tokens);
         let h = ClassHierarchy::build(&module).0.unwrap();
         assert_eq!(
-            tier_of(&known("PortMap"), &h),
+            tier_of(&known("PortMap"), &h, None),
             Tier::HandleScoped(HandleScope::Process)
         );
+    }
+
+    /// BT-2936: a `Value`'s alias-typed field composes the tier of the
+    /// alias's *expansion* (here, `Port` → `HandleScoped(#process)`) when a
+    /// registry is threaded through, instead of falling back to
+    /// `Tier::Unknown` for the opaque alias name — the deferred half of
+    /// BT-2928's `resolve_type_name_string` fix for sendability tiering.
+    #[test]
+    fn value_composition_inherits_alias_typed_field_tier() {
+        use crate::semantic_analysis::alias_registry::AliasRegistry;
+        use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
+
+        let tokens = crate::source_analysis::lex_with_eof(
+            "type PortAlias = Port\ntyped Value subclass: Wrapper\n  field: p :: PortAlias = nil",
+        );
+        let (module, parse_diags) = crate::source_analysis::parse(tokens);
+        assert!(parse_diags.is_empty(), "parse failed: {parse_diags:?}");
+        let h = ClassHierarchy::build(&module).0.unwrap();
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+        let diags = registry.register_module(&module, &h, &protocol_registry);
+        assert!(diags.is_empty(), "unexpected alias diagnostics: {diags:?}");
+
+        assert_eq!(
+            tier_of(&known("Wrapper"), &h, Some(&registry)),
+            Tier::HandleScoped(HandleScope::Process)
+        );
+        // Without the registry, the alias name stays opaque — the
+        // pre-BT-2936 fallback this test guards against regressing back to.
+        assert_eq!(tier_of(&known("Wrapper"), &h, None), Tier::Unknown);
     }
 
     #[test]

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_control_flow_legacy.rs
@@ -1020,7 +1020,7 @@ fn test_refine_singleton_eq_splits_union() {
         vec![symbol_lit("infinity")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy, None);
     assert_eq!(refined.true_type, InferredType::known("#infinity"));
     assert_eq!(refined.false_type, Some(InferredType::known("Integer")));
 }
@@ -1037,7 +1037,7 @@ fn test_refine_singleton_inequality_swaps_branches() {
         vec![symbol_lit("infinity")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy, None);
     assert_eq!(refined.true_type, InferredType::known("Integer"));
     assert_eq!(refined.false_type, Some(InferredType::known("#infinity")));
 }
@@ -1058,7 +1058,7 @@ fn test_refine_singleton_eq_multi_member_union_keeps_rest() {
         vec![symbol_lit("north")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy, None);
     assert_eq!(refined.true_type, InferredType::known("#north"));
     assert_eq!(
         refined.false_type,
@@ -1079,7 +1079,7 @@ fn test_refine_singleton_eq_all_removed_is_never() {
         vec![symbol_lit("north")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy, None);
     assert_eq!(refined.true_type, InferredType::known("#north"));
     assert_eq!(refined.false_type, Some(InferredType::Never));
 }
@@ -1097,7 +1097,7 @@ fn test_refine_singleton_eq_dynamic_variable_keeps_false_dynamic() {
         vec![symbol_lit("foo")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy, None);
     assert_eq!(refined.true_type, InferredType::known("#foo"));
     assert_eq!(
         refined.false_type,
@@ -1119,7 +1119,7 @@ fn test_refine_singleton_symbol_left_inequality_swaps_branches() {
         vec![var("ms")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy, None);
     assert_eq!(refined.true_type, InferredType::known("Integer"));
     assert_eq!(refined.false_type, Some(InferredType::known("#infinity")));
 }
@@ -1141,7 +1141,7 @@ fn test_refine_singleton_eq_impossible_true_branch_is_never() {
         vec![symbol_lit("foo")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy, None);
     // True branch is unreachable — the value can never be `#foo`.
     assert_eq!(refined.true_type, InferredType::Never);
     // False branch keeps the full `Integer` type (nothing removable).
@@ -1162,7 +1162,7 @@ fn test_refine_singleton_eq_symbol_false_branch_is_negation() {
         vec![symbol_lit("foo")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy, None);
     // True branch narrows to the singleton itself.
     assert_eq!(refined.true_type, InferredType::known("#foo"));
     // False branch is the complement `Symbol \ #foo`.
@@ -1473,7 +1473,7 @@ fn bt2764_refine_singleton_eq_symbol_supertype_true_branch_is_singleton() {
         vec![symbol_lit("foo")],
     );
     let info = TypeChecker::detect_narrowing(&expr).unwrap();
-    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy);
+    let refined = TypeChecker::refine_singleton_narrowing(info, &env, &hierarchy, None);
     assert_eq!(refined.true_type, InferredType::known("#foo"));
     assert_eq!(refined.false_type, Some(InferredType::known("ProtoObject")));
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
@@ -513,11 +513,18 @@ pub(in crate::semantic_analysis) fn receiver_type_for_class(
 ///
 /// [`SuperclassTypeArg::ParamRef`]: crate::semantic_analysis::class_hierarchy::SuperclassTypeArg::ParamRef
 /// [`SuperclassTypeArg::Concrete`]: crate::semantic_analysis::class_hierarchy::SuperclassTypeArg::Concrete
+///
+/// `alias_registry` (BT-2936, ADR 0108 follow-up to BT-2928) is threaded
+/// through to the `Concrete` arm below so an alias-typed `extends
+/// Base(SomeAlias)` type argument expands to its declared type instead of
+/// staying an opaque nominal class. Pass `None` when no registry is
+/// available, matching this function's pre-BT-2936 behaviour.
 pub(in crate::semantic_analysis) fn super_receiver_type(
     child_class: &EcoString,
     child_type_args: &[InferredType],
     parent_class: &EcoString,
     hierarchy: &ClassHierarchy,
+    alias_registry: Option<&AliasRegistry>,
 ) -> InferredType {
     use crate::semantic_analysis::class_hierarchy::SuperclassTypeArg;
 
@@ -541,12 +548,8 @@ pub(in crate::semantic_analysis) fn super_receiver_type(
             // generics (`List(Integer)`), unions (`Integer | Nil`), and `Nil`
             // keyword aliases canonicalise correctly instead of becoming an
             // opaque `Known("List(Integer)")`.
-            // No alias registry threaded here (BT-2928 follow-up) — this
-            // free function's callers don't have one in scope; an
-            // alias-typed `extends Base(SomeAlias)` type arg falls back to
-            // an opaque nominal class, same as before this fix.
             SuperclassTypeArg::Concrete { type_name } => {
-                super::TypeChecker::resolve_type_name_string(type_name, None)
+                super::TypeChecker::resolve_type_name_string(type_name, alias_registry)
             }
         })
         .collect();
@@ -1668,8 +1671,13 @@ mod tests {
             "Object subclass: Base(E)\n  state: x :: E = nil\n\nBase(R) subclass: Sub(R)\n",
         );
         let child_type_args = vec![InferredType::known("R")];
-        let result =
-            super_receiver_type(&"Sub".into(), &child_type_args, &"Base".into(), &hierarchy);
+        let result = super_receiver_type(
+            &"Sub".into(),
+            &child_type_args,
+            &"Base".into(),
+            &hierarchy,
+            None,
+        );
         let InferredType::Known {
             class_name,
             type_args,
@@ -1689,7 +1697,7 @@ mod tests {
         let (_, hierarchy) = parse_module(
             "Object subclass: Base(E)\n  state: x :: E = nil\n\nBase(Integer) subclass: IntBase\n",
         );
-        let result = super_receiver_type(&"IntBase".into(), &[], &"Base".into(), &hierarchy);
+        let result = super_receiver_type(&"IntBase".into(), &[], &"Base".into(), &hierarchy, None);
         let InferredType::Known {
             class_name,
             type_args,
@@ -1702,12 +1710,50 @@ mod tests {
         assert_eq!(type_args, vec![InferredType::known("Integer")]);
     }
 
+    /// BT-2936: `IntBase extends Base(SomeAlias)` where `type SomeAlias =
+    /// Integer` — the `Concrete` superclass type arg expands the alias
+    /// through the threaded `alias_registry` instead of staying an opaque
+    /// nominal class named `SomeAlias`.
+    #[test]
+    fn super_receiver_expands_alias_typed_concrete_superclass_arg() {
+        let (_, hierarchy) = parse_module(
+            "Object subclass: Base(E)\n  state: x :: E = nil\n\nBase(SomeAlias) subclass: IntBase\n",
+        );
+        let registry = alias_registry_with("SomeAlias", TypeAnnotation::Simple(ident("Integer")));
+        let result = super_receiver_type(
+            &"IntBase".into(),
+            &[],
+            &"Base".into(),
+            &hierarchy,
+            Some(&registry),
+        );
+        let InferredType::Known {
+            class_name,
+            type_args,
+            ..
+        } = result
+        else {
+            panic!("expected Known");
+        };
+        assert_eq!(class_name.as_str(), "Base");
+        assert_eq!(type_args, vec![InferredType::known("Integer")]);
+
+        // Without the registry, the alias name stays opaque — the
+        // pre-BT-2936 fallback this test guards against regressing back to.
+        let unresolved =
+            super_receiver_type(&"IntBase".into(), &[], &"Base".into(), &hierarchy, None);
+        let InferredType::Known { type_args, .. } = unresolved else {
+            panic!("expected Known");
+        };
+        assert_eq!(type_args, vec![InferredType::known("SomeAlias")]);
+    }
+
     #[test]
     fn super_receiver_falls_back_when_no_extends_annotation() {
         // Non-generic child of non-generic parent — no superclass_type_args.
         // super's receiver should match `receiver_type_for_class(parent)`.
         let (_, hierarchy) = parse_module("Object subclass: Parent\n\nParent subclass: Child\n");
-        let result = super_receiver_type(&"Child".into(), &[], &"Parent".into(), &hierarchy);
+        let result = super_receiver_type(&"Child".into(), &[], &"Parent".into(), &hierarchy, None);
         let expected = receiver_type_for_class(&"Parent".into(), &hierarchy);
         assert_eq!(result, expected);
     }
@@ -1722,6 +1768,7 @@ mod tests {
             &[InferredType::known("R")],
             &"Base".into(),
             &hierarchy,
+            None,
         );
         let expected = receiver_type_for_class(&"Base".into(), &hierarchy);
         assert_eq!(result, expected);

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -886,7 +886,7 @@ impl TypeChecker {
                 continue;
             };
             let sendability::Tier::HandleScoped(sendability::HandleScope::Process) =
-                sendability::tier_of(value_ty, hierarchy)
+                sendability::tier_of(value_ty, hierarchy, self.alias_registry.as_ref())
             else {
                 continue;
             };
@@ -949,7 +949,7 @@ impl TypeChecker {
         }
         for (i, arg_ty) in arg_types.iter().enumerate() {
             let sendability::Tier::HandleScoped(sendability::HandleScope::Process) =
-                sendability::tier_of(arg_ty, hierarchy)
+                sendability::tier_of(arg_ty, hierarchy, self.alias_registry.as_ref())
             else {
                 continue;
             };

--- a/crates/beamtalk-core/src/semantic_analysis/validators/sendability_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/sendability_validators.rs
@@ -24,6 +24,7 @@ use ecow::EcoString;
 
 use crate::ast::{Block, ClassKind, Expression, Module};
 use crate::ast_walker::walk_expression;
+use crate::semantic_analysis::alias_registry::AliasRegistry;
 use crate::semantic_analysis::type_checker::TypeMap;
 use crate::semantic_analysis::type_checker::sendability::{self, HandleScope, Tier};
 use crate::semantic_analysis::{BlockInfo, ClassHierarchy};
@@ -39,11 +40,16 @@ use crate::state_threading_selectors::is_state_threading_keyword_selector;
 /// a non-self, non-state-threading message to an actor. Blocks in local
 /// positions (`do:`, `collect:`, `ifTrue:`, `whileTrue:`, self-sends) stay
 /// silent. `#node`-scoped and `Dynamic` captures are silent in v1.
+///
+/// `alias_registry` (BT-2936, ADR 0108 follow-up to BT-2928) lets a captured
+/// alias-typed field's tier compose through the alias's expansion instead of
+/// falling back to `Tier::Unknown` for the opaque alias name.
 pub(crate) fn check_block_capture_sendability(
     module: &Module,
     hierarchy: &ClassHierarchy,
     type_map: &TypeMap,
     block_info: &HashMap<Span, BlockInfo>,
+    alias_registry: Option<&AliasRegistry>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let mut visit = |expr: &Expression| {
@@ -63,7 +69,14 @@ pub(crate) fn check_block_capture_sendability(
         }
         for arg in arguments {
             if let Expression::Block(block) = arg {
-                check_block_captures(block, hierarchy, type_map, block_info, diagnostics);
+                check_block_captures(
+                    block,
+                    hierarchy,
+                    type_map,
+                    block_info,
+                    alias_registry,
+                    diagnostics,
+                );
             }
         }
     };
@@ -137,6 +150,7 @@ fn check_block_captures(
     hierarchy: &ClassHierarchy,
     type_map: &TypeMap,
     block_info: &HashMap<Span, BlockInfo>,
+    alias_registry: Option<&AliasRegistry>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let Some(info) = block_info.get(&block.span) else {
@@ -149,7 +163,9 @@ fn check_block_captures(
         let Some(ty) = type_map.get(use_span) else {
             continue;
         };
-        let Tier::HandleScoped(HandleScope::Process) = sendability::tier_of(ty, hierarchy) else {
+        let Tier::HandleScoped(HandleScope::Process) =
+            sendability::tier_of(ty, hierarchy, alias_registry)
+        else {
             continue;
         };
         let ty_name = ty


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2936

Follow-up to BT-2928, which made `TypeChecker::resolve_type_name_string` alias-aware by adding an `alias_registry: Option<&AliasRegistry>` parameter, threaded through every call site where `self` was directly reachable. A handful of call sites deliberately kept passing `None` to bound that PR's scope — this PR threads the registry through the rest of them.

- **`inference.rs`**: `resolve_narrowing_variable_type` and its ~8 call sites (narrowing on `self.field isNil ifFalse: [...]` etc.), plus the `refine_result_narrowing` / `refine_singleton_narrowing` / `early_return_false_branch_type` free functions in the narrowing chain.
- **`sendability.rs`**: `tier_of` / `tier_of_depth` / `tier_of_known` (ADR 0103), so an alias-typed `Value` field composes its sendability tier through the alias's expansion instead of falling back to `Tier::Unknown`.
- **`type_resolver.rs`**: `super_receiver_type`'s `SuperclassTypeArg::Concrete` branch, so an aliased `extends Base(SomeAlias)` type argument expands.
- **`hover_provider.rs`**: `find_hover_in_expr`'s call chain now forwards the `alias_registry` `compute_hover` already receives (found during this PR's own adversarial review pass — the registry was reachable at `compute_hover` but never threaded the last step into the recursive hover walk, so alias-typed field hover silently omitted the sendability tier).
- **`sendability_validators.rs`**: the block-capture sendability check (`check_block_capture_sendability`) now receives the real registry from `analyse_full`'s `result.alias_registry`.
- **`validation.rs`**: `check_spawn_with_sendability` / `check_arg_sendability` now pass `self.alias_registry.as_ref()`.

`class_object_tower_return` (inference.rs) stays deliberately un-threaded — revisited and confirmed out of scope, since the built-in Metaclass/Class/Behaviour/Object/ProtoObject tower's method table is fixed/generated and has no alias-typed entries to expand.

## Test plan

- [x] 4 new regression tests, each with a positive case (registry present, alias expands) and a negative control (registry absent, stays opaque nominal class — the pre-fix behavior):
  - `resolve_narrowing_variable_type_expands_alias_for_self_field` (inference.rs)
  - `value_composition_inherits_alias_typed_field_tier` (sendability.rs)
  - `super_receiver_expands_alias_typed_concrete_superclass_arg` (type_resolver.rs)
  - `hover_shows_composed_handle_scope_for_alias_typed_value_field` (hover_provider.rs)
- [x] `cargo build --workspace` clean
- [x] `cargo clippy --all-targets` (pedantic, `-D warnings`) clean
- [x] `cargo fmt --check` clean
- [x] Full `beamtalk-core` lib suite: 5218 passed, 0 failed
- [x] `just test-stdlib`: 223/223 passed
- [x] `just test-bunit`: 2774/2776 passed, 0 failed
- [x] `just ci-changed`: all checks green (build, clippy, Dialyzer, generated-spec validation, Erlang/JS/Elixir/Beamtalk formatting, lint) except one **pre-existing, unrelated** failure — see note below.

### Known-unrelated test failure

`commands::workspace::epmd::tests::bt2424_default_deployment_keeps_epmd_off_public_interfaces` fails locally in this sandbox. Root-caused: it's a live-system probe of the actual `epmd` daemon's network binding, and this shared dev host has an `epmd` process (running since well before this session, registering other concurrent worktrees' workspace names) bound promiscuously to `0.0.0.0:4369` rather than loopback-only. This diff never touches `beamtalk-cli`, `epmd.rs`, or any networking code, and the failure reproduces identically on an unmodified checkout. Expected to pass on GitHub Actions' clean runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)