### PR TITLE
PendingDeclarationExpect::apply_to no longer discards leading_blank_line (BT-2944)

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -79,25 +79,37 @@ impl PendingDeclarationExpect {
         doc_comment: &mut Option<String>,
         comments: &mut CommentAttachment,
     ) {
-        if self.expect.is_some() {
+        let had_expect = self.expect.is_some();
+        if had_expect {
             *expect = self.expect;
         }
         if doc_comment.is_none() {
             *doc_comment = self.doc_comment;
         }
+        // BT-2944: decide `leading_blank_line` explicitly, independently of
+        // whether `leading`/`trailing` get replaced below, rather than
+        // piggybacking on the `comments.is_empty()` check below (which only
+        // ever looks at `leading`/`trailing`). When an `@expect` was
+        // actually present, it — and anything directly above it — is the
+        // true start of this declaration's leading trivia, so the
+        // blank-line-before-`@expect` signal always wins over the
+        // destination's own signal, which only reflects the (usually
+        // nonexistent) gap between `@expect` and the declaration keyword.
+        // Without this, a declaration with its own leading comment
+        // sandwiched between `@expect` and itself would keep its own
+        // (typically `false`) `leading_blank_line` and silently drop the
+        // fact that a blank line separated the whole `@expect`-annotated
+        // declaration from the previous one. No unparser reads
+        // `leading_blank_line` on class-member-level `CommentAttachment`s
+        // yet (state/class-var/method — only top-level class/protocol/
+        // type-alias declarations), but the correct merge is captured now
+        // so it doesn't need rediscovering once that changes.
+        let expect_leading_blank_line = self.comments.leading_blank_line;
         if comments.is_empty() {
-            // `CommentAttachment::is_empty()` only looks at `leading`/
-            // `trailing`, so this deliberately ignores `leading_blank_line`
-            // on both sides (BT-2929) — the declaration's own (usually
-            // `false`, since it directly follows `@expect` with no blank
-            // line) `leading_blank_line` is kept when `comments` is
-            // otherwise non-empty, and overwritten by `self.comments`'s
-            // value when it's replaced wholesale. Harmless today because no
-            // unparser reads `leading_blank_line` on class-member-level
-            // `CommentAttachment`s (state/class-var/method) — only on
-            // top-level class/protocol/type-alias declarations. Tracked as
-            // BT-2944: revisit this overwrite if that ever changes.
             *comments = self.comments;
+        }
+        if had_expect {
+            comments.leading_blank_line = expect_leading_blank_line;
         }
     }
 }

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/method_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/method_tests.rs
@@ -1221,6 +1221,50 @@ fn declaration_level_expect_does_not_strand_preceding_plain_comment() {
 }
 
 #[test]
+fn declaration_level_expect_preserves_leading_blank_line_with_own_comment() {
+    // BT-2944 regression test for `PendingDeclarationExpect::apply_to`.
+    // When the destination declaration has its *own* leading comment
+    // sandwiched between `@expect` and itself, `comments.is_empty()` is
+    // `false`, so `apply_to` keeps the destination's own `CommentAttachment`
+    // instead of replacing it wholesale with the `@expect` token's. Before
+    // the BT-2944 fix, that meant the blank line preceding `@expect` (i.e.
+    // separating the whole `@expect`-annotated method from the previous
+    // one) was silently discarded along with the rest of `self.comments`.
+    //
+    // No unparser reads `leading_blank_line` on a class-member
+    // `CommentAttachment` yet (only top-level class/protocol/type-alias
+    // declarations — see BT-2944), so this asserts directly on the parsed
+    // AST rather than through a format round-trip.
+    let module = parse_ok(
+        "typed Object subclass: Foo\n\
+         \x20\x20first => 1\n\
+         \n\
+         \x20\x20@expect type\n\
+         \x20\x20// trailing note\n\
+         \x20\x20second -> String => 2",
+    );
+    assert_eq!(module.classes.len(), 1);
+    let class = &module.classes[0];
+    assert_eq!(class.methods.len(), 2);
+
+    let second = &class.methods[1];
+    assert_eq!(second.selector.name(), "second");
+    assert_eq!(
+        second.comments.leading.len(),
+        1,
+        "the comment between `@expect` and `second` must still attach: {:?}",
+        second.comments
+    );
+    assert!(
+        second.comments.leading_blank_line,
+        "the blank line before `@expect` must survive the merge even when \
+         the destination keeps its own (otherwise non-empty) leading \
+         comments: {:?}",
+        second.comments
+    );
+}
+
+#[test]
 fn statement_level_expect_inside_body_still_works() {
     // Companion case: `@expect` as the first statement *inside* a method body
     // (deeper than col 2) must keep working exactly as before — it is not a


### PR DESCRIPTION
## Summary

Fixes the latent bug tracked in [BT-2944](https://linear.app/beamtalk/issue/BT-2944): `PendingDeclarationExpect::apply_to` in `crates/beamtalk-core/src/source_analysis/parser/declarations.rs` used to decide `CommentAttachment::leading_blank_line` as an incidental side effect of whether `comments.is_empty()` caused the whole `CommentAttachment` to be replaced. When a class member (state/class-var/method) had its own leading comment sandwiched between `@expect` and itself, `comments.is_empty()` was `false`, so the destination kept its own (typically `false`) `leading_blank_line` and silently discarded the fact that a blank line separated the whole `@expect`-annotated declaration from the previous one.

No unparser reads `leading_blank_line` on class-member-level `CommentAttachment`s yet — only top-level class/protocol/type-alias declarations (BT-2929) — so this was harmless today, but would have silently produced wrong output for any `@expect`-annotated member the moment member-level blank-line preservation is added (e.g. BT-2943).

## Changes

- `PendingDeclarationExpect::apply_to`: decide `leading_blank_line` in its own explicit branch, keyed on whether `@expect` was actually present, independent of whether `leading`/`trailing` get replaced.
- Added a parser-level regression test (`declaration_level_expect_preserves_leading_blank_line_with_own_comment`) that constructs the failing scenario and asserts on the parsed AST directly (no unparser reads the field yet, so there's no format round-trip to assert through). Verified the test fails without the fix and passes with it.

## Test plan

- [x] `cargo test -p beamtalk-core --lib source_analysis::parser::` — 597 passed
- [x] `cargo test -p beamtalk-core --lib unparse::` — 183 passed
- [x] `just ci-changed` — green (build, lint, Rust/stdlib/BUnit/runtime tests, corpus check, surface-parity check)
- [x] Confirmed new test fails on the pre-fix code and passes on the fixed code

🤖 Generated with [Claude Code](https://claude.com/claude-code)