### PR TITLE
beamtalk fmt: preserve blank line between leading comment and declaration (BT-2945)

### DIFF
--- a/crates/beamtalk-core/src/ast/mod.rs
+++ b/crates/beamtalk-core/src/ast/mod.rs
@@ -317,6 +317,12 @@ impl CommentAttachment {
     /// `PendingDeclarationExpect::apply_to` for the production call site —
     /// an overwrite — where this is already known to be harmless
     /// (tracked as BT-2944).
+    ///
+    /// Also ignores `blank_line_after_comments` for the same reason, though
+    /// that field is always `false` whenever `leading` is empty (the parser
+    /// enforces `blank_line_after_comments = !leading.is_empty() &&
+    /// saw_blank_line`), so `is_empty()` staying silent on it here is
+    /// implicitly sound rather than merely overlooked.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.leading.is_empty() && self.trailing.is_none()

--- a/crates/beamtalk-core/src/ast/mod.rs
+++ b/crates/beamtalk-core/src/ast/mod.rs
@@ -291,6 +291,20 @@ pub struct CommentAttachment {
     /// the blank line separating top-level class / protocol / type-alias
     /// declarations (BT-2929).
     pub leading_blank_line: bool,
+    /// Whether a blank line separates the *last* leading comment from
+    /// whatever follows it (a doc comment, or the node itself when there is
+    /// no doc comment) — the mirror image of `leading_blank_line`, which
+    /// only tracks a blank line *before* the whole comment block.
+    ///
+    /// `leading_blank_line` alone cannot represent the `// note\n\ntype Foo
+    /// = Bar` shape: a blank line inside the leading trivia, after the last
+    /// comment, was previously dropped outright on `beamtalk fmt` (BT-2945).
+    /// Meaningless (always `false`) when `leading` is empty — there is no
+    /// comment block to have a gap after.
+    ///
+    /// Populated by [`crate::source_analysis::parser`]'s
+    /// `collect_comment_attachment`, mirroring `leading_blank_line`'s scope.
+    pub blank_line_after_comments: bool,
 }
 
 impl CommentAttachment {
@@ -933,6 +947,7 @@ mod tests {
             leading: vec![Comment::line("a comment", Span::new(0, 11))],
             trailing: None,
             leading_blank_line: false,
+            blank_line_after_comments: false,
         };
         assert!(!ca.is_empty());
     }
@@ -943,6 +958,7 @@ mod tests {
             leading: Vec::new(),
             trailing: Some(Comment::line("trailing", Span::new(10, 20))),
             leading_blank_line: false,
+            blank_line_after_comments: false,
         };
         assert!(!ca.is_empty());
     }
@@ -953,6 +969,7 @@ mod tests {
             leading: vec![Comment::line("leading", Span::new(0, 9))],
             trailing: Some(Comment::line("trailing", Span::new(20, 30))),
             leading_blank_line: false,
+            blank_line_after_comments: false,
         };
         assert!(!ca.is_empty());
         assert_eq!(ca.leading.len(), 1);
@@ -986,6 +1003,7 @@ mod tests {
                 leading: vec![Comment::line("before", Span::new(0, 8))],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: expr,
             preceding_blank_line: false,

--- a/crates/beamtalk-core/src/source_analysis/parser/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/mod.rs
@@ -1013,6 +1013,16 @@ impl Parser {
         // consecutive leading comments (BT-2929).
         let leading_blank_line = self.current_token().has_blank_line_before_first_comment();
         let mut leading = Vec::new();
+        // Tracks blank lines *between* consecutive leading comments (BT-2929)
+        // as the loop below walks the trivia. Its value when the loop ends
+        // additionally doubles as "is there a blank line after the very last
+        // leading comment, before whatever follows" (BT-2945) — see
+        // `blank_line_after_comments` below, which reads it in that final
+        // state. An already-attached `///` doc-comment trivia item (handled
+        // in the `DocComment` arm) does not reset this flag, so a blank line
+        // detected right after the last non-doc-comment leading comment
+        // survives untouched through any attached doc-comment trivia that
+        // follows, correctly describing the gap before that doc comment too.
         let mut saw_blank_line = false;
         // Positions (within this token's leading trivia) already captured by
         // the immediately-preceding `collect_doc_comment()` call, if any —
@@ -1083,10 +1093,16 @@ impl Parser {
                 }
             }
         }
+        // BT-2945: a blank line after the *last* leading comment (before the
+        // declaration's own doc comment, or the declaration itself when it
+        // has none) — meaningless without a leading comment to have a gap
+        // after, hence gated on `leading` being non-empty.
+        let blank_line_after_comments = !leading.is_empty() && saw_blank_line;
         CommentAttachment {
             leading,
             trailing: None,
             leading_blank_line,
+            blank_line_after_comments,
         }
     }
 

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -432,8 +432,14 @@ pub(crate) fn unparse_class_definition(class: &ClassDefinition) -> Document<'sta
     // Non-doc leading comments
     docs.extend(unparse_comment_attachment_leading(&class.comments));
 
-    // Blank line between leading comments (e.g. license block) and doc/header
-    if !class.comments.leading.is_empty() {
+    // Blank line between leading comments (e.g. license block) and doc/header:
+    // either because the source actually had one there (BT-2945), or because
+    // the last leading entry is an orphaned `///` block that must, by
+    // construction, always be separated from what follows (BT-2924) — see
+    // `leading_ends_with_orphaned_doc_comment`.
+    if leading_ends_with_orphaned_doc_comment(&class.comments)
+        || class.comments.blank_line_after_comments
+    {
         docs.push(line());
     }
 
@@ -610,10 +616,14 @@ fn unparse_type_alias_definition(type_alias: &TypeAliasDefinition) -> Document<'
     // Non-doc leading comments
     docs.extend(unparse_comment_attachment_leading(&type_alias.comments));
 
-    // Blank line between a preserved, earlier `///` block that broke away
-    // from a different declaration (BT-2924) and this alias's own doc
-    // comment — see `leading_ends_with_orphaned_doc_comment`.
-    if leading_ends_with_orphaned_doc_comment(&type_alias.comments) {
+    // Blank line between this alias's leading comments and its own doc
+    // comment/header: either because the source actually had one there
+    // (BT-2945), or because the last leading entry is a preserved, earlier
+    // `///` block that broke away from a different declaration (BT-2924) —
+    // see `leading_ends_with_orphaned_doc_comment`.
+    if leading_ends_with_orphaned_doc_comment(&type_alias.comments)
+        || type_alias.comments.blank_line_after_comments
+    {
         docs.push(line());
     }
 
@@ -667,10 +677,14 @@ fn unparse_protocol_definition(protocol: &ProtocolDefinition) -> Document<'stati
     // Non-doc leading comments
     docs.extend(unparse_comment_attachment_leading(&protocol.comments));
 
-    // Blank line between a preserved, earlier `///` block that broke away
-    // from a different declaration (BT-2924) and this protocol's own doc
-    // comment — see `leading_ends_with_orphaned_doc_comment`.
-    if leading_ends_with_orphaned_doc_comment(&protocol.comments) {
+    // Blank line between this protocol's leading comments and its own doc
+    // comment/header: either because the source actually had one there
+    // (BT-2945), or because the last leading entry is a preserved, earlier
+    // `///` block that broke away from a different declaration (BT-2924) —
+    // see `leading_ends_with_orphaned_doc_comment`.
+    if leading_ends_with_orphaned_doc_comment(&protocol.comments)
+        || protocol.comments.blank_line_after_comments
+    {
         docs.push(line());
     }
 
@@ -2303,6 +2317,7 @@ mod tests {
                 leading: vec![Comment::line("This is 42", span())],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Expression::Literal(Literal::Integer(42), span()),
             preceding_blank_line: false,
@@ -2318,6 +2333,7 @@ mod tests {
                 leading: Vec::new(),
                 trailing: Some(Comment::line("trailing", span())),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Expression::Literal(Literal::Integer(1), span()),
             preceding_blank_line: false,
@@ -2333,6 +2349,7 @@ mod tests {
                 leading: vec![Comment::line("before", span())],
                 trailing: Some(Comment::line("after", span())),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Expression::Literal(Literal::Integer(99), span()),
             preceding_blank_line: false,
@@ -2374,6 +2391,7 @@ mod tests {
             leading: vec![Comment::line("Returns the current value", span())],
             trailing: None,
             leading_blank_line: false,
+            blank_line_after_comments: false,
         };
         let output = unparse_method_definition(&method).to_pretty_string();
         assert_eq!(output, "// Returns the current value\ngetValue => 0");
@@ -2676,6 +2694,7 @@ mod tests {
                 leading: vec![Comment::line("the result", span())],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Expression::Identifier(Identifier::new("x", span())),
             preceding_blank_line: false,
@@ -2742,6 +2761,7 @@ mod tests {
                 leading: vec![Comment::line("do the thing", span())],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Expression::Identifier(Identifier::new("x", span())),
             preceding_blank_line: false,
@@ -2766,6 +2786,7 @@ mod tests {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Expression::Literal(Literal::Integer(42), span()),
             preceding_blank_line: false,
@@ -4129,6 +4150,80 @@ mod tests {
             "Object subclass: Server\n",
             "\n",
             "  start => 1\n",
+            "\n",
+            "type Timeout = Integer\n",
+        ));
+    }
+
+    // --- Blank line between a leading comment and its declaration (BT-2945) ---
+    //
+    // `has_blank_line_before_first_comment` (BT-2929's `leading_blank_line`)
+    // only detects a blank line *before* the whole leading-comment block; it
+    // has no way to represent a blank line *inside* that block, between the
+    // last comment and the declaration itself. `blank_line_after_comments`
+    // fills that gap.
+
+    #[test]
+    fn blank_line_preserved_between_leading_comment_and_type_alias() {
+        assert_identity(concat!("// note\n", "\n", "type Foo = Bar\n"));
+    }
+
+    #[test]
+    fn blank_line_preserved_between_leading_comment_and_protocol() {
+        assert_identity(concat!(
+            "// note\n",
+            "\n",
+            "Protocol define: Startable\n",
+            "  start -> Integer\n",
+        ));
+    }
+
+    #[test]
+    fn blank_line_preserved_between_leading_comment_and_class() {
+        assert_identity(concat!(
+            "// note\n",
+            "\n",
+            "Object subclass: Foo\n",
+            "\n",
+            "  m => 1\n",
+        ));
+    }
+
+    #[test]
+    fn no_blank_line_between_leading_comment_and_declaration_stays_absent() {
+        // The converse of the three tests above, for all three declaration
+        // kinds: no blank line in source between the comment and the
+        // declaration must not gain one. This also guards against
+        // `unparse_class_definition`'s pre-fix behaviour, which used to
+        // unconditionally insert a blank line after any non-empty leading
+        // comment regardless of what the source actually had.
+        assert_identity("// note\ntype Foo = Bar\n");
+        assert_identity(concat!(
+            "// note\n",
+            "Protocol define: Startable\n",
+            "  start -> Integer\n",
+        ));
+        assert_identity(concat!(
+            "// note\n",
+            "Object subclass: Foo\n",
+            "\n",
+            "  m => 1\n",
+        ));
+    }
+
+    #[test]
+    fn blank_line_before_comment_block_and_after_it_are_independent_signals() {
+        // A blank line before the whole comment block (BT-2929's
+        // `leading_blank_line`) and a blank line after the last comment,
+        // before the declaration (BT-2945's `blank_line_after_comments`) are
+        // tracked independently and must both round-trip when both are
+        // present in the same source, between two top-level declarations
+        // (blank-before-the-first-declaration-in-a-section is dropped by
+        // design, so this needs a preceding declaration to attach to).
+        assert_identity(concat!(
+            "type Port = Integer\n",
+            "\n",
+            "// note\n",
             "\n",
             "type Timeout = Integer\n",
         ));

--- a/test-package-compiler/tests/snapshots/compiler_tests__abstract_class_spawn_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__abstract_class_spawn_parser.snap
@@ -42,6 +42,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -76,6 +77,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -118,6 +120,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,
@@ -139,6 +142,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: ClassReference {

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_conditional_field_mutations_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_conditional_field_mutations_parser.snap
@@ -66,6 +66,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -99,6 +100,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -138,6 +140,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -170,6 +173,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -266,6 +270,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -312,6 +317,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -349,6 +355,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -381,6 +388,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -477,6 +485,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -523,6 +532,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -560,6 +570,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -599,6 +610,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -656,6 +668,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -718,6 +731,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -764,6 +778,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -801,6 +816,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -841,6 +857,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -903,6 +920,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -949,6 +967,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -986,6 +1005,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -1019,6 +1039,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -1051,6 +1072,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Assignment {
                                                         target: Identifier(
@@ -1134,6 +1156,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -1185,6 +1208,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1353,6 +1377,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_enumeration_ops_parser.snap
@@ -66,6 +66,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -105,6 +106,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -152,6 +154,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -275,6 +278,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -330,6 +334,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -367,6 +372,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -414,6 +420,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -505,6 +512,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Assignment {
                                                         target: FieldAccess {
@@ -601,6 +609,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -656,6 +665,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -693,6 +703,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -726,6 +737,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -773,6 +785,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Identifier(
                                                         Identifier {
@@ -801,6 +814,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Assignment {
                                                         target: Identifier(
@@ -871,6 +885,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -913,6 +928,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1090,6 +1106,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_list_ops_no_mutation_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_list_ops_no_mutation_parser.snap
@@ -123,6 +123,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -211,6 +212,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -231,6 +233,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -271,6 +274,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -350,6 +354,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -370,6 +375,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -410,6 +416,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -489,6 +496,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -509,6 +517,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -549,6 +558,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -628,6 +638,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -648,6 +659,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -695,6 +707,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -744,6 +757,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: Literal(
                                                             Integer(
@@ -802,6 +816,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -822,6 +837,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -862,6 +878,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -941,6 +958,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -961,6 +979,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1001,6 +1020,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: ListLiteral {
                                                             elements: [
@@ -1077,6 +1097,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1097,6 +1118,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1137,6 +1159,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1216,6 +1239,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1236,6 +1260,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1276,6 +1301,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1355,6 +1381,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1375,6 +1402,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1415,6 +1443,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1494,6 +1523,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1514,6 +1544,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1554,6 +1585,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1633,6 +1665,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1653,6 +1686,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1716,6 +1750,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1795,6 +1830,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1815,6 +1851,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1855,6 +1892,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1934,6 +1972,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1954,6 +1993,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1994,6 +2034,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -2073,6 +2114,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2093,6 +2135,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -2133,6 +2176,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -2212,6 +2256,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2232,6 +2277,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -2272,6 +2318,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -84,6 +85,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -104,6 +106,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Assignment {
                                     target: FieldAccess {
@@ -199,6 +202,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_spawn_with_args_parser.snap
@@ -105,6 +105,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -138,6 +139,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -158,6 +160,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Assignment {
                                     target: FieldAccess {
@@ -273,6 +276,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__actor_state_mutation_parser.snap
@@ -69,6 +69,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -112,6 +113,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -132,6 +134,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Assignment {
                                     target: FieldAccess {
@@ -212,6 +215,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Return {
                                     value: FieldAccess {
@@ -283,6 +287,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -303,6 +308,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Return {
                                     value: FieldAccess {

--- a/test-package-compiler/tests/snapshots/compiler_tests__annotated_local_vars_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__annotated_local_vars_parser.snap
@@ -66,6 +66,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -86,6 +87,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -132,6 +134,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -183,6 +186,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,
@@ -231,6 +235,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -274,6 +279,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -328,6 +334,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -346,6 +353,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -447,6 +455,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -480,6 +489,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -498,6 +508,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -558,6 +569,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -591,6 +603,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -605,6 +618,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_keyword_message_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -71,6 +72,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Return {
                                     value: MessageSend {

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_unary_message_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -71,6 +72,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Return {
                                     value: MessageSend {

--- a/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__async_with_await_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -71,6 +72,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Return {
                                     value: MessageSend {

--- a/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__binary_operators_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -114,6 +115,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -168,6 +170,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -222,6 +225,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -276,6 +280,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -330,6 +335,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -394,6 +400,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -458,6 +465,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -522,6 +530,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -586,6 +595,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -650,6 +660,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -714,6 +725,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -778,6 +790,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -842,6 +855,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -906,6 +920,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -989,6 +1004,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1074,6 +1090,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1159,6 +1176,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1277,6 +1295,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1312,6 +1331,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -1396,6 +1416,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1429,6 +1450,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1462,6 +1484,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1531,6 +1554,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__blocks_no_args_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -80,6 +81,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -112,6 +114,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -166,6 +169,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -199,6 +203,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -219,6 +224,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -272,6 +278,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -326,6 +333,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -346,6 +354,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -399,6 +408,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -431,6 +441,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -511,6 +522,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -531,6 +543,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -563,6 +576,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -583,6 +597,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -615,6 +630,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -635,6 +651,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Literal(
                                     Integer(

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_deeply_nested_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -184,6 +185,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -315,6 +317,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -527,6 +530,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -547,6 +551,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Block(
                                     Block {
@@ -557,6 +562,7 @@ Module {
                                                     leading: [],
                                                     trailing: None,
                                                     leading_blank_line: false,
+                                                    blank_line_after_comments: false,
                                                 },
                                                 expression: Block(
                                                     Block {
@@ -567,6 +573,7 @@ Module {
                                                                     leading: [],
                                                                     trailing: None,
                                                                     leading_blank_line: false,
+                                                                    blank_line_after_comments: false,
                                                                 },
                                                                 expression: Block(
                                                                     Block {
@@ -577,6 +584,7 @@ Module {
                                                                                     leading: [],
                                                                                     trailing: None,
                                                                                     leading_blank_line: false,
+                                                                                    blank_line_after_comments: false,
                                                                                 },
                                                                                 expression: Block(
                                                                                     Block {
@@ -587,6 +595,7 @@ Module {
                                                                                                     leading: [],
                                                                                                     trailing: None,
                                                                                                     leading_blank_line: false,
+                                                                                                    blank_line_after_comments: false,
                                                                                                 },
                                                                                                 expression: Block(
                                                                                                     Block {
@@ -597,6 +606,7 @@ Module {
                                                                                                                     leading: [],
                                                                                                                     trailing: None,
                                                                                                                     leading_blank_line: false,
+                                                                                                                    blank_line_after_comments: false,
                                                                                                                 },
                                                                                                                 expression: Literal(
                                                                                                                     Integer(
@@ -684,6 +694,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -704,6 +715,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Block(
                                     Block {
@@ -722,6 +734,7 @@ Module {
                                                     leading: [],
                                                     trailing: None,
                                                     leading_blank_line: false,
+                                                    blank_line_after_comments: false,
                                                 },
                                                 expression: Block(
                                                     Block {
@@ -732,6 +745,7 @@ Module {
                                                                     leading: [],
                                                                     trailing: None,
                                                                     leading_blank_line: false,
+                                                                    blank_line_after_comments: false,
                                                                 },
                                                                 expression: Block(
                                                                     Block {
@@ -750,6 +764,7 @@ Module {
                                                                                     leading: [],
                                                                                     trailing: None,
                                                                                     leading_blank_line: false,
+                                                                                    blank_line_after_comments: false,
                                                                                 },
                                                                                 expression: Block(
                                                                                     Block {
@@ -760,6 +775,7 @@ Module {
                                                                                                     leading: [],
                                                                                                     trailing: None,
                                                                                                     leading_blank_line: false,
+                                                                                                    blank_line_after_comments: false,
                                                                                                 },
                                                                                                 expression: Block(
                                                                                                     Block {
@@ -778,6 +794,7 @@ Module {
                                                                                                                     leading: [],
                                                                                                                     trailing: None,
                                                                                                                     leading_blank_line: false,
+                                                                                                                    blank_line_after_comments: false,
                                                                                                                 },
                                                                                                                 expression: MessageSend {
                                                                                                                     receiver: Identifier(
@@ -892,6 +909,7 @@ Module {
                                     ],
                                     trailing: None,
                                     leading_blank_line: true,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_long_identifiers_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -103,6 +104,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -146,6 +148,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -250,6 +253,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_mixed_errors_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -110,6 +111,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Literal(
                 Integer(
@@ -137,6 +139,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -239,6 +242,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__boundary_unicode_identifiers_parser.snap
@@ -69,6 +69,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Identifier(
                 Identifier {
@@ -86,6 +87,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Invalid assignment target",

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascade_complex_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -109,6 +110,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Cascade {
                 receiver: MessageSend {
@@ -175,6 +177,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Cascade {
                 receiver: MessageSend {
@@ -343,6 +346,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -467,6 +471,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Cascade {
                 receiver: MessageSend {
@@ -508,6 +513,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -586,6 +592,7 @@ Module {
                                                 leading: [],
                                                 trailing: None,
                                                 leading_blank_line: false,
+                                                blank_line_after_comments: false,
                                             },
                                             expression: MessageSend {
                                                 receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__cascades_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__cascades_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -80,6 +81,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Cascade {
                                     receiver: MessageSend {

--- a/test-package-compiler/tests/snapshots/compiler_tests__character_literals_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__character_literals_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -84,6 +85,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -117,6 +119,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -160,6 +163,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -193,6 +197,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =",

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_definition_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_definition_parser.snap
@@ -56,6 +56,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -76,6 +77,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -162,6 +164,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -180,6 +183,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Return {
                                 value: FieldAccess {
@@ -222,6 +226,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -264,6 +269,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__class_methods_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__class_methods_parser.snap
@@ -56,6 +56,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -76,6 +77,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -162,6 +164,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -180,6 +183,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -216,6 +220,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -236,6 +241,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -316,6 +322,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -350,6 +357,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -368,6 +376,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -404,6 +413,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -439,6 +449,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -479,6 +490,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__comment_handling_parser.snap
@@ -70,6 +70,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -131,6 +132,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -174,6 +176,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -217,6 +220,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -270,6 +274,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -326,6 +331,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -346,6 +352,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Literal(
                                     Integer(

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_errors_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Invalid assignment target",
@@ -75,6 +76,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -90,6 +92,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Invalid assignment target",
@@ -105,6 +108,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -152,6 +156,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -167,6 +172,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Return {
                 value: Identifier(
@@ -190,6 +196,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -205,6 +212,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -220,6 +228,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -235,6 +244,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -250,6 +260,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",

--- a/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__control_flow_mutations_parser.snap
@@ -87,6 +87,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -120,6 +121,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Block(
@@ -131,6 +133,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -192,6 +195,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -281,6 +285,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -314,6 +319,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Block(
                 Block {
@@ -324,6 +330,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -350,6 +357,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =",
@@ -365,6 +373,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -395,6 +404,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -484,6 +494,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -517,6 +528,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -550,6 +562,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -583,6 +596,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Block(
@@ -594,6 +608,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -655,6 +670,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -709,6 +725,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -763,6 +780,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -879,6 +897,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -912,6 +931,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Literal(
@@ -944,6 +964,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -1033,6 +1054,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1066,6 +1088,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Literal(
@@ -1122,6 +1145,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -1238,6 +1262,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1315,6 +1340,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1348,6 +1374,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -1388,6 +1415,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -1477,6 +1505,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1510,6 +1539,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1560,6 +1590,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Assignment {
                                             target: Identifier(
@@ -1663,6 +1694,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =",
@@ -1678,6 +1710,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -1708,6 +1741,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Literal(
                                         Integer(
@@ -1741,6 +1775,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found )",
@@ -1756,6 +1791,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -1771,6 +1807,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -1786,6 +1823,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -1801,6 +1839,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -1816,6 +1855,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -1831,6 +1871,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -1846,6 +1887,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -1861,6 +1903,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -1876,6 +1919,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -1891,6 +1935,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -1906,6 +1951,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -1936,6 +1982,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -1969,6 +2016,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: MessageSend {
                                         receiver: Block(
@@ -1980,6 +2028,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -2041,6 +2090,7 @@ Module {
                                                                 leading: [],
                                                                 trailing: None,
                                                                 leading_blank_line: false,
+                                                                blank_line_after_comments: false,
                                                             },
                                                             expression: Assignment {
                                                                 target: Identifier(
@@ -2095,6 +2145,7 @@ Module {
                                                                 leading: [],
                                                                 trailing: None,
                                                                 leading_blank_line: false,
+                                                                blank_line_after_comments: false,
                                                             },
                                                             expression: Assignment {
                                                                 target: Identifier(
@@ -2165,6 +2216,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -2219,6 +2271,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -2326,6 +2379,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             expression: Error {
                 message: "Invalid assignment target",
@@ -2341,6 +2395,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -2356,6 +2411,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -2403,6 +2459,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -2433,6 +2490,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: FieldAccess {
@@ -2529,6 +2587,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Return {
                 value: FieldAccess {
@@ -2565,6 +2624,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -2591,6 +2651,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =>",
@@ -2606,6 +2667,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Invalid assignment target",
@@ -2621,6 +2683,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -2668,6 +2731,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -2683,6 +2747,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Return {
                 value: FieldAccess {
@@ -2719,6 +2784,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Identifier(
                 Identifier {
@@ -2736,6 +2802,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =>",
@@ -2751,6 +2818,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -2766,6 +2834,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -2807,6 +2876,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -2877,6 +2947,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: FieldAccess {
@@ -2923,6 +2994,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Return {
                 value: Identifier(
@@ -2946,6 +3018,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Identifier(
                 Identifier {
@@ -2963,6 +3036,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =>",
@@ -2978,6 +3052,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -2993,6 +3068,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -3040,6 +3116,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -3070,6 +3147,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: FieldAccess {
@@ -3150,6 +3228,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -3233,6 +3312,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Return {
                 value: Identifier(
@@ -3256,6 +3336,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Type annotations on non-identifier assignments are not supported",
@@ -3271,6 +3352,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -3286,6 +3368,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -3301,6 +3384,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -3316,6 +3400,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -3331,6 +3416,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -3346,6 +3432,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found .",
@@ -3361,6 +3448,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -3391,6 +3479,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -3445,6 +3534,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_blocks_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -104,6 +105,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -148,6 +150,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -192,6 +195,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__empty_method_body_parser.snap
@@ -56,6 +56,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -81,6 +82,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -99,6 +101,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -135,6 +138,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -160,6 +164,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -219,6 +224,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_message_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_message_parser.snap
@@ -42,6 +42,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -94,6 +95,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -112,6 +114,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -145,6 +148,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -197,6 +201,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -248,6 +253,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_invalid_syntax_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -91,6 +92,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Literal(
                 Integer(
@@ -118,6 +120,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -149,6 +152,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Identifier(
                 Identifier {
@@ -176,6 +180,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Invalid assignment target",

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_malformed_message_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -116,6 +117,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -183,6 +185,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -243,6 +246,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Literal(
                 Integer(
@@ -270,6 +274,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__error_recovery_unterminated_string_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -125,6 +126,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__expect_directive_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__expect_directive_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: ExpectDirective {
                 category: Dnu,
@@ -76,6 +77,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Literal(
@@ -114,6 +116,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: ExpectDirective {
                 category: Type,
@@ -130,6 +133,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Literal(
@@ -178,6 +182,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: ExpectDirective {
                 category: Unused,
@@ -194,6 +199,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -237,6 +243,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: ExpectDirective {
                 category: All,
@@ -253,6 +260,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Identifier(
                 Identifier {
@@ -280,6 +288,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: ExpectDirective {
                 category: Dnu,
@@ -296,6 +305,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: ExpectDirective {
                 category: Type,
@@ -312,6 +322,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Literal(

--- a/test-package-compiler/tests/snapshots/compiler_tests__foreign_extension_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__foreign_extension_parser.snap
@@ -27,6 +27,7 @@ Module {
                             leading: [],
                             trailing: None,
                             leading_blank_line: false,
+                            blank_line_after_comments: false,
                         },
                         expression: MessageSend {
                             receiver: Identifier(
@@ -117,6 +118,7 @@ Module {
                     ],
                     trailing: None,
                     leading_blank_line: false,
+                    blank_line_after_comments: false,
                 },
                 doc_comment: None,
                 span: Span {

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_pattern_matching_parser.snap
@@ -69,6 +69,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -124,6 +125,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found |",
@@ -139,6 +141,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -154,6 +157,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -169,6 +173,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -184,6 +189,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -199,6 +205,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",
@@ -214,6 +221,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",
@@ -229,6 +237,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",
@@ -244,6 +253,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -302,6 +312,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =>",
@@ -317,6 +328,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found )",
@@ -332,6 +344,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found )",
@@ -347,6 +360,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found )",
@@ -362,6 +376,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found )",
@@ -377,6 +392,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found )",
@@ -392,6 +408,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",
@@ -407,6 +424,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",
@@ -422,6 +440,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -437,6 +456,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -452,6 +472,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: MessageSend {
@@ -510,6 +531,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =>",
@@ -525,6 +547,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -540,6 +563,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",
@@ -555,6 +579,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -570,6 +595,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",

--- a/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__future_string_interpolation_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -84,6 +85,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -143,6 +145,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -176,6 +179,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -256,6 +260,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -289,6 +294,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -322,6 +328,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -392,6 +399,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -448,6 +456,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -481,6 +490,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -554,6 +564,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -587,6 +598,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -664,6 +676,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -728,6 +741,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -781,6 +795,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__hello_world_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__hello_world_parser.snap
@@ -42,6 +42,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: ClassReference {

--- a/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__initializing_counter_parser.snap
@@ -56,6 +56,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -89,6 +90,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -109,6 +111,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -155,6 +158,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -207,6 +211,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -225,6 +230,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -261,6 +267,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -279,6 +286,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -315,6 +323,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -384,6 +393,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__intrinsic_keyword_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__intrinsic_keyword_parser.snap
@@ -42,6 +42,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "blockValue",
@@ -66,6 +67,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -84,6 +86,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "size",
@@ -108,6 +111,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -159,6 +163,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__logging_counter_parser.snap
@@ -56,6 +56,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -76,6 +77,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -156,6 +158,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Super(
@@ -187,6 +190,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -205,6 +209,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -241,6 +246,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -310,6 +316,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__logging_init_counter_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__logging_init_counter_parser.snap
@@ -56,6 +56,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -76,6 +77,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -128,6 +130,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -146,6 +149,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -226,6 +230,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Super(
@@ -257,6 +262,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -275,6 +281,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -311,6 +318,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -407,6 +415,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__map_literals_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__map_literals_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -92,6 +93,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -182,6 +184,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -272,6 +275,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -386,6 +390,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -500,6 +505,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -684,6 +690,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -774,6 +781,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__match_exhaustiveness_missing_arm_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__match_exhaustiveness_missing_arm_parser.snap
@@ -61,6 +61,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Match {
                                 value: Identifier(
@@ -117,6 +118,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -161,6 +163,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         span: Span {
                                             start: 243,
@@ -187,6 +190,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -238,6 +242,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__method_lookup_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__method_lookup_parser.snap
@@ -42,6 +42,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: ClassReference {
@@ -101,6 +102,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -138,6 +140,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -192,6 +195,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -270,6 +274,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__multi_keyword_complex_args_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -107,6 +108,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: MessageSend {
                                         receiver: Identifier(
@@ -164,6 +166,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: MessageSend {
                                         receiver: Identifier(
@@ -228,6 +231,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -384,6 +388,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -514,6 +519,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -575,6 +581,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: MessageSend {
                                         receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_blocks_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -80,6 +81,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Block(
                                     Block {
@@ -98,6 +100,7 @@ Module {
                                                     leading: [],
                                                     trailing: None,
                                                     leading_blank_line: false,
+                                                    blank_line_after_comments: false,
                                                 },
                                                 expression: MessageSend {
                                                     receiver: Identifier(
@@ -160,6 +163,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -204,6 +208,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -276,6 +281,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -296,6 +302,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Block(
                                     Block {
@@ -306,6 +313,7 @@ Module {
                                                     leading: [],
                                                     trailing: None,
                                                     leading_blank_line: false,
+                                                    blank_line_after_comments: false,
                                                 },
                                                 expression: Block(
                                                     Block {
@@ -316,6 +324,7 @@ Module {
                                                                     leading: [],
                                                                     trailing: None,
                                                                     leading_blank_line: false,
+                                                                    blank_line_after_comments: false,
                                                                 },
                                                                 expression: Literal(
                                                                     Integer(
@@ -376,6 +385,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -404,6 +414,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -432,6 +443,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: MessageSend {
                                                         receiver: Identifier(
@@ -485,6 +497,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -556,6 +569,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -612,6 +626,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -640,6 +655,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -693,6 +709,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: MessageSend {
                                         receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__nested_keyword_messages_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -202,6 +203,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -344,6 +346,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Parenthesized {
@@ -435,6 +438,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__sealed_class_violation_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__sealed_class_violation_parser.snap
@@ -42,6 +42,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -86,6 +87,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -137,6 +139,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__sealed_method_override_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__sealed_method_override_parser.snap
@@ -42,6 +42,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Literal(
                                 Integer(
@@ -65,6 +66,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -116,6 +118,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,
@@ -164,6 +167,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Literal(
                                 Integer(
@@ -187,6 +191,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -201,6 +206,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             doc_comment: None,
             backing_module: None,
@@ -249,6 +255,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Literal(
                                 Integer(
@@ -272,6 +279,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -286,6 +294,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__set_theoretic_operators_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__set_theoretic_operators_parser.snap
@@ -42,6 +42,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Literal(
                                 Symbol(
@@ -107,6 +108,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -169,6 +171,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -232,6 +235,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -306,6 +310,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Match {
                                 value: Identifier(
@@ -342,6 +347,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         span: Span {
                                             start: 1771,
@@ -372,6 +378,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         span: Span {
                                             start: 1793,
@@ -402,6 +409,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         span: Span {
                                             start: 1817,
@@ -466,6 +474,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -652,6 +661,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,
@@ -686,6 +696,7 @@ Module {
                             leading: [],
                             trailing: None,
                             leading_blank_line: false,
+                            blank_line_after_comments: false,
                         },
                         expression: Literal(
                             Symbol(
@@ -796,6 +807,7 @@ Module {
                     ],
                     trailing: None,
                     leading_blank_line: false,
+                    blank_line_after_comments: false,
                 },
                 doc_comment: None,
                 span: Span {
@@ -829,6 +841,7 @@ Module {
                             leading: [],
                             trailing: None,
                             leading_blank_line: false,
+                            blank_line_after_comments: false,
                         },
                         expression: Identifier(
                             Identifier {
@@ -1008,6 +1021,7 @@ Module {
                     ],
                     trailing: None,
                     leading_blank_line: false,
+                    blank_line_after_comments: false,
                 },
                 doc_comment: None,
                 span: Span {

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_dictionary_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_dictionary_parser.snap
@@ -42,6 +42,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "size",
@@ -76,6 +77,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -94,6 +96,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "keys",
@@ -118,6 +121,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -136,6 +140,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "values",
@@ -160,6 +165,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -197,6 +203,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "at:",
@@ -221,6 +228,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -275,6 +283,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "at:ifAbsent:",
@@ -299,6 +308,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -353,6 +363,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "at:put:",
@@ -377,6 +388,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -414,6 +426,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "includesKey:",
@@ -438,6 +451,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -475,6 +489,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "removeKey:",
@@ -509,6 +524,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -546,6 +562,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "merge:",
@@ -570,6 +587,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -607,6 +625,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "keysAndValuesDo:",
@@ -641,6 +660,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -701,6 +721,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_list_parser.snap
@@ -42,6 +42,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "size",
@@ -76,6 +77,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -94,6 +96,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "isEmpty",
@@ -118,6 +121,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -136,6 +140,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "first",
@@ -160,6 +165,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -178,6 +184,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "rest",
@@ -202,6 +209,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -220,6 +228,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "last",
@@ -244,6 +253,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -281,6 +291,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "at:",
@@ -305,6 +316,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -342,6 +354,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "includes:",
@@ -366,6 +379,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -384,6 +398,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "sort",
@@ -418,6 +433,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -455,6 +471,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "sort:",
@@ -479,6 +496,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -497,6 +515,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "reversed",
@@ -521,6 +540,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -539,6 +559,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "unique",
@@ -563,6 +584,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -600,6 +622,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "detect:",
@@ -634,6 +657,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -688,6 +712,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "detect:ifNone:",
@@ -712,6 +737,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -749,6 +775,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "do:",
@@ -783,6 +810,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -820,6 +848,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "collect:",
@@ -844,6 +873,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -881,6 +911,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "select:",
@@ -905,6 +936,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -942,6 +974,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "reject:",
@@ -966,6 +999,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1020,6 +1054,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "inject:into:",
@@ -1044,6 +1079,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1081,6 +1117,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "take:",
@@ -1115,6 +1152,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1152,6 +1190,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "drop:",
@@ -1176,6 +1215,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1194,6 +1234,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "flatten",
@@ -1218,6 +1259,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1255,6 +1297,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "flatMap:",
@@ -1279,6 +1322,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1316,6 +1360,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "count:",
@@ -1340,6 +1385,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1377,6 +1423,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "anySatisfy:",
@@ -1401,6 +1448,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1438,6 +1486,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "allSatisfy:",
@@ -1462,6 +1511,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1491,6 +1541,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "++",
@@ -1525,6 +1576,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1579,6 +1631,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "from:to:",
@@ -1613,6 +1666,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1650,6 +1704,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -1713,6 +1768,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Assignment {
                                                         target: Identifier(
@@ -1767,6 +1823,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: MessageSend {
                                                         receiver: MessageSend {
@@ -1820,6 +1877,7 @@ Module {
                                                                                 leading: [],
                                                                                 trailing: None,
                                                                                 leading_blank_line: false,
+                                                                                blank_line_after_comments: false,
                                                                             },
                                                                             expression: Return {
                                                                                 value: Identifier(
@@ -1859,6 +1917,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Identifier(
                                                         Identifier {
@@ -1892,6 +1951,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -1915,6 +1975,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -1952,6 +2013,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -2015,6 +2077,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Assignment {
                                                         target: Identifier(
@@ -2069,6 +2132,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: MessageSend {
                                                         receiver: Identifier(
@@ -2131,6 +2195,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Identifier(
                                                         Identifier {
@@ -2164,6 +2229,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -2197,6 +2263,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2234,6 +2301,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "zip:",
@@ -2268,6 +2336,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2305,6 +2374,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "groupBy:",
@@ -2329,6 +2399,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2366,6 +2437,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "partition:",
@@ -2390,6 +2462,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2427,6 +2500,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "takeWhile:",
@@ -2451,6 +2525,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2488,6 +2563,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "dropWhile:",
@@ -2512,6 +2588,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2549,6 +2626,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "intersperse:",
@@ -2573,6 +2651,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2610,6 +2689,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "add:",
@@ -2634,6 +2714,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -2685,6 +2766,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_set_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_set_parser.snap
@@ -55,6 +55,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -75,6 +76,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "size",
@@ -109,6 +111,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -127,6 +130,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "isEmpty",
@@ -151,6 +155,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -188,6 +193,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "includes:",
@@ -222,6 +228,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -259,6 +266,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "add:",
@@ -293,6 +301,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -330,6 +339,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "remove:",
@@ -354,6 +364,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -391,6 +402,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "union:",
@@ -425,6 +437,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -462,6 +475,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "intersection:",
@@ -486,6 +500,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -523,6 +538,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "difference:",
@@ -547,6 +563,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -584,6 +601,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "isSubsetOf:",
@@ -618,6 +636,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -636,6 +655,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "asList",
@@ -670,6 +690,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -707,6 +728,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "fromList:",
@@ -731,6 +753,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -768,6 +791,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "do:",
@@ -802,6 +826,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -853,6 +878,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_tuple_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__stdlib_class_tuple_parser.snap
@@ -42,6 +42,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "size",
@@ -76,6 +77,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -113,6 +115,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "at:",
@@ -137,6 +140,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -155,6 +159,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "isOk",
@@ -189,6 +194,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -207,6 +213,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "isError",
@@ -231,6 +238,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -249,6 +257,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "unwrap",
@@ -283,6 +292,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -320,6 +330,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "unwrapOr:",
@@ -344,6 +355,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -381,6 +393,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "unwrapOrElse:",
@@ -405,6 +418,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -423,6 +437,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "asString",
@@ -457,6 +472,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -517,6 +533,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__string_operations_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__string_operations_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -84,6 +85,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -117,6 +119,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -223,6 +226,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -277,6 +281,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -331,6 +336,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -385,6 +391,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -439,6 +446,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -503,6 +511,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -547,6 +556,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -601,6 +611,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -634,6 +645,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -688,6 +700,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -721,6 +734,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -765,6 +779,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -819,6 +834,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -881,6 +897,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -953,6 +970,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1015,6 +1033,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1087,6 +1106,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1149,6 +1169,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1221,6 +1242,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1254,6 +1276,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1326,6 +1349,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_class_warnings_parser.snap
@@ -66,6 +66,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -86,6 +87,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -142,6 +144,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -160,6 +163,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -240,6 +244,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -286,6 +291,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -323,6 +329,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -403,6 +410,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -459,6 +467,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -528,6 +537,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_methods_parser.snap
@@ -66,6 +66,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -86,6 +87,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -142,6 +144,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -189,6 +192,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -295,6 +299,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -313,6 +318,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Parenthesized {
@@ -392,6 +398,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: FieldAccess {
                                                         receiver: Identifier(
@@ -433,6 +440,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Identifier(
                                                         Identifier {
@@ -509,6 +517,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -527,6 +536,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: FieldAccess {
@@ -623,6 +633,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -665,6 +676,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__typed_value_type_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__typed_value_type_parser.snap
@@ -66,6 +66,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -109,6 +110,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -129,6 +131,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -185,6 +188,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -203,6 +207,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: FieldAccess {
                                 receiver: Identifier(
@@ -249,6 +254,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -296,6 +302,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "distanceTo:",
@@ -340,6 +347,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -358,6 +366,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Primitive {
                                 name: "printString",
@@ -392,6 +401,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -434,6 +444,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unary_operators_parser.snap
@@ -79,6 +79,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -143,6 +144,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -203,6 +205,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -247,6 +250,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -301,6 +305,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -345,6 +350,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -408,6 +414,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -452,6 +459,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -515,6 +523,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -580,6 +589,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -613,6 +623,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -679,6 +690,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -707,6 +719,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -756,6 +769,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -784,6 +798,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__unicode_string_literals_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -84,6 +85,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -117,6 +119,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -160,6 +163,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_enumeration_ops_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_enumeration_ops_parser.snap
@@ -61,6 +61,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Assignment {
                                 target: Identifier(
@@ -94,6 +95,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -141,6 +143,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: Assignment {
                                                         target: Identifier(
@@ -238,6 +241,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Identifier(
                                 Identifier {
@@ -280,6 +284,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -403,6 +408,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_type_multi_expr_method_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_type_multi_expr_method_parser.snap
@@ -61,6 +61,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: ClassReference {
@@ -112,6 +113,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -166,6 +168,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -220,6 +223,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -258,6 +262,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -296,6 +301,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -350,6 +356,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -437,6 +444,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__value_type_param_collision_parser.snap
@@ -61,6 +61,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -99,6 +100,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: Identifier(
@@ -180,6 +182,7 @@ Module {
                         ],
                         trailing: None,
                         leading_blank_line: true,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -267,6 +270,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__while_true_simple_parser.snap
@@ -42,6 +42,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -62,6 +63,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -95,6 +97,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Block(
@@ -106,6 +109,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: MessageSend {
                                                         receiver: Identifier(
@@ -167,6 +171,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: Assignment {
                                                             target: Identifier(
@@ -237,6 +242,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -285,6 +291,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -305,6 +312,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -338,6 +346,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Block(
@@ -349,6 +358,7 @@ Module {
                                                         leading: [],
                                                         trailing: None,
                                                         leading_blank_line: false,
+                                                        blank_line_after_comments: false,
                                                     },
                                                     expression: MessageSend {
                                                         receiver: Identifier(
@@ -410,6 +420,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: Assignment {
                                                             target: Identifier(
@@ -480,6 +491,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -528,6 +540,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -548,6 +561,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -577,6 +591,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Block(
@@ -588,6 +603,7 @@ Module {
                                                                                 leading: [],
                                                                                 trailing: None,
                                                                                 leading_blank_line: false,
+                                                                                blank_line_after_comments: false,
                                                                             },
                                                                             expression: MessageSend {
                                                                                 receiver: Identifier(
@@ -649,6 +665,7 @@ Module {
                                                                                     leading: [],
                                                                                     trailing: None,
                                                                                     leading_blank_line: false,
+                                                                                    blank_line_after_comments: false,
                                                                                 },
                                                                                 expression: Assignment {
                                                                                     target: Identifier(
@@ -719,6 +736,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: Identifier(
                                                             Identifier {
@@ -779,6 +797,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -827,6 +846,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -847,6 +867,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -876,6 +897,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Block(
@@ -887,6 +909,7 @@ Module {
                                                                                 leading: [],
                                                                                 trailing: None,
                                                                                 leading_blank_line: false,
+                                                                                blank_line_after_comments: false,
                                                                             },
                                                                             expression: MessageSend {
                                                                                 receiver: Identifier(
@@ -948,6 +971,7 @@ Module {
                                                                                     leading: [],
                                                                                     trailing: None,
                                                                                     leading_blank_line: false,
+                                                                                    blank_line_after_comments: false,
                                                                                 },
                                                                                 expression: Assignment {
                                                                                     target: Identifier(
@@ -1018,6 +1042,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: Identifier(
                                                             Identifier {
@@ -1078,6 +1103,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -1126,6 +1152,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1146,6 +1173,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -1179,6 +1207,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Literal(
@@ -1211,6 +1240,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: Assignment {
                                                             target: Identifier(
@@ -1281,6 +1311,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -1329,6 +1360,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1349,6 +1381,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -1378,6 +1411,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Literal(
@@ -1410,6 +1444,7 @@ Module {
                                                                                     leading: [],
                                                                                     trailing: None,
                                                                                     leading_blank_line: false,
+                                                                                    blank_line_after_comments: false,
                                                                                 },
                                                                                 expression: Assignment {
                                                                                     target: Identifier(
@@ -1480,6 +1515,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: Identifier(
                                                             Identifier {
@@ -1540,6 +1576,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -1588,6 +1625,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1608,6 +1646,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -1641,6 +1680,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Literal(
@@ -1697,6 +1737,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: Assignment {
                                                             target: Identifier(
@@ -1767,6 +1808,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Return {
                                     value: Identifier(
@@ -1815,6 +1857,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1835,6 +1878,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Assignment {
                                     target: Identifier(
@@ -1864,6 +1908,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: Assignment {
                                                             target: Identifier(
@@ -1897,6 +1942,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: MessageSend {
                                                             receiver: Identifier(
@@ -1953,6 +1999,7 @@ Module {
                                                                                     leading: [],
                                                                                     trailing: None,
                                                                                     leading_blank_line: false,
+                                                                                    blank_line_after_comments: false,
                                                                                 },
                                                                                 expression: Assignment {
                                                                                     target: Identifier(
@@ -2023,6 +2070,7 @@ Module {
                                                             leading: [],
                                                             trailing: None,
                                                             leading_blank_line: false,
+                                                            blank_line_after_comments: false,
                                                         },
                                                         expression: Identifier(
                                                             Identifier {
@@ -2083,6 +2131,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Return {
                                     value: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__whitespace_handling_parser.snap
@@ -60,6 +60,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -124,6 +125,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -188,6 +190,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -252,6 +255,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -295,6 +299,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -338,6 +343,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_cascade_parser.snap
@@ -42,6 +42,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: Cascade {
                                 receiver: MessageSend {
@@ -145,6 +146,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -178,6 +180,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__workspace_binding_send_parser.snap
@@ -42,6 +42,7 @@ Module {
                                 leading: [],
                                 trailing: None,
                                 leading_blank_line: false,
+                                blank_line_after_comments: false,
                             },
                             expression: MessageSend {
                                 receiver: ClassReference {
@@ -99,6 +100,7 @@ Module {
                         leading: [],
                         trailing: None,
                         leading_blank_line: false,
+                        blank_line_after_comments: false,
                     },
                     doc_comment: None,
                     span: Span {
@@ -132,6 +134,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             doc_comment: None,
             backing_module: None,

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_mutations_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_mutations_parser.snap
@@ -69,6 +69,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -89,6 +90,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -121,6 +123,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ,",
@@ -136,6 +139,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -151,6 +155,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -166,6 +171,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -181,6 +187,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -196,6 +203,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -211,6 +219,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -226,6 +235,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_search_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_search_parser.snap
@@ -69,6 +69,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -89,6 +90,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -121,6 +123,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ,",
@@ -136,6 +139,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -151,6 +155,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -166,6 +171,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -181,6 +187,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -196,6 +203,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -226,6 +234,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Literal(
                                         Integer(
@@ -269,6 +278,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -302,6 +312,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -352,6 +363,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Assignment {
                                             target: Identifier(
@@ -406,6 +418,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -476,6 +489,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -509,6 +523,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -559,6 +574,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Assignment {
                                             target: Identifier(
@@ -613,6 +629,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -683,6 +700,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -716,6 +734,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -766,6 +785,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Assignment {
                                             target: Identifier(
@@ -820,6 +840,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -890,6 +911,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -923,6 +945,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -980,6 +1003,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Assignment {
                                             target: Identifier(
@@ -1034,6 +1058,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1083,6 +1108,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             Integer(

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_simple_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_list_ops_simple_parser.snap
@@ -78,6 +78,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: true,
             },
             expression: Assignment {
                 target: Identifier(
@@ -98,6 +99,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -130,6 +132,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ,",
@@ -145,6 +148,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -160,6 +164,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -175,6 +180,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -190,6 +196,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -205,6 +212,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -220,6 +228,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -235,6 +244,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_array_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -82,6 +83,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -113,6 +115,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -154,6 +157,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -216,6 +220,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -288,6 +293,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -332,6 +338,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -386,6 +393,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -440,6 +448,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -528,6 +537,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -568,6 +578,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -645,6 +656,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -695,6 +707,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -765,6 +778,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -815,6 +829,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -885,6 +900,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -958,6 +974,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1028,6 +1045,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1100,6 +1118,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1131,6 +1150,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ++",
@@ -1146,6 +1166,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found }",

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_block_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -71,6 +72,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -103,6 +105,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -157,6 +160,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -185,6 +189,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -238,6 +243,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -310,6 +316,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -345,6 +352,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -398,6 +406,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -486,6 +495,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -519,6 +529,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Block(
@@ -530,6 +541,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -591,6 +603,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Assignment {
                                         target: Identifier(
@@ -671,6 +684,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -704,6 +718,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -724,6 +739,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: MessageSend {
                                     receiver: Identifier(
@@ -777,6 +793,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_boolean_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -90,6 +91,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -152,6 +154,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -229,6 +232,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -268,6 +272,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -330,6 +335,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -407,6 +413,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -449,6 +456,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -488,6 +496,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -530,6 +539,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -569,6 +579,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -611,6 +622,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -660,6 +672,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -702,6 +715,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -741,6 +755,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -783,6 +798,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -822,6 +838,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -864,6 +881,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -913,6 +931,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -957,6 +976,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_dictionary_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -155,6 +156,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -196,6 +198,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -258,6 +261,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -330,6 +334,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -388,6 +393,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -437,6 +443,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -525,6 +532,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -613,6 +621,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -667,6 +676,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -729,6 +739,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -801,6 +812,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -873,6 +885,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -917,6 +930,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -971,6 +985,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Identifier(
@@ -1018,6 +1033,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -1069,6 +1085,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: MessageSend {
                                         receiver: ClassReference {
@@ -1146,6 +1163,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1243,6 +1261,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1313,6 +1332,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1393,6 +1413,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1473,6 +1494,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_integer_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -105,6 +106,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -159,6 +161,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -213,6 +216,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -287,6 +291,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -320,6 +325,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -384,6 +390,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -438,6 +445,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -492,6 +500,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -525,6 +534,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found =",
@@ -540,6 +550,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -555,6 +566,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -570,6 +582,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -585,6 +598,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_list_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -71,6 +72,7 @@ Module {
                                     leading: [],
                                     trailing: None,
                                     leading_blank_line: false,
+                                    blank_line_after_comments: false,
                                 },
                                 expression: Literal(
                                     Integer(
@@ -103,6 +105,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ,",
@@ -118,6 +121,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -133,6 +137,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -148,6 +153,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -163,6 +169,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -178,6 +185,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -193,6 +201,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -208,6 +217,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: MessageSend {
                 receiver: Error {
@@ -230,6 +240,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Literal(
                                         Integer(
@@ -263,6 +274,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ,",
@@ -278,6 +290,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_object_parser.snap
@@ -88,6 +88,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -142,6 +143,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -196,6 +198,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -260,6 +263,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -314,6 +318,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -368,6 +373,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -432,6 +438,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -486,6 +493,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -540,6 +548,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -594,6 +603,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -685,6 +695,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -727,6 +738,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -786,6 +798,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -836,6 +849,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -916,6 +930,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -965,6 +980,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -1001,6 +1017,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1071,6 +1088,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1128,6 +1146,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1177,6 +1196,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -1263,6 +1283,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1313,6 +1334,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1383,6 +1405,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1433,6 +1456,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1503,6 +1527,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1553,6 +1578,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Parenthesized {
@@ -1687,6 +1713,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1739,6 +1766,7 @@ Module {
                                                     leading: [],
                                                     trailing: None,
                                                     leading_blank_line: false,
+                                                    blank_line_after_comments: false,
                                                 },
                                                 expression: MessageSend {
                                                     receiver: Identifier(
@@ -1844,6 +1872,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1894,6 +1923,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1934,6 +1964,7 @@ Module {
                                                                     leading: [],
                                                                     trailing: None,
                                                                     leading_blank_line: false,
+                                                                    blank_line_after_comments: false,
                                                                 },
                                                                 expression: MessageSend {
                                                                     receiver: Identifier(
@@ -2030,6 +2061,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2074,6 +2106,7 @@ Module {
                                                     leading: [],
                                                     trailing: None,
                                                     leading_blank_line: false,
+                                                    blank_line_after_comments: false,
                                                 },
                                                 expression: Literal(
                                                     Integer(
@@ -2185,6 +2218,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2238,6 +2272,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -2287,6 +2322,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2340,6 +2376,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -2399,6 +2436,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2459,6 +2497,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -2487,6 +2526,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -2573,6 +2613,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2594,6 +2635,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Literal(
                                         Integer(
@@ -2646,6 +2688,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2675,6 +2718,7 @@ Module {
                                         leading: [],
                                         trailing: None,
                                         leading_blank_line: false,
+                                        blank_line_after_comments: false,
                                     },
                                     expression: Identifier(
                                         Identifier {
@@ -2764,6 +2808,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2808,6 +2853,7 @@ Module {
                                                     leading: [],
                                                     trailing: None,
                                                     leading_blank_line: false,
+                                                    blank_line_after_comments: false,
                                                 },
                                                 expression: Literal(
                                                     Integer(
@@ -2892,6 +2938,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2934,6 +2981,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Literal(
@@ -3052,6 +3100,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3095,6 +3144,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3155,6 +3205,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -3183,6 +3234,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -3232,6 +3284,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3275,6 +3328,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3325,6 +3379,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -3405,6 +3460,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3454,6 +3510,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -3490,6 +3547,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -3539,6 +3597,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3588,6 +3647,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -3624,6 +3684,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -3710,6 +3771,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3762,6 +3824,7 @@ Module {
                                                     leading: [],
                                                     trailing: None,
                                                     leading_blank_line: false,
+                                                    blank_line_after_comments: false,
                                                 },
                                                 expression: MessageSend {
                                                     receiver: Identifier(
@@ -3867,6 +3930,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3911,6 +3975,7 @@ Module {
                                                     leading: [],
                                                     trailing: None,
                                                     leading_blank_line: false,
+                                                    blank_line_after_comments: false,
                                                 },
                                                 expression: Literal(
                                                     Integer(
@@ -4012,6 +4077,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -4055,6 +4121,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -4105,6 +4172,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: MessageSend {
@@ -4196,6 +4264,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -4239,6 +4308,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -4281,6 +4351,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -4330,6 +4401,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -4373,6 +4445,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -4422,6 +4495,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -4458,6 +4532,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_nil_parser.snap
@@ -88,6 +88,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -142,6 +143,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -223,6 +225,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -265,6 +268,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -314,6 +318,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -364,6 +369,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -434,6 +440,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -483,6 +490,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -519,6 +527,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -568,6 +577,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -625,6 +635,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -653,6 +664,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -729,6 +741,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -773,6 +786,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -817,6 +831,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -881,6 +896,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -972,6 +988,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1016,6 +1033,7 @@ Module {
                                                     leading: [],
                                                     trailing: None,
                                                     leading_blank_line: false,
+                                                    blank_line_after_comments: false,
                                                 },
                                                 expression: Literal(
                                                     Integer(
@@ -1100,6 +1118,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1144,6 +1163,7 @@ Module {
                                                     leading: [],
                                                     trailing: None,
                                                     leading_blank_line: false,
+                                                    blank_line_after_comments: false,
                                                 },
                                                 expression: Literal(
                                                     String(
@@ -1218,6 +1238,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1260,6 +1281,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -1292,6 +1314,7 @@ Module {
                                                                     leading: [],
                                                                     trailing: None,
                                                                     leading_blank_line: false,
+                                                                    blank_line_after_comments: false,
                                                                 },
                                                                 expression: Literal(
                                                                     String(
@@ -1367,6 +1390,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1409,6 +1433,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -1495,6 +1520,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1569,6 +1595,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1633,6 +1660,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1697,6 +1725,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1798,6 +1827,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1851,6 +1881,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -1900,6 +1931,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -1953,6 +1985,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -2002,6 +2035,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2055,6 +2089,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -2104,6 +2139,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2157,6 +2193,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Identifier(
                                             Identifier {
@@ -2216,6 +2253,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2276,6 +2314,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -2304,6 +2343,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             String(
@@ -2390,6 +2430,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2432,6 +2473,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Literal(
@@ -2533,6 +2575,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2583,6 +2626,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -2701,6 +2745,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2745,6 +2790,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2789,6 +2835,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2843,6 +2890,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -2885,6 +2933,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: MessageSend {
                                             receiver: Identifier(
@@ -2917,6 +2966,7 @@ Module {
                                                                     leading: [],
                                                                     trailing: None,
                                                                     leading_blank_line: false,
+                                                                    blank_line_after_comments: false,
                                                                 },
                                                                 expression: Identifier(
                                                                     Identifier {
@@ -2982,6 +3032,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3025,6 +3076,7 @@ Module {
                     },
                 ),
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3116,6 +3168,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3158,6 +3211,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -3217,6 +3271,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3259,6 +3314,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             Integer(
@@ -3318,6 +3374,7 @@ Module {
                     },
                 ),
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -3362,6 +3419,7 @@ Module {
                                                     leading: [],
                                                     trailing: None,
                                                     leading_blank_line: false,
+                                                    blank_line_after_comments: false,
                                                 },
                                                 expression: Literal(
                                                     Integer(

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_set_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -98,6 +99,7 @@ Module {
                                             leading: [],
                                             trailing: None,
                                             leading_blank_line: false,
+                                            blank_line_after_comments: false,
                                         },
                                         expression: Literal(
                                             Symbol(
@@ -137,6 +139,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ,",
@@ -152,6 +155,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -167,6 +171,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -182,6 +187,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -197,6 +203,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",
@@ -212,6 +219,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Error {
                 message: "Unexpected token: expected expression, found ]",

--- a/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_parser.snap
+++ b/test-package-compiler/tests/snapshots/compiler_tests__ws_stdlib_string_parser.snap
@@ -51,6 +51,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -84,6 +85,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -127,6 +129,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -233,6 +236,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -287,6 +291,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -341,6 +346,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -405,6 +411,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -449,6 +456,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -503,6 +511,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -547,6 +556,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -601,6 +611,7 @@ Module {
                 ],
                 trailing: None,
                 leading_blank_line: true,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(
@@ -663,6 +674,7 @@ Module {
                 leading: [],
                 trailing: None,
                 leading_blank_line: false,
+                blank_line_after_comments: false,
             },
             expression: Assignment {
                 target: Identifier(


### PR DESCRIPTION
## Summary
- `has_blank_line_before_first_comment` only detected a blank line *before* the whole leading-comment block, not a blank line *inside* it, between the last comment and the declaration — so `beamtalk fmt` silently dropped the blank line in the `// note\n\ntype Foo = Bar` shape for class/protocol/type-alias declarations.
- Adds `CommentAttachment.blank_line_after_comments`, computed in `collect_comment_attachment` from the existing blank-line-tracking loop state, and consults it (alongside the existing orphaned-doc-comment check) in the three top-level declaration unparsers (`unparse_class_definition`, `unparse_protocol_definition`, `unparse_type_alias_definition`).
- Also fixes `unparse_class_definition`, which previously forced a blank line there *unconditionally* whenever any leading comment was present, regardless of what the source actually had (found via a probe test while investigating this issue).
- Snapshot files (`test-package-compiler/tests/snapshots/*.snap`) are regenerated via `cargo insta accept` to include the new struct field — each is a mechanical one-line addition, verified by diffing all 79 changed files against the field-addition-only expectation.

Follow-up from Claude review bot feedback on #3058 (BT-2929). Related fidelity gaps in the same area (BT-2943, BT-2944) are tracked separately and intentionally out of scope here.

## Test plan
- [x] `just test` — full suite green (Rust unit/property tests, stdlib, BUnit, Erlang runtime tests)
- [x] `just push` lint gate — clippy, rustfmt, dialyzer, erlfmt, elixir formatting all passed
- [x] New regression tests added for all three declaration kinds (class/protocol/type-alias): blank-line-present round-trips, blank-line-absent stays absent, and independence from the pre-existing "blank line before the whole comment block" (BT-2929) signal
- [x] Spot-checked snapshot diffs to confirm only the new field was added, no other AST changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)