### PR TITLE
Protocol method signatures register hot-reload alias-xref edges (BT-2917)

### DIFF
--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -565,11 +565,18 @@ fn method_definition_ok_response(
 }
 
 /// Build a response map for a successful protocol definition in REPL (BT-1612).
+///
+/// `referenced_aliases` (ADR 0108 hot-reload re-check trigger, BT-2899 /
+/// BT-2917 follow-up) mirrors `compile_ok_response`'s field of the same
+/// name — every alias name this protocol's own method-signature annotations
+/// transitively depended on, so the Erlang side can register the same
+/// `beamtalk_alias_xref` dependency edges a class-defining compile gets.
 fn protocol_definition_ok_response(
     core_erlang: &str,
     module_name: &str,
     protocol_names: &[String],
     warnings: &[String],
+    referenced_aliases: &[ecow::EcoString],
 ) -> Term {
     let protocol_terms: Vec<Term> = protocol_names.iter().map(|n| binary(n)).collect();
     Term::from(Map::from([
@@ -581,6 +588,10 @@ fn protocol_definition_ok_response(
         (
             atom("warnings"),
             Term::from(List::from(build_warning_terms(warnings))),
+        ),
+        (
+            atom("referenced_aliases"),
+            Term::from(List::from(build_referenced_alias_terms(referenced_aliases))),
         ),
     ]))
 }
@@ -1218,6 +1229,14 @@ fn handle_compile_expression(request: &Map) -> Term {
 
     // BT-1612: If the parsed module contains protocol definitions, compile and return them
     if !module.protocols.is_empty() {
+        // BT-2917: `parse_and_check_expression` doesn't compute
+        // `referenced_aliases` for this REPL-expression path (unlike
+        // `handle_compile`'s file-compile path below) — mirrors the same,
+        // pre-existing gap `handle_inline_class_definition` has for REPL
+        // inline class definitions. An empty set here is a known limitation
+        // (BT-2917), not a regression: a `Protocol define:` typed directly
+        // at the REPL still installs correctly, it just doesn't get
+        // alias-xref edges until compiled via a file (`compile`/`handle_load`).
         return handle_inline_protocol_definition(
             &module,
             &source,
@@ -1227,6 +1246,7 @@ fn handle_compile_expression(request: &Map) -> Term {
             pre_class_hierarchy,
             module_name_override.as_deref(),
             false, // REPL expressions are never stdlib
+            &[],
         );
     }
 
@@ -1459,6 +1479,11 @@ fn handle_inline_class_definition(
 /// with protocol registration via BT-1610), then returns a `protocol_definition`
 /// response so the Erlang side can load and execute the module.
 /// BT-1670: Accepts optional `module_name_override` for package-mode consistency.
+/// BT-2917: Accepts `referenced_aliases` — the caller's already-computed
+/// alias-dependency set (empty when the caller hasn't computed one, e.g. the
+/// REPL `compile_expression` path — see that call site's comment), threaded
+/// straight into the response so the Erlang side can register the same
+/// `beamtalk_alias_xref` dependency edges a class-defining compile gets.
 #[allow(clippy::too_many_arguments)]
 fn handle_inline_protocol_definition(
     module: &beamtalk_core::ast::Module,
@@ -1469,6 +1494,7 @@ fn handle_inline_protocol_definition(
     pre_class_hierarchy: Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
     module_name_override: Option<&str>,
     stdlib_mode: bool,
+    referenced_aliases: &[ecow::EcoString],
 ) -> Term {
     let first_protocol_name = &module.protocols[0].name.name;
     let protocol_module_name =
@@ -1489,9 +1515,13 @@ fn handle_inline_protocol_definition(
             .with_class_module_index(class_module_index)
             .with_class_hierarchy(pre_class_hierarchy),
     ) {
-        Ok(code) => {
-            protocol_definition_ok_response(&code, &protocol_module_name, &protocol_names, warnings)
-        }
+        Ok(code) => protocol_definition_ok_response(
+            &code,
+            &protocol_module_name,
+            &protocol_names,
+            warnings,
+            referenced_aliases,
+        ),
         Err(e) => error_response(&[format_codegen_error(&e, source)]),
     }
 }
@@ -1682,6 +1712,10 @@ fn handle_compile(request: &Map) -> Term {
     // protocol-only files. Route through the protocol codegen instead.
     if !module.protocols.is_empty() && module.classes.is_empty() {
         let warning_msgs: Vec<String> = warnings.iter().map(|w| w.message.clone()).collect();
+        // BT-2917: `referenced_aliases` was already computed above (BT-2899)
+        // for this file-compile path — thread it through so a protocol-only
+        // file's alias-typed method signatures get the same
+        // `beamtalk_alias_xref` registration a class-defining compile gets.
         return handle_inline_protocol_definition(
             &module,
             &source,
@@ -1691,6 +1725,7 @@ fn handle_compile(request: &Map) -> Term {
             pre_class_hierarchy,
             module_name_override.as_deref(),
             stdlib_mode,
+            &referenced_aliases,
         );
     }
 
@@ -3155,6 +3190,59 @@ mod tests {
             map_get(m, "status"),
             Some(&atom("ok")),
             "expected compile to succeed: {response:?}"
+        );
+        let Some(Term::List(referenced)) = map_get(m, "referenced_aliases") else {
+            panic!("Expected referenced_aliases list: {response:?}");
+        };
+        let names: Vec<String> = referenced
+            .elements
+            .iter()
+            .filter_map(term_to_string)
+            .collect();
+        assert_eq!(
+            names,
+            vec!["Direction".to_string()],
+            "expected Direction to be recorded as referenced: {response:?}"
+        );
+    }
+
+    /// BT-2917 (BT-2899 follow-up): the sibling of
+    /// `compile_with_known_type_aliases_reports_referenced_aliases` for a
+    /// protocol-only `compile` — before this fix, `protocol_definition`'s
+    /// response had no `referenced_aliases` field at all, so
+    /// `beamtalk_repl_compiler.erl`'s protocol arm had nothing to register
+    /// into `beamtalk_alias_xref`, even though the exact same annotation on
+    /// a class method's signature (the test above) already worked.
+    #[test]
+    fn compile_protocol_with_known_type_aliases_reports_referenced_aliases() {
+        let request = Map::from([
+            (atom("command"), atom("compile")),
+            (
+                atom("source"),
+                binary("Protocol define: Directional\n  heading: d :: Direction -> Boolean\n"),
+            ),
+            (atom("module_name"), binary("bt@directional")),
+            (
+                atom("known_type_aliases"),
+                Term::from(List::from(vec![binary(
+                    "type Direction = #north | #south | #east | #west",
+                )])),
+            ),
+        ]);
+
+        let response = handle_compile(&request);
+        let Term::Map(ref m) = response else {
+            panic!("Expected map response");
+        };
+        assert_eq!(
+            map_get(m, "status"),
+            Some(&atom("ok")),
+            "expected compile to succeed: {response:?}"
+        );
+        assert_eq!(
+            map_get(m, "kind"),
+            Some(&atom("protocol_definition")),
+            "expected a protocol_definition response: {response:?}"
         );
         let Some(Term::List(referenced)) = map_get(m, "referenced_aliases") else {
             panic!("Expected referenced_aliases list: {response:?}");

--- a/crates/beamtalk-core/src/semantic_analysis/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/tests.rs
@@ -4553,6 +4553,36 @@ fn referenced_aliases_records_a_seeded_cross_package_alias_and_excludes_a_foreig
     );
 }
 
+// BT-2917 (BT-2899 follow-up, ADR 0108 hot-reload re-check trigger): a
+// protocol's own declared method-signature annotations must record
+// `referenced_aliases` dependency edges exactly like a class method's do —
+// confirmed missing by inspection before this fix (protocol method
+// signatures have no body, so the class-method-body-only call sites that
+// normally populate this field never visit them). Both an instance-side
+// parameter annotation (`heading:`) and a class-side return-type annotation
+// (`class default`) are covered, since `beamtalk_alias_xref` needs edges for
+// both sides of a protocol's signature.
+#[test]
+fn protocol_method_signature_records_referenced_aliases() {
+    let src = "type Direction = #north | #south | #east | #west\n\n\
+               Protocol define: Directional\n  \
+               heading: d :: Direction -> Boolean\n  \
+               class default -> Direction\n";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _parse_diags) = crate::source_analysis::parse(tokens);
+
+    let result = analyse(&module);
+
+    assert!(
+        result
+            .referenced_aliases
+            .contains(&EcoString::from("Direction")),
+        "expected Direction in referenced_aliases from the protocol's own \
+         method signatures, got: {:?}",
+        result.referenced_aliases
+    );
+}
+
 // BT-2898: end-to-end wiring check — the E0402 alias-leak checks (Phase 8)
 // must fire through the full `analyse_with_options` pipeline, not just when
 // the validator functions are called directly in `visibility_validators.rs`.

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/mod.rs
@@ -602,6 +602,16 @@ impl TypeChecker {
         // the `protocol_registry` parameter directly, not `self`.
         self.protocol_registry = None;
 
+        // Phase 2a (ADR 0108 hot-reload re-check trigger, BT-2899 / BT-2917
+        // follow-up): record every alias name a protocol's own declared
+        // method signatures transitively depend on. Protocol method
+        // signatures have no body, so the main `check_module` pass above —
+        // which normally records `referenced_aliases` while resolving a
+        // class method's `::`-annotated parameters/return type — never
+        // visits them. See `record_protocol_signature_referenced_aliases`'s
+        // doc for why this dedicated walk is needed.
+        self.record_protocol_signature_referenced_aliases(module, protocol_registry);
+
         // Phase 2b: Protocol conformance checking on type annotations.
         // When a parameter type annotation resolves to a protocol name, check
         // that the argument type (if known) conforms structurally.

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/protocol.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/protocol.rs
@@ -237,6 +237,63 @@ impl TypeChecker {
         }
     }
 
+    /// Records every alias name a protocol's declared method signatures
+    /// (instance- and class-side) transitively depend on, into
+    /// `self.referenced_aliases` (ADR 0108 hot-reload re-check trigger,
+    /// BT-2899 / BT-2917 follow-up).
+    ///
+    /// Protocol method signatures ([`crate::ast::ProtocolMethodSignature`])
+    /// have no body — unlike a class method, there is nothing for the main
+    /// [`Self::check_module`] pass to type-check, so
+    /// [`Self::set_param_types`]'s `referenced_aliases.extend(deps)` (the
+    /// call site that normally records this for a `::`-annotated class
+    /// method parameter) never runs for them. Without this dedicated walk, a
+    /// live redefinition of an alias named only in a `Protocol define:`
+    /// body's signature (e.g. `direction :: Direction`) would never register
+    /// a dependency edge for anything, even though the identical annotation
+    /// on a class method's signature works correctly.
+    ///
+    /// Every parameter and return-type annotation is resolved unconditionally
+    /// (not just `TypeAnnotation::Generic`, unlike
+    /// [`Self::check_bounds_in_type_annotation`]'s bounds-only walk) since an
+    /// alias dependency can appear on a plain `Simple` annotation too.
+    pub(super) fn record_protocol_signature_referenced_aliases(
+        &mut self,
+        module: &Module,
+        protocol_registry: &ProtocolRegistry,
+    ) {
+        let subst = super::type_resolver::SubstitutionMap::new();
+        for protocol in &module.protocols {
+            for sig in protocol
+                .method_signatures
+                .iter()
+                .chain(protocol.class_method_signatures.iter())
+            {
+                for param in &sig.parameters {
+                    if let Some(ref ann) = param.type_annotation {
+                        let (_, deps) =
+                            super::type_resolver::resolve_type_annotation_with_alias_deps(
+                                ann,
+                                &subst,
+                                Some(protocol_registry),
+                                self.alias_registry.as_ref(),
+                            );
+                        self.referenced_aliases.extend(deps);
+                    }
+                }
+                if let Some(ref ann) = sig.return_type {
+                    let (_, deps) = super::type_resolver::resolve_type_annotation_with_alias_deps(
+                        ann,
+                        &subst,
+                        Some(protocol_registry),
+                        self.alias_registry.as_ref(),
+                    );
+                    self.referenced_aliases.extend(deps);
+                }
+            }
+        }
+    }
+
     /// Check type parameter bounds for all generic type annotations in a module (ADR 0068 Phase 2d).
     ///
     /// Walks class definitions, standalone methods, and protocol definitions looking for

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -1204,19 +1204,28 @@ handle_compile_response(
     }};
 %% BT-1950: Protocol definitions use a different response shape (kind := protocol_definition)
 %% and have no `classes` key — they have `protocols` instead.
-handle_compile_response(#{
-    status := ok,
-    kind := protocol_definition,
-    core_erlang := CoreErlang,
-    module_name := ModuleName,
-    protocols := Protocols,
-    warnings := Warnings
-}) ->
+handle_compile_response(
+    #{
+        status := ok,
+        kind := protocol_definition,
+        core_erlang := CoreErlang,
+        module_name := ModuleName,
+        protocols := Protocols,
+        warnings := Warnings
+    } = Response
+) ->
+    %% ADR 0108 hot-reload re-check trigger (BT-2899 follow-up, BT-2917):
+    %% see the class-definition clause immediately above's identical field —
+    %% a protocol-defining compile's own method-signature annotations get
+    %% the same forwarding so `beamtalk_repl_compiler` can register the same
+    %% `beamtalk_alias_xref` dependency edges a class-defining compile gets.
+    ReferencedAliases = maps:get(referenced_aliases, Response, []),
     {ok, protocol_definition, #{
         core_erlang => CoreErlang,
         module_name => ModuleName,
         protocols => Protocols,
-        warnings => Warnings
+        warnings => Warnings,
+        referenced_aliases => ReferencedAliases
     }};
 handle_compile_response(#{status := error, diagnostics := Diagnostics}) ->
     {error, Diagnostics};

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
@@ -66,6 +66,67 @@ handle_compile_response_ok_test() ->
         Result
     ).
 
+%% ADR 0108 hot-reload re-check trigger (BT-2899): a class-defining
+%% compile's `referenced_aliases` field must survive this response
+%% reshaping, defaulting to `[]` for an older compiler-port binary that
+%% omits the key.
+handle_compile_response_ok_forwards_referenced_aliases_test() ->
+    Response = #{
+        status => ok,
+        core_erlang => <<"core">>,
+        module_name => <<"mod">>,
+        classes => [<<"Foo">>],
+        warnings => [],
+        referenced_aliases => [<<"Direction">>]
+    },
+    Result = beamtalk_compiler_server:handle_compile_response(Response),
+    ?assertMatch(
+        {ok, #{referenced_aliases := [<<"Direction">>]}},
+        Result
+    ).
+
+%% BT-2917 (BT-2899 follow-up): the protocol_definition clause is a
+%% *separate* reshaping match arm from the class-definition one above — it
+%% must forward `referenced_aliases` too. Confirmed missing by inspection
+%% before this fix: the port response carried the field, but this reshaping
+%% step silently dropped it (rebuilds the reply map by hand instead of
+%% forwarding `Response` verbatim), so nothing downstream ever saw it, even
+%% though `crates/beamtalk-compiler-port/src/main.rs`'s
+%% `protocol_definition_ok_response` had already started sending it.
+handle_compile_response_protocol_definition_forwards_referenced_aliases_test() ->
+    Response = #{
+        status => ok,
+        kind => protocol_definition,
+        core_erlang => <<"core">>,
+        module_name => <<"mod">>,
+        protocols => [<<"Directional">>],
+        warnings => [],
+        referenced_aliases => [<<"Direction">>]
+    },
+    Result = beamtalk_compiler_server:handle_compile_response(Response),
+    ?assertMatch(
+        {ok, protocol_definition, #{referenced_aliases := [<<"Direction">>]}},
+        Result
+    ).
+
+%% Defensive default: a protocol_definition response omitting the field
+%% entirely (an older compiler-port binary predating BT-2917) must still
+%% decode, with `referenced_aliases => []` rather than crashing.
+handle_compile_response_protocol_definition_defaults_referenced_aliases_test() ->
+    Response = #{
+        status => ok,
+        kind => protocol_definition,
+        core_erlang => <<"core">>,
+        module_name => <<"mod">>,
+        protocols => [<<"Directional">>],
+        warnings => []
+    },
+    Result = beamtalk_compiler_server:handle_compile_response(Response),
+    ?assertMatch(
+        {ok, protocol_definition, #{referenced_aliases := []}},
+        Result
+    ).
+
 handle_compile_response_error_test() ->
     Response = #{status => error, diagnostics => [<<"parse error">>]},
     Result = beamtalk_compiler_server:handle_compile_response(Response),

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_compiler.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_compiler.erl
@@ -475,7 +475,13 @@ compile_expression_via_port(Expression, ModuleName, Bindings, KnownTypeAliasSour
         direct
     ).
 
-%% BT-1612: Compile a protocol definition result to BEAM bytecode.
+-doc """
+Compile a protocol definition result to BEAM bytecode (BT-1612).
+
+Deliberately does NOT register `beamtalk_alias_xref` edges itself — see
+`register_alias_xref_for_protocols/2`'s doc for why that has to happen at
+specific call sites instead, not here.
+""".
 -spec compile_protocol_definition_result(map()) ->
     {ok, protocol_definition, map(), [binary()]} | {error, binary()}.
 compile_protocol_definition_result(ProtocolInfo) ->
@@ -502,6 +508,51 @@ compile_protocol_definition_result(ProtocolInfo) ->
             ),
             {error, ErrMsg}
     end.
+
+-doc """
+`compile_protocol_definition_result/1`, additionally registering
+`beamtalk_alias_xref` edges for the compiled protocols — the file-compile
+(`compile_file_via_port/5`) path ONLY (ADR 0108 hot-reload re-check trigger,
+BT-2899 follow-up, BT-2917).
+
+## Why not inside `compile_protocol_definition_result/1` itself
+
+`compile_protocol_definition_result/1` is shared by *two* callers:
+`compile_file_via_port/5` (a real file compile — `ProtocolInfo`'s
+`referenced_aliases` is the compiler-port's genuinely-computed set, threaded
+from `handle_compile`'s own alias-dependency analysis) and
+`compile_expression_via_port/4` (a REPL-typed `Protocol define: ...` —
+`referenced_aliases` is hardcoded `[]` on the Rust side today, since that
+path doesn't compute it yet; tracked separately as BT-2952).
+
+`beamtalk_alias_xref:register_class/2` is **whole-set replacement**, not a
+delta (see its own doc). If registration lived inside
+`compile_protocol_definition_result/1`, the sequence "`:load` a protocol
+file with a real alias-typed signature (registers the real edge), then
+retype the identical `Protocol define: ...` inline at the REPL (registers
+`[]`)" would silently *clobber* the edge `:load` just registered — a
+regression of previously-correct state, not the same "REPL-inline just
+doesn't get edges yet" limitation BT-2952 documents for the empty-vs-real
+gap itself. Registering only from this file-compile wrapper means the
+REPL-inline path leaves whatever `beamtalk_alias_xref` already has for that
+protocol name untouched, matching how classes already behave (only
+`compile_file_core/4`/`compile_method_reload/3` call
+`register_alias_xref_for_classes/2` — `compile_class_definition_result/2`,
+classes' REPL-inline equivalent, never does).
+""".
+-spec compile_protocol_definition_result_for_file(map()) ->
+    {ok, protocol_definition, map(), [binary()]} | {error, binary()}.
+compile_protocol_definition_result_for_file(ProtocolInfo) ->
+    Result = compile_protocol_definition_result(ProtocolInfo),
+    case Result of
+        {ok, protocol_definition, _, _} ->
+            Protocols = maps:get(protocols, ProtocolInfo, []),
+            ReferencedAliases = maps:get(referenced_aliases, ProtocolInfo, []),
+            register_alias_xref_for_protocols(Protocols, ReferencedAliases);
+        {error, _} ->
+            ok
+    end,
+    Result.
 
 %% Compile a class definition result including optional trailing expressions.
 -spec compile_class_definition_result(map(), atom()) ->
@@ -601,8 +652,14 @@ compile_file_via_port(Source, Path, StdlibMode, ModuleNameOverride, PrebuiltInde
                     compile_file_core(CoreErlang, ModuleName, Classes, ReferencedAliases);
                 %% BT-1950: Protocol definitions from the compile path — compile
                 %% Core Erlang to BEAM and return a protocol_definition result.
+                %% BT-2917: this file-compile path is the only caller of
+                %% `compile_protocol_definition_result/1` with a trustworthy
+                %% `referenced_aliases` — see
+                %% `compile_protocol_definition_result_for_file/1`'s doc for
+                %% why registration happens here, not inside that shared
+                %% helper.
                 {ok, protocol_definition, ProtocolInfo} ->
-                    compile_protocol_definition_result(ProtocolInfo);
+                    compile_protocol_definition_result_for_file(ProtocolInfo);
                 {error, Diagnostics} ->
                     {error, {compile_error, format_formatted_diagnostics(Diagnostics)}}
             end
@@ -666,6 +723,34 @@ register_alias_xref_for_classes(Classes, ReferencedAliases) ->
             end
         end,
         Classes
+    ).
+
+-doc """
+Register `ReferencedAliases` into `beamtalk_alias_xref` for every protocol
+name in `Protocols` (ADR 0108 hot-reload re-check trigger, BT-2899 follow-up,
+BT-2917).
+
+Protocol-shaped adapter over `beamtalk_alias_xref:register_class/2` (which is
+itself name-shape-agnostic — see that function's doc — it just indexes
+`binary() -> [binary()]`): `Protocols` here is a plain `[binary()]` of
+protocol names (`protocol_definition_ok_response`'s `protocols` field, see
+`crates/beamtalk-compiler-port/src/main.rs`), unlike `Classes`'
+`#{name := ..., superclass := ...}` maps, so this can't reuse
+`register_alias_xref_for_classes/2` directly.
+""".
+-spec register_alias_xref_for_protocols([binary()], [binary()]) -> ok.
+register_alias_xref_for_protocols(Protocols, ReferencedAliases) ->
+    lists:foreach(
+        fun
+            %% Mirrors register_alias_xref_for_classes/2's empty-name guard —
+            %% belt-and-braces against a malformed/empty protocol name
+            %% binary reaching the xref index.
+            (<<>>) ->
+                ok;
+            (ProtocolNameBin) ->
+                beamtalk_alias_xref:register_class(ProtocolNameBin, ReferencedAliases)
+        end,
+        Protocols
     ).
 
 %% Build and merge class superclass and module indexes into a compile options map.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_alias_change_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_alias_change_recheck_tests.erl
@@ -478,3 +478,146 @@ live_redefinition_of_a_deeply_transitive_alias_triggers_recheck_test_() ->
                 end)
             ]
         end}}.
+
+%%====================================================================
+%% BT-2917 (BT-2899 follow-up): a protocol's own method-signature
+%% annotation registers the same `beamtalk_alias_xref` dependency edge a
+%% class-defining compile gets — exercised through the file-compile
+%% (`handle_load/2` -> `protocol_definition`) path, the protocol-shaped
+%% sibling of `compile_method_patch_registers_alias_dependency_test_` above.
+%%
+%% Unlike a class, a protocol has no live source tracked in
+%% `beamtalk_workspace_meta` (`load_protocol_module/3` never calls
+%% `set_class_source/2` — only classes do), so `trigger_alias_change/1`'s
+%% re-check of the protocol as an owner degrades to `skipped` (no source to
+%% recompile against) rather than `ok`. That's a separate, larger gap
+%% (protocol source isn't tracked for re-check at all yet) than this issue's
+%% scope: the assertion below proves the alias-xref edge is registered *and*
+%% that the trigger mechanism recognises the protocol as a genuine re-check
+%% candidate (`total_candidates => 1`) the moment the alias changes — i.e. a
+%% re-check is triggered for it — without depending on that separate gap
+%% being closed.
+%%====================================================================
+
+protocol_definition_registers_alias_dependency_test_() ->
+    {timeout, 30,
+        {setup, fun alias_recheck_setup/0, fun alias_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    State0 = beamtalk_repl_state:new(undefined, 0),
+                    State1 = declare_alias(
+                        <<"AliasChangeProtocolDirection">>,
+                        <<"#north | #south | #east">>,
+                        State0
+                    ),
+
+                    ProtocolSource =
+                        <<
+                            "Protocol define: AliasChangeProtocolDirectional\n"
+                            "  heading: d :: AliasChangeProtocolDirection -> Boolean\n"
+                        >>,
+                    ProtocolPath = filename:join(
+                        temp_dir(),
+                        io_lib:format("alias_recheck_protocol_~p.bt", [
+                            erlang:unique_integer([positive])
+                        ])
+                    ),
+                    ok = file:write_file(ProtocolPath, ProtocolSource),
+                    {ok, _, _State2} = beamtalk_repl_loader:handle_load(ProtocolPath, State1),
+
+                    %% The protocol itself gets the same alias-xref
+                    %% dependency edge a class-defining compile gets
+                    %% (BT-2917 acceptance criterion #3).
+                    ?assertEqual(
+                        [<<"AliasChangeProtocolDirectional">>],
+                        beamtalk_alias_xref:dependents_of(<<"AliasChangeProtocolDirection">>)
+                    ),
+
+                    %% A live redefinition of the alias picks the protocol up
+                    %% as a real re-check candidate — confirming a re-check
+                    %% is actually triggered for it (BT-2917 acceptance
+                    %% criterion #4), not just silently indexed.
+                    Result = beamtalk_recheck:trigger_alias_change([
+                        <<"AliasChangeProtocolDirection">>
+                    ]),
+                    ?assertEqual(1, maps:get(total_candidates, Result)),
+                    ?assert(
+                        lists:member(
+                            <<"AliasChangeProtocolDirectional">>,
+                            maps:get(not_verified_owners, Result)
+                        )
+                    )
+                end)
+            ]
+        end}}.
+
+%%====================================================================
+%% Regression (adversarial review, BT-2917): a REPL-inline redefinition of
+%% the SAME protocol (`compile_expression`, not `:load`) must NOT clobber
+%% the alias-xref edge a prior file-compile registered.
+%%
+%% `beamtalk_alias_xref:register_class/2` is whole-set replacement, not a
+%% delta (see its own doc). `compile_protocol_definition_result/1` is shared
+%% by both the file-compile and REPL-inline paths, but only the file-compile
+%% path (`compile_protocol_definition_result_for_file/1`) has a trustworthy
+%% `referenced_aliases` — the REPL-inline path hardcodes `[]` today (BT-2952
+%% tracks fixing that). Before this fix, registration lived inside the
+%% shared function, so retyping the identical protocol inline at the REPL
+%% would register `[]` and silently erase the edge the earlier `:load` had
+%% registered. This pins that registration now only happens from the
+%% file-compile wrapper, so the REPL-inline recompile leaves the existing
+%% edge untouched instead of clobbering it.
+%%====================================================================
+
+protocol_definition_repl_inline_recompile_does_not_clobber_file_registered_alias_dependency_test_() ->
+    {timeout, 30,
+        {setup, fun alias_recheck_setup/0, fun alias_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    State0 = beamtalk_repl_state:new(undefined, 0),
+                    State1 = declare_alias(
+                        <<"AliasChangeProtocolClobberDirection">>,
+                        <<"#north | #south | #east">>,
+                        State0
+                    ),
+
+                    ProtocolSource =
+                        "Protocol define: AliasChangeProtocolClobberDirectional\n"
+                        "  heading: d :: AliasChangeProtocolClobberDirection -> Boolean\n",
+
+                    %% Turn 1: `:load` the protocol from a file — registers
+                    %% the real alias-xref edge (BT-2917 acceptance criterion
+                    %% #3, same as protocol_definition_registers_alias_
+                    %% dependency_test_ above).
+                    ProtocolPath = filename:join(
+                        temp_dir(),
+                        io_lib:format("alias_recheck_protocol_clobber_~p.bt", [
+                            erlang:unique_integer([positive])
+                        ])
+                    ),
+                    ok = file:write_file(ProtocolPath, ProtocolSource),
+                    {ok, _, _State2} = beamtalk_repl_loader:handle_load(ProtocolPath, State1),
+                    ?assertEqual(
+                        [<<"AliasChangeProtocolClobberDirectional">>],
+                        beamtalk_alias_xref:dependents_of(
+                            <<"AliasChangeProtocolClobberDirection">>
+                        )
+                    ),
+
+                    %% Turn 2: retype the IDENTICAL protocol inline at the
+                    %% REPL (`compile_expression`, the `Protocol define:`
+                    %% typed-directly path) — must compile successfully but
+                    %% must NOT touch the edge Turn 1 registered.
+                    ExprResult = beamtalk_repl_compiler:compile_expression(
+                        ProtocolSource, alias_recheck_protocol_clobber_expr, #{}
+                    ),
+                    ?assertMatch({ok, protocol_definition, _, _}, ExprResult),
+                    ?assertEqual(
+                        [<<"AliasChangeProtocolClobberDirectional">>],
+                        beamtalk_alias_xref:dependents_of(
+                            <<"AliasChangeProtocolClobberDirection">>
+                        )
+                    )
+                end)
+            ]
+        end}}.


### PR DESCRIPTION
## Summary

Fixes [BT-2917](https://linear.app/beamtalk/issue/BT-2917/protocol-method-signatures-referencing-type-aliases-dont-register-hot): protocol method signatures referencing a `type Name = ...` alias didn't register `beamtalk_alias_xref` hot-reload dependency edges the way class method signatures do (ADR 0108, BT-2899).

- **beamtalk-core**: new `TypeChecker::record_protocol_signature_referenced_aliases` walks a protocol's instance- and class-side method signatures and folds their alias dependencies into `referenced_aliases` — protocol signatures have no body, so the existing class-method-body-only recording path never visited them.
- **beamtalk-compiler-port**: `protocol_definition_ok_response` now carries a `referenced_aliases` field, mirroring the class-definition response shape (threaded with real values on the file-compile path; empty on the REPL-inline `compile_expression` path, matching a pre-existing class-side gap now tracked separately in BT-2952).
- **beamtalk_compiler_server.erl**: fixed the actual root-cause bug found while wiring this up — `handle_compile_response/1`'s `protocol_definition` clause was silently dropping `referenced_aliases` even when the port response already carried it, because it hand-rebuilt the reply map instead of forwarding the field.
- **beamtalk_repl_compiler.erl**: registers the alias-xref dependency edge for protocols via a new `register_alias_xref_for_protocols/2`, but *only* from the file-compile path (`compile_protocol_definition_result_for_file/1`) — an adversarial review pass caught that registering from the shared `compile_protocol_definition_result/1` (used by both file-compile and REPL-inline) would let a REPL-inline redefinition (which always reports an empty alias set today) whole-set-replace-clobber real edges a prior `:load` had registered.

## Test plan

- [x] Rust unit test: a protocol's own method signature records `referenced_aliases` (`crates/beamtalk-core/src/semantic_analysis/tests.rs`)
- [x] Rust unit test: the compiler-port `compile` response for a protocol-only file includes `referenced_aliases` (`crates/beamtalk-compiler-port/src/main.rs`)
- [x] Erlang unit test: `handle_compile_response/1` forwards `referenced_aliases` for both the class and protocol clauses, with a defensive default (`beamtalk_compiler_server_tests.erl`)
- [x] Erlang end-to-end test: `:load`ing a protocol file registers the `beamtalk_alias_xref` edge, and a live alias redefinition is recognised as a re-check candidate (`beamtalk_repl_alias_change_recheck_tests.erl`)
- [x] Erlang regression test: a REPL-inline recompile of the same protocol does NOT clobber the edge the file-compile registered — verified experimentally by reverting the fix and confirming this specific test (and only this one) fails
- [x] `just ci-changed` clean (build, clippy, Rust/Erlang/JS/Elixir/Beamtalk fmt, Dialyzer, spec validation, workaround-comment lint, all Rust/Erlang/stdlib/BUnit test suites)
- [x] Filed [BT-2952](https://linear.app/beamtalk/issue/BT-2952) for the related-but-out-of-scope REPL-inline `compile_expression` gap (both classes and protocols never compute real `referenced_aliases` for that path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)