### PR TITLE
REPL-inline compile_expression class/protocol definitions now populate referenced_aliases (BT-2952)

### DIFF
--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -458,12 +458,18 @@ fn ok_response(core_erlang: &str, warnings: &[String]) -> Term {
 
 /// Build a response map for a successful inline class definition in REPL.
 /// BT-885: `trailing_core_erlang` is Some when trailing expressions follow the class body.
+/// `referenced_aliases` (ADR 0108 hot-reload re-check trigger, BT-2899 /
+/// BT-2952 follow-up) mirrors `compile_ok_response`'s field of the same
+/// name — every alias name this class's own method-signature annotations
+/// transitively depended on, so the Erlang side can register the same
+/// `beamtalk_alias_xref` dependency edges a file-defining compile gets.
 fn class_definition_ok_response(
     core_erlang: &str,
     module_name: &str,
     classes: &[(String, String)],
     trailing_core_erlang: Option<&str>,
     warnings: &[String],
+    referenced_aliases: &[ecow::EcoString],
 ) -> Term {
     let mut map: std::collections::HashMap<Term, Term> = std::collections::HashMap::from([
         (atom("status"), atom("ok")),
@@ -477,6 +483,10 @@ fn class_definition_ok_response(
         (
             atom("warnings"),
             Term::from(List::from(build_warning_terms(warnings))),
+        ),
+        (
+            atom("referenced_aliases"),
+            Term::from(List::from(build_referenced_alias_terms(referenced_aliases))),
         ),
     ]);
     if let Some(trailing) = trailing_core_erlang {
@@ -1095,26 +1105,43 @@ fn load_native_type_registry_from(
 
 /// Parse a Beamtalk expression source and run full diagnostics with primitive validation.
 ///
-/// Returns `Ok((module, warnings))` on success, or `Err(response_term)` containing a
-/// formatted `diagnostic_error_response` that the caller should return directly.
+/// Returns `Ok((module, warnings, referenced_aliases))` on success, or
+/// `Err(response_term)` containing a formatted `diagnostic_error_response`
+/// that the caller should return directly.
 ///
 /// `pre_loaded_aliases` (ADR 0108 Phase 8, BT-2902) carries type aliases
 /// declared in earlier turns of the same REPL session, re-parsed standalone
 /// by [`extract_known_type_aliases`] — see that function's doc for why
 /// aliases need their own re-parse path rather than `pre_class_hierarchy`'s
 /// recover-from-live-BEAM-state mechanism.
+///
+/// BT-2952: uses `compute_diagnostics_and_referenced_aliases` (the same
+/// analysis as `compute_diagnostics_with_known_vars_classes_and_aliases`,
+/// additionally returning `AnalysisResult::referenced_aliases`) so the
+/// REPL-inline `compile_expression` path computes the same alias-dependency
+/// set `handle_compile`'s file-compile path already did — previously this
+/// function discarded it, so `handle_inline_class_definition` never got a
+/// real set to thread through and `handle_inline_protocol_definition` was
+/// called with a hardcoded `&[]` (BT-2917's known limitation).
 fn parse_and_check_expression(
     source: &str,
     known_vars: &[String],
     pre_class_hierarchy: Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
     pre_loaded_aliases: Vec<beamtalk_core::semantic_analysis::AliasInfo>,
-) -> Result<(beamtalk_core::ast::Module, Vec<String>), Term> {
+) -> Result<
+    (
+        beamtalk_core::ast::Module,
+        Vec<String>,
+        Vec<ecow::EcoString>,
+    ),
+    Term,
+> {
     let tokens = beamtalk_core::source_analysis::lex_with_eof(source);
     let (module, parse_diagnostics) = beamtalk_core::source_analysis::parse(tokens);
 
     let known_var_refs: Vec<&str> = known_vars.iter().map(String::as_str).collect();
-    let mut all_diagnostics =
-        beamtalk_core::queries::diagnostic_provider::compute_diagnostics_with_known_vars_classes_and_aliases(
+    let (mut all_diagnostics, referenced_aliases) =
+        beamtalk_core::queries::diagnostic_provider::compute_diagnostics_and_referenced_aliases(
             &module,
             parse_diagnostics,
             &known_var_refs,
@@ -1137,7 +1164,7 @@ fn parse_and_check_expression(
         return Err(diagnostic_error_response(&error_diags, source));
     }
 
-    Ok((module, warnings))
+    Ok((module, warnings, referenced_aliases))
 }
 
 /// Handle a single `compile_expression` request.
@@ -1167,7 +1194,7 @@ fn handle_compile_expression(request: &Map) -> Term {
     let pre_class_hierarchy = extract_class_hierarchy(request);
     let pre_loaded_aliases = extract_known_type_aliases(request);
 
-    let (module, warnings) = match parse_and_check_expression(
+    let (module, warnings, referenced_aliases) = match parse_and_check_expression(
         &source,
         &known_vars,
         pre_class_hierarchy.clone(),
@@ -1193,6 +1220,7 @@ fn handle_compile_expression(request: &Map) -> Term {
             pre_class_hierarchy,
             pre_loaded_aliases,
             module_name_override.as_deref(),
+            &referenced_aliases,
         );
     }
 
@@ -1229,14 +1257,13 @@ fn handle_compile_expression(request: &Map) -> Term {
 
     // BT-1612: If the parsed module contains protocol definitions, compile and return them
     if !module.protocols.is_empty() {
-        // BT-2917: `parse_and_check_expression` doesn't compute
-        // `referenced_aliases` for this REPL-expression path (unlike
-        // `handle_compile`'s file-compile path below) — mirrors the same,
-        // pre-existing gap `handle_inline_class_definition` has for REPL
-        // inline class definitions. An empty set here is a known limitation
-        // (BT-2917), not a regression: a `Protocol define:` typed directly
-        // at the REPL still installs correctly, it just doesn't get
-        // alias-xref edges until compiled via a file (`compile`/`handle_load`).
+        // BT-2952: `parse_and_check_expression` now computes
+        // `referenced_aliases` for this REPL-expression path too (mirroring
+        // `handle_compile`'s file-compile path below), closing the gap
+        // `handle_inline_protocol_definition`'s doc comment used to describe
+        // (BT-2917 shipped the protocol-side wiring but left this call site
+        // passing a hardcoded `&[]`, since the Rust side didn't compute a
+        // real set yet).
         return handle_inline_protocol_definition(
             &module,
             &source,
@@ -1247,7 +1274,7 @@ fn handle_compile_expression(request: &Map) -> Term {
             pre_loaded_aliases,
             module_name_override.as_deref(),
             false, // REPL expressions are never stdlib
-            &[],
+            &referenced_aliases,
         );
     }
 
@@ -1305,7 +1332,11 @@ fn handle_compile_expression_trace(request: &Map) -> Term {
     let pre_class_hierarchy = extract_class_hierarchy(request);
     let pre_loaded_aliases = extract_known_type_aliases(request);
 
-    let (module, warnings) = match parse_and_check_expression(
+    // Trace mode never defines classes/protocols/aliases (rejected below), so
+    // the `referenced_aliases` this also now computes (BT-2952) has no
+    // consumer here — trace-mode expressions can't reference an alias in a
+    // position that needs xref registration.
+    let (module, warnings, _referenced_aliases) = match parse_and_check_expression(
         &source,
         &known_vars,
         pre_class_hierarchy,
@@ -1383,6 +1414,12 @@ fn derive_class_module_name(
 /// expressions and the class body itself.
 /// BT-1670: Accepts optional `module_name_override` so package-qualified names
 /// are used consistently across all load paths.
+/// BT-2952: Accepts `referenced_aliases` — the caller's already-computed
+/// alias-dependency set (`parse_and_check_expression`'s
+/// `compute_diagnostics_and_referenced_aliases` result), threaded into the
+/// response so the Erlang side can register the same `beamtalk_alias_xref`
+/// dependency edges a file-defining compile gets. Mirrors
+/// `handle_inline_protocol_definition`'s identical parameter.
 #[allow(clippy::too_many_arguments)]
 fn handle_inline_class_definition(
     module: beamtalk_core::ast::Module,
@@ -1394,6 +1431,7 @@ fn handle_inline_class_definition(
     pre_class_hierarchy: Vec<beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo>,
     pre_loaded_aliases: Vec<beamtalk_core::semantic_analysis::AliasInfo>,
     module_name_override: Option<&str>,
+    referenced_aliases: &[ecow::EcoString],
 ) -> Term {
     let mut module = module;
     let mut warnings = warnings.to_vec();
@@ -1469,6 +1507,7 @@ fn handle_inline_class_definition(
             &classes,
             trailing_core_erlang.as_deref(),
             &warnings,
+            referenced_aliases,
         ),
         Err(e) => error_response(&[format_codegen_error(&e, source)]),
     }
@@ -1481,10 +1520,12 @@ fn handle_inline_class_definition(
 /// response so the Erlang side can load and execute the module.
 /// BT-1670: Accepts optional `module_name_override` for package-mode consistency.
 /// BT-2917: Accepts `referenced_aliases` — the caller's already-computed
-/// alias-dependency set (empty when the caller hasn't computed one, e.g. the
-/// REPL `compile_expression` path — see that call site's comment), threaded
-/// straight into the response so the Erlang side can register the same
-/// `beamtalk_alias_xref` dependency edges a class-defining compile gets.
+/// alias-dependency set, threaded straight into the response so the Erlang
+/// side can register the same `beamtalk_alias_xref` dependency edges a
+/// class-defining compile gets. BT-2952: both callers (the REPL
+/// `compile_expression` path and `handle_compile`'s file-compile path) now
+/// pass a genuinely-computed set — `compile_expression`'s used to pass a
+/// hardcoded `&[]` since the Rust side didn't compute one for that path yet.
 /// BT-2941: Accepts `pre_loaded_aliases` — mirrors the `.with_pre_loaded_aliases(...)`
 /// wiring BT-2932 applied to the other three `CodegenOptions` call sites in this
 /// file (`handle_inline_class_definition`, `handle_compile`'s class path,
@@ -3248,6 +3289,116 @@ mod tests {
             map_get(m, "status"),
             Some(&atom("ok")),
             "expected compile to succeed: {response:?}"
+        );
+        assert_eq!(
+            map_get(m, "kind"),
+            Some(&atom("protocol_definition")),
+            "expected a protocol_definition response: {response:?}"
+        );
+        let Some(Term::List(referenced)) = map_get(m, "referenced_aliases") else {
+            panic!("Expected referenced_aliases list: {response:?}");
+        };
+        let names: Vec<String> = referenced
+            .elements
+            .iter()
+            .filter_map(term_to_string)
+            .collect();
+        assert_eq!(
+            names,
+            vec!["Direction".to_string()],
+            "expected Direction to be recorded as referenced: {response:?}"
+        );
+    }
+
+    /// BT-2952: the REPL-inline sibling of
+    /// `compile_with_known_type_aliases_reports_referenced_aliases` for a
+    /// class defined via `compile_expression` (as opposed to `:load`d from
+    /// a file via `compile`) — before this fix, `parse_and_check_expression`
+    /// called `compute_diagnostics_with_known_vars_classes_and_aliases`,
+    /// which discards `AnalysisResult::referenced_aliases` entirely, so
+    /// `class_definition_ok_response` had no field to carry it in at all.
+    #[test]
+    fn compile_expression_class_with_known_type_aliases_reports_referenced_aliases() {
+        let request = Map::from([
+            (atom("command"), atom("compile_expression")),
+            (
+                atom("source"),
+                binary(
+                    "Object subclass: Dashboard\n  \
+                     heading: h :: Direction -> Integer => 0\n",
+                ),
+            ),
+            (atom("module"), binary("bt@repl_eval_1")),
+            (atom("known_vars"), Term::from(List::from(vec![]))),
+            (
+                atom("known_type_aliases"),
+                Term::from(List::from(vec![binary(
+                    "type Direction = #north | #south | #east | #west",
+                )])),
+            ),
+        ]);
+
+        let response = handle_compile_expression(&request);
+        let Term::Map(ref m) = response else {
+            panic!("Expected map response");
+        };
+        assert_eq!(
+            map_get(m, "status"),
+            Some(&atom("ok")),
+            "expected compile_expression to succeed: {response:?}"
+        );
+        assert_eq!(
+            map_get(m, "kind"),
+            Some(&atom("class_definition")),
+            "expected a class_definition response: {response:?}"
+        );
+        let Some(Term::List(referenced)) = map_get(m, "referenced_aliases") else {
+            panic!("Expected referenced_aliases list: {response:?}");
+        };
+        let names: Vec<String> = referenced
+            .elements
+            .iter()
+            .filter_map(term_to_string)
+            .collect();
+        assert_eq!(
+            names,
+            vec!["Direction".to_string()],
+            "expected Direction to be recorded as referenced: {response:?}"
+        );
+    }
+
+    /// BT-2952: the REPL-inline sibling of
+    /// `compile_protocol_with_known_type_aliases_reports_referenced_aliases`
+    /// for a protocol defined via `compile_expression` — before this fix,
+    /// `handle_compile_expression`'s protocol branch called
+    /// `handle_inline_protocol_definition` with a hardcoded `&[]` since
+    /// `parse_and_check_expression` never computed a real set for this path.
+    #[test]
+    fn compile_expression_protocol_with_known_type_aliases_reports_referenced_aliases() {
+        let request = Map::from([
+            (atom("command"), atom("compile_expression")),
+            (
+                atom("source"),
+                binary("Protocol define: Directional\n  heading: d :: Direction -> Boolean\n"),
+            ),
+            (atom("module"), binary("bt@repl_eval_1")),
+            (atom("known_vars"), Term::from(List::from(vec![]))),
+            (
+                atom("known_type_aliases"),
+                Term::from(List::from(vec![binary(
+                    "type Direction = #north | #south | #east | #west",
+                )])),
+            ),
+        ]);
+
+        let response = handle_compile_expression(&request);
+        let Term::Map(ref m) = response else {
+            panic!("Expected map response");
+        };
+        assert_eq!(
+            map_get(m, "status"),
+            Some(&atom("ok")),
+            "expected compile_expression to succeed: {response:?}"
         );
         assert_eq!(
             map_get(m, "kind"),

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_port.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_port.erl
@@ -985,11 +985,19 @@ handle_response(
     } = Response
 ) ->
     PrettyCore = maybe_pretty_core(CoreErlang),
+    %% ADR 0108 hot-reload re-check trigger (BT-2899 / BT-2952 follow-up):
+    %% the alias names this REPL-inline class definition's annotations
+    %% transitively referenced — `[]` when omitted (an older compiler-port
+    %% binary predating BT-2952). Forwarded so `beamtalk_repl_compiler` can
+    %% register `beamtalk_alias_xref` dependency edges for it, mirroring
+    %% `beamtalk_compiler_server:handle_compile_response/1`'s identical field.
+    ReferencedAliases = maps:get(referenced_aliases, Response, []),
     BaseInfo = #{
         core_erlang => PrettyCore,
         module_name => ModuleName,
         classes => Classes,
-        warnings => Warnings
+        warnings => Warnings,
+        referenced_aliases => ReferencedAliases
     },
     %% BT-903: Forward trailing_core_erlang when present (inline class + trailing expressions)
     ClassInfo =
@@ -1029,20 +1037,30 @@ handle_response(
         warnings => Warnings
     }};
 %% BT-1612: Protocol definition response
-handle_response(#{
-    status := ok,
-    kind := protocol_definition,
-    core_erlang := CoreErlang,
-    module_name := ModuleName,
-    protocols := Protocols,
-    warnings := Warnings
-}) ->
+handle_response(
+    #{
+        status := ok,
+        kind := protocol_definition,
+        core_erlang := CoreErlang,
+        module_name := ModuleName,
+        protocols := Protocols,
+        warnings := Warnings
+    } = Response
+) ->
     PrettyCore = maybe_pretty_core(CoreErlang),
+    %% ADR 0108 hot-reload re-check trigger (BT-2899 / BT-2917 / BT-2952
+    %% follow-up): see the class-definition clause above's identical field —
+    %% a REPL-inline protocol definition's own method-signature annotations
+    %% get the same forwarding so `beamtalk_repl_compiler` can register the
+    %% same `beamtalk_alias_xref` dependency edges a class-defining compile
+    %% gets.
+    ReferencedAliases = maps:get(referenced_aliases, Response, []),
     {ok, protocol_definition, #{
         core_erlang => PrettyCore,
         module_name => ModuleName,
         protocols => Protocols,
-        warnings => Warnings
+        warnings => Warnings,
+        referenced_aliases => ReferencedAliases
     }};
 %% ADR 0108 Phase 8 (BT-2902): type alias definition response — no
 %% core_erlang, since an alias erases entirely at resolution time and has no

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_compiler.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_compiler.erl
@@ -499,8 +499,20 @@ file-compile path alone called.
 BT-2952 made the compiler port compute a genuine `referenced_aliases` set
 for the REPL-inline path too (mirroring `compile_class_definition_result/2`,
 classes' REPL-inline equivalent, which registers directly for the same
-reason), so both callers now carry trustworthy data and the split is no
-longer needed.
+reason), so both callers now carry trustworthy data for *aliases declared in
+the REPL session* and the split is no longer needed for that case.
+
+## Known gap: file-local aliases (BT-2955)
+
+"Trustworthy" above does not extend to an alias declared inside the SAME
+file as the protocol/class (e.g. `stdlib/src/Ets.bt`'s `type EtsTableType =
+...` alongside `Ets`'s own method signatures) — a REPL-inline redefinition
+of that protocol/class has no way to see a file-local alias it didn't also
+declare in-session, so its `referenced_aliases` silently omits it and this
+function's registration call clobbers whatever a prior `:load` of that file
+registered. Tracked as BT-2955; not fixed here because a real fix needs
+either an additive-only registration mode or a way to recover file-local
+alias declarations from live state, both bigger than this function.
 """.
 -spec compile_protocol_definition_result(map()) ->
     {ok, protocol_definition, map(), [binary()]} | {error, binary()}.
@@ -542,8 +554,13 @@ registered against every class in a multi-class source. Previously this
 never registered anything (only the file-compile path's `compile_file_core/4`
 did) because the compiler port hardcoded an empty `referenced_aliases` set
 for REPL-inline class definitions; now that the port computes a genuine set
-(BT-2952), registering here is exactly as safe as `compile_file_core/4`
-doing it for the file-compile path.
+(BT-2952) for aliases declared in the REPL session, registering here is as
+safe as `compile_file_core/4` doing it for the file-compile path — but see
+`compile_protocol_definition_result/1`'s "Known gap: file-local aliases"
+section (BT-2955): a REPL-inline redefinition of a class whose alias
+reference was declared *inside the same file* the class originally came
+from, not in the REPL session, still silently under-reports and can clobber
+a real edge a prior `:load` registered.
 """.
 -spec compile_class_definition_result(map(), atom()) ->
     {ok, class_definition, map(), [binary()]} | {error, binary()}.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_compiler.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_compiler.erl
@@ -478,9 +478,29 @@ compile_expression_via_port(Expression, ModuleName, Bindings, KnownTypeAliasSour
 -doc """
 Compile a protocol definition result to BEAM bytecode (BT-1612).
 
-Deliberately does NOT register `beamtalk_alias_xref` edges itself — see
-`register_alias_xref_for_protocols/2`'s doc for why that has to happen at
-specific call sites instead, not here.
+ADR 0108 hot-reload re-check trigger (BT-2899 follow-up, BT-2917, BT-2952):
+also registers `ProtocolInfo`'s `referenced_aliases` into `beamtalk_alias_xref`
+for the compiled protocols — see `register_alias_xref_for_protocols/2`'s doc.
+
+## History: why this used to be split into two functions
+
+This function is shared by *two* callers: `compile_file_via_port/5` (a real
+file compile) and `compile_expression_via_port/4` (a REPL-typed `Protocol
+define: ...`). Before BT-2952, only the file-compile path's
+`referenced_aliases` was the compiler-port's genuinely-computed set — the
+REPL-inline path's was hardcoded `[]` (the Rust side didn't compute one for
+that path yet), so registering unconditionally here would have let a
+REPL-inline recompile of an already-`:load`ed protocol silently *clobber*
+the real edge with `[]` (`beamtalk_alias_xref:register_class/2` is
+whole-set replacement, not a delta — see its own doc). Registration used to
+live only in a `compile_protocol_definition_result_for_file/1` wrapper the
+file-compile path alone called.
+
+BT-2952 made the compiler port compute a genuine `referenced_aliases` set
+for the REPL-inline path too (mirroring `compile_class_definition_result/2`,
+classes' REPL-inline equivalent, which registers directly for the same
+reason), so both callers now carry trustworthy data and the split is no
+longer needed.
 """.
 -spec compile_protocol_definition_result(map()) ->
     {ok, protocol_definition, map(), [binary()]} | {error, binary()}.
@@ -495,6 +515,8 @@ compile_protocol_definition_result(ProtocolInfo) ->
     ModuleName = binary_to_atom(ModuleNameBin, utf8),
     case beamtalk_compiler:compile_core_erlang(CoreErlang) of
         {ok, _CompiledMod, Binary} ->
+            ReferencedAliases = maps:get(referenced_aliases, ProtocolInfo, []),
+            register_alias_xref_for_protocols(Protocols, ReferencedAliases),
             {ok, protocol_definition,
                 #{
                     binary => Binary,
@@ -510,51 +532,19 @@ compile_protocol_definition_result(ProtocolInfo) ->
     end.
 
 -doc """
-`compile_protocol_definition_result/1`, additionally registering
-`beamtalk_alias_xref` edges for the compiled protocols — the file-compile
-(`compile_file_via_port/5`) path ONLY (ADR 0108 hot-reload re-check trigger,
-BT-2899 follow-up, BT-2917).
+Compile a class definition result including optional trailing expressions.
 
-## Why not inside `compile_protocol_definition_result/1` itself
-
-`compile_protocol_definition_result/1` is shared by *two* callers:
-`compile_file_via_port/5` (a real file compile — `ProtocolInfo`'s
-`referenced_aliases` is the compiler-port's genuinely-computed set, threaded
-from `handle_compile`'s own alias-dependency analysis) and
-`compile_expression_via_port/4` (a REPL-typed `Protocol define: ...` —
-`referenced_aliases` is hardcoded `[]` on the Rust side today, since that
-path doesn't compute it yet; tracked separately as BT-2952).
-
-`beamtalk_alias_xref:register_class/2` is **whole-set replacement**, not a
-delta (see its own doc). If registration lived inside
-`compile_protocol_definition_result/1`, the sequence "`:load` a protocol
-file with a real alias-typed signature (registers the real edge), then
-retype the identical `Protocol define: ...` inline at the REPL (registers
-`[]`)" would silently *clobber* the edge `:load` just registered — a
-regression of previously-correct state, not the same "REPL-inline just
-doesn't get edges yet" limitation BT-2952 documents for the empty-vs-real
-gap itself. Registering only from this file-compile wrapper means the
-REPL-inline path leaves whatever `beamtalk_alias_xref` already has for that
-protocol name untouched, matching how classes already behave (only
-`compile_file_core/4`/`compile_method_reload/3` call
-`register_alias_xref_for_classes/2` — `compile_class_definition_result/2`,
-classes' REPL-inline equivalent, never does).
+ADR 0108 hot-reload re-check trigger (BT-2899 / BT-2952 follow-up): also
+registers `ClassInfo`'s `referenced_aliases` into `beamtalk_alias_xref` for
+every class this REPL-inline definition installs — see
+`register_alias_xref_for_classes/2`'s doc for why the same flat set is
+registered against every class in a multi-class source. Previously this
+never registered anything (only the file-compile path's `compile_file_core/4`
+did) because the compiler port hardcoded an empty `referenced_aliases` set
+for REPL-inline class definitions; now that the port computes a genuine set
+(BT-2952), registering here is exactly as safe as `compile_file_core/4`
+doing it for the file-compile path.
 """.
--spec compile_protocol_definition_result_for_file(map()) ->
-    {ok, protocol_definition, map(), [binary()]} | {error, binary()}.
-compile_protocol_definition_result_for_file(ProtocolInfo) ->
-    Result = compile_protocol_definition_result(ProtocolInfo),
-    case Result of
-        {ok, protocol_definition, _, _} ->
-            Protocols = maps:get(protocols, ProtocolInfo, []),
-            ReferencedAliases = maps:get(referenced_aliases, ProtocolInfo, []),
-            register_alias_xref_for_protocols(Protocols, ReferencedAliases);
-        {error, _} ->
-            ok
-    end,
-    Result.
-
-%% Compile a class definition result including optional trailing expressions.
 -spec compile_class_definition_result(map(), atom()) ->
     {ok, class_definition, map(), [binary()]} | {error, binary()}.
 compile_class_definition_result(ClassInfo, ModuleName) ->
@@ -568,6 +558,8 @@ compile_class_definition_result(ClassInfo, ModuleName) ->
     ClassModName = binary_to_atom(ClassModNameBin, utf8),
     case beamtalk_compiler:compile_core_erlang(CoreErlang) of
         {ok, _CompiledMod, Binary} ->
+            ReferencedAliases = maps:get(referenced_aliases, ClassInfo, []),
+            register_alias_xref_for_classes(Classes, ReferencedAliases),
             TrailingResult = compile_trailing_expressions(ClassInfo, ModuleName),
             assemble_class_result(Binary, ClassModName, Classes, Warnings, TrailingResult);
         {error, Reason} ->
@@ -652,14 +644,12 @@ compile_file_via_port(Source, Path, StdlibMode, ModuleNameOverride, PrebuiltInde
                     compile_file_core(CoreErlang, ModuleName, Classes, ReferencedAliases);
                 %% BT-1950: Protocol definitions from the compile path — compile
                 %% Core Erlang to BEAM and return a protocol_definition result.
-                %% BT-2917: this file-compile path is the only caller of
-                %% `compile_protocol_definition_result/1` with a trustworthy
-                %% `referenced_aliases` — see
-                %% `compile_protocol_definition_result_for_file/1`'s doc for
-                %% why registration happens here, not inside that shared
-                %% helper.
+                %% BT-2917/BT-2952: `compile_protocol_definition_result/1`
+                %% itself registers `beamtalk_alias_xref` edges from
+                %% `ProtocolInfo`'s `referenced_aliases` — see that
+                %% function's doc.
                 {ok, protocol_definition, ProtocolInfo} ->
-                    compile_protocol_definition_result_for_file(ProtocolInfo);
+                    compile_protocol_definition_result(ProtocolInfo);
                 {error, Diagnostics} ->
                     {error, {compile_error, format_formatted_diagnostics(Diagnostics)}}
             end

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_alias_change_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_alias_change_recheck_tests.erl
@@ -552,24 +552,30 @@ protocol_definition_registers_alias_dependency_test_() ->
         end}}.
 
 %%====================================================================
-%% Regression (adversarial review, BT-2917): a REPL-inline redefinition of
-%% the SAME protocol (`compile_expression`, not `:load`) must NOT clobber
-%% the alias-xref edge a prior file-compile registered.
+%% Regression (adversarial review, BT-2917; updated for BT-2952): a
+%% REPL-inline redefinition of the SAME protocol (`compile_expression`, not
+%% `:load`) must NOT lose the alias-xref edge a prior file-compile
+%% registered.
 %%
 %% `beamtalk_alias_xref:register_class/2` is whole-set replacement, not a
-%% delta (see its own doc). `compile_protocol_definition_result/1` is shared
-%% by both the file-compile and REPL-inline paths, but only the file-compile
-%% path (`compile_protocol_definition_result_for_file/1`) has a trustworthy
-%% `referenced_aliases` — the REPL-inline path hardcodes `[]` today (BT-2952
-%% tracks fixing that). Before this fix, registration lived inside the
-%% shared function, so retyping the identical protocol inline at the REPL
-%% would register `[]` and silently erase the edge the earlier `:load` had
-%% registered. This pins that registration now only happens from the
-%% file-compile wrapper, so the REPL-inline recompile leaves the existing
-%% edge untouched instead of clobbering it.
+%% delta (see its own doc). Before BT-2917, `compile_protocol_definition_result/1`
+%% was shared by both the file-compile and REPL-inline paths but only the
+%% file-compile path had a trustworthy `referenced_aliases` — the REPL-inline
+%% path hardcoded `[]`, so registering unconditionally there would have
+%% clobbered a `:load`-registered edge with an empty one. BT-2917 avoided
+%% that by only registering from a file-compile-only wrapper.
+%%
+%% BT-2952 made the compiler port compute a genuine `referenced_aliases` set
+%% for the REPL-inline path too, so `compile_protocol_definition_result/1`
+%% now registers unconditionally for both callers (see that function's doc).
+%% This test still pins the observable outcome — retyping the IDENTICAL
+%% protocol inline at the REPL leaves the edge unchanged — but now that's
+%% because the REPL-inline recompile registers the same real
+%% `referenced_aliases` set the file-compile did (idempotent
+%% re-registration), not because REPL-inline skips registration.
 %%====================================================================
 
-protocol_definition_repl_inline_recompile_does_not_clobber_file_registered_alias_dependency_test_() ->
+protocol_definition_repl_inline_recompile_preserves_alias_dependency_test_() ->
     {timeout, 30,
         {setup, fun alias_recheck_setup/0, fun alias_recheck_teardown/1, fun(_) ->
             [
@@ -606,16 +612,121 @@ protocol_definition_repl_inline_recompile_does_not_clobber_file_registered_alias
 
                     %% Turn 2: retype the IDENTICAL protocol inline at the
                     %% REPL (`compile_expression`, the `Protocol define:`
-                    %% typed-directly path) — must compile successfully but
-                    %% must NOT touch the edge Turn 1 registered.
+                    %% typed-directly path) — must compile successfully and
+                    %% leave the resulting edge unchanged (BT-2952: it now
+                    %% re-registers, but with the same genuinely-computed
+                    %% set, so the observable dependents_of/1 result is
+                    %% identical to Turn 1's). Passes State1's
+                    %% `known_type_alias_sources` explicitly, mirroring the
+                    %% real production call shape (`beamtalk_repl_eval:do_eval/3`).
                     ExprResult = beamtalk_repl_compiler:compile_expression(
-                        ProtocolSource, alias_recheck_protocol_clobber_expr, #{}
+                        ProtocolSource,
+                        alias_recheck_protocol_clobber_expr,
+                        #{},
+                        beamtalk_repl_state:known_type_alias_sources(State1)
                     ),
                     ?assertMatch({ok, protocol_definition, _, _}, ExprResult),
                     ?assertEqual(
                         [<<"AliasChangeProtocolClobberDirectional">>],
                         beamtalk_alias_xref:dependents_of(
                             <<"AliasChangeProtocolClobberDirection">>
+                        )
+                    )
+                end)
+            ]
+        end}}.
+
+%%====================================================================
+%% BT-2952 acceptance criterion #4: a class/protocol declared PURELY
+%% inline at the REPL (`compile_expression`, never `:load`ed from a file)
+%% with a method signature referencing a type alias now registers a
+%% `beamtalk_alias_xref` dependency edge — the actual gap this issue closes.
+%% Before this fix:
+%%   - Rust (`crates/beamtalk-compiler-port/src/main.rs`): the compiler
+%%     port's REPL-expression path never computed `referenced_aliases` at
+%%     all for a class definition, and hardcoded `&[]` for a protocol
+%%     definition (BT-2917's known limitation).
+%%   - Erlang (`beamtalk_compiler_port:handle_response/1`): even once the
+%%     Rust side sent a real `referenced_aliases` field, this module's
+%%     `class_definition`/`protocol_definition` clauses silently dropped it.
+%%   - `beamtalk_repl_compiler:compile_class_definition_result/2` never
+%%     called `register_alias_xref_for_classes/2` — only the file-compile
+%%     path (`compile_file_core/4`) did.
+%% These two tests are the class/protocol siblings of
+%% `protocol_definition_registers_alias_dependency_test_` above, which
+%% proves the identical thing through the file-compile (`:load`) path.
+%%====================================================================
+
+class_definition_repl_inline_registers_alias_dependency_test_() ->
+    {timeout, 30,
+        {setup, fun alias_recheck_setup/0, fun alias_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    State0 = beamtalk_repl_state:new(undefined, 0),
+                    State1 = declare_alias(
+                        <<"AliasChangeInlineClassDirection">>,
+                        <<"#north | #south | #east">>,
+                        State0
+                    ),
+
+                    ClassSource =
+                        "Object subclass: AliasChangeInlineClassUser\n"
+                        "  heading: d :: AliasChangeInlineClassDirection => d\n",
+
+                    %% Declared purely at the REPL (`Object subclass: ...`
+                    %% typed directly, the `compile_expression` path) —
+                    %% never `:load`ed from a file. Passes State1's
+                    %% `known_type_alias_sources` explicitly, mirroring the
+                    %% real production call shape (`beamtalk_repl_eval:do_eval/3`).
+                    ExprResult = beamtalk_repl_compiler:compile_expression(
+                        ClassSource,
+                        alias_recheck_inline_class_expr,
+                        #{},
+                        beamtalk_repl_state:known_type_alias_sources(State1)
+                    ),
+                    ?assertMatch({ok, class_definition, _, _}, ExprResult),
+                    ?assertEqual(
+                        [<<"AliasChangeInlineClassUser">>],
+                        beamtalk_alias_xref:dependents_of(
+                            <<"AliasChangeInlineClassDirection">>
+                        )
+                    )
+                end)
+            ]
+        end}}.
+
+protocol_definition_repl_inline_registers_alias_dependency_test_() ->
+    {timeout, 30,
+        {setup, fun alias_recheck_setup/0, fun alias_recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    State0 = beamtalk_repl_state:new(undefined, 0),
+                    State1 = declare_alias(
+                        <<"AliasChangeInlineProtocolDirection">>,
+                        <<"#north | #south | #east">>,
+                        State0
+                    ),
+
+                    ProtocolSource =
+                        "Protocol define: AliasChangeInlineProtocolDirectional\n"
+                        "  heading: d :: AliasChangeInlineProtocolDirection -> Boolean\n",
+
+                    %% Declared purely at the REPL (`Protocol define: ...`
+                    %% typed directly, the `compile_expression` path) —
+                    %% never `:load`ed from a file. Passes State1's
+                    %% `known_type_alias_sources` explicitly, mirroring the
+                    %% real production call shape (`beamtalk_repl_eval:do_eval/3`).
+                    ExprResult = beamtalk_repl_compiler:compile_expression(
+                        ProtocolSource,
+                        alias_recheck_inline_protocol_expr,
+                        #{},
+                        beamtalk_repl_state:known_type_alias_sources(State1)
+                    ),
+                    ?assertMatch({ok, protocol_definition, _, _}, ExprResult),
+                    ?assertEqual(
+                        [<<"AliasChangeInlineProtocolDirectional">>],
+                        beamtalk_alias_xref:dependents_of(
+                            <<"AliasChangeInlineProtocolDirection">>
                         )
                     )
                 end)


### PR DESCRIPTION
https://linear.app/beamtalk/issue/BT-2952

## Summary

`BT-2917` fixed the **file-compile** path (`compile`/`handle_load`) so a protocol definition's `referenced_aliases` reach `beamtalk_alias_xref`. The **REPL-inline** `compile_expression` path (typing `Object subclass: Foo ...` or `Protocol define: Foo ...` directly at the REPL prompt) had the same gap, one level deeper: the Rust side never even computed `referenced_aliases` for this path.

- `crates/beamtalk-compiler-port/src/main.rs`: `parse_and_check_expression` now calls `compute_diagnostics_and_referenced_aliases` (mirroring `handle_compile`'s file-compile path) instead of discarding `AnalysisResult::referenced_aliases`. `handle_inline_class_definition`/`handle_inline_protocol_definition` thread the real set through their responses instead of the class path omitting it entirely / the protocol path's BT-2917 `&[]` placeholder.
- `runtime/apps/beamtalk_compiler/src/beamtalk_compiler_port.erl`: `handle_response/1` forwards `referenced_aliases` (defaulted to `[]` for backward compat) in both `class_definition` and `protocol_definition` clauses.
- `runtime/apps/beamtalk_workspace/src/beamtalk_repl_compiler.erl`: `compile_class_definition_result/2` now registers `beamtalk_alias_xref` edges for REPL-inline class definitions (previously only the file-compile path did, deliberately, to avoid clobbering a real edge with a hardcoded empty set). `compile_protocol_definition_result/1` now registers unconditionally for both callers, removing the now-unneeded file-compile-only `compile_protocol_definition_result_for_file/1` wrapper.
- New Rust unit tests (`compile_expression_class_with_known_type_aliases_reports_referenced_aliases`, `compile_expression_protocol_with_known_type_aliases_reports_referenced_aliases`) and new Erlang EUnit integration tests (`class_definition_repl_inline_registers_alias_dependency_test_`, `protocol_definition_repl_inline_registers_alias_dependency_test_`) prove `beamtalk_alias_xref:dependents_of/1` includes a class/protocol declared purely inline at the REPL (never `:load`ed) — BT-2952's acceptance criterion #4.

## Follow-ups filed during review

Adversarial review (3-pass `/review-code`) surfaced a real, narrow gap this PR doesn't fully close, and two smaller wiring inconsistencies — both filed rather than rushed into this PR:

- **BT-2955**: a `.bt` file that declares a type alias and a class/protocol referencing it in the *same file* (e.g. `stdlib/src/Ets.bt`) can have its REPL-inline redefinition clobber the real `beamtalk_alias_xref` edge a prior `:load` registered, since the REPL-inline compile has no way to see the file-local alias. Needs either an additive-only registration mode or live-state alias recovery — bigger than this PR.
- **BT-2956**: `beamtalk_compiler_server.erl`'s `{compile_expression}` handler doesn't inject the ambient session alias cache the way `{compile}`/`{compile_method}` do (currently benign — the one production caller that needs it threads aliases explicitly), and `eval_with_self/2` triggers a spurious `beamtalk_alias_xref` registration on a path that always rejects class/protocol definitions.

## Test plan

- [x] `cargo test -p beamtalk-compiler-port` (70 tests, including 2 new)
- [x] `rebar3 eunit --app=beamtalk_runtime,beamtalk_workspace,beamtalk_compiler` (5385 tests, including 2 new)
- [x] `just test` (Rust + stdlib + BUnit + runtime, all green)
- [x] `just ci-changed` (build/lint/test/check-corpus/check-surface-drift/repl-protocol/mcp/parity, all green)