### PR TITLE
is_assignable_to/is_type_compatible resolve alias-typed declarations (BT-2953)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_display_provenance.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_display_provenance.rs
@@ -10,6 +10,12 @@
 //! suggestion, reusing `validation.rs`'s `edit_distance` "did you mean"
 //! machinery), and the core `TypeProvenance::Aliased` display mechanics that
 //! back both surfaces.
+//!
+//! BT-2953 also covers the *structural correctness* of the three `EcoString`-
+//! based compatibility checks BT-2911 deliberately left untouched
+//! (`check_field_assignment`, `check_spawn_with_value`,
+//! `check_argument_types`) — see the tests below asserting a valid alias
+//! member is no longer flagged, and an invalid one still is.
 
 /// Parses `source` and runs the full `analyse_with_options_and_classes`
 /// pipeline (alias registration + `check_module_with_protocols_and_aliases`,
@@ -222,22 +228,23 @@ Actor subclass: Supervisor
 fn argument_mismatch_on_alias_typed_parameter_names_the_alias() {
     // `check_argument_types` reads `expected_ty` as a bare `EcoString` from
     // `MethodInfo::param_types` — the same pre-ADR-0108 storage
-    // `check_field_assignment` sits on. Unlike that sibling, this path
-    // cannot be exercised through the *full* compile pipeline: an alias
-    // name is never registered as a class in `ClassHierarchy`
+    // `check_field_assignment` sits on. Before BT-2953, this path could not
+    // be exercised through the *full* compile pipeline: an alias name is
+    // never registered as a class in `ClassHierarchy`
     // (`hierarchy.has_class("RestartStrategy")` is always `false`), and
-    // `is_type_compatible`'s pre-existing, unrelated "unknown declared
-    // class → conservatively compatible" fallback (validation.rs, the
+    // `is_type_compatible`'s "unknown declared class → conservatively
+    // compatible" fallback (validation.rs, the
     // `!hierarchy.has_class(actual_base) || !hierarchy.has_class(expected_base)`
-    // check) absorbs *every* argument against a bare alias-typed parameter
-    // as compatible, so the mismatch branch this test targets never runs
-    // end-to-end today. That gap is pre-existing and out of BT-2911's
-    // display-only scope (its own acceptance criteria: no change to
-    // `is_assignable_to`/`is_type_compatible`) — fixing it would mean
-    // resolving `param_types` through the alias table before the
-    // compatibility check itself, a bigger change than display provenance.
+    // check) absorbed *every* argument against a bare alias-typed parameter
+    // as compatible, so the mismatch branch this test targets never ran
+    // end-to-end. BT-2953 closed that gap by resolving `expected_ty` to its
+    // structural expansion (`resolve_alias_structural`) before it ever
+    // reaches `is_type_compatible`, so the scenario is now also reachable
+    // through the full pipeline — see
+    // `argument_of_an_invalid_alias_member_type_is_flagged` below for that
+    // version.
     //
-    // So this test calls `check_argument_types` directly (mirroring
+    // This test keeps calling `check_argument_types` directly (mirroring
     // `local_annotations.rs`'s `register_test_alias` pattern) with a
     // hierarchy where a `RestartStrategy` *class* happens to also exist —
     // purely to satisfy `is_type_compatible`'s `has_class` guard and reach
@@ -245,9 +252,9 @@ fn argument_mismatch_on_alias_typed_parameter_names_the_alias() {
     // name is seeded independently via `register_test_alias`, bypassing
     // `AliasRegistry::register_module`'s namespace-collision check (which
     // would legitimately reject a real alias/class name collision — see
-    // that method's doc). This is an intentionally synthetic setup to reach
-    // otherwise-unreachable code; it does not assert anything about
-    // real-world alias/class collisions.
+    // that method's doc). This is an intentionally synthetic setup that
+    // isolates `check_argument_types` from the rest of the pipeline; it
+    // does not assert anything about real-world alias/class collisions.
     use crate::semantic_analysis::alias_registry::{AliasInfo, AliasRegistry};
 
     let source = r"
@@ -319,27 +326,19 @@ Object subclass: Widget
 }
 
 #[test]
-fn field_assignment_of_a_valid_alias_member_currently_false_positives_bt2953() {
-    // KNOWN BUG, tracked as BT-2953 — pinned here deliberately, not silently
-    // left as a gap: `check_field_assignment` calls `is_assignable_to`
-    // (validation.rs) with the *bare* alias name (`"RestartStrategy"`,
-    // never expanded — `ClassHierarchy` predates ADR 0108 and has no
-    // `AliasRegistry` access). `is_assignable_to` has no "unknown declared
-    // class" escape hatch, so a bare alias name that never matches any
-    // registered class falls through to a superclass-chain walk that always
-    // returns `false` — meaning it currently reports EVERY value as
-    // incompatible with an alias-typed field, including values that ARE
-    // valid members of the alias (like `#transient` here).
-    //
-    // BT-2911 (this file's own issue) is display-only per its own
-    // acceptance criteria ("No regression to existing EcoString-based
-    // assignability logic") — it intentionally left `is_assignable_to`
-    // untouched, so it correctly makes the (already-wrong) message *name*
-    // the alias without fixing the underlying false positive. That's why
-    // the assertion below looks paradoxical: the message literally lists
-    // `#transient` inside the union it says `#transient` doesn't belong to.
-    // BT-2953 tracks fixing the compatibility check itself; when it lands,
-    // this test must be updated to assert NO diagnostic fires.
+fn field_assignment_of_a_valid_alias_member_is_not_flagged() {
+    // BT-2953 positive case: `check_field_assignment` used to call
+    // `is_assignable_to` (validation.rs) with the *bare* alias name
+    // (`"RestartStrategy"`, never expanded — `ClassHierarchy` predates ADR
+    // 0108 and has no `AliasRegistry` access). `is_assignable_to` has no
+    // "unknown declared class" escape hatch, so a bare alias name that never
+    // matched any registered class fell through to a superclass-chain walk
+    // that always returned `false` — reporting EVERY value as incompatible
+    // with an alias-typed field, including values that ARE valid members of
+    // the alias (like `#transient` here). BT-2953 fixed this by resolving
+    // the declared field type to its structural expansion
+    // (`resolve_alias_structural`) before it reaches `is_assignable_to`, so
+    // a valid member no longer produces a false "Type mismatch" warning.
     let source = r"
 type RestartStrategy = #temporary | #transient | #permanent
 
@@ -354,20 +353,91 @@ Actor subclass: Supervisor
         .iter()
         .filter(|d| d.message.contains("Type mismatch: field"))
         .collect();
-    assert_eq!(
-        hits.len(),
-        1,
-        "BT-2953: expected the known false-positive to still fire — if this \
-         now fails with 0 hits, BT-2953 has been fixed and this test (and \
-         its doc comment) should be rewritten to assert no diagnostic fires. \
-         Got: {diags:?}"
-    );
     assert!(
-        hits[0]
-            .message
-            .contains("RestartStrategy (#temporary | #transient | #permanent)"),
-        "display should still name the alias even while the underlying \
-         check is wrong (BT-2953), got: {}",
+        hits.is_empty(),
+        "valid alias member must not be flagged, got: {diags:?}"
+    );
+}
+
+#[test]
+fn spawn_with_value_of_a_valid_alias_member_is_not_flagged() {
+    // BT-2953 positive case, sibling to the field-assignment case above:
+    // `check_spawn_with_value` resolves the declared slot's alias type to
+    // its structural expansion before `is_assignable_to`, so a `spawnWith:`
+    // value that IS a member of the alias's union is not flagged.
+    let source = r"
+type RestartStrategy = #temporary | #transient | #permanent
+
+Actor subclass: Supervisor
+  state: policy :: RestartStrategy = #temporary
+
+Supervisor spawnWith: #{#policy => #transient}
+";
+    let diags = analyse_diagnostics(source);
+    let hits: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("type mismatch for state key"))
+        .collect();
+    assert!(
+        hits.is_empty(),
+        "valid alias member must not be flagged, got: {diags:?}"
+    );
+}
+
+#[test]
+fn argument_of_a_valid_alias_member_type_is_not_flagged() {
+    // BT-2953 positive case: an alias-typed parameter accepts a valid
+    // member of its union without a false "expects ... got ..." diagnostic,
+    // now that `check_argument_types` resolves `expected_ty` through the
+    // alias registry before `is_type_compatible`.
+    let source = r"
+type RestartStrategy = #temporary | #transient | #permanent
+
+Object subclass: Widget
+  restart: policy :: RestartStrategy => policy
+
+Widget new restart: #temporary
+";
+    let diags = analyse_diagnostics(source);
+    let hits: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("expects"))
+        .collect();
+    assert!(
+        hits.is_empty(),
+        "valid alias member argument must not be flagged, got: {diags:?}"
+    );
+}
+
+#[test]
+fn argument_of_an_invalid_alias_member_type_is_flagged() {
+    // BT-2953 negative case, now reachable through the full pipeline.
+    // Before the fix, `is_type_compatible`'s "unknown declared class"
+    // escape hatch absorbed every argument against a bare alias-typed
+    // parameter as compatible, so this scenario could only be reached via
+    // the synthetic direct-call setup in
+    // `argument_mismatch_on_alias_typed_parameter_names_the_alias` above.
+    // An incompatible argument (`Integer`) against an alias-typed
+    // parameter now actually rejects end-to-end.
+    let source = r"
+type RestartStrategy = #temporary | #transient | #permanent
+
+Object subclass: Widget
+  restart: policy :: RestartStrategy => policy
+
+Widget new restart: 42
+";
+    let diags = analyse_diagnostics(source);
+    let hits: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("expects"))
+        .collect();
+    assert_eq!(hits.len(), 1, "expected one diagnostic, got: {diags:?}");
+    assert!(
+        hits[0].message.contains(
+            "expects RestartStrategy (#temporary | #transient | #permanent), got Integer"
+        ),
+        "should name the alias with its expansion, got: {}",
         hits[0].message
     );
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -16,6 +16,7 @@
 use std::collections::HashMap;
 
 use crate::ast::{Expression, Literal, TypeAnnotation};
+use crate::semantic_analysis::alias_registry::AliasRegistry;
 use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
 use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
 use crate::semantic_analysis::receiver_knowledge;
@@ -1072,6 +1073,16 @@ impl TypeChecker {
                 .as_ref()
                 .and_then(|registry| registry.resolve_display_name(expected_ty))
                 .unwrap_or_else(|| InferredType::class_name_for_diagnostic(expected_ty.as_str()));
+            // BT-2953: `expected_display` above only fixed the diagnostic
+            // text (BT-2911's "display-only" scope). `is_type_compatible`
+            // below still has an "unknown declared class → conservatively
+            // compatible" escape hatch that fires on the unresolved bare
+            // alias name, making argument-type checking against an
+            // alias-typed parameter a silent no-op. Resolve to the
+            // structural expansion so the checks below actually validate.
+            let (expected_structural, alias_deps) =
+                Self::resolve_alias_structural(expected_ty, self.alias_registry.as_ref());
+            self.referenced_aliases.extend(alias_deps);
             let is_class_ref_arg = arg_exprs
                 .and_then(|exprs| exprs.get(i))
                 .is_some_and(|e| matches!(e, Expression::ClassReference { .. }));
@@ -1095,11 +1106,15 @@ impl TypeChecker {
                     let class_shortcut_applies =
                         expected_ty.as_str() == "Class" && !is_class_ref_arg;
                     let instance_compat = !class_shortcut_applies
-                        && Self::is_type_compatible(actual_ty, expected_ty, hierarchy);
+                        && Self::is_type_compatible(actual_ty, &expected_structural, hierarchy);
                     let class_literal_compat = !instance_compat
                         && is_class_ref_arg
                         && hierarchy.has_class(actual_ty)
-                        && Self::is_type_compatible(&metaclass_name, expected_ty, hierarchy);
+                        && Self::is_type_compatible(
+                            &metaclass_name,
+                            &expected_structural,
+                            hierarchy,
+                        );
                     if !instance_compat && !class_literal_compat {
                         let param_pos = i + 1;
                         // BT-1588: Use hint severity for generic type params (likely false positive)
@@ -1154,7 +1169,8 @@ impl TypeChecker {
                     // hierarchy walk, so e.g. `:: Behaviour` accepts it but
                     // `:: Integer` does not.
                     let class_name_ty: EcoString = "Class".into();
-                    let compat = Self::is_type_compatible(&class_name_ty, expected_ty, hierarchy);
+                    let compat =
+                        Self::is_type_compatible(&class_name_ty, &expected_structural, hierarchy);
                     if !compat {
                         let param_pos = i + 1;
                         let actual_display: EcoString = format!("{meta_class} class").into();
@@ -1177,7 +1193,7 @@ impl TypeChecker {
                     // BT-1832: Check all union members against the expected type.
                     let Some((compat, total, incompatible)) =
                         Self::classify_union_members(members, |m| {
-                            Self::is_type_compatible(m, expected_ty, hierarchy)
+                            Self::is_type_compatible(m, &expected_structural, hierarchy)
                         })
                     else {
                         continue; // Contains Dynamic — skip
@@ -1921,6 +1937,7 @@ impl TypeChecker {
     ///
     /// If the field has a type annotation in the class hierarchy and the inferred
     /// value type is known and incompatible, emits a warning.
+    #[allow(clippy::too_many_lines)] // BT-2953 added alias-structural resolution
     pub(super) fn check_field_assignment(
         &mut self,
         field: &crate::ast::Identifier,
@@ -1949,6 +1966,16 @@ impl TypeChecker {
             .as_ref()
             .and_then(|registry| registry.resolve_display_name(&declared_type))
             .unwrap_or_else(|| InferredType::class_name_for_diagnostic(declared_type.as_str()));
+        // BT-2953: `declared_type` above is still the bare, unresolved name —
+        // `declared_display` only fixed the diagnostic text (BT-2911's
+        // "display-only" scope). Resolve it to its structural expansion
+        // (e.g. `RestartStrategy` -> `#temporary | #transient | #permanent`)
+        // before it reaches `is_assignable_to`'s structural comparison below,
+        // or an alias-typed field falsely rejects every one of its own union
+        // members (no "unknown class" escape hatch in `is_assignable_to`).
+        let (declared_type, alias_deps) =
+            Self::resolve_alias_structural(&declared_type, self.alias_registry.as_ref());
+        self.referenced_aliases.extend(alias_deps);
         match value_ty {
             InferredType::Known {
                 class_name: value_type,
@@ -2186,12 +2213,20 @@ impl TypeChecker {
             .as_ref()
             .and_then(|registry| registry.resolve_display_name(declared_ty))
             .unwrap_or_else(|| InferredType::class_name_for_diagnostic(declared_ty.as_str()));
+        // BT-2953: mirror `check_field_assignment`'s structural resolution —
+        // `declared_display` above only fixed the diagnostic text (BT-2911's
+        // "display-only" scope); `is_assignable_to` below still needs the
+        // alias's structural expansion, not the opaque unresolved name, or a
+        // valid `spawnWith:` slot value falsely fails the check.
+        let (declared_structural, alias_deps) =
+            Self::resolve_alias_structural(declared_ty, self.alias_registry.as_ref());
+        self.referenced_aliases.extend(alias_deps);
         match &value_ty {
             InferredType::Known {
                 class_name: value_type,
                 ..
             } => {
-                if !Self::is_assignable_to(value_type, declared_ty, hierarchy) {
+                if !Self::is_assignable_to(value_type, &declared_structural, hierarchy) {
                     let value_display =
                         InferredType::class_name_for_diagnostic(value_type.as_str());
                     self.diagnostics.push(
@@ -2211,7 +2246,7 @@ impl TypeChecker {
             InferredType::Union { members, .. } => {
                 let Some((compat, total, incompatible)) =
                     Self::classify_union_members(members, |m| {
-                        Self::is_assignable_to(m, declared_ty, hierarchy)
+                        Self::is_assignable_to(m, &declared_structural, hierarchy)
                     })
                 else {
                     return; // Contains Dynamic — skip.
@@ -2604,6 +2639,76 @@ impl TypeChecker {
             "Nil" => Some(WellKnownClass::UndefinedObject.as_str().into()),
             _ => None,
         }
+    }
+
+    /// BT-2953 (ADR 0108): resolve a declared type name that refers to a
+    /// registered type alias (e.g. `"RestartStrategy"`) to its structural
+    /// expansion (e.g. `"#temporary | #transient | #permanent"`), so
+    /// [`Self::is_assignable_to`]/[`Self::is_type_compatible`]'s nominal
+    /// class-hierarchy comparison sees the alias's union members instead of
+    /// an opaque, never-registered class name.
+    ///
+    /// `ClassHierarchy::state_field_type`/`MethodInfo::param_types` store an
+    /// alias-typed declaration as the bare alias name —
+    /// `TypeAnnotation::type_name()` is purely syntactic and never resolves
+    /// through `AliasRegistry`. BT-2911 re-resolved the *display* string at
+    /// these same call sites (`declared_display`/`expected_display`) but its
+    /// own acceptance criteria left the string handed to the structural
+    /// comparison functions unresolved on purpose ("display-only"). This
+    /// closes that gap: `is_assignable_to` had no "unknown class" escape
+    /// hatch, so an unresolved alias name produced false-positive "Type
+    /// mismatch" warnings even for valid union members; `is_type_compatible`
+    /// has one, so an unresolved alias name made argument-type checking a
+    /// silent no-op instead.
+    ///
+    /// Reconstructs a `TypeAnnotation::Simple` reference to `name` (mirroring
+    /// [`AliasRegistry::resolve_display_name`]'s own approach) and routes it
+    /// through the shared [`super::type_resolver::resolve_type_annotation_with_alias_deps`]
+    /// resolver, so an alias-of-alias chain expands all the way down to a
+    /// plain structural type exactly like every other alias reference in the
+    /// checker. The second element of the returned pair is the (possibly
+    /// empty) set of alias names touched while resolving — callers fold this
+    /// into `self.referenced_aliases` (ADR 0108 hot-reload re-check trigger,
+    /// BT-2899) the same way every other alias-aware resolution site does.
+    ///
+    /// A name that is not a registered alias — an ordinary class name, a
+    /// singleton, or an annotation already spelled out as a union (e.g.
+    /// `"Integer | Symbol"` from a builtin) — is returned unchanged with no
+    /// alias deps, so non-alias assignability/compatibility behavior is
+    /// untouched.
+    ///
+    /// Deliberately not the more general `inference.rs::resolve_type_name_string`
+    /// (BT-2928, also alias-registry-aware): that helper additionally
+    /// re-parses keywords (`nil`/`true`/`false`), generics, and pre-spelled
+    /// unions, which would change what a *non-alias* declared type resolves
+    /// to here (e.g. `"Nil"` -> `"UndefinedObject"`) — a broader behavior
+    /// change than this ticket's scope, and it doesn't report alias deps for
+    /// hot-reload tracking. This function only ever touches a name that
+    /// `AliasRegistry::get` recognises, then reuses the same
+    /// `resolve_type_annotation_with_alias_deps`/`referenced_aliases`
+    /// convention `check_return_type`/`check_state_defaults` already use in
+    /// this file for their (AST-`TypeAnnotation`-sourced) alias resolution.
+    fn resolve_alias_structural(
+        name: &EcoString,
+        alias_registry: Option<&AliasRegistry>,
+    ) -> (EcoString, Vec<EcoString>) {
+        let Some(registry) = alias_registry else {
+            return (name.clone(), Vec::new());
+        };
+        let Some(alias_info) = registry.get(name) else {
+            return (name.clone(), Vec::new());
+        };
+        let reference = TypeAnnotation::Simple(crate::ast::Identifier {
+            name: alias_info.name.clone(),
+            span: alias_info.span,
+        });
+        let (resolved, deps) = super::type_resolver::resolve_type_annotation_with_alias_deps(
+            &reference,
+            &super::type_resolver::SubstitutionMap::new(),
+            None,
+            Some(registry),
+        );
+        (Self::inferred_type_to_string(&resolved), deps)
     }
 
     /// Emit a warning diagnostic for an unknown selector.


### PR DESCRIPTION
## Summary

Linear issue: https://linear.app/beamtalk/issue/BT-2953

`ClassHierarchy::state_field_type`/`MethodInfo::param_types` store an alias-typed declaration (e.g. `RestartStrategy`) as the bare alias name — never its structural expansion. Neither `is_assignable_to` nor `is_type_compatible` (both in `validation.rs`) has access to `AliasRegistry`, so:

- `is_assignable_to` (used by `check_field_assignment`, `check_spawn_with_value`) has no "unknown class" escape hatch, so it reported **every** value as incompatible with an alias-typed field/slot — including values that ARE valid members of the alias's union. False positives.
- `is_type_compatible` (used by `check_argument_types`) DOES have an "unknown declared class → conservatively compatible" escape hatch, so argument-type checking against an alias-typed parameter was a **complete no-op** — any value, valid or not, silently accepted.

BT-2911 fixed the *display* text for these same three call sites (rendering `AliasName (expansion)` instead of the bare name) but its own acceptance criteria scoped that fix as display-only, leaving this structural bug untouched.

## Changes

- Added `TypeChecker::resolve_alias_structural` (`validation.rs`): resolves a declared type name that refers to a registered alias to its structural expansion (e.g. `RestartStrategy` → `"#temporary | #transient | #permanent"`) via the shared alias-annotation resolver, before the value reaches `is_assignable_to`/`is_type_compatible`. Non-alias names round-trip unchanged. Folds touched alias names into `self.referenced_aliases` for hot-reload re-checking, mirroring `check_return_type`/`check_state_defaults`'s existing convention.
- Wired into all three affected paths: `check_field_assignment`, `check_spawn_with_value`, `check_argument_types`.
- Regression tests in `type_alias_display_provenance.rs`: positive (valid alias member is NOT flagged) and negative (invalid value IS flagged) cases for all three paths, plus a non-alias regression pin.

## Test plan

- [x] `cargo test -p beamtalk-core type_alias_display_provenance` — 12/12 pass, including new positive/negative BT-2953 cases
- [x] `just ci-changed` — full local CI green (Rust tests, build, Erlang runtime build, stdlib build/tests, BUnit tests, runtime tests, corpus check, surface-drift check)
- [x] `just clippy` / `just fmt-check` / `just build` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)