### PR TITLE
Alias display-name provenance doesn't reach EcoString-based diagnostic paths (BT-2911)

### DIFF
--- a/crates/beamtalk-core/src/queries/hover_provider.rs
+++ b/crates/beamtalk-core/src/queries/hover_provider.rs
@@ -124,6 +124,7 @@ pub fn compute_hover(
             hierarchy,
             &type_map,
             native_types,
+            alias_registry,
         ) {
             return Some(hover);
         }
@@ -143,6 +144,7 @@ pub fn compute_hover(
                     hierarchy,
                     &type_map,
                     native_types,
+                    alias_registry,
                 ) {
                     return Some(hover);
                 }
@@ -160,6 +162,7 @@ pub fn compute_hover(
                     hierarchy,
                     &type_map,
                     native_types,
+                    alias_registry,
                 ) {
                     return Some(hover);
                 }
@@ -182,6 +185,7 @@ pub fn compute_hover(
                 hierarchy,
                 &type_map,
                 native_types,
+                alias_registry,
             ) {
                 return Some(hover);
             }
@@ -714,6 +718,7 @@ fn find_hover_in_expr(
     hierarchy: &ClassHierarchy,
     type_map: &TypeMap,
     native_types: Option<&NativeTypeRegistry>,
+    alias_registry: Option<&AliasRegistry>,
 ) -> Option<HoverInfo> {
     let span = expr.span();
     if offset < span.start() || offset >= span.end() {
@@ -791,11 +796,26 @@ fn find_hover_in_expr(
                 None
             }
         }
-        Expression::Assignment { target, value, .. } => {
-            find_hover_in_expr(target, offset, context, hierarchy, type_map, native_types).or_else(
-                || find_hover_in_expr(value, offset, context, hierarchy, type_map, native_types),
+        Expression::Assignment { target, value, .. } => find_hover_in_expr(
+            target,
+            offset,
+            context,
+            hierarchy,
+            type_map,
+            native_types,
+            alias_registry,
+        )
+        .or_else(|| {
+            find_hover_in_expr(
+                value,
+                offset,
+                context,
+                hierarchy,
+                type_map,
+                native_types,
+                alias_registry,
             )
-        }
+        }),
         Expression::MessageSend {
             receiver,
             selector,
@@ -804,13 +824,27 @@ fn find_hover_in_expr(
             ..
         } => {
             // First check receiver and arguments
-            if let Some(hover) =
-                find_hover_in_expr(receiver, offset, context, hierarchy, type_map, native_types)
-            {
+            if let Some(hover) = find_hover_in_expr(
+                receiver,
+                offset,
+                context,
+                hierarchy,
+                type_map,
+                native_types,
+                alias_registry,
+            ) {
                 return Some(hover);
             }
             if let Some(hover) = arguments.iter().find_map(|arg| {
-                find_hover_in_expr(arg, offset, context, hierarchy, type_map, native_types)
+                find_hover_in_expr(
+                    arg,
+                    offset,
+                    context,
+                    hierarchy,
+                    type_map,
+                    native_types,
+                    alias_registry,
+                )
             }) {
                 return Some(hover);
             }
@@ -871,14 +905,29 @@ fn find_hover_in_expr(
                 hierarchy,
                 type_map,
                 native_types,
+                alias_registry,
             )
         }),
-        Expression::Return { value, .. } => {
-            find_hover_in_expr(value, offset, context, hierarchy, type_map, native_types)
-        }
+        Expression::Return { value, .. } => find_hover_in_expr(
+            value,
+            offset,
+            context,
+            hierarchy,
+            type_map,
+            native_types,
+            alias_registry,
+        ),
         Expression::DestructureAssignment { pattern, value, .. } => {
             find_hover_in_pattern(pattern, offset, type_map).or_else(|| {
-                find_hover_in_expr(value, offset, context, hierarchy, type_map, native_types)
+                find_hover_in_expr(
+                    value,
+                    offset,
+                    context,
+                    hierarchy,
+                    type_map,
+                    native_types,
+                    alias_registry,
+                )
             })
         }
         Expression::Parenthesized { expression, .. } => find_hover_in_expr(
@@ -888,6 +937,7 @@ fn find_hover_in_expr(
             hierarchy,
             type_map,
             native_types,
+            alias_registry,
         ),
         Expression::FieldAccess {
             receiver, field, ..
@@ -895,19 +945,16 @@ fn find_hover_in_expr(
             if offset >= field.span.start() && offset < field.span.end() {
                 // Show declared state type if available from the class hierarchy.
                 //
-                // BT-2897 boundary (not this issue's scope, tracked as a
-                // follow-up): `state_field_type` returns a bare `EcoString`
-                // from `ClassHierarchy`, not a resolved `InferredType`, so
-                // this path never sees a `TypeProvenance::Aliased` tag —
-                // hovering a state field *access* (`self someField`) shows
-                // the raw annotation text, never `AliasName (expansion)`,
-                // unlike hovering a local/parameter value (which flows
-                // through `type_map`'s `InferredType`s). Fixing this would
-                // mean threading alias-aware `InferredType`s (or at least
-                // display strings) through `ClassHierarchy`'s field-type
-                // storage — the same EcoString-based boundary
-                // `check_field_assignment`/`check_argument_types`
-                // (validation.rs) sit on, out of scope for BT-2897.
+                // BT-2911: `state_field_type` returns a bare `EcoString` from
+                // `ClassHierarchy`, not a resolved `InferredType`, so it
+                // never carries a `TypeProvenance::Aliased` tag the way
+                // `type_map`'s `InferredType`s do for a local/parameter
+                // value (BT-2897). Re-resolve through
+                // `AliasRegistry::resolve_display_name` when the declared
+                // type names a registered alias so hovering a state field
+                // *access* (`self someField`) shows `AliasName (expansion)`
+                // too, matching local/parameter hover; fall back to the raw
+                // annotation text otherwise.
                 let field_type = match context {
                     HoverClassContext::InstanceMethod(class) => {
                         hierarchy.state_field_type(class.name.name.as_str(), field.name.as_str())
@@ -918,7 +965,10 @@ fn find_hover_in_expr(
                     _ => None,
                 };
                 let contents = if let Some(ty) = field_type {
-                    format!("`{} :: {ty}`", field.name)
+                    let display = alias_registry
+                        .and_then(|registry| registry.resolve_display_name(&ty))
+                        .unwrap_or(ty);
+                    format!("`{} :: {display}`", field.name)
                 } else {
                     format!("`{}`", field.name)
                 };
@@ -927,22 +977,44 @@ fn find_hover_in_expr(
                         .with_documentation("_state variable_".to_string()),
                 )
             } else {
-                find_hover_in_expr(receiver, offset, context, hierarchy, type_map, native_types)
+                find_hover_in_expr(
+                    receiver,
+                    offset,
+                    context,
+                    hierarchy,
+                    type_map,
+                    native_types,
+                    alias_registry,
+                )
             }
         }
         Expression::Cascade {
             receiver, messages, ..
         } => {
-            if let Some(hover) =
-                find_hover_in_expr(receiver, offset, context, hierarchy, type_map, native_types)
-            {
+            if let Some(hover) = find_hover_in_expr(
+                receiver,
+                offset,
+                context,
+                hierarchy,
+                type_map,
+                native_types,
+                alias_registry,
+            ) {
                 return Some(hover);
             }
             // Check each cascaded message
             for msg in messages {
                 // Check arguments first
                 if let Some(hover) = msg.arguments.iter().find_map(|arg| {
-                    find_hover_in_expr(arg, offset, context, hierarchy, type_map, native_types)
+                    find_hover_in_expr(
+                        arg,
+                        offset,
+                        context,
+                        hierarchy,
+                        type_map,
+                        native_types,
+                        alias_registry,
+                    )
                 }) {
                     return Some(hover);
                 }
@@ -973,37 +1045,44 @@ fn find_hover_in_expr(
             }
             None
         }
-        Expression::Match { value, arms, .. } => {
-            find_hover_in_expr(value, offset, context, hierarchy, type_map, native_types).or_else(
-                || {
-                    arms.iter().find_map(|arm| {
-                        find_hover_in_pattern(&arm.pattern, offset, type_map)
-                            .or_else(|| {
-                                arm.guard.as_ref().and_then(|g| {
-                                    find_hover_in_expr(
-                                        g,
-                                        offset,
-                                        context,
-                                        hierarchy,
-                                        type_map,
-                                        native_types,
-                                    )
-                                })
-                            })
-                            .or_else(|| {
-                                find_hover_in_expr(
-                                    &arm.body,
-                                    offset,
-                                    context,
-                                    hierarchy,
-                                    type_map,
-                                    native_types,
-                                )
-                            })
+        Expression::Match { value, arms, .. } => find_hover_in_expr(
+            value,
+            offset,
+            context,
+            hierarchy,
+            type_map,
+            native_types,
+            alias_registry,
+        )
+        .or_else(|| {
+            arms.iter().find_map(|arm| {
+                find_hover_in_pattern(&arm.pattern, offset, type_map)
+                    .or_else(|| {
+                        arm.guard.as_ref().and_then(|g| {
+                            find_hover_in_expr(
+                                g,
+                                offset,
+                                context,
+                                hierarchy,
+                                type_map,
+                                native_types,
+                                alias_registry,
+                            )
+                        })
                     })
-                },
-            )
-        }
+                    .or_else(|| {
+                        find_hover_in_expr(
+                            &arm.body,
+                            offset,
+                            context,
+                            hierarchy,
+                            type_map,
+                            native_types,
+                            alias_registry,
+                        )
+                    })
+            })
+        }),
         Expression::MapLiteral { pairs, span } => {
             if offset >= span.start() && offset < span.end() {
                 // Check if hovering over a specific key or value
@@ -1015,6 +1094,7 @@ fn find_hover_in_expr(
                         hierarchy,
                         type_map,
                         native_types,
+                        alias_registry,
                     ) {
                         return Some(hover);
                     }
@@ -1025,6 +1105,7 @@ fn find_hover_in_expr(
                         hierarchy,
                         type_map,
                         native_types,
+                        alias_registry,
                     ) {
                         return Some(hover);
                     }
@@ -1045,16 +1126,28 @@ fn find_hover_in_expr(
         } => {
             if offset >= span.start() && offset < span.end() {
                 for elem in elements {
-                    if let Some(hover) =
-                        find_hover_in_expr(elem, offset, context, hierarchy, type_map, native_types)
-                    {
+                    if let Some(hover) = find_hover_in_expr(
+                        elem,
+                        offset,
+                        context,
+                        hierarchy,
+                        type_map,
+                        native_types,
+                        alias_registry,
+                    ) {
                         return Some(hover);
                     }
                 }
                 if let Some(t) = tail {
-                    if let Some(hover) =
-                        find_hover_in_expr(t, offset, context, hierarchy, type_map, native_types)
-                    {
+                    if let Some(hover) = find_hover_in_expr(
+                        t,
+                        offset,
+                        context,
+                        hierarchy,
+                        type_map,
+                        native_types,
+                        alias_registry,
+                    ) {
                         return Some(hover);
                     }
                 }
@@ -1069,9 +1162,15 @@ fn find_hover_in_expr(
         Expression::ArrayLiteral { elements, span } => {
             if offset >= span.start() && offset < span.end() {
                 for elem in elements {
-                    if let Some(hover) =
-                        find_hover_in_expr(elem, offset, context, hierarchy, type_map, native_types)
-                    {
+                    if let Some(hover) = find_hover_in_expr(
+                        elem,
+                        offset,
+                        context,
+                        hierarchy,
+                        type_map,
+                        native_types,
+                        alias_registry,
+                    ) {
                         return Some(hover);
                     }
                 }
@@ -1119,6 +1218,7 @@ fn find_hover_in_expr(
                             hierarchy,
                             type_map,
                             native_types,
+                            alias_registry,
                         ) {
                             return Some(info);
                         }
@@ -1742,7 +1842,7 @@ mod tests {
             is_inferred: false,
             span: Span::new(0, 22),
         };
-        let hover = find_hover_in_expr(&expr, 5, &ctx, &hierarchy, &TypeMap::new(), None);
+        let hover = find_hover_in_expr(&expr, 5, &ctx, &hierarchy, &TypeMap::new(), None, None);
         assert!(hover.is_some());
         let hover = hover.unwrap();
         assert!(hover.contents.contains("`@primitive \"erlang_add\"`"));
@@ -1763,7 +1863,7 @@ mod tests {
             is_inferred: false,
             span: Span::new(0, 15),
         };
-        let hover = find_hover_in_expr(&expr, 5, &ctx, &hierarchy, &TypeMap::new(), None);
+        let hover = find_hover_in_expr(&expr, 5, &ctx, &hierarchy, &TypeMap::new(), None, None);
         assert!(hover.is_some());
         let hover = hover.unwrap();
         assert!(hover.contents.contains("`@primitive size`"));
@@ -2814,6 +2914,71 @@ mod tests {
         assert!(
             hover.contents.contains("internal type"),
             "Got: {}",
+            hover.contents
+        );
+    }
+
+    // ── BT-2911: state field *access* hover (the `Expression::FieldAccess`
+    // gap BT-2897 left, since `state_field_type` reads a bare `EcoString`
+    // from `ClassHierarchy` with no alias provenance) ─────────────────────
+
+    #[test]
+    fn hover_on_alias_typed_state_field_access_shows_alias_name_and_expansion() {
+        // Hovering `self.policy` (a state field *access*) must show
+        // `AliasName (expansion)` too, matching what hovering an
+        // alias-typed parameter/local already shows (BT-2897's
+        // `hover_on_alias_typed_param_shows_alias_name_and_expansion`).
+        let source = "type RestartStrategy = #temporary | #transient | #permanent\n\n\
+                       Actor subclass: Supervisor\n  state: policy :: RestartStrategy = #temporary\n\n  \
+                       currentPolicy => self.policy\n";
+        let tokens = lex_with_eof(source);
+        let (module, _) = parse(tokens);
+        let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+        let alias_registry = alias_registry_for(&module, &hierarchy);
+
+        // Hover over `policy` in `self.policy` (the field access, not the
+        // `state:` declaration itself).
+        let offset = source.rfind("self.policy").unwrap() + "self.".len();
+        let pos = pos_at(source, offset);
+        let hover = compute_hover(
+            &module,
+            source,
+            pos,
+            &hierarchy,
+            None,
+            Some(&alias_registry),
+        );
+        let hover = hover.expect("should get hover for alias-typed state field access");
+        assert!(
+            hover
+                .contents
+                .contains("RestartStrategy (#temporary | #transient | #permanent)"),
+            "Alias-typed field access should show `AliasName (expansion)`. Got: {}",
+            hover.contents
+        );
+    }
+
+    #[test]
+    fn hover_on_alias_typed_state_field_access_without_alias_registry_shows_raw_name() {
+        // Sanity check mirroring `hover_without_alias_registry_does_not_resolve_alias`:
+        // without a registry, the field access falls back to the raw
+        // (unresolved) declared type text — pre-BT-2911 behaviour, and the
+        // real-LSP-caller default when no project-wide alias table is
+        // available yet.
+        let source = "type RestartStrategy = #temporary | #transient | #permanent\n\n\
+                       Actor subclass: Supervisor\n  state: policy :: RestartStrategy = #temporary\n\n  \
+                       currentPolicy => self.policy\n";
+        let tokens = lex_with_eof(source);
+        let (module, _) = parse(tokens);
+        let hierarchy = ClassHierarchy::build(&module).0.unwrap();
+
+        let offset = source.rfind("self.policy").unwrap() + "self.".len();
+        let pos = pos_at(source, offset);
+        let hover = compute_hover(&module, source, pos, &hierarchy, None, None);
+        let hover = hover.expect("should get hover for alias-typed state field access");
+        assert!(
+            hover.contents.contains("RestartStrategy") && !hover.contents.contains('('),
+            "Without an alias registry, hover must show the raw name with no expansion. Got: {}",
             hover.contents
         );
     }

--- a/crates/beamtalk-core/src/semantic_analysis/alias_registry.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/alias_registry.rs
@@ -54,10 +54,10 @@ use std::collections::HashMap;
 
 use ecow::EcoString;
 
-use crate::ast::{Module, TypeAliasDefinition, TypeAnnotation};
+use crate::ast::{Identifier, Module, TypeAliasDefinition, TypeAnnotation};
 use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
 use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
-use crate::semantic_analysis::type_checker::is_generic_type_param;
+use crate::semantic_analysis::type_checker::{is_generic_type_param, resolve_type_annotation};
 use crate::source_analysis::{Diagnostic, DiagnosticCategory, Span};
 
 /// Information about a type alias in the registry.
@@ -561,6 +561,46 @@ impl AliasRegistry {
     #[must_use]
     pub fn get(&self, name: &str) -> Option<&AliasInfo> {
         self.aliases.get(name)
+    }
+
+    /// Best-effort alias-aware display for a bare type name pulled from
+    /// [`ClassHierarchy`]'s pre-ADR-0108 `EcoString` storage (state field
+    /// types via `state_field_type`, method parameter types via
+    /// `MethodInfo::param_types`) — BT-2911, closing the gap BT-2897's
+    /// `TypeProvenance::Aliased` left in diagnostic paths that never touch
+    /// `InferredType` at all: `hover_provider.rs`'s `Expression::FieldAccess`
+    /// branch, and `type_checker::validation`'s `check_field_assignment` /
+    /// `check_argument_types`.
+    ///
+    /// Returns `Some("AliasName (expansion)")` when `name` is *exactly* a
+    /// registered alias name — built by re-resolving a synthetic `Simple`
+    /// reference to `name` through [`resolve_type_annotation`] with `self`
+    /// as the alias registry, then
+    /// [`InferredType::display_for_diagnostic`](crate::semantic_analysis::type_checker::InferredType::display_for_diagnostic).
+    /// That is the exact same path production `InferredType`-based
+    /// diagnostics already use (see `type_resolver.rs`'s
+    /// `resolve_type_annotation_inner`, which tags the resolved value via
+    /// `InferredType::tag_alias_expansion` on every alias reference), so the
+    /// returned string is byte-identical to what hovering a parameter/local
+    /// declared with the same alias type already renders.
+    ///
+    /// Returns `None` when `name` is not a registered alias name —
+    /// including when `name` is a flattened multi-token annotation string
+    /// (a union or generic, e.g. `"RestartStrategy | Foo"`) that merely
+    /// *contains* an alias name as a substring: `ClassHierarchy`'s current
+    /// storage is a single opaque `EcoString` per field/param with no
+    /// re-parseable structure, so only the common bare-alias-reference case
+    /// (`field :: AliasName`) is recognised. Callers should fall back to
+    /// their existing plain-name display in that case.
+    #[must_use]
+    pub fn resolve_display_name(&self, name: &str) -> Option<EcoString> {
+        let info = self.aliases.get(name)?;
+        let reference = TypeAnnotation::Simple(Identifier {
+            name: info.name.clone(),
+            span: info.span,
+        });
+        let resolved = resolve_type_annotation(&reference, &HashMap::new(), None, Some(self));
+        resolved.display_for_diagnostic()
     }
 
     /// Checks if an alias exists in the registry.

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_display_provenance.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_display_provenance.rs
@@ -158,3 +158,248 @@ Object subclass: Supervisor
         "negated case must never suggest, got: {message}"
     );
 }
+// ── BT-2911: EcoString-based diagnostic paths never touched by BT-2897 ─────
+
+#[test]
+fn field_assignment_mismatch_on_alias_typed_state_field_names_the_alias() {
+    // `check_field_assignment` reads `declared_type` as a bare `EcoString`
+    // from `ClassHierarchy::state_field_type` — pre-ADR-0108 storage that
+    // never carries a `TypeProvenance::Aliased` tag the way an
+    // `InferredType` does. Assigning an incompatible `Integer` to a
+    // `RestartStrategy`-typed `state:` field must still name the alias in
+    // the "Type mismatch: field ... declared as ..." message, matching what
+    // an alias-typed parameter mismatch already renders (BT-2897).
+    let source = r"
+type RestartStrategy = #temporary | #transient | #permanent
+
+Actor subclass: Supervisor
+  state: policy :: RestartStrategy = #temporary
+
+  reset =>
+    self.policy := 42
+";
+    let diags = analyse_diagnostics(source);
+    let hits: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("Type mismatch: field"))
+        .collect();
+    assert_eq!(hits.len(), 1, "expected one diagnostic, got: {diags:?}");
+    assert!(
+        hits[0]
+            .message
+            .contains("RestartStrategy (#temporary | #transient | #permanent)"),
+        "should name the alias with its expansion, got: {}",
+        hits[0].message
+    );
+}
+
+#[test]
+fn field_assignment_mismatch_on_plain_typed_state_field_is_unaffected() {
+    // Sibling to the alias case above with a plain (non-alias) declared
+    // field type — pins that the BT-2911 fix is a no-op when there is no
+    // alias registry entry to resolve, matching pre-BT-2911 behaviour.
+    let source = r#"
+Actor subclass: Supervisor
+  state: count :: Integer = 0
+
+  reset =>
+    self.count := "oops"
+"#;
+    let diags = analyse_diagnostics(source);
+    let hits: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("Type mismatch: field"))
+        .collect();
+    assert_eq!(hits.len(), 1, "expected one diagnostic, got: {diags:?}");
+    assert!(
+        hits[0].message.contains("declared as Integer, got String"),
+        "plain declared type must render unchanged, got: {}",
+        hits[0].message
+    );
+}
+
+#[test]
+fn argument_mismatch_on_alias_typed_parameter_names_the_alias() {
+    // `check_argument_types` reads `expected_ty` as a bare `EcoString` from
+    // `MethodInfo::param_types` — the same pre-ADR-0108 storage
+    // `check_field_assignment` sits on. Unlike that sibling, this path
+    // cannot be exercised through the *full* compile pipeline: an alias
+    // name is never registered as a class in `ClassHierarchy`
+    // (`hierarchy.has_class("RestartStrategy")` is always `false`), and
+    // `is_type_compatible`'s pre-existing, unrelated "unknown declared
+    // class → conservatively compatible" fallback (validation.rs, the
+    // `!hierarchy.has_class(actual_base) || !hierarchy.has_class(expected_base)`
+    // check) absorbs *every* argument against a bare alias-typed parameter
+    // as compatible, so the mismatch branch this test targets never runs
+    // end-to-end today. That gap is pre-existing and out of BT-2911's
+    // display-only scope (its own acceptance criteria: no change to
+    // `is_assignable_to`/`is_type_compatible`) — fixing it would mean
+    // resolving `param_types` through the alias table before the
+    // compatibility check itself, a bigger change than display provenance.
+    //
+    // So this test calls `check_argument_types` directly (mirroring
+    // `local_annotations.rs`'s `register_test_alias` pattern) with a
+    // hierarchy where a `RestartStrategy` *class* happens to also exist —
+    // purely to satisfy `is_type_compatible`'s `has_class` guard and reach
+    // the mismatch branch — while the `AliasRegistry` alias of the same
+    // name is seeded independently via `register_test_alias`, bypassing
+    // `AliasRegistry::register_module`'s namespace-collision check (which
+    // would legitimately reject a real alias/class name collision — see
+    // that method's doc). This is an intentionally synthetic setup to reach
+    // otherwise-unreachable code; it does not assert anything about
+    // real-world alias/class collisions.
+    use crate::semantic_analysis::alias_registry::{AliasInfo, AliasRegistry};
+
+    let source = r"
+Object subclass: RestartStrategy
+
+Object subclass: Widget
+  restart: policy :: RestartStrategy => policy
+";
+    let tokens = crate::source_analysis::lex_with_eof(source);
+    let (module, parse_diags) = crate::source_analysis::parse(tokens);
+    assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
+    let (hierarchy, hierarchy_diags) = crate::semantic_analysis::ClassHierarchy::build(&module);
+    let hierarchy = hierarchy.expect("hierarchy should build");
+    assert!(
+        hierarchy_diags.is_empty(),
+        "unexpected: {hierarchy_diags:?}"
+    );
+
+    let mut alias_registry = AliasRegistry::new();
+    alias_registry.register_test_alias(AliasInfo {
+        name: "RestartStrategy".into(),
+        annotation: crate::ast::TypeAnnotation::Union {
+            types: vec![
+                crate::ast::TypeAnnotation::Singleton {
+                    name: "temporary".into(),
+                    span: crate::source_analysis::Span::new(0, 1),
+                },
+                crate::ast::TypeAnnotation::Singleton {
+                    name: "transient".into(),
+                    span: crate::source_analysis::Span::new(0, 1),
+                },
+                crate::ast::TypeAnnotation::Singleton {
+                    name: "permanent".into(),
+                    span: crate::source_analysis::Span::new(0, 1),
+                },
+            ],
+            span: crate::source_analysis::Span::new(0, 1),
+        },
+        is_internal: false,
+        package: None,
+        span: crate::source_analysis::Span::new(0, 1),
+    });
+
+    let mut checker = crate::semantic_analysis::type_checker::TypeChecker::new();
+    checker.set_alias_registry(alias_registry);
+    checker.check_argument_types(
+        &"Widget".into(),
+        "restart:",
+        &[crate::semantic_analysis::InferredType::known("Integer")],
+        crate::source_analysis::Span::new(0, 1),
+        &hierarchy,
+        false,
+        None,
+        None,
+    );
+    let diags = checker.diagnostics();
+    let hits: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("expects"))
+        .collect();
+    assert_eq!(hits.len(), 1, "expected one diagnostic, got: {diags:?}");
+    assert!(
+        hits[0].message.contains(
+            "expects RestartStrategy (#temporary | #transient | #permanent), got Integer"
+        ),
+        "should name the alias with its expansion, got: {}",
+        hits[0].message
+    );
+}
+
+#[test]
+fn field_assignment_of_a_valid_alias_member_currently_false_positives_bt2953() {
+    // KNOWN BUG, tracked as BT-2953 — pinned here deliberately, not silently
+    // left as a gap: `check_field_assignment` calls `is_assignable_to`
+    // (validation.rs) with the *bare* alias name (`"RestartStrategy"`,
+    // never expanded — `ClassHierarchy` predates ADR 0108 and has no
+    // `AliasRegistry` access). `is_assignable_to` has no "unknown declared
+    // class" escape hatch, so a bare alias name that never matches any
+    // registered class falls through to a superclass-chain walk that always
+    // returns `false` — meaning it currently reports EVERY value as
+    // incompatible with an alias-typed field, including values that ARE
+    // valid members of the alias (like `#transient` here).
+    //
+    // BT-2911 (this file's own issue) is display-only per its own
+    // acceptance criteria ("No regression to existing EcoString-based
+    // assignability logic") — it intentionally left `is_assignable_to`
+    // untouched, so it correctly makes the (already-wrong) message *name*
+    // the alias without fixing the underlying false positive. That's why
+    // the assertion below looks paradoxical: the message literally lists
+    // `#transient` inside the union it says `#transient` doesn't belong to.
+    // BT-2953 tracks fixing the compatibility check itself; when it lands,
+    // this test must be updated to assert NO diagnostic fires.
+    let source = r"
+type RestartStrategy = #temporary | #transient | #permanent
+
+Actor subclass: Supervisor
+  state: policy :: RestartStrategy = #temporary
+
+  reset =>
+    self.policy := #transient
+";
+    let diags = analyse_diagnostics(source);
+    let hits: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("Type mismatch: field"))
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "BT-2953: expected the known false-positive to still fire — if this \
+         now fails with 0 hits, BT-2953 has been fixed and this test (and \
+         its doc comment) should be rewritten to assert no diagnostic fires. \
+         Got: {diags:?}"
+    );
+    assert!(
+        hits[0]
+            .message
+            .contains("RestartStrategy (#temporary | #transient | #permanent)"),
+        "display should still name the alias even while the underlying \
+         check is wrong (BT-2953), got: {}",
+        hits[0].message
+    );
+}
+
+#[test]
+fn spawn_with_value_mismatch_on_alias_typed_slot_names_the_alias() {
+    // `check_spawn_with_value` (validation.rs) sits on the same
+    // pre-ADR-0108 `state_field_type` `EcoString` boundary as
+    // `check_field_assignment` — found during BT-2911's own adversarial
+    // review as a fourth EcoString-based display path the issue's three
+    // named call sites didn't enumerate. `C spawnWith: #{ slot: value }`
+    // must name the alias in its "type mismatch for state key ..." message
+    // too.
+    let source = r"
+type RestartStrategy = #temporary | #transient | #permanent
+
+Actor subclass: Supervisor
+  state: policy :: RestartStrategy = #temporary
+
+Supervisor spawnWith: #{#policy => 42}
+";
+    let diags = analyse_diagnostics(source);
+    let hits: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("type mismatch for state key"))
+        .collect();
+    assert_eq!(hits.len(), 1, "expected one diagnostic, got: {diags:?}");
+    assert!(
+        hits[0]
+            .message
+            .contains("RestartStrategy (#temporary | #transient | #permanent)"),
+        "should name the alias with its expansion, got: {}",
+        hits[0].message
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -1055,6 +1055,23 @@ impl TypeChecker {
             if hierarchy.is_protocol_class(super::type_resolver::base_name_of_string(expected_ty)) {
                 continue;
             }
+            // BT-2911: `method.param_types` predates ADR 0108 and stores a
+            // bare `EcoString` with no alias provenance — unlike an
+            // `InferredType`, which BT-2897 already tags via
+            // `TypeProvenance::Aliased` when resolved through
+            // `resolve_type_annotation`. Re-resolve `expected_ty` through
+            // `AliasRegistry::resolve_display_name` when it names a
+            // registered alias so this diagnostic renders `AliasName
+            // (expansion)` just like a mismatched alias-typed local/return
+            // type already does; fall back to the existing `UndefinedObject`
+            // -> `Nil` display (BT-2066) otherwise. Computed once here
+            // (after the protocol-type early-continue above, which never
+            // needs it) and reused by every `arg_ty` arm below.
+            let expected_display = self
+                .alias_registry
+                .as_ref()
+                .and_then(|registry| registry.resolve_display_name(expected_ty))
+                .unwrap_or_else(|| InferredType::class_name_for_diagnostic(expected_ty.as_str()));
             let is_class_ref_arg = arg_exprs
                 .and_then(|exprs| exprs.get(i))
                 .is_some_and(|e| matches!(e, Expression::ClassReference { .. }));
@@ -1090,8 +1107,7 @@ impl TypeChecker {
                         // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
                         let actual_display =
                             InferredType::class_name_for_diagnostic(actual_ty.as_str());
-                        let expected_display =
-                            InferredType::class_name_for_diagnostic(expected_ty.as_str());
+                        let expected_display = expected_display.clone();
                         let mut diag = if is_generic {
                             Diagnostic::hint(
                                 format!(
@@ -1142,8 +1158,7 @@ impl TypeChecker {
                     if !compat {
                         let param_pos = i + 1;
                         let actual_display: EcoString = format!("{meta_class} class").into();
-                        let expected_display =
-                            InferredType::class_name_for_diagnostic(expected_ty.as_str());
+                        let expected_display = expected_display.clone();
                         self.diagnostics.push(
                             Diagnostic::warning(
                                 format!(
@@ -1174,9 +1189,7 @@ impl TypeChecker {
                     let union_display = arg_ty
                         .display_for_diagnostic()
                         .unwrap_or_else(|| EcoString::from("Dynamic"));
-                    // BT-2066: Render `UndefinedObject` as `Nil` for the declared type too.
-                    let expected_display =
-                        InferredType::class_name_for_diagnostic(expected_ty.as_str());
+                    let expected_display = expected_display.clone();
                     let mut diag = if compat == 0 {
                         Diagnostic::warning(
                             format!("Argument {param_pos} of '{selector}' on {class_name} expects {expected_display}, got {union_display}"),
@@ -1922,6 +1935,20 @@ impl TypeChecker {
         let Some(declared_type) = hierarchy.state_field_type(&class_name, &field.name) else {
             return; // No type annotation on this field
         };
+        // BT-2911: `ClassHierarchy::state_field_type` predates ADR 0108 and
+        // returns a bare `EcoString` with no alias provenance — unlike an
+        // `InferredType`, which BT-2897 already tags via
+        // `TypeProvenance::Aliased` when it flows through
+        // `resolve_type_annotation`. Re-resolve `declared_type` through
+        // `AliasRegistry::resolve_display_name` when it names a registered
+        // alias so this diagnostic renders `AliasName (expansion)` just like
+        // a mismatched alias-typed parameter already does; fall back to the
+        // existing `UndefinedObject` -> `Nil` display (BT-2066) otherwise.
+        let declared_display = self
+            .alias_registry
+            .as_ref()
+            .and_then(|registry| registry.resolve_display_name(&declared_type))
+            .unwrap_or_else(|| InferredType::class_name_for_diagnostic(declared_type.as_str()));
         match value_ty {
             InferredType::Known {
                 class_name: value_type,
@@ -1929,8 +1956,7 @@ impl TypeChecker {
             } => {
                 if !Self::is_assignable_to(value_type, &declared_type, hierarchy) {
                     // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
-                    let declared_display =
-                        InferredType::class_name_for_diagnostic(declared_type.as_str());
+                    let declared_display = declared_display.clone();
                     let value_display =
                         InferredType::class_name_for_diagnostic(value_type.as_str());
                     self.diagnostics.push(
@@ -1963,9 +1989,7 @@ impl TypeChecker {
                 let union_display = value_ty
                     .display_for_diagnostic()
                     .unwrap_or_else(|| EcoString::from("Dynamic"));
-                // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
-                let declared_display =
-                    InferredType::class_name_for_diagnostic(declared_type.as_str());
+                let declared_display = declared_display.clone();
                 let diag = if compat == 0 {
                     Diagnostic::warning(
                         format!("Type mismatch: field `{}` declared as {declared_display}, got {union_display}", field.name),
@@ -1997,8 +2021,7 @@ impl TypeChecker {
                 // assignability walk.
                 let class_name_ty: EcoString = "Class".into();
                 if !Self::is_assignable_to(&class_name_ty, &declared_type, hierarchy) {
-                    let declared_display =
-                        InferredType::class_name_for_diagnostic(declared_type.as_str());
+                    let declared_display = declared_display.clone();
                     let value_display: EcoString = format!("{meta_class} class").into();
                     self.diagnostics.push(
                         Diagnostic::warning(
@@ -2153,7 +2176,16 @@ impl TypeChecker {
         let Some(value_ty) = self.type_map.get(value_expr.span()).cloned() else {
             return; // Dynamic / unknown value type — skip conservatively.
         };
-        let declared_display = InferredType::class_name_for_diagnostic(declared_ty.as_str());
+        // BT-2911: `declared_ty` is a bare `EcoString` pulled from
+        // `ClassHierarchy::state_field_type` — the same pre-ADR-0108
+        // storage `check_field_assignment` sits on. Re-resolve through
+        // `AliasRegistry::resolve_display_name` when it names a registered
+        // alias, mirroring that sibling check.
+        let declared_display = self
+            .alias_registry
+            .as_ref()
+            .and_then(|registry| registry.resolve_display_name(declared_ty))
+            .unwrap_or_else(|| InferredType::class_name_for_diagnostic(declared_ty.as_str()));
         match &value_ty {
             InferredType::Known {
                 class_name: value_type,
@@ -2284,6 +2316,17 @@ impl TypeChecker {
             if type_param_names.contains(&declared_type.as_str()) {
                 continue;
             }
+            // BT-2911: `resolved_declared` already carries BT-2897's
+            // `TypeProvenance::Aliased` tag when `type_annotation` names a
+            // registered alias (see the doc above) — `display_for_diagnostic`
+            // renders it as `AliasName (expansion)` directly. Computed once
+            // here, before the tag is discarded by the `inferred_type_to_string`
+            // flattening above (needed for `is_assignable_to`'s structural
+            // comparison), and reused by every arm below instead of
+            // re-deriving a plain display from the flattened `declared_type`.
+            let declared_display = resolved_declared
+                .display_for_diagnostic()
+                .unwrap_or_else(|| EcoString::from("Dynamic"));
             let mut env = TypeEnv::new();
             env.set_local("self", InferredType::known(class.name.name.clone()));
             let inferred = self.infer_expr(default_value, hierarchy, &mut env, false);
@@ -2293,9 +2336,8 @@ impl TypeChecker {
                     ..
                 } => {
                     if !Self::is_assignable_to(value_type, &declared_type, hierarchy) {
+                        let declared_display = declared_display.clone();
                         // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
-                        let declared_display =
-                            InferredType::class_name_for_diagnostic(declared_type.as_str());
                         let value_display =
                             InferredType::class_name_for_diagnostic(value_type.as_str());
                         self.diagnostics.push(
@@ -2330,9 +2372,7 @@ impl TypeChecker {
                     let union_display = inferred
                         .display_for_diagnostic()
                         .unwrap_or_else(|| EcoString::from("Dynamic"));
-                    // BT-2066: Render `UndefinedObject` as `Nil` in user-facing messages.
-                    let declared_display =
-                        InferredType::class_name_for_diagnostic(declared_type.as_str());
+                    let declared_display = declared_display.clone();
                     let diag = if compat == 0 {
                         Diagnostic::warning(
                             format!(


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2911

BT-2897 (ADR 0108 Phase 4) tagged `InferredType`-based diagnostics — hover on locals/parameters, membership-violation messages — with `TypeProvenance::Aliased` so they render `AliasName (expansion)` instead of the bare structural expansion. Three older diagnostic paths never touch `InferredType` at all — they read a plain, already-flattened `EcoString` type name straight from `ClassHierarchy`, which predates ADR 0108 and never resolves through `resolve_type_annotation`, so they never see the tag:

- `hover_provider.rs`'s `Expression::FieldAccess` arm (hovering `self.field`)
- `validation.rs`'s `check_field_assignment` (`self.field := value` mismatches)
- `validation.rs`'s `check_argument_types` (method-argument mismatches)

## Key changes

- Added `AliasRegistry::resolve_display_name(&self, name: &str) -> Option<EcoString>`, which re-resolves a bare name through the *same* `resolve_type_annotation` + `display_for_diagnostic` path production `InferredType` diagnostics already use — so the rendered string is byte-identical to what alias-typed parameter/local hover already shows.
- Wired that helper into all three named call sites, plus `check_spawn_with_value` and `check_state_defaults` (same EcoString boundary, found during adversarial review — not explicitly named in the issue but the same category of gap).
- `hover_provider.rs` threads `alias_registry: Option<&AliasRegistry>` through `find_hover_in_expr` and its ~27 recursive call sites (mechanical parameter threading, `cargo fmt`'d).
- Confirmed the real production hover entry point (`language_service::hover`, shared by LSP and MCP surfaces) already passes a project-wide `AliasRegistry`, so this fix is live end-to-end, not test-only.
- 9 new/updated tests across `hover_provider.rs` and `type_alias_display_provenance.rs` covering all three required paths plus the `spawnWith:` sibling.

## Scope note: filed BT-2953

Adversarial review surfaced a real, **pre-existing** correctness bug (not introduced here): `is_assignable_to`/`is_type_compatible` don't understand alias-typed declarations as unions, since the alias name is never a registered class in `ClassHierarchy`. This causes:
- False positives: assigning a *valid* alias member to an alias-typed field (e.g. `self.policy := #transient` where `#transient` is a real `RestartStrategy` member) triggers a spurious "Type mismatch" warning.
- Dead checks: alias-typed method parameters accept any argument, valid or not, via an unrelated "unknown class → compatible" escape hatch.

Fixing this requires threading `AliasRegistry` into compatibility-check functions with many call sites across `validation.rs`/`inference.rs`/`protocol.rs` — a materially bigger change than display provenance, and explicitly out of this issue's own "display-only" acceptance criteria ("No regression to existing EcoString-based assignability logic"). Filed **BT-2953** (High priority, `Bug`) with full repro and scope analysis, and pinned the current (wrong) behavior with a documented regression test (`field_assignment_of_a_valid_alias_member_currently_false_positives_bt2953`) so it's tracked rather than silently left as a gap.

## Test plan

- [x] `cargo test -p beamtalk-core --lib` — 5221 passed
- [x] `just clippy` — clean
- [x] `just build && just clippy && just fmt-check` — clean
- [x] `just test-stdlib` (223 tests), `just test-bunit` (2774 tests) — all passing
- [x] `just check-corpus`, `just check-surface-drift` — clean (no stdlib/examples changes)
- [x] Adversarial review pass (opus) — findings triaged: 1 fixed inline (`check_spawn_with_value`), 1 filed as follow-up (BT-2953) with a pinning regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)