### PR TITLE
Wire compiled stdlib aliases into REPL/workspace session alias table (BT-2938)

### DIFF
--- a/crates/beamtalk-cli/src/commands/app_file.rs
+++ b/crates/beamtalk-cli/src/commands/app_file.rs
@@ -239,7 +239,13 @@ fn format_native_modules_entry(native_module_names: &[String]) -> String {
 /// [`format_native_modules_entry`] — packages with no `type` declarations
 /// are unaffected (no `type_aliases` key at all, distinct from an empty
 /// list, matching the `native_modules` precedent).
-fn format_type_aliases_entry(alias_metadata: &[AliasMetadata]) -> String {
+///
+/// `pub(crate)` (not private): reused by
+/// [`super::build_stdlib::generate_app_file`]/`generate_app_src_file`
+/// (BT-2938) so `beamtalk_stdlib.app`'s `env` gets the same `{type_aliases,
+/// [...]}` key the ordinary `beamtalk build` pipeline already emits here —
+/// see this module's `AliasMetadata` doc for why that key exists.
+pub(crate) fn format_type_aliases_entry(alias_metadata: &[AliasMetadata]) -> String {
     if alias_metadata.is_empty() {
         return String::new();
     }

--- a/crates/beamtalk-cli/src/commands/build_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/build_stdlib.rs
@@ -15,6 +15,8 @@
 use crate::beam_compiler::{
     BeamCompiler, ClassHierarchyContext, CompileContext, compile_source_with_bindings,
 };
+use crate::commands::app_file;
+use crate::commands::build::build_alias_metadata;
 use crate::commands::util;
 use beamtalk_core::semantic_analysis::alias_registry::AliasRegistry;
 use beamtalk_core::semantic_analysis::type_checker::NativeTypeRegistry;
@@ -134,11 +136,33 @@ pub fn build_stdlib(quiet: bool, warnings_as_errors: bool) -> Result<()> {
         .compile_batch(&core_files)
         .wrap_err("Failed to compile stdlib Core Erlang to BEAM")?;
 
-    generate_app_file(&ebin_dir, &source_files, &class_metadata, &protocol_modules)?;
+    // BT-2938: `{type_aliases, [...]}` `.app`/`.app.src` env metadata — the
+    // same `build_alias_metadata` extraction the ordinary `beamtalk build`
+    // pipeline already uses (`build.rs`'s `ClassIndexResult::all_alias_infos`
+    // call site), independently re-parsing `source_files` for doc
+    // comments/display expansions `AliasSource`/`ClassHierarchyContext`
+    // above don't carry. This is what lets `beamtalk_repl_state:new/3` (the
+    // REPL/workspace session's alias-seeding path) and `browse-type-aliases`
+    // read stdlib's own aliases back via `application:get_env(beamtalk_stdlib,
+    // type_aliases)`.
+    let alias_metadata = build_alias_metadata(&source_files);
+
+    generate_app_file(
+        &ebin_dir,
+        &source_files,
+        &class_metadata,
+        &protocol_modules,
+        &alias_metadata,
+    )?;
     // Also update .app.src so rebar3 picks up the classes env
     let app_src_dir = Utf8PathBuf::from("runtime/apps/beamtalk_stdlib/src");
     if app_src_dir.exists() {
-        generate_app_src_file(&app_src_dir, &class_metadata, &protocol_modules)?;
+        generate_app_src_file(
+            &app_src_dir,
+            &class_metadata,
+            &protocol_modules,
+            &alias_metadata,
+        )?;
     }
 
     // Generate Rust builtins file from parsed class metadata and aliases.
@@ -1019,20 +1043,21 @@ fn format_stdlib_classes_list(class_metadata: &[ClassMeta], separator: &str) -> 
 /// Lists all modules and embeds class hierarchy metadata in the `env` section.
 /// The metadata is used by `beamtalk_stdlib` to load modules in dependency order.
 ///
-/// **No `type_aliases` env key (ADR 0108 Phase 8, BT-2903):** unlike
+/// **`type_aliases` env key (ADR 0108 Phase 8, BT-2903/BT-2938):** mirrors
 /// [`super::app_file::generate_app_file`] (the real `beamtalk build`
-/// pipeline, which now emits `{type_aliases, [...]}` via
-/// [`super::build::build_alias_metadata`]), this stdlib-specific writer does
-/// not — stdlib itself declares no `type` aliases yet. When the ADR's
-/// "Stdlib follow-through" work lands (`RestartStrategy`, `JsonValue`,
-/// tracked against BT-2618/BT-2827 in the ADR), this function needs the same
-/// `build_alias_metadata`/`format_type_aliases_entry` wiring, or
-/// `browse-type-aliases` will never show stdlib's own aliases.
+/// pipeline), which emits `{type_aliases, [...]}` via
+/// [`super::build::build_alias_metadata`] + [`app_file::format_type_aliases_entry`].
+/// Without this key, `application:get_env(beamtalk_stdlib, type_aliases)`
+/// returns `undefined` forever, so neither `browse-type-aliases`
+/// (`beamtalk_repl_ops_browse.erl`) nor the REPL/workspace session's
+/// alias-seeding path (`beamtalk_repl_state:new/3`, BT-2938) can ever learn
+/// stdlib's own `type Name = ...` declarations.
 fn generate_app_file(
     ebin_dir: &Utf8Path,
     source_files: &[Utf8PathBuf],
     class_metadata: &[ClassMeta],
     protocol_modules: &[String],
+    alias_metadata: &[app_file::AliasMetadata],
 ) -> Result<()> {
     let module_names: Vec<String> = source_files
         .iter()
@@ -1055,6 +1080,11 @@ fn generate_app_file(
         .collect::<Vec<_>>()
         .join(", ");
 
+    // BT-2938: same `{type_aliases, [...]}` entry the ordinary `beamtalk
+    // build` pipeline emits (`app_file::format_type_aliases_entry`) — empty
+    // string (no key at all) when stdlib declares no aliases.
+    let type_aliases_entry = app_file::format_type_aliases_entry(alias_metadata);
+
     let version = env!("BEAMTALK_VERSION");
     let app_content = format!(
         "{{application, beamtalk_stdlib, [\n\
@@ -1065,7 +1095,7 @@ fn generate_app_file(
          \x20   {{applications, [kernel, stdlib, beamtalk_runtime]}},\n\
          \x20   {{env, [\n\
          \x20       {{classes, [{classes_list}]}},\n\
-         \x20       {{protocol_modules, [{protocol_modules_list}]}}\n\
+         \x20       {{protocol_modules, [{protocol_modules_list}]}}{type_aliases_entry}\n\
          \x20   ]}}\n\
          ]}}.\n"
     );
@@ -1082,11 +1112,13 @@ fn generate_app_file(
 /// Generate/update the `.app.src` file so rebar3 picks up the classes metadata.
 ///
 /// The `.app.src` uses `{modules, []}` (rebar3 auto-fills modules) but embeds
-/// the `{classes, [...]}` env for the runtime to read via `application:get_env`.
+/// the `{classes, [...]}` and (BT-2938) `{type_aliases, [...]}` envs for the
+/// runtime to read via `application:get_env`.
 fn generate_app_src_file(
     src_dir: &Utf8Path,
     class_metadata: &[ClassMeta],
     protocol_modules: &[String],
+    alias_metadata: &[app_file::AliasMetadata],
 ) -> Result<()> {
     // ADR 0070 Phase 4: Generate extended class hierarchy entries for env
     let classes_list = format_stdlib_classes_list(class_metadata, ",\n            ");
@@ -1097,6 +1129,9 @@ fn generate_app_src_file(
         .map(|m| format!("'{m}'"))
         .collect::<Vec<_>>()
         .join(", ");
+
+    // BT-2938: see `generate_app_file`'s doc.
+    let type_aliases_entry = app_file::format_type_aliases_entry(alias_metadata);
 
     let app_src_content = format!(
         "{{application, beamtalk_stdlib, [\n\
@@ -1109,7 +1144,7 @@ fn generate_app_src_file(
          \x20       {{classes, [\n\
          \x20           {classes_list}\n\
          \x20       ]}},\n\
-         \x20       {{protocol_modules, [{protocol_modules_list}]}}\n\
+         \x20       {{protocol_modules, [{protocol_modules_list}]}}{type_aliases_entry}\n\
          \x20   ]}}\n\
          ]}}.\n"
     );
@@ -1900,7 +1935,7 @@ mod tests {
             Utf8PathBuf::from("lib/String.bt"),
         ];
 
-        generate_app_file(&ebin_dir, &source_files, &[], &[]).unwrap();
+        generate_app_file(&ebin_dir, &source_files, &[], &[], &[]).unwrap();
 
         let app_file = ebin_dir.join("beamtalk_stdlib.app");
         assert!(app_file.exists());
@@ -1916,10 +1951,13 @@ mod tests {
     fn test_generate_app_file_empty() {
         let (_temp, ebin_dir) = temp_utf8_dir();
 
-        generate_app_file(&ebin_dir, &[], &[], &[]).unwrap();
+        generate_app_file(&ebin_dir, &[], &[], &[], &[]).unwrap();
 
         let content = fs::read_to_string(ebin_dir.join("beamtalk_stdlib.app")).unwrap();
         assert!(content.contains("{modules, []}"));
+        // BT-2938: no type-alias metadata => no `type_aliases` env key at all
+        // (matches `format_type_aliases_entry`'s empty-input contract).
+        assert!(!content.contains("type_aliases"));
     }
 
     #[test]
@@ -1931,7 +1969,7 @@ mod tests {
             Utf8PathBuf::from("lib/my-bad-name.bt"),
         ];
 
-        let result = generate_app_file(&ebin_dir, &source_files, &[], &[]);
+        let result = generate_app_file(&ebin_dir, &source_files, &[], &[], &[]);
         assert!(result.is_err());
     }
 
@@ -1942,12 +1980,36 @@ mod tests {
         let source_files = vec![Utf8PathBuf::from("lib/Integer.bt")];
         let protocol_modules = vec!["bt@stdlib@printable".to_string()];
 
-        generate_app_file(&ebin_dir, &source_files, &[], &protocol_modules).unwrap();
+        generate_app_file(&ebin_dir, &source_files, &[], &protocol_modules, &[]).unwrap();
 
         let content = fs::read_to_string(ebin_dir.join("beamtalk_stdlib.app")).unwrap();
         assert!(
             content.contains("{protocol_modules, ['bt@stdlib@printable']}"),
             "Should contain protocol_modules env key. Got:\n{content}"
+        );
+    }
+
+    #[test]
+    fn test_generate_app_file_with_type_aliases() {
+        let (_temp, ebin_dir) = temp_utf8_dir();
+
+        let source_files = vec![Utf8PathBuf::from("lib/Supervisor.bt")];
+        let alias_metadata = vec![app_file::AliasMetadata {
+            name: "SupervisionStrategy".to_string(),
+            expansion: "#oneForOne | #oneForAll | #restForOne".to_string(),
+            doc: None,
+            source_file: "lib/Supervisor.bt".to_string(),
+            internal: false,
+        }];
+
+        generate_app_file(&ebin_dir, &source_files, &[], &[], &alias_metadata).unwrap();
+
+        let content = fs::read_to_string(ebin_dir.join("beamtalk_stdlib.app")).unwrap();
+        assert!(
+            content.contains("{type_aliases, [")
+                && content.contains("name => 'SupervisionStrategy'")
+                && content.contains("expansion => \"#oneForOne | #oneForAll | #restForOne\""),
+            "Should contain type_aliases env key with the alias entry. Got:\n{content}"
         );
     }
 

--- a/docs/development/surface-parity.md
+++ b/docs/development/surface-parity.md
@@ -238,7 +238,7 @@ These MCP tools provide AI-assistant-specific capabilities that have no direct R
 | `search_classes` | `surface-specific: offline class discovery by keyword` |
 | `list_packages` | `surface-specific: list loaded Beamtalk packages` |
 | `package_classes` | `surface-specific: list classes in a named package` |
-| `docs` | Wraps `Beamtalk help: ClassName` (optionally `selector: #sel` for instance- or class-side methods) — REPL `docs` op was hard-removed (BT-2091). **BT-2902 (ADR 0108 Phase 8):** when `ClassName` names a `type Name = ...` alias declared earlier in *this session*, the eval layer (`beamtalk_repl_eval:maybe_help_for_alias/2`) answers from the session's alias table before the expression ever reaches `Beamtalk help:` — aliases erase entirely at compile time, so there is no live class/process for the global `beamtalk_class_registry` lookup `Beamtalk help:` normally does to ever see. Renders `type Name = <expansion>`, the doc comment (if any), and `Declared in: REPL`. Since MCP tool calls run through the same per-session `beamtalk_repl_shell`/`do_eval` pipeline as the CLI REPL, this is automatic cross-surface parity, not a separate implementation — a session-local alias is visible identically from whichever surface opened that session. Cross-package/exported aliases (visible regardless of which session declared them) are BT-2898's seeding mechanism, not yet wired into this lookup. |
+| `docs` | Wraps `Beamtalk help: ClassName` (optionally `selector: #sel` for instance- or class-side methods) — REPL `docs` op was hard-removed (BT-2091). **BT-2902 (ADR 0108 Phase 8):** when `ClassName` names a `type Name = ...` alias declared earlier in *this session*, the eval layer (`beamtalk_repl_eval:maybe_help_for_alias/2`) answers from the session's alias table before the expression ever reaches `Beamtalk help:` — aliases erase entirely at compile time, so there is no live class/process for the global `beamtalk_class_registry` lookup `Beamtalk help:` normally does to ever see. Renders `type Name = <expansion>`, the doc comment (if any), and `Declared in: REPL`. Since MCP tool calls run through the same per-session `beamtalk_repl_shell`/`do_eval` pipeline as the CLI REPL, this is automatic cross-surface parity, not a separate implementation — a session-local alias is visible identically from whichever surface opened that session. **BT-2938:** the same session alias table (`beamtalk_repl_state`) is now also seeded, at session creation, with every public `type Name = ...` alias stdlib itself declares (`beamtalk_repl_state:stdlib_alias_table/0`, reading `beamtalk_stdlib`'s compiled `.app` `{type_aliases, [...]}` env key — the same durable record `browse-type-aliases` reads) — a fresh session's `:help SupervisionStrategy` (`stdlib/src/Supervisor.bt`) and a `::`-typed local referencing it both resolve without the session ever declaring it itself, mirroring how a compiled-in stdlib *class* is already known out of the box. Renders `Declared in: stdlib` (not `REPL`) for one of these — see the Declaration-echo-values section below. A stdlib entry is shadowed by a same-named session-local `type` redeclaration (ADR 0108 Semantics' "current turn wins"). Cross-package/exported *project or dependency* aliases (visible regardless of which session declared them) remain BT-2898's seeding mechanism, not yet wired into this lookup. |
 | `load_file` | Wraps `Workspace load: "path"` — REPL `load-file` op was hard-removed (BT-2091) |
 | `reload_class` | Wraps `ClassName reload` — REPL `reload` op was hard-removed (BT-2091) |
 | `try_method` | Ephemeral counterpart of `save_method` (ADR 0082 Phase 3, BT-2288). Wraps `aClass tryCompile: #sel source: body` — installs in memory and logs an ephemeral ChangeLog entry that does not flush. Listed here because the `live-edit-method` REPL op row only carries one MCP binding (`save_method`, the durable path); humans typing `>>` at the REPL reach the same install chokepoint without a separate token. Promote a successful spike by calling `save_method` with the same body. |
@@ -351,6 +351,16 @@ the LSP has no eval affordance and is unaffected).
   new display text with no prior precedent, also pinned by the same
   `.btscript` test. A file-declared alias's `:help` shows its real
   `source_file` path instead (see the `docs` row in Core Operations).
+- **BT-2938:** an alias seeded from stdlib's own compiled declarations
+  (never declared by this session at all) instead reads **`Declared in:
+  stdlib`** — chosen to match `package => 'stdlib'`'s existing convention
+  elsewhere (e.g. `build_stdlib.rs`'s `format_stdlib_class_entry`) rather
+  than stdlib's real `source_file` path (e.g. `stdlib/src/Supervisor.bt`),
+  since that path is an implementation detail no Beamtalk user program can
+  `:load`. Same maintainer-sign-off caveat as `Declared in: REPL` above —
+  flagged in BT-2938's own PR description, not yet a closed decision.
+  Pinned by `tests/repl-protocol/cases/type_alias_repl.btscript`'s
+  `:help SupervisionStrategy` section.
 
 ## Drift Check (CI)
 

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_stdlib.app.src
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_stdlib.app.src
@@ -109,6 +109,11 @@
             #{name => 'Value', module => 'bt@stdlib@value', parent => 'Object', package => 'stdlib', kind => object, type_params => []},
             #{name => 'WorkspaceInterface', module => 'bt@stdlib@workspace_interface', parent => 'Object', package => 'stdlib', kind => object, type_params => []}
         ]},
-        {protocol_modules, ['bt@stdlib@json_representable', 'bt@stdlib@printable']}
+        {protocol_modules, ['bt@stdlib@json_representable', 'bt@stdlib@printable']},
+        {type_aliases, [#{name => 'EtsTableType', expansion => "#set | #orderedSet | #bag | #duplicateBag", doc => "The ETS table type — see the \"Table Types\" section on `Ets` for the\nsemantics of each member.", source_file => "stdlib/src/Ets.bt", internal => false},
+            #{name => 'JsonValue', expansion => "Nil | Boolean | Integer | Float | String | List | Dictionary", doc => "A parsed or parseable JSON value (BT-2827).\n\nJSON objects become Dictionary, arrays become List, strings become\nString, numbers become Integer or Float, booleans stay true/false,\nand null becomes nil — see `Json`'s class comment for the full mapping.", source_file => "stdlib/src/Json.bt", internal => false},
+            #{name => 'LogFormat', expansion => "#text | #json", doc => "The log output format on the file handler.", source_file => "stdlib/src/BeamtalkInterface.bt", internal => false},
+            #{name => 'LogLevel', expansion => "#emergency | #alert | #critical | #error | #warning | #notice | #info | #debug", doc => "The OTP primary log level severities that `Beamtalk logLevel:` accepts.", source_file => "stdlib/src/BeamtalkInterface.bt", internal => false},
+            #{name => 'SupervisionStrategy', expansion => "#oneForOne | #oneForAll | #restForOne", doc => "OTP supervisor restart strategy — how sibling children are affected when\none of them crashes.", source_file => "stdlib/src/Supervisor.bt", internal => false}]}
     ]}
 ]}.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
@@ -212,31 +212,38 @@ maybe_help_for_alias(Expression, State) ->
     end.
 
 -doc """
-Render `:help <Alias>` output (ADR 0108 Phase 8, BT-2902).
+Render `:help <Alias>` output (ADR 0108 Phase 8, BT-2902; stdlib
+provenance BT-2938).
 
 `type Name = <expansion>`, then — only when a doc comment is present — a
 blank line and the indented doc text, then a blank line and
-`Declared in: REPL`. A session-declared alias has no source file, so `REPL`
-is this issue's chosen convention (flagged in the PR description for
-maintainer sign-off per CLAUDE.md's REPL-output rule, alongside the
-`type` declaration's own echo-value decision).
+`Declared in: <declared_in>`. `declared_in` is `<<"REPL">>` for a
+session-declared alias (this issue's chosen convention, flagged in the PR
+description for maintainer sign-off per CLAUDE.md's REPL-output rule,
+alongside the `type` declaration's own echo-value decision) or
+`<<"stdlib">>` for one seeded from stdlib's own compiled declarations
+(`beamtalk_repl_state:stdlib_alias_table/0`) — same sign-off flag, chosen to
+match `package => 'stdlib'`'s existing convention elsewhere (e.g.
+`format_stdlib_class_entry`) rather than a full `source_file` path.
 """.
 -spec format_alias_help(binary(), beamtalk_repl_state:alias_entry()) -> binary().
-format_alias_help(Name, #{expansion := Expansion, doc_comment := DocComment}) ->
+format_alias_help(Name, #{
+    expansion := Expansion, doc_comment := DocComment, declared_in := DeclaredIn
+}) ->
     Header = <<"type ", Name/binary, " = ", Expansion/binary>>,
     CommentBlock =
         case DocComment of
             undefined -> <<>>;
             Doc -> <<"\n\n  ", Doc/binary>>
         end,
-    <<Header/binary, CommentBlock/binary, "\n\nDeclared in: REPL">>.
+    <<Header/binary, CommentBlock/binary, "\n\nDeclared in: ", DeclaredIn/binary>>.
 
 -doc "Handle a `type Name = ...` declaration (ADR 0108 Phase 8, BT-2902).".
 -spec handle_type_alias_definition(map(), [binary()], beamtalk_repl_state:state()) ->
     eval_result().
 handle_type_alias_definition(AliasInfo, Warnings, State) ->
     #{alias_name := Name, expansion := Expansion, doc_comment := DocComment} = AliasInfo,
-    Entry = #{expansion => Expansion, doc_comment => DocComment},
+    Entry = #{expansion => Expansion, doc_comment => DocComment, declared_in => <<"REPL">>},
     NewState = beamtalk_repl_state:put_alias(Name, Entry, State),
     %% ADR 0108 hot-reload re-check trigger (BT-2899): keep the compiler
     %% server's ambient alias cache in sync with session state so a later

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_state.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_state.erl
@@ -399,13 +399,19 @@ stdlib_type_aliases_env() ->
 %% missing the `name`/`expansion` keys every `format_type_aliases_entry`
 %% row carries.
 %%
-%% Fails **safe**, not open, on a missing `internal` key (`maps:get(internal,
-%% Entry, true)` — should never happen, `format_type_aliases_entry` always
-%% emits it): mirrors `beamtalk_repl_ops_browse:alias_visible/2`'s explicit
-%% "no `internal` key at all... fail safe by treating as internal"
-%% convention, so a row shape this reader doesn't yet know about can't
-%% silently leak a should-be-internal alias into every fresh REPL session
-%% instead of just being dropped.
+%% Fails **safe**, not open, on a missing (or non-boolean) `internal` key
+%% (`maps:get(internal, Entry, true)` plus the catch-all `_ -> Acc` case
+%% arm below — should never happen, `format_type_aliases_entry` always
+%% emits a proper boolean): mirrors `beamtalk_repl_ops_browse:
+%% alias_visible/2`'s explicit "no `internal` key at all... fail safe by
+%% treating as internal" convention, so a row shape this reader doesn't
+%% yet know about can't silently leak a should-be-internal alias into
+%% every fresh REPL session instead of just being dropped. The catch-all
+%% case arm also keeps this row-level-skip, not whole-table-wipe: without
+%% it, a non-boolean `internal` value (e.g. a hand-edited `.app` file)
+%% would throw `case_clause`, caught by `stdlib_alias_table/0`'s outer
+%% `try/catch` as an empty table — discarding every other, well-formed
+%% row along with this one bad row.
 -spec stdlib_alias_fold(term(), #{binary() => alias_entry()}) -> #{binary() => alias_entry()}.
 stdlib_alias_fold(#{name := Name, expansion := Expansion} = Entry, Acc) ->
     case maps:get(internal, Entry, true) of
@@ -418,7 +424,9 @@ stdlib_alias_fold(#{name := Name, expansion := Expansion} = Entry, Acc) ->
                     doc_comment => app_env_doc(maps:get(doc, Entry, undefined)),
                     declared_in => <<"stdlib">>
                 }
-            }
+            };
+        _ ->
+            Acc
     end;
 stdlib_alias_fold(_Entry, Acc) ->
     Acc.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_state.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_state.erl
@@ -407,24 +407,31 @@ stdlib_type_aliases_env() ->
 %% treating as internal" convention, so a row shape this reader doesn't
 %% yet know about can't silently leak a should-be-internal alias into
 %% every fresh REPL session instead of just being dropped. The catch-all
-%% case arm also keeps this row-level-skip, not whole-table-wipe: without
-%% it, a non-boolean `internal` value (e.g. a hand-edited `.app` file)
-%% would throw `case_clause`, caught by `stdlib_alias_table/0`'s outer
-%% `try/catch` as an empty table — discarding every other, well-formed
-%% row along with this one bad row.
+%% case arm, and the inner `try/catch` around row construction, both keep
+%% this row-level-skip, not whole-table-wipe: without the case arm, a
+%% non-boolean `internal` value would throw `case_clause`; without the
+%% inner `try/catch`, a malformed `name`/`expansion`/`doc` (e.g. an
+%% improper charlist in a hand-edited `.app` file) would throw out of
+%% `app_env_binary`/`app_env_doc`. Either, uncaught here, would be caught
+%% by `stdlib_alias_table/0`'s outer `try/catch` as an *empty* table —
+%% discarding every other, well-formed row along with this one bad row.
 -spec stdlib_alias_fold(term(), #{binary() => alias_entry()}) -> #{binary() => alias_entry()}.
 stdlib_alias_fold(#{name := Name, expansion := Expansion} = Entry, Acc) ->
     case maps:get(internal, Entry, true) of
         true ->
             Acc;
         false ->
-            Acc#{
-                app_env_binary(Name) => #{
-                    expansion => app_env_binary(Expansion),
-                    doc_comment => app_env_doc(maps:get(doc, Entry, undefined)),
-                    declared_in => <<"stdlib">>
+            try
+                Acc#{
+                    app_env_binary(Name) => #{
+                        expansion => app_env_binary(Expansion),
+                        doc_comment => app_env_doc(maps:get(doc, Entry, undefined)),
+                        declared_in => <<"stdlib">>
+                    }
                 }
-            };
+            catch
+                _:_ -> Acc
+            end;
         _ ->
             Acc
     end;

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_state.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_state.erl
@@ -398,17 +398,28 @@ stdlib_type_aliases_env() ->
 %% dropping internal rows (see `stdlib_alias_table/0` doc) and any row
 %% missing the `name`/`expansion` keys every `format_type_aliases_entry`
 %% row carries.
+%%
+%% Fails **safe**, not open, on a missing `internal` key (`maps:get(internal,
+%% Entry, true)` — should never happen, `format_type_aliases_entry` always
+%% emits it): mirrors `beamtalk_repl_ops_browse:alias_visible/2`'s explicit
+%% "no `internal` key at all... fail safe by treating as internal"
+%% convention, so a row shape this reader doesn't yet know about can't
+%% silently leak a should-be-internal alias into every fresh REPL session
+%% instead of just being dropped.
 -spec stdlib_alias_fold(term(), #{binary() => alias_entry()}) -> #{binary() => alias_entry()}.
-stdlib_alias_fold(#{internal := true}, Acc) ->
-    Acc;
 stdlib_alias_fold(#{name := Name, expansion := Expansion} = Entry, Acc) ->
-    Acc#{
-        app_env_binary(Name) => #{
-            expansion => app_env_binary(Expansion),
-            doc_comment => app_env_doc(maps:get(doc, Entry, undefined)),
-            declared_in => <<"stdlib">>
-        }
-    };
+    case maps:get(internal, Entry, true) of
+        true ->
+            Acc;
+        false ->
+            Acc#{
+                app_env_binary(Name) => #{
+                    expansion => app_env_binary(Expansion),
+                    doc_comment => app_env_doc(maps:get(doc, Entry, undefined)),
+                    declared_in => <<"stdlib">>
+                }
+            }
+    end;
 stdlib_alias_fold(_Entry, Acc) ->
     Acc.
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_state.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_state.erl
@@ -99,18 +99,27 @@ for manipulating state during REPL sessions.
     | {clear, undefined, undefined}.
 
 -doc """
-A session-local type alias entry (ADR 0108 Phase 8, BT-2902).
+A session-visible type alias entry (ADR 0108 Phase 8, BT-2902; stdlib
+seeding BT-2938).
 
 `expansion` is the alias's unparsed `TypeAnnotation` display form (e.g.
-`<<"#north | #south | #east | #west">>`), exactly as returned by the
-compiler port's `type_alias_definition` response — both what `:help`
-renders and what round-trips through `known_type_alias_sources/1` as a
-reparseable `type Name = <expansion>` line. `doc_comment` is `undefined`
-when the declaration had no `///` doc comment.
+`<<"#north | #south | #east | #west">>`) — both what `:help` renders and
+what round-trips through `known_type_alias_sources/1` as a reparseable
+`type Name = <expansion>` line. `doc_comment` is `undefined` when the
+declaration had no `///` doc comment.
+
+`declared_in` is `:help`'s provenance line (`format_alias_help/2` in
+`beamtalk_repl_eval.erl`): `<<"REPL">>` for a `type Name = ...` this
+session declared itself (exactly as returned by the compiler port's
+`type_alias_definition` response), or `<<"stdlib">>` for an alias seeded
+from stdlib's own compiled declarations (`stdlib_alias_table/0`) — a
+session never has to declare `SupervisionStrategy` etc. itself for `:help`
+or a `::` annotation to resolve it.
 """.
 -type alias_entry() :: #{
     expansion := binary(),
-    doc_comment := binary() | undefined
+    doc_comment := binary() | undefined,
+    declared_in := binary()
 }.
 
 -opaque state() :: #state{}.
@@ -147,7 +156,13 @@ new(ListenSocket, Port, Options) ->
         module_tracker = beamtalk_repl_modules:new(),
         pending_module_removals = [],
         pending_mutations = [],
-        alias_table = #{}
+        %% BT-2938: seed with stdlib's own compiled aliases so `:help
+        %% <StdlibAlias>` and `::`-typed locals referencing one resolve in a
+        %% fresh session — see `stdlib_alias_table/0`. A later `type Name =
+        %% ...` declaration at this session's REPL prompt (`put_alias/3`)
+        %% legally shadows a same-named stdlib entry (ADR 0108 Semantics'
+        %% "current turn wins" precedent).
+        alias_table = stdlib_alias_table()
     }.
 
 -doc "Get current variable bindings.".
@@ -334,3 +349,89 @@ known_type_alias_sources(#state{alias_table = AliasTable}) ->
         <<"type ", Name/binary, " = ", (maps:get(expansion, Entry))/binary>>
      || {Name, Entry} <- maps:to_list(AliasTable)
     ].
+
+-doc """
+Seed a fresh session's alias table from stdlib's own compiled `type Name =
+...` declarations (BT-2938).
+
+Reads `beamtalk_stdlib`'s `.app` `{type_aliases, [...]}` env key (ADR 0108
+Phase 8/BT-2903, written by `build_stdlib.rs`'s `generate_app_file`/
+`generate_app_src_file` from `app_file::AliasMetadata`) — the same durable
+record `beamtalk_repl_ops_browse:package_type_aliases/1` reads for
+`browse-type-aliases`. Without this, a stdlib alias like `SupervisionStrategy`
+(`stdlib/src/Supervisor.bt`) has no live BEAM class/process the way a stdlib
+*class* does (`beamtalk_class_registry`, populated at boot from the same
+`.app`'s `{classes, [...]}` env) for a fresh session to already know about —
+aliases erase entirely at compile time, so this session-state table is the
+only place a bare `:help SupervisionStrategy` or a `::`-typed local
+referencing it can resolve from.
+
+Only public (non-`internal`) aliases are seeded: an `internal type Foo =
+...` stdlib alias is usable only *within* stdlib itself (ADR 0108
+Semantics), and a REPL session is never "inside" the stdlib package —
+mirrors the seeding-boundary exclusion `beamtalk_repl_ops_browse:
+alias_visible/2` applies to every non-project package's internal aliases.
+
+Best-effort: `[]`/`#{}` (an empty seed, not a crash) if `beamtalk_stdlib`'s
+env is missing/malformed or a row doesn't have the shape
+`format_type_aliases_entry` always emits — a corrupted or
+toolchain-mismatched `.app` file must not prevent a session from starting.
+""".
+-spec stdlib_alias_table() -> #{binary() => alias_entry()}.
+stdlib_alias_table() ->
+    try
+        lists:foldl(fun stdlib_alias_fold/2, #{}, stdlib_type_aliases_env())
+    catch
+        _:_ -> #{}
+    end.
+
+%% `beamtalk_stdlib`'s `.app` `{type_aliases, [...]}` env key, `[]` if
+%% absent (older `.app` build) or malformed.
+-spec stdlib_type_aliases_env() -> [map()].
+stdlib_type_aliases_env() ->
+    case application:get_env(beamtalk_stdlib, type_aliases) of
+        {ok, Aliases} when is_list(Aliases) -> Aliases;
+        _ -> []
+    end.
+
+%% Fold one `.app`-env alias row into the session alias table being built,
+%% dropping internal rows (see `stdlib_alias_table/0` doc) and any row
+%% missing the `name`/`expansion` keys every `format_type_aliases_entry`
+%% row carries.
+-spec stdlib_alias_fold(term(), #{binary() => alias_entry()}) -> #{binary() => alias_entry()}.
+stdlib_alias_fold(#{internal := true}, Acc) ->
+    Acc;
+stdlib_alias_fold(#{name := Name, expansion := Expansion} = Entry, Acc) ->
+    Acc#{
+        app_env_binary(Name) => #{
+            expansion => app_env_binary(Expansion),
+            doc_comment => app_env_doc(maps:get(doc, Entry, undefined)),
+            declared_in => <<"stdlib">>
+        }
+    };
+stdlib_alias_fold(_Entry, Acc) ->
+    Acc.
+
+%% Normalise a `.app`-file alias field (atom | Erlang string() | binary(),
+%% never JSON — `app_file.rs` emits a literal `.app` Erlang term consulted
+%% via `application:get_env/2`, not a wire payload) to the binary
+%% `alias_entry()` uses. Deliberately not shared with
+%% `beamtalk_repl_ops_browse:alias_field_binary/1` (that helper is
+%% `-ifdef(TEST)`-exported only, and maps an absent `doc` to `null`, a
+%% term-op/JSON convention this module's `undefined` doesn't want).
+-spec app_env_binary(atom() | string() | binary()) -> binary().
+app_env_binary(V) when is_binary(V) ->
+    V;
+app_env_binary(V) when is_atom(V) ->
+    atom_to_binary(V, utf8);
+app_env_binary(V) when is_list(V) ->
+    case unicode:characters_to_binary(V) of
+        B when is_binary(B) -> B;
+        _ -> list_to_binary(V)
+    end.
+
+-spec app_env_doc(undefined | atom() | string() | binary()) -> binary() | undefined.
+app_env_doc(undefined) ->
+    undefined;
+app_env_doc(V) ->
+    app_env_binary(V).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_eval_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_eval_tests.erl
@@ -1481,7 +1481,11 @@ handle_type_alias_definition_success_test() ->
     ?assertMatch({ok, <<"Direction">>, <<>>, [], _}, Result),
     {ok, _, _, _, NewState} = Result,
     ?assertEqual(
-        #{expansion => <<"#north | #south | #east | #west">>, doc_comment => undefined},
+        #{
+            expansion => <<"#north | #south | #east | #west">>,
+            doc_comment => undefined,
+            declared_in => <<"REPL">>
+        },
         maps:get(<<"Direction">>, beamtalk_repl_state:get_alias_table(NewState))
     ).
 
@@ -1501,13 +1505,21 @@ handle_type_alias_definition_redefine_overwrites_test() ->
     },
     {ok, _, _, _, State2} = beamtalk_repl_eval:handle_type_alias_definition(Second, [], State1),
     ?assertEqual(
-        #{expansion => <<"#north | #south | #east | #west">>, doc_comment => undefined},
+        #{
+            expansion => <<"#north | #south | #east | #west">>,
+            doc_comment => undefined,
+            declared_in => <<"REPL">>
+        },
         maps:get(<<"Direction">>, beamtalk_repl_state:get_alias_table(State2))
     ).
 
 -doc "format_alias_help/2 omits the comment block when there is no doc comment.".
 format_alias_help_without_doc_comment_test() ->
-    Entry = #{expansion => <<"#north | #south | #east | #west">>, doc_comment => undefined},
+    Entry = #{
+        expansion => <<"#north | #south | #east | #west">>,
+        doc_comment => undefined,
+        declared_in => <<"REPL">>
+    },
     Result = beamtalk_repl_eval:format_alias_help(<<"Direction">>, Entry),
     ?assertEqual(
         <<"type Direction = #north | #south | #east | #west\n\nDeclared in: REPL">>,
@@ -1518,7 +1530,8 @@ format_alias_help_without_doc_comment_test() ->
 format_alias_help_with_doc_comment_test() ->
     Entry = #{
         expansion => <<"#temporary | #transient | #permanent">>,
-        doc_comment => <<"How a supervised child restarts after exit.">>
+        doc_comment => <<"How a supervised child restarts after exit.">>,
+        declared_in => <<"REPL">>
     },
     Result = beamtalk_repl_eval:format_alias_help(<<"RestartStrategy">>, Entry),
     ?assertEqual(
@@ -1530,10 +1543,25 @@ format_alias_help_with_doc_comment_test() ->
         Result
     ).
 
+-doc "format_alias_help/2 renders the stdlib provenance line (BT-2938).".
+format_alias_help_stdlib_declared_in_test() ->
+    Entry = #{
+        expansion => <<"#oneForOne | #oneForAll | #restForOne">>,
+        doc_comment => undefined,
+        declared_in => <<"stdlib">>
+    },
+    Result = beamtalk_repl_eval:format_alias_help(<<"SupervisionStrategy">>, Entry),
+    ?assertEqual(
+        <<"type SupervisionStrategy = #oneForOne | #oneForAll | #restForOne\n\nDeclared in: stdlib">>,
+        Result
+    ).
+
 -doc "maybe_help_for_alias/2 answers a bare `Beamtalk help: <Alias>` for a known alias.".
 maybe_help_for_alias_found_test() ->
     State0 = beamtalk_repl_state:new(undefined, 0),
-    Entry = #{expansion => <<"#north | #south">>, doc_comment => undefined},
+    Entry = #{
+        expansion => <<"#north | #south">>, doc_comment => undefined, declared_in => <<"REPL">>
+    },
     State = beamtalk_repl_state:put_alias(<<"Direction">>, Entry, State0),
     Result = beamtalk_repl_eval:maybe_help_for_alias("Beamtalk help: Direction", State),
     ?assertEqual(
@@ -1555,7 +1583,9 @@ which will report the usual does-not-understand/not-found error).
 """.
 maybe_help_for_alias_ignores_selector_and_class_forms_test() ->
     State0 = beamtalk_repl_state:new(undefined, 0),
-    Entry = #{expansion => <<"#north | #south">>, doc_comment => undefined},
+    Entry = #{
+        expansion => <<"#north | #south">>, doc_comment => undefined, declared_in => <<"REPL">>
+    },
     State = beamtalk_repl_state:put_alias(<<"Direction">>, Entry, State0),
     ?assertEqual(
         not_found,

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_state_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_state_tests.erl
@@ -235,3 +235,166 @@ state_independence_test() ->
 
     ?assertEqual(#{}, beamtalk_repl_state:get_bindings(State3)),
     ?assertEqual(1, beamtalk_repl_state:get_eval_counter(State3)).
+
+%%% BT-2938: fresh-session seeding from stdlib's own compiled aliases
+
+%% Temporarily set `beamtalk_stdlib`'s `type_aliases` env to `Aliases`, run
+%% `Fun`, then restore the original env (`undefined` → unset). Mirrors
+%% `beamtalk_repl_ops_browse_tests:with_stdlib_aliases/2` — stdlib is the one
+%% app always loaded under the EUnit harness, and `application:set_env/3` on
+%% it is the minimal, precedent-consistent way to fixture its alias env
+%% without building a real `.app` file end-to-end.
+with_stdlib_aliases(Aliases, Fun) ->
+    _ = application:load(beamtalk_stdlib),
+    Previous = application:get_env(beamtalk_stdlib, type_aliases),
+    ok = application:set_env(beamtalk_stdlib, type_aliases, Aliases),
+    try
+        Fun()
+    after
+        case Previous of
+            {ok, V} -> application:set_env(beamtalk_stdlib, type_aliases, V);
+            undefined -> application:unset_env(beamtalk_stdlib, type_aliases)
+        end
+    end.
+
+stdlib_alias_seeded_into_fresh_session_test() ->
+    with_stdlib_aliases(
+        [
+            #{
+                name => 'SupervisionStrategy',
+                expansion => "#oneForOne | #oneForAll | #restForOne",
+                doc => "Restart strategy for a supervised child.",
+                source_file => "stdlib/src/Supervisor.bt",
+                internal => false
+            }
+        ],
+        fun() ->
+            State = beamtalk_repl_state:new(undefined, 0),
+            AliasTable = beamtalk_repl_state:get_alias_table(State),
+            ?assertEqual(
+                #{
+                    expansion => <<"#oneForOne | #oneForAll | #restForOne">>,
+                    doc_comment => <<"Restart strategy for a supervised child.">>,
+                    declared_in => <<"stdlib">>
+                },
+                maps:get(<<"SupervisionStrategy">>, AliasTable)
+            )
+        end
+    ).
+
+%% `known_type_alias_sources/1` folds every seeded alias (stdlib included)
+%% into the compiler-port `known_type_aliases` request field — this is what
+%% makes a `::`-typed local referencing a stdlib alias resolve.
+stdlib_alias_seeded_reaches_known_type_alias_sources_test() ->
+    with_stdlib_aliases(
+        [
+            #{
+                name => 'SupervisionStrategy',
+                expansion => "#oneForOne | #oneForAll | #restForOne",
+                doc => undefined,
+                source_file => "stdlib/src/Supervisor.bt",
+                internal => false
+            }
+        ],
+        fun() ->
+            State = beamtalk_repl_state:new(undefined, 0),
+            Sources = beamtalk_repl_state:known_type_alias_sources(State),
+            ?assertEqual(
+                [<<"type SupervisionStrategy = #oneForOne | #oneForAll | #restForOne">>], Sources
+            )
+        end
+    ).
+
+stdlib_alias_without_doc_comment_test() ->
+    with_stdlib_aliases(
+        [
+            #{
+                name => 'LogFormat',
+                expansion => "#text | #json",
+                doc => undefined,
+                source_file => "stdlib/src/BeamtalkInterface.bt",
+                internal => false
+            }
+        ],
+        fun() ->
+            State = beamtalk_repl_state:new(undefined, 0),
+            Entry = maps:get(<<"LogFormat">>, beamtalk_repl_state:get_alias_table(State)),
+            ?assertEqual(undefined, maps:get(doc_comment, Entry))
+        end
+    ).
+
+%% Seeding-boundary exclusion (mirrors `beamtalk_repl_ops_browse:
+%% alias_visible/2`): an `internal type Foo = ...` stdlib alias is never
+%% seeded into a session — a REPL session is never "inside" the stdlib
+%% package.
+stdlib_internal_alias_excluded_test() ->
+    with_stdlib_aliases(
+        [
+            #{
+                name => 'InternalOnlyStrategy',
+                expansion => "#a | #b",
+                doc => undefined,
+                source_file => "stdlib/src/Fixture.bt",
+                internal => true
+            }
+        ],
+        fun() ->
+            State = beamtalk_repl_state:new(undefined, 0),
+            AliasTable = beamtalk_repl_state:get_alias_table(State),
+            ?assertNot(maps:is_key(<<"InternalOnlyStrategy">>, AliasTable))
+        end
+    ).
+
+%% A session-declared `type Name = ...` legally shadows a same-named stdlib
+%% entry (ADR 0108 Semantics' "current turn wins" precedent) rather than
+%% erroring or being ignored.
+session_declared_alias_shadows_stdlib_entry_test() ->
+    with_stdlib_aliases(
+        [
+            #{
+                name => 'SupervisionStrategy',
+                expansion => "#oneForOne | #oneForAll | #restForOne",
+                doc => undefined,
+                source_file => "stdlib/src/Supervisor.bt",
+                internal => false
+            }
+        ],
+        fun() ->
+            State0 = beamtalk_repl_state:new(undefined, 0),
+            SessionEntry = #{
+                expansion => <<"#custom">>, doc_comment => undefined, declared_in => <<"REPL">>
+            },
+            State1 = beamtalk_repl_state:put_alias(<<"SupervisionStrategy">>, SessionEntry, State0),
+            ?assertEqual(
+                SessionEntry,
+                maps:get(<<"SupervisionStrategy">>, beamtalk_repl_state:get_alias_table(State1))
+            )
+        end
+    ).
+
+%% Best-effort: a malformed `type_aliases` env (not even a list) seeds an
+%% empty table rather than crashing session creation.
+stdlib_alias_table_malformed_env_is_empty_test() ->
+    with_stdlib_aliases(
+        not_a_list,
+        fun() ->
+            State = beamtalk_repl_state:new(undefined, 0),
+            ?assertEqual(#{}, beamtalk_repl_state:get_alias_table(State))
+        end
+    ).
+
+%% No `type_aliases` env key at all (older `.app` build, or a package with
+%% no aliases) — same empty-table fallback, no crash.
+stdlib_alias_table_missing_env_is_empty_test() ->
+    _ = application:load(beamtalk_stdlib),
+    Previous = application:get_env(beamtalk_stdlib, type_aliases),
+    application:unset_env(beamtalk_stdlib, type_aliases),
+    try
+        State = beamtalk_repl_state:new(undefined, 0),
+        ?assertEqual(#{}, beamtalk_repl_state:get_alias_table(State))
+    after
+        case Previous of
+            {ok, V} -> application:set_env(beamtalk_stdlib, type_aliases, V);
+            undefined -> ok
+        end
+    end.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_state_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_state_tests.erl
@@ -399,6 +399,40 @@ stdlib_alias_non_boolean_internal_drops_only_that_row_test() ->
         end
     ).
 
+%% Same row-level-isolation guarantee, this time for a field so malformed
+%% that `app_env_binary`/`app_env_doc` themselves throw (e.g. a `name` that
+%% is neither atom, binary, nor list) — not just a bad `internal` value.
+%% The inner `try/catch` in `stdlib_alias_fold/2` must catch this too, or
+%% it escapes to `stdlib_alias_table/0`'s outer `try/catch` and wipes every
+%% other well-formed row (review finding, Claude BeamTalk Review on this
+%% PR).
+stdlib_alias_unconvertible_field_drops_only_that_row_test() ->
+    with_stdlib_aliases(
+        [
+            #{
+                name => 'GoodStrategy',
+                expansion => "#a | #b",
+                doc => undefined,
+                source_file => "stdlib/src/Fixture.bt",
+                internal => false
+            },
+            #{
+                %% Neither atom, binary, nor list — app_env_binary/1 has no
+                %% catch-all clause for this, so it throws function_clause.
+                name => 42,
+                expansion => "#c | #d",
+                doc => undefined,
+                source_file => "stdlib/src/Fixture.bt",
+                internal => false
+            }
+        ],
+        fun() ->
+            State = beamtalk_repl_state:new(undefined, 0),
+            AliasTable = beamtalk_repl_state:get_alias_table(State),
+            ?assert(maps:is_key(<<"GoodStrategy">>, AliasTable))
+        end
+    ).
+
 %% A session-declared `type Name = ...` legally shadows a same-named stdlib
 %% entry (ADR 0108 Semantics' "current turn wins" precedent) rather than
 %% erroring or being ignored.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_state_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_state_tests.erl
@@ -367,6 +367,38 @@ stdlib_alias_missing_internal_key_excluded_test() ->
         end
     ).
 
+%% A non-boolean `internal` value (hand-edited/corrupted `.app` file) must
+%% only drop this one row, not wipe every other well-formed alias in the
+%% same env — the `case` in `stdlib_alias_fold/2` needs its own catch-all
+%% arm, not just the outer `try/catch` in `stdlib_alias_table/0`, or a
+%% `case_clause` here would surface as an empty table (review finding,
+%% Claude BeamTalk Review on this PR).
+stdlib_alias_non_boolean_internal_drops_only_that_row_test() ->
+    with_stdlib_aliases(
+        [
+            #{
+                name => 'GoodStrategy',
+                expansion => "#a | #b",
+                doc => undefined,
+                source_file => "stdlib/src/Fixture.bt",
+                internal => false
+            },
+            #{
+                name => 'BadInternalStrategy',
+                expansion => "#c | #d",
+                doc => undefined,
+                source_file => "stdlib/src/Fixture.bt",
+                internal => not_a_boolean
+            }
+        ],
+        fun() ->
+            State = beamtalk_repl_state:new(undefined, 0),
+            AliasTable = beamtalk_repl_state:get_alias_table(State),
+            ?assert(maps:is_key(<<"GoodStrategy">>, AliasTable)),
+            ?assertNot(maps:is_key(<<"BadInternalStrategy">>, AliasTable))
+        end
+    ).
+
 %% A session-declared `type Name = ...` legally shadows a same-named stdlib
 %% entry (ADR 0108 Semantics' "current turn wins" precedent) rather than
 %% erroring or being ignored.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_state_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_state_tests.erl
@@ -345,6 +345,28 @@ stdlib_internal_alias_excluded_test() ->
         end
     ).
 
+%% Fail-safe (not fail-open) on a row missing the `internal` key entirely —
+%% mirrors `beamtalk_repl_ops_browse:alias_visible/2`'s convention. Should
+%% never happen against real `format_type_aliases_entry` output (which
+%% always emits `internal`), but a row shape this reader doesn't recognise
+%% must not default to seeding it as public.
+stdlib_alias_missing_internal_key_excluded_test() ->
+    with_stdlib_aliases(
+        [
+            #{
+                name => 'NoInternalKeyStrategy',
+                expansion => "#a | #b",
+                doc => undefined,
+                source_file => "stdlib/src/Fixture.bt"
+            }
+        ],
+        fun() ->
+            State = beamtalk_repl_state:new(undefined, 0),
+            AliasTable = beamtalk_repl_state:get_alias_table(State),
+            ?assertNot(maps:is_key(<<"NoInternalKeyStrategy">>, AliasTable))
+        end
+    ).
+
 %% A session-declared `type Name = ...` legally shadows a same-named stdlib
 %% entry (ADR 0108 Semantics' "current turn wins" precedent) rather than
 %% erroring or being ignored.

--- a/tests/repl-protocol/cases/type_alias_repl.btscript
+++ b/tests/repl-protocol/cases/type_alias_repl.btscript
@@ -7,7 +7,10 @@
 // hot-reload re-check trigger verified end-to-end from a live REPL session
 // (ADR 0108 Phase 10, BT-2905 — the epic's required final E2E validation
 // phase; per CLAUDE.md, "EUnit and BUnit alone are insufficient for
-// user-facing features").
+// user-facing features"). The very first section below (BT-2938) instead
+// proves a *stdlib-declared* alias resolves in a session that never
+// declared it at all — the gap this file's other sections don't cover,
+// since every other section's aliases are typed at the REPL first.
 //
 // REPL display-value decision (flagged for maintainer sign-off — see the
 // PR description and CLAUDE.md's REPL-output rule): a `type` declaration
@@ -30,6 +33,27 @@
 // and `hover_resolves_alias_through_project_wide_registry` in
 // crates/beamtalk-core/src/queries/hover_provider.rs and
 // crates/beamtalk-core/src/language_service/mod.rs respectively (BT-2901).
+
+// ===========================================================================
+// BT-2938: a *stdlib-declared* alias (`type SupervisionStrategy = ...`,
+// `stdlib/src/Supervisor.bt`) resolves in this fresh session — which has
+// not typed a single `type` declaration yet — for both `:help` and a
+// `::`-typed local, exactly the way a compiled-in stdlib *class* already
+// resolves out of the box. Before this issue, `:help SupervisionStrategy`
+// failed with `Class 'SupervisionStrategy' not found` (the session's
+// alias table only ever tracked session-declared aliases). The `__`
+// wildcards skip the blank-line-delimited doc-comment block (present here,
+// unlike `Direction` below) without pinning its exact line-wrapping; the
+// `Declared in: stdlib` provenance line (distinct from `Declared in: REPL`
+// below) is this issue's own REPL-output convention, flagged in the PR
+// description for maintainer sign-off per CLAUDE.md's REPL-output rule.
+// ===========================================================================
+
+:help SupervisionStrategy
+// => type SupervisionStrategy = #oneForOne | #oneForAll | #restForOne__OTP supervisor restart strategy__Declared in: stdlib
+
+sup :: SupervisionStrategy := #oneForOne
+// => oneForOne
 
 // ===========================================================================
 // Declaring a type alias directly at the REPL echoes its name.


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2938

A fresh REPL/workspace session's alias table only ever tracked *session-declared* `type Name = ...` aliases (ADR 0108 Phase 8) — it never seeded from stdlib's own compiled aliases (e.g. `type SupervisionStrategy = ...` in `stdlib/src/Supervisor.bt`), unlike compiled-in stdlib *classes*, which a fresh session already knows about out of the box. `:help SupervisionStrategy` failed with `Class 'SupervisionStrategy' not found`, and a `::`-typed local referencing a stdlib alias didn't resolve either.

This depended on BT-2935 (seed `AliasRegistry` from `generated_builtins.rs` for `build_stdlib.rs`), which has already landed.

## Key changes

- `crates/beamtalk-cli/src/commands/build_stdlib.rs` / `app_file.rs`: `beamtalk build-stdlib` now emits a `{type_aliases, [...]}` env key into `beamtalk_stdlib.app`/`.app.src`, reusing `build::build_alias_metadata` + `app_file::format_type_aliases_entry` — the same mechanism the ordinary `beamtalk build` pipeline already uses for a package's aliases.
- `runtime/apps/beamtalk_workspace/src/beamtalk_repl_state.erl`: a fresh session's `alias_table` is now seeded via `stdlib_alias_table/0`, reading `application:get_env(beamtalk_stdlib, type_aliases)` and excluding `internal` aliases (fails *safe*, not open, on a row missing the `internal` key — mirrors `beamtalk_repl_ops_browse:alias_visible/2`'s convention).
- `runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl`: `alias_entry()` gained a `declared_in` field so `:help`'s `Declared in:` line distinguishes `stdlib`-seeded aliases from session-declared (`REPL`) ones. A session-declared `type` legally shadows a same-named stdlib entry (ADR 0108 Semantics' "current turn wins").
- `tests/repl-protocol/cases/type_alias_repl.btscript`: new e2e section proving `:help SupervisionStrategy` and `sup :: SupervisionStrategy := #oneForOne` both resolve in a session that never declared the alias.
- `docs/development/surface-parity.md`: documents the new seeding path and the `Declared in: stdlib` display-value convention (flagged for maintainer sign-off per CLAUDE.md's REPL-output rule, same as the existing `Declared in: REPL` convention).
- New eunit coverage in `beamtalk_repl_state_tests.erl` for the seeding, doc-comment-less entries, internal-alias exclusion (including the fail-safe fallback), session-declared shadowing, and malformed/missing-env resilience.

Filed BT-2958 as a follow-up (not blocking) for a scaling concern raised in adversarial review: `known_type_alias_sources/1` re-derives and resends every seeded alias — stdlib included — on every REPL compile; negligible at today's ~5 stdlib aliases, worth revisiting if that count grows substantially.

## Test plan

- [x] `just ci` — full local CI (build, clippy, fmt, dialyzer, spec validation, corpus, surface-drift, integration, MCP, REPL-protocol, parity) — all green.
- [x] New REPL-protocol e2e case: `:help SupervisionStrategy` and a `::`-typed local both resolve in a fresh session.
- [x] New eunit coverage for `beamtalk_repl_state:stdlib_alias_table/0` (seeding, exclusion, shadowing, fail-safe fallback).
- [x] `beamtalk_repl_state_tests.erl` (35 tests) and full `beamtalk_workspace` eunit suite (2572 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)