### PR TITLE
test: cover beamtalk_recheck's compiler-port exit-catch path (BT-2806)

### DIFF
--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -311,6 +311,18 @@ other) reaches a fresh, healthy process — no explicit re-clear needed, unlike
 `inject_diagnostics_failure/1`'s flag (a fresh `init/1` always starts with
 `diagnostics_exit_fault = false`). Never touches the port itself, and
 unrelated requests (`compile_expression`, `compile`, ...) are unaffected.
+
+**Shared crash budget:** each use spends one of `beamtalk_compiler_sup`'s
+`one_for_one` restart allowance (`intensity => 5, period => 60` — production
+crash tolerance, not test-specific), and that allowance is NOT reset between
+test groups that never stop the `beamtalk_compiler` application between them
+(e.g. within a single `*_tests.erl` module using a no-op teardown — see
+`beamtalk_compiler_server_tests.erl`'s `stop_compiler/1`). Fine for a
+handful of uses; a test suite piling up more than a couple of these within
+one un-torn-down run risks exceeding the budget and leaving the server
+permanently down (`noproc`) for every subsequent test. Prefer scoping call
+sites that *do* `application:stop(beamtalk_compiler)` between test groups
+(e.g. `beamtalk_recheck_tests.erl`'s `recheck_teardown/1`) when adding more.
 """.
 -spec inject_diagnostics_exit() -> ok.
 inject_diagnostics_exit() ->

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -57,7 +57,8 @@ to avoid temp files on disk (BT-48).
     handle_diagnostics_response/1,
     handle_version_response/1,
     clear_classes/0,
-    inject_diagnostics_failure/1
+    inject_diagnostics_failure/1,
+    inject_diagnostics_exit/0
 ]).
 -endif.
 
@@ -110,7 +111,16 @@ to avoid temp files on disk (BT-48).
     %% reason instead of reaching the real compiler port, then self-clears.
     %% Always `undefined` in production — nothing outside TEST builds can set
     %% it. See inject_diagnostics_failure/1's doc for why this exists.
-    diagnostics_fault = undefined :: undefined | binary()
+    diagnostics_fault = undefined :: undefined | binary(),
+    %% BT-2806 (test-only): when `true` (via inject_diagnostics_exit/0, only
+    %% exported in TEST builds), the *next* diagnostics/3 call stops this
+    %% process instead of replying, simulating the compiler port's
+    %% gen_server:call itself exiting (`noproc`/`timeout`) rather than an
+    %% ordinary `{error, _}` return. No self-clear flag needed, unlike
+    %% `diagnostics_fault` above — the process restart itself is the clear
+    %% (a fresh `init/1` always starts with `false`). Always `false` in
+    %% production. See inject_diagnostics_exit/0's doc for why this exists.
+    diagnostics_exit_fault = false :: boolean()
 }).
 
 %%% Public API
@@ -278,6 +288,33 @@ one consumed — are unaffected.
 -spec inject_diagnostics_failure(binary()) -> ok.
 inject_diagnostics_failure(Reason) ->
     gen_server:call(?MODULE, {inject_diagnostics_failure, Reason}, 5000).
+
+-doc """
+Force the *next* `diagnostics/3' call to exit instead of returning a value at
+all — a stricter sibling of `inject_diagnostics_failure/1' (BT-2806, test use
+only).
+
+`beamtalk_recheck:recheck_image_class/2' and `recheck_owner_for_leaf_change/3'
+each additionally `catch` the compiler port's `gen_server:call` itself exiting
+(`noproc`/`timeout`), not just an `{error, Reason}` return —
+`inject_diagnostics_failure/1' cannot reach that `catch` clause, since it
+still replies normally (with an error *value*) to a live call. This hook
+instead arms a flag that makes the *next* `{diagnostics, ...}' request stop
+this gen_server without replying at all, so the caller's `gen_server:call`
+raises an `exit` — the same shape of failure a real port crash or timeout
+would produce.
+
+Deterministic and safe to use per-test: `beamtalk_compiler_sup` supervises
+this server with `one_for_one`/`permanent`, so it is restarted immediately
+after the stop, and the very next `diagnostics/3` call (in this test or any
+other) reaches a fresh, healthy process — no explicit re-clear needed, unlike
+`inject_diagnostics_failure/1`'s flag (a fresh `init/1` always starts with
+`diagnostics_exit_fault = false`). Never touches the port itself, and
+unrelated requests (`compile_expression`, `compile`, ...) are unaffected.
+""".
+-spec inject_diagnostics_exit() -> ok.
+inject_diagnostics_exit() ->
+    gen_server:call(?MODULE, inject_diagnostics_exit, 5000).
 -endif.
 
 -doc """
@@ -727,6 +764,16 @@ handle_call({resolve_completion_type, Expression}, _From, State) ->
     ),
     {reply, Result, State};
 handle_call(
+    {diagnostics, _Source, _Mode, _Options}, _From, #state{diagnostics_exit_fault = true} = State
+) ->
+    %% BT-2806 (test-only fault injection, see inject_diagnostics_exit/0):
+    %% stop without replying — the caller's gen_server:call raises an exit
+    %% (`{shutdown, {gen_server, call, [...]}}`) instead of getting a normal
+    %% return, simulating the compiler port's call itself exiting. `shutdown`
+    %% (not a crash reason) so this produces no crash report noise; the
+    %% `permanent` supervisor restarts it regardless of exit reason.
+    {stop, shutdown, State};
+handle_call(
     {diagnostics, _Source, _Mode, _Options}, _From, #state{diagnostics_fault = Fault} = State
 ) when
     Fault =/= undefined
@@ -806,6 +853,8 @@ handle_call(clear_classes, _From, State) ->
     {reply, ok, State#state{classes = #{}, aliases = #{}}};
 handle_call({inject_diagnostics_failure, Reason}, _From, State) ->
     {reply, ok, State#state{diagnostics_fault = Reason}};
+handle_call(inject_diagnostics_exit, _From, State) ->
+    {reply, ok, State#state{diagnostics_exit_fault = true}};
 handle_call(get_classes, _From, State) ->
     {reply, State#state.classes, State};
 handle_call(get_aliases, _From, State) ->

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
@@ -419,6 +419,61 @@ no_fault_reaches_port() ->
     ?assertMatch({ok, _}, Result).
 
 %%% ---------------------------------------------------------------
+%%% BT-2806: inject_diagnostics_exit/0 (test-only fault injection)
+%%%
+%%% Sibling to BT-2832's inject_diagnostics_failure/1 above: that mechanism
+%%% only forces an ordinary `{error, _}' *return*, which cannot reach
+%%% `beamtalk_recheck:recheck_image_class/2''s (and
+%%% `recheck_owner_for_leaf_change/3''s) additional `catch' clause guarding
+%%% against the compiler port's `gen_server:call' itself *exiting*
+%%% (`noproc'/`timeout'). This hook instead stops the server without
+%%% replying, so the caller's `gen_server:call' raises an exit — see
+%%% `beamtalk_recheck_tests.erl' for the higher-level regression coverage
+%%% this exists to enable.
+%%% ---------------------------------------------------------------
+
+diagnostics_exit_fault_injection_test_() ->
+    {timeout, 10,
+        {setup, fun start_compiler/0, fun stop_compiler/1, [
+            {"armed exit fault makes the next diagnostics call exit, not return",
+                fun exit_fault_makes_next_call_exit/0},
+            {"compiler server recovers (supervisor restart) after the injected exit",
+                fun exit_fault_recovers_after_restart/0}
+        ]}}.
+
+exit_fault_makes_next_call_exit() ->
+    ok = beamtalk_compiler_server:inject_diagnostics_exit(),
+    ?assertExit({shutdown, _}, beamtalk_compiler_server:diagnostics(<<"1 + 2">>)),
+    %% Let beamtalk_compiler_sup finish restarting before the next test in
+    %% this group runs — otherwise its own inject call could race the
+    %% not-yet-re-registered name.
+    ok = wait_for_compiler_server_restart().
+
+exit_fault_recovers_after_restart() ->
+    ok = beamtalk_compiler_server:inject_diagnostics_exit(),
+    ?assertExit({shutdown, _}, beamtalk_compiler_server:diagnostics(<<"1 + 2">>)),
+    %% beamtalk_compiler_sup (one_for_one/permanent) restarts the server
+    %% immediately after the injected stop — wait for the registered name to
+    %% come back, then prove the next call reaches a fresh, healthy process
+    %% (the fault is one-shot, not stuck broken for the rest of the run).
+    ok = wait_for_compiler_server_restart(),
+    ?assertMatch({ok, _}, beamtalk_compiler_server:diagnostics(<<"1 + 2">>)).
+
+wait_for_compiler_server_restart() ->
+    wait_for_compiler_server_restart(100).
+
+wait_for_compiler_server_restart(0) ->
+    error(compiler_server_did_not_restart);
+wait_for_compiler_server_restart(Attempts) ->
+    case whereis(beamtalk_compiler_server) of
+        undefined ->
+            timer:sleep(10),
+            wait_for_compiler_server_restart(Attempts - 1);
+        Pid when is_pid(Pid) ->
+            ok
+    end.
+
+%%% ---------------------------------------------------------------
 %%% Helpers
 %%% ---------------------------------------------------------------
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
@@ -1329,3 +1329,108 @@ trigger_image_empty_when_no_classes_test_() ->
                 )
             ]
         end}}.
+
+%%====================================================================
+%% Compiler-port exit-catch coverage (BT-2806, trigger_image/0 and
+%% trigger_leaf_change/1)
+%%
+%% Both `recheck_image_class/2` and `recheck_owner_for_leaf_change/3` wrap
+%% their `diagnostics/3` round trip in `try ... catch Class:Reason:Stack ->
+%% {failed, []} end` — not just the `{error, Reason}` case every other
+%% `recheck_owner*` function already handles, but the compiler port's
+%% `gen_server:call` itself exiting (`noproc`/`timeout` in production). Prior
+%% to BT-2806 that `catch` clause had no regression test: BT-2832's
+%% `inject_diagnostics_failure/1` only forces an ordinary `{error, _}`
+%% *return* from a live call, never an actual exit.
+%%
+%% `beamtalk_compiler_server:inject_diagnostics_exit/0` (BT-2806) instead
+%% stops the compiler server without replying, so the pending
+%% `gen_server:call` raises — deterministically exercising the `catch`
+%% clause. Each test below is split into two sequential top-level calls
+%% (fault, then a later recovered call) rather than one sweep over two
+%% classes: `beamtalk_compiler_sup` (one_for_one/permanent) restarts the
+%% server asynchronously, so a *second class in the same synchronous sweep*
+%% would race the restart. Waiting for the restart between two separate
+%% calls sidesteps that race while still proving both halves of the
+%% guarantee: the sweep degrades gracefully (does not crash/abort) on the
+%% exit, and it is not left permanently broken afterward.
+%%====================================================================
+
+recheck_exit_fault_source() ->
+    <<"Object subclass: ReCheckExitFaultClass\n  ok -> Integer => 42\n">>.
+
+wait_for_compiler_server_restart() ->
+    wait_for_compiler_server_restart(100).
+
+wait_for_compiler_server_restart(0) ->
+    error(compiler_server_did_not_restart);
+wait_for_compiler_server_restart(Attempts) ->
+    case whereis(beamtalk_compiler_server) of
+        undefined ->
+            timer:sleep(10),
+            wait_for_compiler_server_restart(Attempts - 1);
+        Pid when is_pid(Pid) ->
+            ok
+    end.
+
+trigger_image_degrades_on_compiler_port_exit_without_aborting_test_() ->
+    {timeout, 30,
+        {setup, fun recheck_setup/0, fun recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    ok = beamtalk_workspace_meta:set_class_source(
+                        <<"ReCheckExitFaultClass">>, recheck_exit_fault_source()
+                    ),
+                    ok = beamtalk_compiler_server:inject_diagnostics_exit(),
+
+                    %% The injected exit degrades this class to `failed`
+                    %% (recheck_image_class/2's catch clause) — trigger_image/0
+                    %% itself must not crash or propagate the exit.
+                    ?assertEqual(
+                        #{findings => [], checked => 0, stale => 0},
+                        beamtalk_recheck:trigger_image()
+                    ),
+
+                    %% Not left permanently broken: after the supervisor
+                    %% restarts the server, the same class checks clean.
+                    ok = wait_for_compiler_server_restart(),
+                    Recovered = beamtalk_recheck:trigger_image(),
+                    ?assertEqual(1, maps:get(checked, Recovered)),
+                    ?assertEqual([], maps:get(findings, Recovered))
+                end)
+            ]
+        end}}.
+
+trigger_leaf_change_degrades_on_compiler_port_exit_without_aborting_test_() ->
+    {timeout, 30,
+        {setup, fun recheck_setup/0, fun recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    ok = beamtalk_workspace_meta:set_class_source(
+                        <<"ReCheckExitFaultClass">>, recheck_exit_fault_source()
+                    ),
+                    ok = beamtalk_compiler_server:inject_diagnostics_exit(),
+
+                    %% The injected exit degrades this class to `failed`
+                    %% (recheck_owner_for_leaf_change/3's catch clause) —
+                    %% trigger_leaf_change/1 itself must not crash or
+                    %% propagate the exit. Never checked, so it lands in
+                    %% not_verified_owners (BT-2828's widened bucket) rather
+                    %% than being silently dropped.
+                    Result = beamtalk_recheck:trigger_leaf_change([<<"SomeSuperclass">>]),
+                    ?assertEqual([], maps:get(findings, Result)),
+                    ?assertEqual(0, maps:get(checked, Result)),
+                    ?assertEqual([], maps:get(checked_owners, Result)),
+                    ?assertEqual(
+                        [<<"ReCheckExitFaultClass">>], maps:get(not_verified_owners, Result)
+                    ),
+
+                    %% Not left permanently broken: after the supervisor
+                    %% restarts the server, the same class checks clean.
+                    ok = wait_for_compiler_server_restart(),
+                    Recovered = beamtalk_recheck:trigger_leaf_change([<<"SomeSuperclass">>]),
+                    ?assertEqual(1, maps:get(checked, Recovered)),
+                    ?assertEqual([<<"ReCheckExitFaultClass">>], maps:get(checked_owners, Recovered))
+                end)
+            ]
+        end}}.


### PR DESCRIPTION
## Summary

- `recheck_image_class/2` and `recheck_owner_for_leaf_change/3` both catch the compiler port's `gen_server:call` itself exiting (`noproc`/`timeout`), not just an `{error, Reason}` return — but neither branch had a regression test. BT-2832's `inject_diagnostics_failure/1` only forces an ordinary error *return*, which can't reach that `catch` clause.
- Adds `beamtalk_compiler_server:inject_diagnostics_exit/0`, a sibling test-only hook that stops the compiler server without replying, so the caller's `gen_server:call` raises an exit instead. Safe to use per-test: `beamtalk_compiler_sup` (`one_for_one`/`permanent`) restarts the server immediately after.
- Adds direct mechanism coverage in `beamtalk_compiler_server_tests.erl` and integration regression tests in `beamtalk_recheck_tests.erl` covering both `trigger_image/0` and `trigger_leaf_change/1`'s catch clauses.
- Documents the shared restart-budget constraint the new hook draws from (found during self-review).
- Item 2 from the tracked issue (ambient-cache restore-clobbers-commit race in `trigger_pending/5`) is left as documented accepted risk per this issue's own re-evaluation — no code change.

Linear: https://linear.app/beamtalk/issue/BT-2806

## Test plan

- [x] `rebar3 eunit --module=beamtalk_compiler_server_tests,beamtalk_recheck_tests` — 117 tests, 0 failures
- [x] `just test-runtime` (full suite) — 5403 + 1588 tests, 0 failures
- [x] `just dialyzer` — clean
- [x] `just fmt-check-erlang` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01TPT6GXXrAEY4yc5ZN9cbMB)_