### PR TITLE
build_stdlib.rs: seed AliasRegistry so stdlib's own cross-file aliases resolve (BT-2935)

### DIFF
--- a/crates/beamtalk-cli/src/commands/build_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/build_stdlib.rs
@@ -160,7 +160,6 @@ pub fn build_stdlib(quiet: bool, warnings_as_errors: bool) -> Result<()> {
 /// contribute no `ClassMeta`. Files are independent (no compile ordering
 /// required); cross-file class/alias visibility comes entirely from
 /// `compile_ctx` (built by the caller before this runs).
-#[allow(clippy::too_many_arguments)] // orchestration glue — see call site
 fn compile_all_stdlib_files(
     source_files: &[Utf8PathBuf],
     temp_path: &Utf8Path,

--- a/crates/beamtalk-cli/src/commands/build_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/build_stdlib.rs
@@ -12,8 +12,11 @@
 //!
 //! Part of ADR 0007 (Compilable Stdlib with Primitive Injection).
 
-use crate::beam_compiler::{BeamCompiler, CompileContext, compile_source_with_bindings};
+use crate::beam_compiler::{
+    BeamCompiler, ClassHierarchyContext, CompileContext, compile_source_with_bindings,
+};
 use crate::commands::util;
+use beamtalk_core::semantic_analysis::alias_registry::AliasRegistry;
 use beamtalk_core::semantic_analysis::type_checker::NativeTypeRegistry;
 use camino::{Utf8Path, Utf8PathBuf};
 use miette::{Context, IntoDiagnostic, Result};
@@ -103,22 +106,76 @@ pub fn build_stdlib(quiet: bool, warnings_as_errors: bool) -> Result<()> {
     // get proper type inference instead of Dynamic (ADR 0075).
     let native_type_registry = extract_stdlib_type_specs();
 
+    // BT-2935: live same-run alias pre-pass — see its doc for why.
+    let alias_sources = collect_stdlib_alias_sources(&source_files)?;
     let compile_ctx = CompileContext {
         native_type_registry: native_type_registry.map(std::sync::Arc::new),
+        hierarchy: ClassHierarchyContext {
+            pre_loaded_aliases: stdlib_pre_loaded_aliases(&alias_sources),
+            ..ClassHierarchyContext::default()
+        },
         ..CompileContext::default()
     };
 
     // Compile each .bt file to .core (files are independent, no ordering required)
+    let (core_files, class_metadata, protocol_modules) = compile_all_stdlib_files(
+        &source_files,
+        &temp_path,
+        quiet,
+        &options,
+        &bindings,
+        &compile_ctx,
+    )?;
+
+    // Batch compile .core → .beam into ebin directory
+    info!("Compiling Core Erlang to BEAM");
+    let compiler = BeamCompiler::new(ebin_dir.clone());
+    compiler
+        .compile_batch(&core_files)
+        .wrap_err("Failed to compile stdlib Core Erlang to BEAM")?;
+
+    generate_app_file(&ebin_dir, &source_files, &class_metadata, &protocol_modules)?;
+    // Also update .app.src so rebar3 picks up the classes env
+    let app_src_dir = Utf8PathBuf::from("runtime/apps/beamtalk_stdlib/src");
+    if app_src_dir.exists() {
+        generate_app_src_file(&app_src_dir, &class_metadata, &protocol_modules)?;
+    }
+
+    // Generate Rust builtins file from parsed class metadata and aliases.
+    generate_builtins_rs(
+        &class_metadata,
+        &alias_source_texts_sorted_by_name(alias_sources),
+    )?;
+
+    println!("Built {} stdlib modules", source_files.len());
+
+    Ok(())
+}
+
+/// Compiles every stdlib source file to Core Erlang, collecting class
+/// metadata and protocol module names along the way.
+///
+/// Protocol-only files (e.g. `Printable.bt`) have no class definition — they
+/// are still compiled so the protocol gets registered at runtime, but
+/// contribute no `ClassMeta`. Files are independent (no compile ordering
+/// required); cross-file class/alias visibility comes entirely from
+/// `compile_ctx` (built by the caller before this runs).
+#[allow(clippy::too_many_arguments)] // orchestration glue — see call site
+fn compile_all_stdlib_files(
+    source_files: &[Utf8PathBuf],
+    temp_path: &Utf8Path,
+    quiet: bool,
+    options: &beamtalk_core::CompilerOptions,
+    bindings: &beamtalk_core::erlang::primitive_bindings::PrimitiveBindingTable,
+    compile_ctx: &CompileContext<'_>,
+) -> Result<(Vec<Utf8PathBuf>, Vec<ClassMeta>, Vec<String>)> {
     let mut core_files = Vec::new();
     let mut class_metadata = Vec::new();
     let mut protocol_modules = Vec::new();
-    for source_file in &source_files {
+    for source_file in source_files {
         let module_name = module_name_from_path(source_file)?;
         let core_file = temp_path.join(format!("{module_name}.core"));
 
-        // Protocol-only files (e.g. Printable.bt) have no class definition —
-        // skip metadata extraction but still compile them so the protocol
-        // gets registered at runtime.
         if is_protocol_only_file(source_file)? {
             if !quiet {
                 println!("  Compiling {source_file} (protocol)...");
@@ -127,9 +184,9 @@ pub fn build_stdlib(quiet: bool, warnings_as_errors: bool) -> Result<()> {
                 source_file,
                 &module_name,
                 &core_file,
-                &options,
-                &bindings,
-                &compile_ctx,
+                options,
+                bindings,
+                compile_ctx,
             )?;
             core_files.push(core_file);
             protocol_modules.push(module_name);
@@ -147,33 +204,13 @@ pub fn build_stdlib(quiet: bool, warnings_as_errors: bool) -> Result<()> {
             source_file,
             &module_name,
             &core_file,
-            &options,
-            &bindings,
-            &compile_ctx,
+            options,
+            bindings,
+            compile_ctx,
         )?;
         core_files.push(core_file);
     }
-
-    // Batch compile .core → .beam into ebin directory
-    info!("Compiling Core Erlang to BEAM");
-    let compiler = BeamCompiler::new(ebin_dir.clone());
-    compiler
-        .compile_batch(&core_files)
-        .wrap_err("Failed to compile stdlib Core Erlang to BEAM")?;
-
-    generate_app_file(&ebin_dir, &source_files, &class_metadata, &protocol_modules)?;
-    // Also update .app.src so rebar3 picks up the classes env
-    let app_src_dir = Utf8PathBuf::from("runtime/apps/beamtalk_stdlib/src");
-    if app_src_dir.exists() {
-        generate_app_src_file(&app_src_dir, &class_metadata, &protocol_modules)?;
-    }
-
-    // Generate Rust builtins file from parsed class metadata
-    generate_builtins_rs(&class_metadata)?;
-
-    println!("Built {} stdlib modules", source_files.len());
-
-    Ok(())
+    Ok((core_files, class_metadata, protocol_modules))
 }
 
 /// Remove all `.beam` and `.app` files from the ebin directory.
@@ -698,6 +735,117 @@ fn mark_timer_spawns(class_methods: &mut [MethodMeta]) -> Result<()> {
     Ok(())
 }
 
+/// A single stdlib type-alias declaration collected by
+/// `collect_stdlib_alias_sources` (BT-2935), carrying both its
+/// reconstructed `AliasInfo` (for immediately seeding *this* run's own
+/// `pre_loaded_aliases`) and its exact declaration source text (for
+/// persisting into `generated_builtins.rs`, so a consumer with no direct
+/// access to `stdlib/src/*.bt` — e.g. a REPL/workspace session, BT-2938 —
+/// can still reconstruct it later via
+/// `ClassHierarchy::generated_stdlib_aliases`).
+struct AliasSource {
+    info: beamtalk_core::semantic_analysis::alias_registry::AliasInfo,
+    text: String,
+}
+
+/// Scans every stdlib source file for `type Name = ...` declarations,
+/// reconstructing each into an `AliasSource` immediately (BT-2935).
+///
+/// **Why a live, same-run pre-pass — not a seed from
+/// `ClassHierarchy::generated_stdlib_aliases`'s persisted snapshot** (the
+/// design this replaced during review): `build-stdlib` always runs with
+/// `--warnings-as-errors` (`Justfile`'s `build-stdlib` recipe), and an
+/// unresolved cross-file alias reference surfaces as a
+/// `DiagnosticCategory::Type` warning — a category *not* excluded from
+/// warnings-as-errors promotion, unlike `UnresolvedClass` (see
+/// `beam_compiler.rs`'s exclusion list). Seeding from the *previous* run's
+/// persisted snapshot instead of a live scan would mean a stdlib change that
+/// declares `type Foo = ...` in one file and references `Foo` cross-file in
+/// another, landed in the *same* commit, bails before `generate_builtins_rs`
+/// ever runs — so `Foo` would never get persisted, and every subsequent
+/// `build-stdlib` run would repeat the exact same failure with no way out
+/// short of splitting the change across two builds or dropping
+/// `--warnings-as-errors`. A live pre-pass has direct access to every
+/// stdlib source file right now, so — unlike a consumer with no source
+/// access, which genuinely has no better option than the persisted
+/// snapshot — it never needs to fall back to stale data at all.
+///
+/// Fails loudly (`Result::Err`, not a silent skip) if a freshly-sliced
+/// declaration fails to re-parse via
+/// [`AliasRegistry::from_source_text`] — that would indicate a bug in the
+/// slicing logic itself (e.g. a span not covering a standalone-parseable
+/// declaration), not a tolerable degradation. Contrast
+/// `ClassHierarchy::generated_stdlib_aliases`'s defensive skip-on-failure,
+/// which exists only to tolerate a corrupted or hand-edited *generated*
+/// file at runtime, long after this build-time check already passed.
+fn collect_stdlib_alias_sources(source_files: &[Utf8PathBuf]) -> Result<Vec<AliasSource>> {
+    let mut all = Vec::new();
+    for file in source_files {
+        for text in extract_alias_source_snippets(file)? {
+            let info = AliasRegistry::from_source_text(&text).ok_or_else(|| {
+                miette::miette!(
+                    "Internal error: sliced type-alias declaration in '{file}' failed to \
+                     re-parse: {text:?}"
+                )
+            })?;
+            all.push(AliasSource { info, text });
+        }
+    }
+    Ok(all)
+}
+
+/// Extracts the `pre_loaded_aliases` value for
+/// [`ClassHierarchyContext`](crate::beam_compiler::ClassHierarchyContext)
+/// from [`collect_stdlib_alias_sources`]'s output, stamping every entry's
+/// `package` as `"stdlib"` (mirroring [`generate_class_entry`]'s hardcoded
+/// `package: Some("stdlib".into())` for generated `ClassInfo`).
+fn stdlib_pre_loaded_aliases(
+    alias_sources: &[AliasSource],
+) -> Vec<beamtalk_core::semantic_analysis::alias_registry::AliasInfo> {
+    alias_sources
+        .iter()
+        .map(|a| {
+            let mut info = a.info.clone();
+            info.package = Some("stdlib".into());
+            info
+        })
+        .collect()
+}
+
+/// Extracts `alias_sources`' declaration texts sorted by alias *name* (not
+/// raw declaration text — `internal type Foo` would otherwise sort under
+/// "i", not alongside plain `type` entries), for
+/// [`generate_alias_sources_section`], which trusts its caller to have
+/// already sorted (see that function's doc).
+fn alias_source_texts_sorted_by_name(mut alias_sources: Vec<AliasSource>) -> Vec<String> {
+    alias_sources.sort_by(|a, b| a.info.name.cmp(&b.info.name));
+    alias_sources.into_iter().map(|a| a.text).collect()
+}
+
+/// Extracts every `type Name = ...` declaration in a `.bt` file as verbatim
+/// source text (BT-2935), one string per alias.
+///
+/// Slices each declaration's exact span out of the original source rather
+/// than reconstructing it from the parsed `TypeAnnotation` — see
+/// `generate_builtins_rs`'s doc for why. A file with no type-alias
+/// declarations (the common case) returns an empty `Vec`.
+fn extract_alias_source_snippets(path: &Utf8Path) -> Result<Vec<String>> {
+    let source = fs::read_to_string(path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Failed to read '{path}'"))?;
+    let tokens = beamtalk_core::source_analysis::lex_with_eof(&source);
+    let (module, _diagnostics) = beamtalk_core::source_analysis::parse(tokens);
+
+    Ok(AliasRegistry::extract_alias_infos(&module)
+        .iter()
+        .filter_map(|info| {
+            let start = usize::try_from(info.span.start()).ok()?;
+            let end = usize::try_from(info.span.end()).ok()?;
+            source.get(start..end).map(str::to_string)
+        })
+        .collect())
+}
+
 /// Check whether a `.bt` file contains only protocol definitions (no classes).
 ///
 /// Protocol-only files (e.g. `Printable.bt`) define structural protocols via
@@ -980,11 +1128,54 @@ fn generate_app_src_file(
 const GENERATED_BUILTINS_PATH: &str =
     "crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs";
 
-/// Generate the `generated_builtins.rs` file from parsed stdlib class metadata.
+/// Generate the `generated_builtins.rs` file from parsed stdlib class and
+/// type-alias metadata.
 ///
-/// This produces a Rust source file that defines `generated_builtin_classes()` and
-/// `is_generated_builtin_class()`, replacing the hand-written tables in `builtins.rs`.
-fn generate_builtins_rs(class_metadata: &[ClassMeta]) -> Result<()> {
+/// This produces a Rust source file that defines `generated_builtin_classes()`,
+/// `is_generated_builtin_class()`, and (BT-2935) `generated_stdlib_alias_sources()`,
+/// replacing the hand-written tables in `builtins.rs`.
+///
+/// **BT-2935 design decision — how a stdlib `type Name = ...` alias is
+/// persisted here:** `AliasInfo::annotation` is a full, recursive
+/// `TypeAnnotation` AST (unions, generics, `\`/`&`, nested `Box`es, `Span`s
+/// on every node) — nothing like `ClassInfo`/`MethodInfo`'s flat
+/// `Option<EcoString>` return/param-type strings, which this generator
+/// already emits as simple quoted-string literals (see
+/// `generate_method_list`). Three representations were considered:
+///
+/// 1. **Add `serde` derives to `TypeAnnotation`** (and transitively
+///    `Identifier`) and embed a serialized (e.g. JSON) blob. Rejected: both
+///    types are deep in the shared AST used by parser, semantic analysis,
+///    codegen, and the LSP — adding derives there is a real, ongoing
+///    maintenance surface (every future `TypeAnnotation` variant needs a
+///    serde-compatible shape) for a feature only this one generator needs.
+/// 2. **Hand-write a recursive Rust-literal-construction emitter** for
+///    `TypeAnnotation` (mirroring `generate_superclass_type_args`'s much
+///    simpler two-variant `SuperclassTypeArg` emitter). Rejected: it would
+///    duplicate the parser's own understanding of the AST's shape in a
+///    second, hand-maintained place that silently falls out of sync (no
+///    compile error) whenever `TypeAnnotation` gains a variant — the emitter
+///    would need a matching arm added by hand, and forgetting one would
+///    silently miscompile or panic on a real alias RHS instead of failing to
+///    build.
+/// 3. **Store each alias's verbatim declaration source text** (`"type
+///    RestartStrategy = #temporary | #transient | #permanent"`, sliced
+///    directly from the original `.bt` file via
+///    [`extract_alias_source_snippets`]) and re-parse it back into an
+///    `AliasInfo` at load time via
+///    [`beamtalk_core::semantic_analysis::alias_registry::AliasRegistry::from_source_text`].
+///    **Chosen.** Zero new derives, zero hand-maintained AST mirror — every
+///    consumer goes through the same lexer/parser the rest of the compiler
+///    already trusts, so a new `TypeAnnotation` variant just works the
+///    moment the parser supports it. The cost is a handful of cheap
+///    single-line re-lexes at `ClassHierarchy::generated_stdlib_aliases()`
+///    call time (today: 5 stdlib aliases) — negligible next to compiling
+///    every stdlib file in the same pipeline. This mirrors
+///    `MethodInfo::return_type`'s existing stringly-typed precedent in this
+///    very generator, just keeping the *whole* declaration instead of a bare
+///    type name (a bare name isn't enough to reconstruct a union/generic
+///    RHS).
+fn generate_builtins_rs(class_metadata: &[ClassMeta], alias_sources: &[String]) -> Result<()> {
     let mut code = String::new();
 
     code.push_str(
@@ -1043,6 +1234,10 @@ fn generate_builtins_rs(class_metadata: &[ClassMeta]) -> Result<()> {
     }
 
     code.push_str("    classes\n}\n");
+
+    // Generate generated_stdlib_alias_sources() (BT-2935) — see this
+    // function's own doc for the source-text-persisted-and-reparsed design.
+    generate_alias_sources_section(&mut code, alias_sources);
 
     let dest = Utf8PathBuf::from(GENERATED_BUILTINS_PATH);
 
@@ -1193,6 +1388,42 @@ fn generate_class_entry(code: &mut String, meta: &ClassMeta) {
     code.push_str("        },\n    );\n\n");
 }
 
+/// Emit the `generated_stdlib_alias_sources()` function body (BT-2935): one
+/// `&'static str` literal per stdlib type-alias declaration, in the order
+/// given by `alias_sources`.
+///
+/// Unlike [`generate_class_entry`]'s `sorted_meta` (sorted right before
+/// calling this file's class-entry generator), sorting alias entries by
+/// *name* requires the caller's already-reconstructed `AliasInfo` — plain
+/// declaration text alone would sort `internal type Foo = ...` under "i",
+/// not alongside `type` entries — so the caller (`build_stdlib()`) is
+/// responsible for passing `alias_sources` pre-sorted by name; this function
+/// only formats whatever order it's given.
+///
+/// See `generate_builtins_rs`'s doc for why each alias is persisted as its
+/// verbatim declaration source text rather than a literal-Rust
+/// `TypeAnnotation` construction or a `serde` blob.
+fn generate_alias_sources_section(code: &mut String, alias_sources: &[String]) {
+    code.push_str(
+        "\n/// Returns the verbatim `type Name = ...` declaration source text for every\n\
+         /// stdlib type alias (BT-2935), sorted by alias name.\n\
+         ///\n\
+         /// Auto-generated from `stdlib/src/*.bt` ASTs. See\n\
+         /// `crates/beamtalk-cli/src/commands/build_stdlib.rs`'s `generate_builtins_rs`\n\
+         /// doc for why source text (re-parsed by\n\
+         /// `AliasRegistry::from_source_text`), not a literal-Rust `TypeAnnotation`\n\
+         /// construction or a `serde` blob, was chosen to represent each alias here.\n\
+         pub(super) fn generated_stdlib_alias_sources() -> Vec<&'static str> {\n\
+         \x20   vec![\n",
+    );
+
+    for text in alias_sources {
+        let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
+        let _ = writeln!(code, "        \"{escaped}\",");
+    }
+    code.push_str("    ]\n}\n");
+}
+
 /// Emit `superclass_type_args: vec![...]` for a subclass's parent binding.
 ///
 /// Each entry is either a [`SuperclassTypeArg::ParamRef`] when the argument
@@ -1300,6 +1531,285 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
         (temp, dir)
+    }
+
+    /// BT-2935: End-to-end regression fixture for stdlib's own cross-file
+    /// type-alias resolution, proving the full round trip
+    /// `build_stdlib.rs` relies on: `collect_stdlib_alias_sources` (a live,
+    /// same-run pre-pass — *not* a seed from a previously-persisted
+    /// `generated_builtins.rs` snapshot, see that function's doc for why)
+    /// → `ClassHierarchyContext::pre_loaded_aliases` → cross-file resolution
+    /// during a real compile, in the very same run the alias was first
+    /// declared in. Mirrors the shape of `build.rs`'s
+    /// `test_cross_file_alias_resolution_no_false_type_mismatch` (BT-2928),
+    /// adapted to `build_stdlib`'s own manifest-less compile path
+    /// (`compile_source_with_bindings`, no package/`build_class_module_index`).
+    #[test]
+    fn test_cross_file_alias_resolution_seeds_pre_loaded_aliases() {
+        let (_temp, lib_dir) = temp_utf8_dir();
+
+        // File 1: declares the alias and a class with a method that returns
+        // it. `A` is a `Value` subclass so `A new` is instantiable (`Object`
+        // classes are abstract and not directly instantiable).
+        fs::write(
+            lib_dir.join("AliasFixtureA.bt"),
+            "type Direction = #north | #south | #east | #west\n\
+             Value subclass: AliasFixtureA\n  heading -> Direction => #north\n",
+        )
+        .unwrap();
+
+        // File 2: consumes A's alias-typed return value as an argument to a
+        // parameter typed with the spelled-out equivalent union — the exact
+        // shape of the real `RestartStrategy`/`Timeout` stdlib bug this issue
+        // fixes (BT-2923).
+        fs::write(
+            lib_dir.join("AliasFixtureB.bt"),
+            "Object subclass: AliasFixtureB\n  \
+             useDirection: d :: #north | #south | #east | #west => d\n  \
+             test => self useDirection: AliasFixtureA new heading\n",
+        )
+        .unwrap();
+
+        let file_a = lib_dir.join("AliasFixtureA.bt");
+        let file_b = lib_dir.join("AliasFixtureB.bt");
+
+        // Mirrors build_stdlib()'s own per-file class extraction.
+        let source_a = fs::read_to_string(&file_a).unwrap();
+        let tokens_a = beamtalk_core::source_analysis::lex_with_eof(&source_a);
+        let (module_a, _diags) = beamtalk_core::source_analysis::parse(tokens_a);
+        let pre_loaded_classes =
+            beamtalk_core::semantic_analysis::class_hierarchy::ClassHierarchy::extract_class_infos(
+                &module_a,
+            );
+        assert_eq!(pre_loaded_classes.len(), 1, "expected one class in file A");
+
+        // The real function under test, called the way `build_stdlib()`
+        // actually calls it — over *all* source files in one pass, before
+        // any compile happens — proving this is a live scan (file A's alias
+        // is seeded immediately, in the same call, with no dependency on any
+        // prior "generated" snapshot existing).
+        let alias_sources =
+            collect_stdlib_alias_sources(&[file_a.clone(), file_b.clone()]).unwrap();
+        assert_eq!(
+            alias_sources.len(),
+            1,
+            "expected exactly one alias declaration, from file A (file B declares none)"
+        );
+        assert!(alias_sources[0].text.starts_with("type Direction ="));
+        assert_eq!(alias_sources[0].info.name.as_str(), "Direction");
+
+        let pre_loaded_aliases: Vec<_> = alias_sources
+            .iter()
+            .map(|a| {
+                let mut info = a.info.clone();
+                info.package = Some("stdlib".into());
+                info
+            })
+            .collect();
+        assert_eq!(pre_loaded_aliases.len(), 1);
+        assert_eq!(pre_loaded_aliases[0].name.as_str(), "Direction");
+
+        let options = beamtalk_core::CompilerOptions {
+            stdlib_mode: true,
+            allow_primitives: false,
+            workspace_mode: false,
+            ..Default::default()
+        };
+        let bindings = beamtalk_core::erlang::primitive_bindings::PrimitiveBindingTable::new();
+
+        // Compile B with cross-file class info AND cross-file alias info —
+        // should produce no "Argument ... expects" type-mismatch warning.
+        let core_file = lib_dir.join("b.core");
+        let diagnostics = compile_source_with_bindings(
+            &file_b,
+            "bt@stdlib@alias_fixture_b",
+            &core_file,
+            &options,
+            &bindings,
+            &CompileContext {
+                hierarchy: ClassHierarchyContext {
+                    pre_loaded_classes: pre_loaded_classes.clone(),
+                    pre_loaded_aliases: pre_loaded_aliases.clone(),
+                    ..ClassHierarchyContext::default()
+                },
+                ..CompileContext::default()
+            },
+            None,
+        )
+        .expect("cross-file alias-typed argument should compile without errors");
+
+        assert!(
+            diagnostics.iter().all(|d| !d.message.contains("Argument")),
+            "expected no false argument-type-mismatch diagnostic once cross-file \
+             aliases are seeded, got: {diagnostics:?}"
+        );
+
+        // Negative control: WITHOUT pre_loaded_aliases (but still with
+        // pre_loaded_classes), the same compile reproduces the pre-BT-2935
+        // false positive — proving this test actually exercises the fix
+        // rather than a scenario that never warned.
+        let core_file_unfixed = lib_dir.join("b_unfixed.core");
+        let diagnostics_unfixed = compile_source_with_bindings(
+            &file_b,
+            "bt@stdlib@alias_fixture_b_unfixed",
+            &core_file_unfixed,
+            &options,
+            &bindings,
+            &CompileContext {
+                hierarchy: ClassHierarchyContext {
+                    pre_loaded_classes,
+                    // No pre_loaded_aliases — reproduces the pre-fix gap.
+                    ..ClassHierarchyContext::default()
+                },
+                ..CompileContext::default()
+            },
+            None,
+        )
+        .expect("compile should still succeed even with the false-positive warning");
+
+        assert!(
+            diagnostics_unfixed
+                .iter()
+                .any(|d| d.message.contains("Argument")),
+            "expected the negative control (no pre_loaded_aliases) to reproduce \
+             the pre-BT-2935 false positive, got: {diagnostics_unfixed:?}"
+        );
+    }
+
+    #[test]
+    fn test_extract_alias_source_snippets_captures_verbatim_declaration() {
+        let (_temp, lib_dir) = temp_utf8_dir();
+        let file = lib_dir.join("Fixture.bt");
+        fs::write(
+            &file,
+            "type RestartStrategy = #temporary | #transient | #permanent\n\
+             Object subclass: Fixture\n  noop => nil\n",
+        )
+        .unwrap();
+
+        let snippets = extract_alias_source_snippets(&file).unwrap();
+        assert_eq!(snippets.len(), 1);
+        assert_eq!(
+            snippets[0],
+            "type RestartStrategy = #temporary | #transient | #permanent"
+        );
+
+        // Round-trips through the read side of the generated table.
+        let info = AliasRegistry::from_source_text(&snippets[0])
+            .expect("verbatim declaration text should re-parse");
+        assert_eq!(info.name.as_str(), "RestartStrategy");
+        assert!(!info.is_internal);
+    }
+
+    #[test]
+    fn test_extract_alias_source_snippets_captures_internal_modifier() {
+        let (_temp, lib_dir) = temp_utf8_dir();
+        let file = lib_dir.join("Fixture.bt");
+        fs::write(&file, "internal type Scratch = Integer\n").unwrap();
+
+        let snippets = extract_alias_source_snippets(&file).unwrap();
+        assert_eq!(snippets, vec!["internal type Scratch = Integer"]);
+
+        let info = AliasRegistry::from_source_text(&snippets[0]).unwrap();
+        assert!(
+            info.is_internal,
+            "the `internal` modifier should survive the source-text round trip"
+        );
+    }
+
+    #[test]
+    fn test_extract_alias_source_snippets_no_aliases() {
+        let (_temp, lib_dir) = temp_utf8_dir();
+        let file = lib_dir.join("Fixture.bt");
+        fs::write(&file, "Object subclass: Fixture\n  noop => nil\n").unwrap();
+
+        assert!(extract_alias_source_snippets(&file).unwrap().is_empty());
+    }
+
+    /// Pass 2 (system review) edge case: a declaration that spans multiple
+    /// source lines (a long union wrapped for readability) embeds a literal
+    /// newline in the sliced snippet. Rust string literals accept a raw
+    /// newline verbatim (no escaping needed — `generate_alias_sources_section`
+    /// only escapes `\` and `"`), so this must still round-trip cleanly
+    /// through generation and `AliasRegistry::from_source_text` reparse.
+    #[test]
+    fn test_extract_alias_source_snippets_handles_multiline_declaration() {
+        let (_temp, lib_dir) = temp_utf8_dir();
+        let file = lib_dir.join("Fixture.bt");
+        fs::write(
+            &file,
+            "type Wrapped =\n    #a\n    | #b\n    | #c\n\nObject subclass: Fixture\n  noop => nil\n",
+        )
+        .unwrap();
+
+        let snippets = extract_alias_source_snippets(&file).unwrap();
+        assert_eq!(snippets.len(), 1);
+        assert!(
+            snippets[0].contains('\n'),
+            "expected the multiline declaration to be captured verbatim, got: {:?}",
+            snippets[0]
+        );
+
+        // Generation must produce valid Rust even with an embedded newline.
+        let mut code = String::new();
+        generate_alias_sources_section(&mut code, &snippets);
+        assert!(code.contains("type Wrapped ="));
+
+        // And the read side must still reconstruct the alias correctly.
+        let info = AliasRegistry::from_source_text(&snippets[0])
+            .expect("a multiline declaration should still re-parse");
+        assert_eq!(info.name.as_str(), "Wrapped");
+    }
+
+    #[test]
+    fn test_generate_alias_sources_section_empty() {
+        let mut code = String::new();
+        generate_alias_sources_section(&mut code, &[]);
+        assert!(
+            code.contains("pub(super) fn generated_stdlib_alias_sources() -> Vec<&'static str> {"),
+            "Should always emit the function signature. Got: {code}"
+        );
+        assert!(
+            code.contains("vec![\n    ]"),
+            "Should emit an empty vec when there are no aliases. Got: {code}"
+        );
+    }
+
+    #[test]
+    fn test_generate_alias_sources_section_preserves_caller_order() {
+        // Sorting by alias *name* requires the caller's `AliasInfo` (plain
+        // declaration text alone would put `internal type ...` out of order
+        // — see this function's doc) — so it emits entries in whatever order
+        // it's given, trusting the caller (`build_stdlib()`) to have already
+        // sorted by name.
+        let mut code = String::new();
+        generate_alias_sources_section(
+            &mut code,
+            &[
+                "type Zebra = Integer".to_string(),
+                "type Alpha = String".to_string(),
+            ],
+        );
+
+        let alpha_pos = code.find("type Alpha").unwrap();
+        let zebra_pos = code.find("type Zebra").unwrap();
+        assert!(
+            zebra_pos < alpha_pos,
+            "Should preserve caller order (Zebra before Alpha here), not re-sort. Got: {code}"
+        );
+    }
+
+    #[test]
+    fn test_generate_alias_sources_section_escapes_embedded_quotes() {
+        // Not valid Beamtalk syntax — this only exercises the generator's
+        // Rust-string-literal escaping, not the parser.
+        let mut code = String::new();
+        generate_alias_sources_section(&mut code, &[r#"contains "a quote""#.to_string()]);
+
+        assert!(
+            code.contains(r#"contains \"a quote\""#),
+            "Embedded quotes should be escaped for the Rust string literal. Got: {code}"
+        );
     }
 
     #[test]

--- a/crates/beamtalk-core/src/semantic_analysis/alias_registry.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/alias_registry.rs
@@ -432,6 +432,35 @@ impl AliasRegistry {
             .collect()
     }
 
+    /// Reconstructs a single [`AliasInfo`] from a standalone declaration
+    /// string (e.g. `"type RestartStrategy = #temporary | #transient |
+    /// #permanent"` or `"internal type Foo = Integer"`) — BT-2935.
+    ///
+    /// Lexes and parses `text` as its own tiny module and delegates to
+    /// [`Self::extract_alias_infos`], returning the first (and expected only)
+    /// entry. This is the read-side counterpart of `build_stdlib.rs`'s
+    /// generator, which persists each stdlib alias as exactly this kind of
+    /// verbatim declaration text into `generated_builtins.rs` — see that
+    /// generator's module doc for why source text (re-parsed here with the
+    /// same lexer/parser every other caller already trusts) was chosen over
+    /// adding `serde` derives to the recursive [`TypeAnnotation`] AST or
+    /// hand-rolling a literal-Rust-construction emitter for it.
+    ///
+    /// Returns `None` if `text` contains no parseable `type Name = ...`
+    /// declaration (e.g. empty input, or a caller passing malformed text) —
+    /// non-fatal by design, mirroring [`Self::extract_alias_infos`]'s own
+    /// "always returns whatever was found, however much that is" contract.
+    /// The returned `AliasInfo`'s `span` describes an offset into `text`
+    /// alone, not any original file — fine for a pre-loaded alias, whose
+    /// span is already "foreign" to the module currently being compiled (see
+    /// [`Self::add_pre_loaded`]'s doc).
+    #[must_use]
+    pub fn from_source_text(text: &str) -> Option<AliasInfo> {
+        let tokens = crate::source_analysis::lex_with_eof(text);
+        let (module, _diagnostics) = crate::source_analysis::parse(tokens);
+        Self::extract_alias_infos(&module).into_iter().next()
+    }
+
     /// Seed the registry with aliases pre-compiled from other source files or
     /// packages, or carried over from earlier turns of the same REPL session.
     ///
@@ -2084,6 +2113,55 @@ mod tests {
                 .iter()
                 .any(|i| i.name.as_str() == "Internal" && i.is_internal)
         );
+    }
+
+    // ---- BT-2935: from_source_text (build_stdlib.rs's generated-table
+    //      read-side reparse) ----
+
+    #[test]
+    fn from_source_text_reconstructs_simple_alias() {
+        let info = AliasRegistry::from_source_text("type TimeoutMs = Integer")
+            .expect("should parse a simple alias declaration");
+        assert_eq!(info.name.as_str(), "TimeoutMs");
+        assert!(!info.is_internal);
+        // Spans are relative to `text` alone (not any original file), so
+        // compare structurally via `type_name()` rather than full `PartialEq`
+        // (which would also compare the — necessarily different — spans).
+        assert_eq!(info.annotation.type_name(), "Integer");
+        assert!(matches!(info.annotation, TypeAnnotation::Simple(_)));
+    }
+
+    #[test]
+    fn from_source_text_reconstructs_union_alias() {
+        let info = AliasRegistry::from_source_text(
+            "type RestartStrategy = #temporary | #transient | #permanent",
+        )
+        .expect("should parse a union alias declaration");
+        assert_eq!(info.name.as_str(), "RestartStrategy");
+        let TypeAnnotation::Union { types, .. } = &info.annotation else {
+            panic!("expected a Union annotation, got: {:?}", info.annotation);
+        };
+        let names: Vec<&str> = types
+            .iter()
+            .map(|t| match t {
+                TypeAnnotation::Singleton { name, .. } => name.as_str(),
+                other => panic!("expected a Singleton member, got: {other:?}"),
+            })
+            .collect();
+        assert_eq!(names, vec!["temporary", "transient", "permanent"]);
+    }
+
+    #[test]
+    fn from_source_text_preserves_internal_modifier() {
+        let info = AliasRegistry::from_source_text("internal type Scratch = Integer")
+            .expect("should parse an internal alias declaration");
+        assert!(info.is_internal);
+    }
+
+    #[test]
+    fn from_source_text_returns_none_for_non_alias_text() {
+        assert!(AliasRegistry::from_source_text("").is_none());
+        assert!(AliasRegistry::from_source_text("Object subclass: Foo").is_none());
     }
 
     // ---- BT-2898: add_pre_loaded (pattern to mirror:

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/builtins.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/builtins.rs
@@ -18,6 +18,7 @@ use super::ClassInfo;
 use super::MethodInfo;
 #[cfg(test)]
 use crate::ast::MethodKind;
+use crate::semantic_analysis::alias_registry::{AliasInfo, AliasRegistry};
 use ecow::EcoString;
 use std::collections::HashMap;
 
@@ -112,6 +113,36 @@ pub(super) fn builtin_classes() -> HashMap<EcoString, ClassInfo> {
     classes
 }
 
+/// Returns every stdlib type alias (`type Name = ...`), reconstructed from
+/// `generated_builtins.rs`'s persisted declaration-text table (BT-2935).
+///
+/// Mirrors [`builtin_classes`] immediately above — both are a bootstrap read
+/// of data `beamtalk build-stdlib` snapshotted at the end of its *previous*
+/// successful run, baked into this binary at compile time. Unlike
+/// [`builtin_classes`], which stores each `ClassInfo` as a fully-materialised
+/// Rust struct literal, each alias is stored as its exact `type Name = ...`
+/// declaration source text (`generated::generated_stdlib_alias_sources`) and
+/// reconstructed here via [`AliasRegistry::from_source_text`] — see that
+/// generator's module doc (`build_stdlib.rs`) for the tradeoff behind that
+/// choice. A string that fails to parse into an alias (should not happen for
+/// generator-produced text, but defensive against a hand-edited or corrupted
+/// file) is silently skipped rather than panicking.
+///
+/// Every returned entry has `package` set to `Some("stdlib")`, matching
+/// `build_stdlib.rs`'s `generate_class_entry`, which hardcodes the same
+/// `package: Some("stdlib".into())` for generated `ClassInfo` entries — the
+/// whole generated table is, by construction, one package.
+pub(super) fn stdlib_aliases() -> Vec<AliasInfo> {
+    generated::generated_stdlib_alias_sources()
+        .into_iter()
+        .filter_map(AliasRegistry::from_source_text)
+        .map(|mut info| {
+            info.package = Some("stdlib".into());
+            info
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -184,5 +215,28 @@ mod tests {
         let classes = super::builtin_classes();
         let value = &classes["Value"];
         assert!(!value.is_sealed, "Value should not be sealed");
+    }
+
+    // ---- BT-2935: stdlib_aliases() ----
+
+    #[test]
+    fn stdlib_aliases_reconstructs_known_generated_entries() {
+        // Every entry generated_builtins.rs currently carries should
+        // reconstruct into a real AliasInfo with `package` stamped "stdlib" —
+        // proves the generated-table round trip end to end (as opposed to
+        // unit-testing `AliasRegistry::from_source_text` in isolation, which
+        // `alias_registry.rs`'s own tests already do).
+        let aliases = super::stdlib_aliases();
+        assert!(
+            !aliases.is_empty(),
+            "expected at least one generated stdlib alias (e.g. SupervisionStrategy)"
+        );
+        for info in &aliases {
+            assert_eq!(
+                info.package.as_deref(),
+                Some("stdlib"),
+                "every generated stdlib alias should be stamped package \"stdlib\", got: {info:?}"
+            );
+        }
     }
 }

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/generated_builtins.rs
@@ -4178,3 +4178,21 @@ pub(super) fn generated_builtin_classes() -> HashMap<EcoString, ClassInfo> {
 
     classes
 }
+
+/// Returns the verbatim `type Name = ...` declaration source text for every
+/// stdlib type alias (BT-2935), sorted by alias name.
+///
+/// Auto-generated from `stdlib/src/*.bt` ASTs. See
+/// `crates/beamtalk-cli/src/commands/build_stdlib.rs`'s `generate_builtins_rs`
+/// doc for why source text (re-parsed by
+/// `AliasRegistry::from_source_text`), not a literal-Rust `TypeAnnotation`
+/// construction or a `serde` blob, was chosen to represent each alias here.
+pub(super) fn generated_stdlib_alias_sources() -> Vec<&'static str> {
+    vec![
+        "type EtsTableType = #set | #orderedSet | #bag | #duplicateBag",
+        "type JsonValue = Nil | Boolean | Integer | Float | String | List | Dictionary",
+        "type LogFormat = #text | #json",
+        "type LogLevel = #emergency | #alert | #critical | #error | #warning | #notice | #info | #debug",
+        "type SupervisionStrategy = #oneForOne | #oneForAll | #restForOne",
+    ]
+}

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/mod.rs
@@ -244,6 +244,27 @@ impl ClassHierarchy {
             .clone()
     }
 
+    /// Returns every stdlib type alias declaration (`type Name = ...`),
+    /// bootstrapped from `generated_builtins.rs`'s persisted alias-source
+    /// table the same way [`Self::with_builtins`] bootstraps stdlib classes
+    /// from that file's `generated_builtin_classes()` (BT-2935).
+    ///
+    /// Unlike [`Self::with_builtins`], this is *not* baked automatically into
+    /// every [`ClassHierarchy`]/[`AliasRegistry`](crate::semantic_analysis::alias_registry::AliasRegistry)
+    /// — `AliasRegistry` has no built-in-alias concept analogous to
+    /// `with_builtins`'s always-on class seeding, so a caller that wants
+    /// stdlib's own cross-file aliases visible (today: only
+    /// `beamtalk build-stdlib`'s own compile loop, via
+    /// `ClassHierarchyContext::pre_loaded_aliases`) must call this and thread
+    /// the result through explicitly. Wiring this into every ordinary
+    /// compile's `AliasRegistry` (so application code can reference a stdlib
+    /// alias without importing it) is BT-2938, deliberately out of scope
+    /// here.
+    #[must_use]
+    pub fn generated_stdlib_aliases() -> Vec<crate::semantic_analysis::alias_registry::AliasInfo> {
+        builtins::stdlib_aliases()
+    }
+
     /// How complete the knowledge injected into this hierarchy is (BT-2796).
     #[must_use]
     pub fn knowledge_scope(&self) -> crate::semantic_analysis::receiver_knowledge::KnowledgeScope {

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/mod.rs
@@ -260,9 +260,17 @@ impl ClassHierarchy {
     /// compile's `AliasRegistry` (so application code can reference a stdlib
     /// alias without importing it) is BT-2938, deliberately out of scope
     /// here.
+    ///
+    /// The underlying re-parse (one `AliasRegistry::from_source_text` call
+    /// per stdlib alias) is computed once and cached in a `OnceLock`, exactly
+    /// like [`Self::with_builtins`]'s cached class map — each call clones the
+    /// cached `Vec` rather than re-lexing every stored declaration string
+    /// from scratch.
     #[must_use]
     pub fn generated_stdlib_aliases() -> Vec<crate::semantic_analysis::alias_registry::AliasInfo> {
-        builtins::stdlib_aliases()
+        static STDLIB_ALIASES: OnceLock<Vec<crate::semantic_analysis::alias_registry::AliasInfo>> =
+            OnceLock::new();
+        STDLIB_ALIASES.get_or_init(builtins::stdlib_aliases).clone()
     }
 
     /// How complete the knowledge injected into this hierarchy is (BT-2796).


### PR DESCRIPTION
## Summary

Fixes BT-2935: `build_stdlib.rs` compiled each `stdlib/src/*.bt` file independently with no type-alias visibility across files, so a `type Name = ...` declared in one stdlib file could never resolve when referenced from another. This is the gap that blocked re-aliasing `RestartStrategy`/`Timeout` in BT-2923, and the stdlib-specific follow-up scoped out of BT-2928 (which fixed the same problem for manifest-based `beamtalk build` and LSP diagnostics).

Linear: https://linear.app/beamtalk/issue/BT-2935

## Changes

- **`crates/beamtalk-core/src/semantic_analysis/alias_registry.rs`** — new `AliasRegistry::from_source_text(text) -> Option<AliasInfo>`: reconstructs an alias from a standalone `"type Name = ..."` string via the existing lexer/parser.
- **`crates/beamtalk-core/src/semantic_analysis/class_hierarchy/{builtins,mod}.rs`** — new `ClassHierarchy::generated_stdlib_aliases()`, reading the persisted alias-source table the same way `with_builtins()` already bootstraps stdlib classes. Documented as *not* auto-wired into every compile (unlike class bootstrap) — that's BT-2938, deliberately out of scope.
- **`crates/beamtalk-cli/src/commands/build_stdlib.rs`**:
  - `collect_stdlib_alias_sources` does a **live, same-run pre-pass** over every stdlib source file before compiling anything, and seeds `ClassHierarchyContext::pre_loaded_aliases` from that live scan.
  - `generate_builtins_rs` now also emits `generated_stdlib_alias_sources()` into `generated_builtins.rs`, sorted by alias name, for future consumers with no direct source access (e.g. REPL/workspace sessions, BT-2938).
  - `generated_builtins.rs` regenerated for real — now carries the 5 existing stdlib aliases (`EtsTableType`, `JsonValue`, `LogFormat`, `LogLevel`, `SupervisionStrategy`) as persisted declaration text. Verified idempotent across repeated `build-stdlib` runs.

## Design decision (the AC's flagged tradeoff)

`AliasInfo::annotation` is a full recursive `TypeAnnotation` AST with no `serde` support. Three options were considered (documented in `generate_builtins_rs`'s doc comment):

1. Add `serde` derives to `TypeAnnotation` — rejected: broad, ongoing maintenance surface on a type shared by parser/semantic-analysis/codegen/LSP, for a feature only this one generator needs.
2. Hand-write a recursive Rust-literal-construction emitter (mirroring `generate_superclass_type_args`) — rejected: a second, hand-maintained mirror of the AST's shape that silently falls out of sync (no compile error) whenever `TypeAnnotation` gains a variant.
3. **Chosen**: persist each alias as its **verbatim declaration source text**, sliced from the original file by span, and re-parse it at load time via the same lexer/parser every other caller trusts. Zero new derives, zero hand-maintained AST mirror, and a new `TypeAnnotation` variant just works the moment the parser supports it. Mirrors `MethodInfo::return_type`'s existing stringly-typed precedent in this generator.

## A bug found (and fixed) during review

My first draft seeded `pre_loaded_aliases` from the *previous* run's persisted snapshot (mirroring how `ClassHierarchy::with_builtins()` bootstraps classes). An adversarial review pass caught a critical flaw in that approach: `build-stdlib` always runs with `--warnings-as-errors`, and an unresolved cross-file alias reference surfaces as a `DiagnosticCategory::Type` warning — a category *not* excluded from warnings-as-errors promotion (unlike `UnresolvedClass`). Declaring an alias and referencing it cross-file in the *same* commit would therefore bail before `generate_builtins_rs` ever ran, so the alias could never get persisted — a permanent deadlock on exactly the use case this ticket exists to unblock (BT-2939 will hit this immediately). Fixed by switching to the live same-run pre-pass described above, which matches `build.rs`'s actual BT-2928 precedent more closely than my first draft did.

## Test plan

- [x] `AliasRegistry::from_source_text` unit tests (simple/union/internal-modifier aliases, non-alias input) — `crates/beamtalk-core/src/semantic_analysis/alias_registry.rs`
- [x] `ClassHierarchy::generated_stdlib_aliases`/`stdlib_aliases()` round-trip test against the real generated table
- [x] End-to-end 2-file regression fixture in `build_stdlib.rs` (`test_cross_file_alias_resolution_seeds_pre_loaded_aliases`): positive case (aliases seeded → no false "Argument...expects" diagnostic) + negative control (aliases not seeded → false positive reproduces), calling the real `collect_stdlib_alias_sources` function
- [x] Multi-line declaration span-slicing edge case, generator sorting/escaping tests
- [x] `cargo test -p beamtalk-core --lib` — 5219 passed
- [x] `cargo test -p beamtalk-cli --bin beamtalk` — 859 passed (1 pre-existing, unrelated EPMD network-state test fails only in this shared sandbox due to concurrent parallel-agent Erlang nodes; confirmed via `epmd -names` and by reading the test's own live-network-probe implementation)
- [x] `just test-stdlib` — 223 passed
- [x] `just test-bunit` — 2776 tests, 0 failed
- [x] `just test-runtime` — 5382 + 1588 tests, 0 failures
- [x] `just clippy`, `just fmt-check`, `just check-corpus`, `just check-surface-drift` all pass
- [x] `just build-stdlib` run twice, confirmed byte-identical (idempotent) regeneration

## Follow-ups filed

- BT-2954: `AliasRegistry::add_pre_loaded` never runs cycle detection across pre-loaded + module-local aliases (pre-existing gap shared with BT-2928's `build.rs` mechanism, found during adversarial review, out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)