### PR TITLE
Class header trailing comment dropped with handleScope: on its own line; unparser never emits handleScope: at all (BT-2942)

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -259,6 +259,13 @@ impl Parser {
         // back to the post-`handleScope:` check (its old, only behavior) so
         // a comment trailing the `handleScope: #symbol` line is still
         // captured instead of silently dropped.
+        //
+        // `comments.trailing` is a single slot, so if *both* the header line
+        // and the `handleScope:` line carry a trailing comment, only the
+        // header-line one survives — the `handleScope:`-line comment is
+        // discarded. This is a deliberate choice (the header-line comment is
+        // the more prominent of the two), not an oversight; see
+        // `parse_handle_scope_on_new_line_prefers_header_over_scope_comment_when_both_present`.
         comments.trailing = if handle_scope.is_some() && handle_scope_on_new_line {
             self.collect_trailing_comment_at(header_line_end)
                 .or_else(|| self.collect_trailing_comment())

--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -254,9 +254,14 @@ impl Parser {
         // (after the last header token — class name, type params, or
         // `native:` module — or, when `handleScope:` follows on the same
         // line, its `#symbol`), mirroring the identical fix for type
-        // alias/protocol declarations (BT-2906).
+        // alias/protocol declarations (BT-2906). When `handleScope:` is on
+        // its own line, prefer a comment on the header line itself, but fall
+        // back to the post-`handleScope:` check (its old, only behavior) so
+        // a comment trailing the `handleScope: #symbol` line is still
+        // captured instead of silently dropped.
         comments.trailing = if handle_scope.is_some() && handle_scope_on_new_line {
             self.collect_trailing_comment_at(header_line_end)
+                .or_else(|| self.collect_trailing_comment())
         } else {
             self.collect_trailing_comment()
         };

--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -231,15 +231,35 @@ impl Parser {
             None
         };
 
+        // Anchor for a trailing comment on the class header line itself
+        // (e.g. `Object subclass: Foo  // comment`) — the last token consumed
+        // so far (class name, type params, or `native:` module). Captured
+        // *before* parsing `handleScope:` because that clause conventionally
+        // sits on its own indented line (ADR 0103); if we let
+        // `collect_trailing_comment()` look at `current - 1` unconditionally
+        // after parsing it, it would inspect the `#symbol` token's own
+        // trailing trivia instead of the header line's, silently dropping a
+        // header-line comment (BT-2942).
+        let header_line_end = self.current.saturating_sub(1);
+        let handle_scope_on_new_line = matches!(
+            self.current_kind(),
+            TokenKind::Keyword(k) if k == "handleScope:"
+        ) && self.current_token().has_leading_newline();
+
         // Parse optional `handleScope: #symbol` clause (ADR 0103). Appears at
         // the head of the class body, like `native:` is a header clause.
         let handle_scope = self.parse_optional_handle_scope();
 
         // Collect a trailing end-of-line comment on the class header line
-        // (after the last header token — class name, type params, `native:`
-        // module, or `handleScope:` symbol, whichever comes last), mirroring
-        // the identical fix for type alias/protocol declarations (BT-2906).
-        comments.trailing = self.collect_trailing_comment();
+        // (after the last header token — class name, type params, or
+        // `native:` module — or, when `handleScope:` follows on the same
+        // line, its `#symbol`), mirroring the identical fix for type
+        // alias/protocol declarations (BT-2906).
+        comments.trailing = if handle_scope.is_some() && handle_scope_on_new_line {
+            self.collect_trailing_comment_at(header_line_end)
+        } else {
+            self.collect_trailing_comment()
+        };
 
         // Parse class body (state declarations, instance methods, class methods, class variables)
         let (state, methods, class_methods, class_variables) = self.parse_class_body();

--- a/crates/beamtalk-core/src/source_analysis/parser/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/mod.rs
@@ -1120,7 +1120,20 @@ impl Parser {
         if self.current == 0 {
             return None;
         }
-        let last_token = &self.tokens[self.current - 1];
+        self.collect_trailing_comment_at(self.current - 1)
+    }
+
+    /// Collects a trailing end-of-line comment from the trailing trivia of a
+    /// specific, already-consumed token (`token_idx < self.current`).
+    ///
+    /// Use this instead of [`Self::collect_trailing_comment`] when one or more
+    /// tokens have been consumed *after* the line whose trailing comment you
+    /// want to check — e.g. a class header's `handleScope: #symbol` clause
+    /// (BT-2942) can follow the header on its own line, in which case
+    /// `current - 1` would point at the `#symbol` token rather than the
+    /// header line's last token.
+    pub(super) fn collect_trailing_comment_at(&self, token_idx: usize) -> Option<Comment> {
+        let last_token = &self.tokens[token_idx];
         for trivia in last_token.trailing_trivia() {
             if let super::Trivia::LineComment(text) = trivia {
                 let s = text.as_str();

--- a/crates/beamtalk-core/src/source_analysis/parser/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/mod.rs
@@ -1133,7 +1133,7 @@ impl Parser {
     /// `current - 1` would point at the `#symbol` token rather than the
     /// header line's last token.
     pub(super) fn collect_trailing_comment_at(&self, token_idx: usize) -> Option<Comment> {
-        debug_assert!(
+        assert!(
             token_idx < self.current && token_idx < self.tokens.len(),
             "collect_trailing_comment_at: token_idx {token_idx} must be < current ({}) and < tokens.len() ({})",
             self.current,

--- a/crates/beamtalk-core/src/source_analysis/parser/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/mod.rs
@@ -1133,6 +1133,12 @@ impl Parser {
     /// `current - 1` would point at the `#symbol` token rather than the
     /// header line's last token.
     pub(super) fn collect_trailing_comment_at(&self, token_idx: usize) -> Option<Comment> {
+        debug_assert!(
+            token_idx < self.current && token_idx < self.tokens.len(),
+            "collect_trailing_comment_at: token_idx {token_idx} must be < current ({}) and < tokens.len() ({})",
+            self.current,
+            self.tokens.len()
+        );
         let last_token = &self.tokens[token_idx];
         for trivia in last_token.trailing_trivia() {
             if let super::Trivia::LineComment(text) = trivia {

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/class_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/class_tests.rs
@@ -135,6 +135,67 @@ fn parse_handle_scope_missing_symbol_emits_error() {
 }
 
 #[test]
+fn parse_handle_scope_on_new_line_captures_header_trailing_comment() {
+    // BT-2942: when `handleScope:` sits on its own line, the trailing
+    // comment on the class header line itself (e.g. `Object subclass: Foo
+    // // header comment`) must still be captured — it lives in the class
+    // name token's trailing trivia, not the `#symbol` token's.
+    let module = parse_ok(
+        "Object subclass: Foo  // header comment
+  handleScope: #node",
+    );
+    let class = &module.classes[0];
+    assert_eq!(
+        class.handle_scope.as_ref().map(|id| id.name.as_str()),
+        Some("node")
+    );
+    assert!(
+        class.comments.trailing.is_some(),
+        "expected the header-line trailing comment to be captured"
+    );
+    assert!(
+        class
+            .comments
+            .trailing
+            .as_ref()
+            .unwrap()
+            .content
+            .contains("header comment"),
+        "trailing content: {:?}",
+        class.comments.trailing
+    );
+}
+
+#[test]
+fn parse_handle_scope_on_new_line_falls_back_to_its_own_trailing_comment() {
+    // BT-2942 (edge case guarding against a regression from the fix above):
+    // when the class header line has no trailing comment but the
+    // `handleScope:` line does, that comment must still be captured (the
+    // clause's own `#symbol` token trailing trivia) rather than silently
+    // dropped now that header-line comments are preferred.
+    let module = parse_ok(
+        "Object subclass: Foo
+  handleScope: #node  // scope comment",
+    );
+    let class = &module.classes[0];
+    assert!(
+        class.comments.trailing.is_some(),
+        "expected the handleScope-line trailing comment to be captured"
+    );
+    assert!(
+        class
+            .comments
+            .trailing
+            .as_ref()
+            .unwrap()
+            .content
+            .contains("scope comment"),
+        "trailing content: {:?}",
+        class.comments.trailing
+    );
+}
+
+#[test]
 fn parse_native_keyword_missing_module_name_emits_error() {
     let diagnostics = parse_err("Actor subclass: Foo native:");
     assert!(

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/class_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/class_tests.rs
@@ -196,6 +196,30 @@ fn parse_handle_scope_on_new_line_falls_back_to_its_own_trailing_comment() {
 }
 
 #[test]
+fn parse_handle_scope_on_new_line_prefers_header_over_scope_comment_when_both_present() {
+    // BT-2942 (Claude review bot follow-up): `comments.trailing` is a single
+    // slot, so when *both* the header line and the `handleScope:` line carry
+    // a trailing comment, only one can survive. The header-line comment
+    // deliberately wins (it's the more prominent of the two) — this is not
+    // an oversight, and the `handleScope:`-line comment is silently
+    // discarded in this specific combined case.
+    let module = parse_ok(
+        "Object subclass: Foo  // header comment
+  handleScope: #node  // scope comment",
+    );
+    let class = &module.classes[0];
+    assert!(
+        class
+            .comments
+            .trailing
+            .as_ref()
+            .is_some_and(|c| c.content.contains("header comment")),
+        "expected the header-line comment to win, got: {:?}",
+        class.comments.trailing
+    );
+}
+
+#[test]
 fn parse_native_keyword_missing_module_name_emits_error() {
     let diagnostics = parse_err("Actor subclass: Foo native:");
     assert!(

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -532,6 +532,18 @@ pub(crate) fn unparse_class_definition(class: &ClassDefinition) -> Document<'sta
         header
     };
 
+    // `handleScope: #symbol` (ADR 0103) — canonical style puts it on its own
+    // indented line following the class header (and its trailing comment, if
+    // any), mirroring `docs/ADR/0103-sendability-typing-from-class-kinds.md`.
+    let header = if let Some(hs) = &class.handle_scope {
+        docvec![
+            header,
+            nest(2, docvec![line(), "handleScope: #", leaf::ident(&hs.name)])
+        ]
+    } else {
+        header
+    };
+
     docs.push(header);
 
     // State declarations — use nest(2, ...) so that leading comments and
@@ -3829,6 +3841,69 @@ mod tests {
             "  state: count :: Integer = 0\n",
             "\n",
             "  increment => count := count + 1\n",
+        );
+        assert_identity(source);
+    }
+
+    // --- `handleScope:` unparse emission + header trailing comment (BT-2942) ---
+
+    #[test]
+    fn handle_scope_round_trip() {
+        // BT-2942: the unparser never emitted `handleScope:` at all, so a
+        // class declaring it didn't round-trip. Canonical style (ADR 0103)
+        // puts the clause on its own indented line following the header.
+        let source = concat!(
+            "sealed typed Object subclass: MetricsTable\n",
+            "  handleScope: #node\n",
+        );
+        assert_identity(source);
+    }
+
+    #[test]
+    fn handle_scope_with_state_and_methods_round_trip() {
+        // BT-2942: `handleScope:` alongside a state declaration and a method,
+        // exercising the blank-line-before-first-method logic together with
+        // the new `handleScope:` line.
+        let source = concat!(
+            "Object subclass: Registry\n",
+            "  handleScope: #process\n",
+            "  state: count :: Integer = 0\n",
+            "\n",
+            "  increment => count := count + 1\n",
+        );
+        assert_identity(source);
+    }
+
+    #[test]
+    fn handle_scope_on_new_line_with_header_trailing_comment_round_trip() {
+        // BT-2942: when `handleScope:` sits on its own line (the canonical
+        // style), a trailing comment on the class header line itself (e.g.
+        // `Object subclass: Foo  // comment`) lives in the class-name
+        // token's trailing trivia, not `handleScope:`'s `#symbol` token's.
+        // Before the fix, `collect_trailing_comment()` unconditionally
+        // inspected `current - 1` *after* parsing `handleScope:`, landing on
+        // the `#symbol` token and silently dropping the header comment.
+        let source = concat!(
+            "Object subclass: Foo  // header comment\n",
+            "  handleScope: #node\n",
+            "\n",
+            "  x => 1\n",
+        );
+        assert_identity(source);
+    }
+
+    #[test]
+    fn handle_scope_with_native_and_header_trailing_comment_round_trip() {
+        // BT-2942: header clauses are parsed in a fixed order — `native:`
+        // then `handleScope:` (ADR 0103) — so the trailing-comment anchor
+        // must still be the `native:` module token, not the class name,
+        // when both a `native:` clause and a following-line `handleScope:`
+        // are present.
+        let source = concat!(
+            "Object subclass: Foo native: my_module  // header comment\n",
+            "  handleScope: #node\n",
+            "\n",
+            "  x => 1\n",
         );
         assert_identity(source);
     }


### PR DESCRIPTION
Fixes https://linear.app/beamtalk/issue/BT-2942

## Summary

Two related, pre-existing gaps around `handleScope:` (ADR 0103):

1. **Unparser gap**: `unparse_class_definition` never emitted a class's `handleScope: #symbol` clause at all, so classes declaring it never round-tripped through the formatter.
2. **Trailing-comment gap** (masked by #1 until now): `parse_class_definition`'s trailing-comment collection always inspected the last-consumed token (`current - 1`). When `handleScope:` sits on its own line following the header (ADR 0103's canonical style), that token is the `#symbol`, not the header line's last token — so a comment on the header line itself (e.g. `Object subclass: Foo  // comment`) was silently dropped.

## Changes

- `crates/beamtalk-core/src/unparse/mod.rs`: `unparse_class_definition` now emits `handleScope: #symbol` on its own indented line after the header (and its trailing comment, if any), matching ADR 0103's canonical style.
- `crates/beamtalk-core/src/source_analysis/parser/mod.rs`: added `collect_trailing_comment_at(token_idx)`, a variant of `collect_trailing_comment()` that checks an explicit, already-consumed token instead of always `current - 1`.
- `crates/beamtalk-core/src/source_analysis/parser/declarations.rs`: `parse_class_definition` now anchors trailing-comment collection to the header line's last token when `handleScope:` follows on a new line, falling back to the post-`handleScope:` check (its previous behavior) so a comment trailing the `handleScope: #symbol` line itself isn't regressed.

## Tests

- 4 unparse round-trip tests: `handleScope:` alone, with state+methods, with a header trailing comment, and combined with `native:` + a header trailing comment.
- 2 parser-level tests: header-line comment captured when `handleScope:` is on its own line; fallback to the `handleScope:`-line comment when the header line has none (guards against a regression caught during self-review).

## Test plan

- [x] `just ci-changed` — build, lint, all Rust/stdlib/BUnit/runtime tests, corpus check, surface-drift check all green
- [x] `cargo clippy` clean, `cargo fmt --check` clean