### PR TITLE
Tighten spawn wildcard assertions in REPL protocol tests

### DIFF
--- a/tests/repl-protocol/cases/completion_chain_test.btscript
+++ b/tests/repl-protocol/cases/completion_chain_test.btscript
@@ -39,7 +39,7 @@
 
 // Spawn a TypedCounter to create a binding (tc) that completions can resolve.
 tc := TypedCounter spawn
-// => _
+// => Actor(TypedCounter, _)
 
 // `tc getValue ` — getValue is annotated `-> Integer`, so Integer methods appear.
 :complete tc getValue

--- a/tests/repl-protocol/cases/erlang_interop.btscript
+++ b/tests/repl-protocol/cases/erlang_interop.btscript
@@ -30,7 +30,7 @@ proxy class
 // @load tests/repl-protocol/fixtures/erlang_user.bt
 
 eu := ErlangUser spawn
-// => _
+// => Actor(ErlangUser, _)
 
 // Actor method calls Erlang internally and stores the result in state
 // callErlang assigns self.result := Erlang lists reverse: #(1,2,3), returning [3,2,1]

--- a/tests/repl-protocol/cases/metamorphic_threading.btscript
+++ b/tests/repl-protocol/cases/metamorphic_threading.btscript
@@ -54,7 +54,7 @@ cm := Beamtalk classNamed: #MutationCorpusClassMethod
 //  to:do:
 // ===========================================================================
 a := MutationCorpusActor spawn
-// => _
+// => Actor(MutationCorpusActor, _)
 
 v toDoNonLastWriteOnly
 // => 5
@@ -162,7 +162,7 @@ cm rangeDoNonLastReadWrite
 //  collect:
 // ===========================================================================
 b := MutationCorpusActor spawn
-// => _
+// => Actor(MutationCorpusActor, _)
 
 v collectNonLastReadWrite
 // => 3
@@ -249,7 +249,7 @@ cm countNonLastReadWrite
 //  ifTrue:
 // ===========================================================================
 d := MutationCorpusActor spawn
-// => _
+// => Actor(MutationCorpusActor, _)
 
 v ifTrueNonLastWriteOnly: true
 // => 9

--- a/tests/repl-protocol/cases/workspace_bind.btscript
+++ b/tests/repl-protocol/cases/workspace_bind.btscript
@@ -79,7 +79,7 @@ globals2 includesKey: #MyValue
 
 // Register an actor reference
 counter := Counter spawn
-// => _
+// => Actor(Counter, _)
 
 Workspace bind: counter as: #SharedCounter
 // => nil

--- a/tests/repl-protocol/cases/workspace_flush_roundtrip.btscript
+++ b/tests/repl-protocol/cases/workspace_flush_roundtrip.btscript
@@ -112,7 +112,7 @@ patchEntry isActive
 // In-memory dispatch sees the patched body (the install hot-swap actually
 // installed the new method, not just logged it).
 c1 := Counter spawn
-// => _
+// => Actor(Counter, _)
 
 c1 increment
 // => 5


### PR DESCRIPTION
## Summary

Seven `spawn` calls in REPL protocol test files used the loose `// => _` wildcard assertion instead of the deterministic `// => Actor(ClassName, _)` pattern used consistently everywhere else in the suite.

- Fixes `erlang_interop.btscript`: `ErlangUser spawn`
- Fixes `workspace_bind.btscript`: `Counter spawn`
- Fixes `workspace_flush_roundtrip.btscript`: `Counter spawn`
- Fixes `metamorphic_threading.btscript`: `MutationCorpusActor spawn` (×3)
- Fixes `completion_chain_test.btscript`: `TypedCounter spawn`

## Why this matters

The plain `// => _` wildcard masks class-level regressions — if `Counter spawn` started returning an error or a wrong type, these assertions would silently pass. The tighter `// => Actor(Counter, _)` form catches that failure while still allowing the non-deterministic PID portion via the inner `_`.

## Safety

- All seven class names are confirmed `Actor subclass:` definitions
- No change to test intent or logic — only adds the class-name check that was already implied
- `just test-repl-protocol` passes: 3 suites, 0 failures

## Nightly test-quality pass

This PR was generated by the nightly `test-quality` routine. The smell: spawn calls with `// => _` where the consistent suite-wide pattern is `// => Actor(ClassName, _)`. Linear issue creation was skipped (Linear connector not enabled in this session).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RbMCTvUM53Mvy7aEUytnRh)_