### PR TITLE
Address unresolved Claude review suggestions from PR #3082/#3083

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_display_provenance.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_display_provenance.rs
@@ -631,3 +631,109 @@ fn instance_arg_rejected_for_class_typed_alias_parameter() {
         diags[0].message
     );
 }
+
+#[test]
+fn arg_ty_side_alias_name_is_recorded_in_referenced_aliases() {
+    // BT-2939 hot-reload coverage gap: `argument_that_is_itself_an_alias_typed_return_value_is_not_flagged`
+    // above only asserts the diagnostic side (no false "expects ... got ..."
+    // warning). It doesn't confirm the actual fix's point — that resolving
+    // the *actual* side's bare alias name now folds it into
+    // `self.referenced_aliases` (ADR 0108 hot-reload re-check trigger,
+    // BT-2899) via `resolve_type_annotation_with_alias_deps`, the same way
+    // the `expected_structural`/BT-2953 side already does.
+    //
+    // Declares the parameter with the union *spelled out* (not through the
+    // alias) so the only path that can record `RestartStrategy` as a
+    // dependency is the arg_ty-side resolution this test targets — the
+    // expected_structural side has nothing to resolve, since `expected_ty`
+    // here is never a registered alias name.
+    use crate::semantic_analysis::alias_registry::{AliasInfo, AliasRegistry};
+    use crate::semantic_analysis::class_hierarchy::{ClassHierarchy, ClassInfo, MethodInfo};
+
+    let mut hierarchy = ClassHierarchy::with_builtins();
+    hierarchy.add_from_beam_meta(vec![ClassInfo {
+        surface_incomplete: false,
+        name: "Widget".into(),
+        superclass: Some("Object".into()),
+        is_sealed: false,
+        is_abstract: false,
+        is_typed: false,
+        is_internal: false,
+        package: None,
+        is_value: false,
+        is_native: false,
+        handle_scope: None,
+        state: vec![],
+        state_types: std::collections::HashMap::new(),
+        state_has_default: std::collections::HashMap::new(),
+        methods: vec![MethodInfo {
+            selector: "restart:".into(),
+            arity: 1,
+            kind: crate::ast::MethodKind::Primary,
+            defined_in: "Widget".into(),
+            is_sealed: false,
+            is_internal: false,
+            spawns_block: false,
+            return_type: Some("Boolean".into()),
+            param_types: vec![Some("#temporary | #transient | #permanent".into())],
+            doc: None,
+        }],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        type_param_bounds: vec![],
+        superclass_type_args: vec![],
+    }]);
+
+    let mut alias_registry = AliasRegistry::new();
+    alias_registry.register_test_alias(AliasInfo {
+        name: "RestartStrategy".into(),
+        annotation: crate::ast::TypeAnnotation::Union {
+            types: vec![
+                crate::ast::TypeAnnotation::Singleton {
+                    name: "temporary".into(),
+                    span: crate::source_analysis::Span::new(0, 1),
+                },
+                crate::ast::TypeAnnotation::Singleton {
+                    name: "transient".into(),
+                    span: crate::source_analysis::Span::new(0, 1),
+                },
+                crate::ast::TypeAnnotation::Singleton {
+                    name: "permanent".into(),
+                    span: crate::source_analysis::Span::new(0, 1),
+                },
+            ],
+            span: crate::source_analysis::Span::new(0, 1),
+        },
+        is_internal: false,
+        package: None,
+        span: crate::source_analysis::Span::new(0, 1),
+    });
+
+    let mut checker = crate::semantic_analysis::type_checker::TypeChecker::new();
+    checker.set_alias_registry(alias_registry);
+    checker.check_argument_types(
+        &"Widget".into(),
+        "restart:",
+        &[crate::semantic_analysis::InferredType::known(
+            "RestartStrategy",
+        )],
+        crate::source_analysis::Span::new(0, 1),
+        &hierarchy,
+        false,
+        None,
+        None,
+    );
+    assert!(
+        checker.diagnostics().is_empty(),
+        "a valid member flowing through the alias-typed actual side must not \
+         be flagged, got: {:?}",
+        checker.diagnostics()
+    );
+    let referenced = checker.take_referenced_aliases();
+    assert!(
+        referenced.contains("RestartStrategy"),
+        "the arg_ty-side resolution must record the alias name it touched \
+         for hot-reload re-check, got: {referenced:?}"
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_display_provenance.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_display_provenance.rs
@@ -517,3 +517,117 @@ Supervisor spawnWith: #{#policy => 42}
         hits[0].message
     );
 }
+
+#[test]
+fn instance_arg_rejected_for_class_typed_alias_parameter() {
+    // Claude review on PR #3082 (BT-2953): `check_argument_types`'s
+    // `class_shortcut_applies` guard (validation.rs, `expected_ty.as_str()
+    // == "Class"`) gated the BT-1877 shortcut on the *bare* declared type,
+    // not `expected_structural`. For `type ClassAlias = Class`,
+    // `expected_ty` is `"ClassAlias"` (never `"Class"`) while
+    // `expected_structural` resolves to `"Class"` — so the guard never
+    // fired, `is_type_compatible`'s own `expected == "Class"` shortcut
+    // absorbed *any* known class instance unconditionally, and a plain
+    // `TestCase` instance (not a class literal) wrongly satisfied a `::
+    // ClassAlias` parameter. Sibling to `unions_checking`'s
+    // `instance_identifier_still_rejected_for_class_param`, through the
+    // alias.
+    use crate::semantic_analysis::alias_registry::{AliasInfo, AliasRegistry};
+    use crate::semantic_analysis::class_hierarchy::{ClassHierarchy, ClassInfo, MethodInfo};
+
+    let mut hierarchy = ClassHierarchy::with_builtins();
+    hierarchy.add_from_beam_meta(vec![
+        ClassInfo {
+            surface_incomplete: false,
+            name: "TestCase".into(),
+            superclass: Some("Value".into()),
+            is_sealed: false,
+            is_abstract: false,
+            is_typed: false,
+            is_internal: false,
+            package: None,
+            is_value: true,
+            is_native: false,
+            handle_scope: None,
+            state: vec![],
+            state_types: std::collections::HashMap::new(),
+            state_has_default: std::collections::HashMap::new(),
+            methods: vec![],
+            class_methods: vec![],
+            class_variables: vec![],
+            type_params: vec![],
+            type_param_bounds: vec![],
+            superclass_type_args: vec![],
+        },
+        ClassInfo {
+            surface_incomplete: false,
+            name: "ClassChecker".into(),
+            superclass: Some("Object".into()),
+            is_sealed: false,
+            is_abstract: false,
+            is_typed: false,
+            is_internal: false,
+            package: None,
+            is_value: false,
+            is_native: false,
+            handle_scope: None,
+            state: vec![],
+            state_types: std::collections::HashMap::new(),
+            state_has_default: std::collections::HashMap::new(),
+            methods: vec![MethodInfo {
+                selector: "accept:".into(),
+                arity: 1,
+                kind: crate::ast::MethodKind::Primary,
+                defined_in: "ClassChecker".into(),
+                is_sealed: false,
+                is_internal: false,
+                spawns_block: false,
+                return_type: Some("Boolean".into()),
+                param_types: vec![Some("ClassAlias".into())],
+                doc: None,
+            }],
+            class_methods: vec![],
+            class_variables: vec![],
+            type_params: vec![],
+            type_param_bounds: vec![],
+            superclass_type_args: vec![],
+        },
+    ]);
+
+    let mut alias_registry = AliasRegistry::new();
+    alias_registry.register_test_alias(AliasInfo {
+        name: "ClassAlias".into(),
+        annotation: crate::ast::TypeAnnotation::Simple(crate::ast::Identifier {
+            name: "Class".into(),
+            span: crate::source_analysis::Span::new(0, 1),
+        }),
+        is_internal: false,
+        package: None,
+        span: crate::source_analysis::Span::new(0, 1),
+    });
+
+    let mut checker = crate::semantic_analysis::type_checker::TypeChecker::new();
+    checker.set_alias_registry(alias_registry);
+    checker.check_argument_types(
+        &"ClassChecker".into(),
+        "accept:",
+        &[crate::semantic_analysis::InferredType::known("TestCase")],
+        crate::source_analysis::Span::new(0, 1),
+        &hierarchy,
+        false,
+        None,
+        None,
+    );
+    let diags = checker.diagnostics();
+    assert_eq!(
+        diags.len(),
+        1,
+        "a TestCase instance (not a class literal) must not satisfy a \
+         Class-aliased parameter, got: {diags:?}"
+    );
+    assert!(
+        diags[0].message.contains("expects ClassAlias (Class)"),
+        "should name the alias with its expansion, got: {}",
+        diags[0].message
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -1112,12 +1112,15 @@ impl TypeChecker {
                             name: info.name.clone(),
                             span: info.span,
                         });
-                        super::type_resolver::resolve_type_annotation(
-                            &reference,
-                            &HashMap::new(),
-                            None,
-                            self.alias_registry.as_ref(),
-                        )
+                        let (resolved, arg_alias_deps) =
+                            super::type_resolver::resolve_type_annotation_with_alias_deps(
+                                &reference,
+                                &HashMap::new(),
+                                None,
+                                self.alias_registry.as_ref(),
+                            );
+                        self.referenced_aliases.extend(arg_alias_deps);
+                        resolved
                     }),
                 _ => None,
             };

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -1142,8 +1142,16 @@ impl TypeChecker {
                     // properly, the shortcut must be scoped to class-literal
                     // arguments here so a plain `TestCase` instance does not
                     // satisfy a `:: Class` parameter.
+                    //
+                    // Claude review on PR #3082 (BT-2953): this guard must
+                    // check `expected_structural`, not the bare `expected_ty`
+                    // — otherwise `type MyAlias = Class` would resolve to
+                    // `expected_structural == "Class"` while `expected_ty`
+                    // still names the alias, silently skipping the guard and
+                    // letting `is_type_compatible`'s BT-1877 shortcut accept
+                    // any known class instance against a `:: MyAlias` param.
                     let class_shortcut_applies =
-                        expected_ty.as_str() == "Class" && !is_class_ref_arg;
+                        expected_structural.as_str() == "Class" && !is_class_ref_arg;
                     let instance_compat = !class_shortcut_applies
                         && Self::is_type_compatible(actual_ty, &expected_structural, hierarchy);
                     let class_literal_compat = !instance_compat


### PR DESCRIPTION
## Summary

Two automated Claude code-review suggestions were left unaddressed on already-merged PRs. This picks them up:

- **PR #3083 (BT-2939)**: `check_argument_types`'s actual-side (`arg_ty`) alias resolution used `resolve_type_annotation` instead of `resolve_type_annotation_with_alias_deps`, so the touched alias name was never folded into `self.referenced_aliases`. This left ADR 0108 hot-reload re-check unaware of alias-typed argument values (e.g. a `RestartStrategy`-typed return flowing into an argument) — stale diagnostics could be served after an alias redefinition until a full recompile. No impact on from-scratch builds.
- **PR #3082 (BT-2953)**: the `class_shortcut_applies` guard checked the bare `expected_ty` instead of `expected_structural`. For `type MyAlias = Class`, `expected_ty` names the alias while `expected_structural` resolves to `"Class"`, so the guard never fired and `is_type_compatible`'s BT-1877 shortcut silently accepted any known class *instance* (not just class literals) against a `:: MyAlias` parameter.

Both fixes switch to the `_with_alias_deps` / structural-resolved value already used by the surrounding code, matching the existing convention in `validation.rs`.

## Changes

- `validation.rs`: two narrow fixes in `check_argument_types`, described above.
- Added three regression tests in `type_alias_display_provenance.rs`:
  - `instance_arg_rejected_for_class_typed_alias_parameter` — pins the `class_shortcut_applies` fix.
  - `arg_ty_side_alias_name_is_recorded_in_referenced_aliases` — pins the hot-reload dependency-tracking fix (isolates the arg_ty path specifically, since the existing BT-2939 test only checked diagnostics, not `referenced_aliases`).
  - (existing) `argument_that_is_itself_an_alias_typed_return_value_is_not_flagged` continues to pass.

Each new test was verified to fail against the pre-fix code and pass with the fix.

## Verification

- `cargo test -p beamtalk-core type_checker::` — 1205/1205 pass
- `cargo clippy -p beamtalk-core --all-targets` — clean
- `cargo fmt -p beamtalk-core -- --check` — clean
- Full pre-push CI hook (clippy, dialyzer, stdlib build/spec validation, formatting) — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01AqaxoWvmESSA7kVA236GVs)_