### PR TITLE
test: tighten placeholder assertions in inline_class.btscript (GH-3094)

### DIFF
--- a/tests/repl-protocol/cases/inline_class.btscript
+++ b/tests/repl-protocol/cases/inline_class.btscript
@@ -23,14 +23,14 @@
 Actor subclass: InlineCounter
   state: value = 0
   increment => self.value := self.value + 1
-// => _
+// => InlineCounter
 
 // ---------------------------------------------------------------------------
 // Add more methods using Tonel-style standalone method defs
 // ---------------------------------------------------------------------------
 
 InlineCounter >> getValue => self.value
-// => _
+// => InlineCounter>>getValue
 
 // ---------------------------------------------------------------------------
 // Spawn and use the class
@@ -53,7 +53,7 @@ c getValue
 // ---------------------------------------------------------------------------
 
 InlineCounter >> increment => self.value := self.value + 10
-// => _
+// => InlineCounter>>increment
 
 c2 := InlineCounter spawn
 // => Actor(InlineCounter, _)


### PR DESCRIPTION
## Summary

Replaces 3 `// => _` placeholder assertions in `tests/repl-protocol/cases/inline_class.btscript` with concrete expected values, making the test catch silent regressions in the REPL's class-definition and method-addition return values.

| Line | Expression | Before | After |
|------|-----------|--------|-------|
| 26 | `Actor subclass: InlineCounter ...` | `// => _` | `// => InlineCounter` |
| 33 | `InlineCounter >> getValue => self.value` | `// => _` | `// => InlineCounter>>getValue` |
| 56 | `InlineCounter >> increment => ...` | `// => _` | `// => InlineCounter>>increment` |

## Why these values

Confirmed by `adr_0105_killer_demo.btscript`, which already carries concrete assertions for identical patterns throughout:
- Class definition → class name (lines 44, 56, 62, 68)
- `>>` method addition → `ClassName>>method` (lines 47, 50, 101, 138, 159, 178)

Also confirmed by `repl_inline_class_superclass_index.btscript` which already asserts `// => Triangle` and `// => RightTriangle` for inline class definitions — this PR applies the same discipline to `inline_class.btscript`.

## Test plan

- `just test-repl-protocol` — the inline_class assertions must pass with concrete values
- CI green across all checks

## Notes

No behavioral change — the expressions still run; we now assert what they return instead of wildcarding.

Nightly test-quality routine. Tracked in GH-3094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZyjhFzpPsxLrSKCte9pMR

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZyjhFzpPsxLrSKCte9pMR)_