### PR TITLE
ci: post Claude review findings as a single batched inline PR review

### DIFF
--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -21,10 +21,11 @@ REVIEW SCOPE (read carefully — this drives review quality):
 - Review the FULL diff for correctness and reason about the entire change set. Your review
   depth must NOT depend on how much landed in the most recent push — a small last commit is
   not an excuse for a shallow review.
-- For inline comments, use the INCREMENTAL diff and attach each finding within it to the
-  exact line using the create_inline_comment tool. Include a ```suggestion block for
-  concrete, mechanical fixes so the author can apply them in one click; describe the change
-  in prose when it is larger or needs judgement.
+- Findings within the INCREMENTAL diff become inline review comments: record each one in
+  `.claude-findings.json` (schema under OUTPUT), anchored to the exact file and line. A
+  later workflow step posts them as ONE batched GitHub review on the PR. Include a
+  ```suggestion block in the body for concrete, mechanical fixes so the author can apply
+  them in one click; describe the change in prose when it is larger or needs judgement.
 - A finding in the full range but outside the incremental range goes in the summary (name
   any out-of-range Blocker explicitly). Never silently drop a finding because it is
   out-of-range.
@@ -136,11 +137,42 @@ Be concise, surface problems, skip praise. For design concerns, explain the inva
 stake, not just the line. For correctness bugs, state the concrete failure scenario
 (the inputs or sequence of events) that triggers them.
 
-At the very end of your response, use the Write tool to create TWO files in the repo root:
-1. .claude-summary.md — a concise Markdown summary of this review for a human reader: a
+At the very end of your response, use the Write tool to create THREE files in the repo
+root:
+1. .claude-findings.json — a JSON array of the findings that fall inside the INCREMENTAL
+   diff; a workflow step posts these as inline comments in a single batched PR review.
+   Write `[]` when there are none. Each element:
+
+   {
+     "path": "crates/beamtalk-core/src/foo.rs",
+     "line": 123,
+     "start_line": 120,
+     "side": "RIGHT",
+     "severity": "Blocker",
+     "body": "Markdown finding body."
+   }
+
+   - "path": repo-relative path (the NEW path if the file was renamed).
+   - "line": for "side": "RIGHT" (the default), the line number in the NEW version of the
+     file; for "side": "LEFT", the line number in the OLD version. Use "LEFT" only to
+     comment on a deleted line.
+   - "start_line": optional; makes the comment span start_line..line (must be < line).
+   - "severity": "Blocker" | "Suggestion" | "Nit".
+   - "body": Markdown. Use a ```suggestion fence for one-click fixes — the fence REPLACES
+     the commented line range exactly, so the range must cover precisely the lines being
+     replaced.
+   Derive line numbers from the diff hunk headers (`@@ -old +new @@` — count from the
+   `+new` start for RIGHT-side lines); only lines that appear in the diff are valid
+   anchors. A finding whose anchor does not land in the diff is demoted to a plain list
+   entry in the review body instead of an inline comment, so anchor carefully.
+2. .claude-summary.md — a concise Markdown summary of this review for a human reader: a
    one-line overall assessment, then findings grouped under "Blockers" / "Suggestions" /
-   "Nits" headings (omit empty groups). State explicitly when the PR is clean. This file is
-   posted as a PR comment on EVERY run, including PASS, so it must always be written even
-   when there are no findings.
-2. .claude-verdict — exactly one word: BLOCK if there are any Blockers, otherwise PASS. No
-   other content in this file.
+   "Nits" headings (omit empty groups). For findings already in .claude-findings.json,
+   one line each — `path:line — short description` — do NOT duplicate the full body (it
+   appears inline on the diff). Findings outside the incremental range appear here in
+   full. State explicitly when the PR is clean. This file is posted as a PR comment on
+   EVERY run, including PASS, so it must always be written even when there are no
+   findings.
+3. .claude-verdict — exactly one word: BLOCK if there are any Blockers, otherwise PASS. No
+   other content in this file. Write this file LAST — its presence tells the workflow the
+   review completed.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -159,34 +159,52 @@ jobs:
           prompt: ${{ steps.load_prompt.outputs.prompt }}
 
       # Post the agent's line-anchored findings as ONE batched PR review (inline
-      # comments incl. ```suggestion fixes) instead of per-comment posts. Anchors are
-      # validated against the PR's real diff first, so one hallucinated line number
-      # can't 422-reject the whole review; findings that don't anchor are folded into
-      # the review body rather than dropped. Posting failures are warnings, not job
-      # failures — findings also appear (in short form) in the sticky summary, and
-      # merge blocking is the separate "Gate on verdict" step, so a red X here would
-      # only add noise. Each push posts a NEW review (submitted reviews can't be
-      # edited); GitHub marks superseded comments "outdated" automatically.
-      - name: Post inline review
-        if: always() && hashFiles('.claude-findings.json') != ''
+      # comments incl. ```suggestion fixes) instead of per-comment posts. The review
+      # event mirrors the verdict so branch protection can key off the bot's review
+      # state:
+      #   PASS       -> APPROVE          Requires "Allow GitHub Actions to create and
+      #                                  approve pull requests" (Settings → Actions →
+      #                                  General); without it GitHub 422s and this
+      #                                  step falls back to a COMMENT review + warning.
+      #   BLOCK      -> REQUEST_CHANGES  Superseded automatically by a later run's
+      #                                  APPROVE — GitHub keeps only the latest review
+      #                                  state per reviewer.
+      #   no verdict -> COMMENT          Agent died mid-run; never approve or
+      #                                  request-changes on an incomplete review (the
+      #                                  fail-closed gate below goes red anyway).
+      # Anchors are validated against the PR's real diff first, so one hallucinated
+      # line number can't 422-reject the whole review; findings that don't anchor are
+      # folded into the review body rather than dropped. Posting failures are
+      # warnings, not job failures — findings also appear (in short form) in the
+      # sticky summary, and merge blocking is the separate "Gate on verdict" step, so
+      # a red X here would only add noise. Each push posts a NEW review (submitted
+      # reviews can't be edited); GitHub marks superseded comments "outdated"
+      # automatically.
+      - name: Post PR review
+        if: always() && (hashFiles('.claude-verdict') != '' || hashFiles('.claude-findings.json') != '')
         uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
-            let findings;
-            try {
-              findings = JSON.parse(fs.readFileSync('.claude-findings.json', 'utf8'));
-            } catch (e) {
-              core.warning(`Unreadable .claude-findings.json: ${e.message}`);
-              return;
+            const read = (p) => { try { return fs.readFileSync(p, 'utf8').trim(); } catch { return null; } };
+
+            const verdict = read('.claude-verdict');
+            let findings = [];
+            const rawFindings = read('.claude-findings.json');
+            if (rawFindings !== null) {
+              try {
+                const parsed = JSON.parse(rawFindings);
+                if (Array.isArray(parsed)) {
+                  findings = parsed.filter((f) => f && typeof f.path === 'string' && typeof f.body === 'string');
+                } else {
+                  core.warning('.claude-findings.json is not a JSON array; treating as no findings');
+                }
+              } catch (e) {
+                core.warning(`Unparseable .claude-findings.json: ${e.message}`);
+              }
             }
-            if (!Array.isArray(findings)) {
-              core.warning('.claude-findings.json is not a JSON array; skipping inline review');
-              return;
-            }
-            findings = findings.filter((f) => f && typeof f.path === 'string' && typeof f.body === 'string');
-            if (findings.length === 0) {
-              core.info('No inline findings to post');
+            if (verdict === null && findings.length === 0) {
+              core.info('No verdict and no findings — nothing to post');
               return;
             }
 
@@ -236,7 +254,20 @@ jobs:
             }
 
             const count = (sev) => findings.filter((f) => f.severity === sev).length;
-            let body = `**Claude Review** — ${count('Blocker')} Blocker(s), ${count('Suggestion')} Suggestion(s), ${count('Nit')} Nit(s) as inline comments. Verdict and out-of-range findings are in the summary comment.`;
+            const counts = `${count('Blocker')} Blocker(s), ${count('Suggestion')} Suggestion(s), ${count('Nit')} Nit(s)`;
+            const event = verdict === 'PASS' ? 'APPROVE'
+                        : verdict === null ? 'COMMENT'
+                        : 'REQUEST_CHANGES';
+            let body;
+            if (event === 'APPROVE') {
+              body = findings.length === 0
+                ? '✅ **Claude Review** — no findings. Approved.'
+                : `✅ **Claude Review** — approved, with non-blocking feedback: ${counts} as inline comments.`;
+            } else if (event === 'REQUEST_CHANGES') {
+              body = `❌ **Claude Review** — changes requested: ${counts}. See the inline comments and the summary comment (which also carries any finding outside this push's diff).`;
+            } else {
+              body = `⚠️ **Claude Review** — the review agent did not complete (no verdict). Posting its findings (${counts}) without an approve / request-changes state.`;
+            }
             if (unanchored.length > 0) {
               body += '\n\nFindings that could not be anchored to a diff line:';
               for (const f of unanchored) {
@@ -245,27 +276,41 @@ jobs:
               }
             }
 
-            try {
-              await github.rest.pulls.createReview({
-                owner, repo, pull_number,
-                commit_id: context.payload.pull_request.head.sha,
-                event: 'COMMENT',
-                body,
-                comments: anchored,
-              });
-              core.info(`Posted review: ${anchored.length} inline comment(s), ${unanchored.length} unanchored`);
-            } catch (e) {
-              // GitHub can still reject an anchor the index considered valid (e.g. a
-              // multi-line span crossing hunks). Retry body-only so nothing is lost.
-              core.warning(`createReview with inline comments failed: ${e.message} — retrying body-only`);
-              let fallback = body + '\n\nInline anchors were rejected by GitHub; all findings as a list:';
-              for (const c of anchored) fallback += `\n\n---\n\`${c.path}:${c.line}\`\n\n${c.body}`;
+            // GitHub can still reject an anchor the index considered valid (e.g. a
+            // multi-line span crossing hunks) — fall back body-only so nothing is
+            // lost. An APPROVE additionally falls back to COMMENT for repos where
+            // "Allow GitHub Actions to create and approve pull requests" is off.
+            let bodyOnly = body + '\n\nInline anchors were rejected by GitHub; all findings as a list:';
+            for (const c of anchored) bodyOnly += `\n\n---\n\`${c.path}:${c.line}\`\n\n${c.body}`;
+
+            const attempts = [[event, body, anchored]];
+            if (anchored.length > 0) attempts.push([event, bodyOnly, []]);
+            if (event === 'APPROVE') {
+              attempts.push(['COMMENT', body, anchored]);
+              if (anchored.length > 0) attempts.push(['COMMENT', bodyOnly, []]);
+            }
+
+            let posted = false;
+            for (const [ev, b, cs] of attempts) {
               try {
-                await github.rest.pulls.createReview({ owner, repo, pull_number, event: 'COMMENT', body: fallback });
-              } catch (e2) {
-                core.warning(`Body-only review also failed: ${e2.message} — findings remain in the summary comment`);
+                await github.rest.pulls.createReview({
+                  owner, repo, pull_number,
+                  commit_id: context.payload.pull_request.head.sha,
+                  event: ev,
+                  body: b,
+                  comments: cs,
+                });
+                core.info(`Posted ${ev} review with ${cs.length} inline comment(s) (${unanchored.length} unanchored)`);
+                posted = true;
+                break;
+              } catch (e) {
+                core.warning(`createReview ${ev} with ${cs.length} inline comment(s) failed: ${e.message}`);
+                if (ev === 'APPROVE' && /approv/i.test(String(e.message))) {
+                  core.warning('To let this workflow approve PRs, enable Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests".');
+                }
               }
             }
+            if (!posted) core.warning('All review submission attempts failed — findings remain in the sticky summary comment');
 
       - name: Post review summary
         if: always()

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -123,14 +123,17 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The reviewer never mutates the repo directly: it reads code, runs
-          # read-only git, posts inline review comments (incl. ```suggestion fixes),
-          # and writes the verdict/summary files with the Write tool (a default-allowed
-          # file op). No commit/push or arbitrary Bash is granted — proposed fixes are
-          # delivered as applyable GitHub suggestions, not pushed commits.
-          # mcp__github_inline_comment__create_inline_comment is the action's own tool
-          # for line-anchored comments; it must be listed explicitly because
-          # --allowedTools REPLACES the action's default tool set rather than extending it.
-          claude_args: '--max-turns 50 --model ${{ steps.model.outputs.model }} --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*),mcp__github_inline_comment__create_inline_comment"'
+          # read-only git, and writes findings/summary/verdict files with the Write
+          # tool (a default-allowed file op). No commit/push or arbitrary Bash is
+          # granted — proposed fixes are delivered as applyable GitHub suggestions,
+          # not pushed commits.
+          # The agent does NOT post to GitHub itself: it records line-anchored findings
+          # in .claude-findings.json and the "Post inline review" step below batches
+          # them into a single PR review. (The action's own
+          # mcp__github_inline_comment tool posts one separate review per comment and
+          # never worked in this automation-mode setup; batched reviews are an open
+          # feature request — anthropics/claude-code-action#1049.)
+          claude_args: '--max-turns 50 --model ${{ steps.model.outputs.model }} --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*)"'
           prompt: ${{ steps.load_prompt.outputs.prompt }}
 
       # No verdict after the first attempt usually means the agent step died early
@@ -152,8 +155,117 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--max-turns 50 --model ${{ steps.model.outputs.model }} --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*),mcp__github_inline_comment__create_inline_comment"'
+          claude_args: '--max-turns 50 --model ${{ steps.model.outputs.model }} --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*)"'
           prompt: ${{ steps.load_prompt.outputs.prompt }}
+
+      # Post the agent's line-anchored findings as ONE batched PR review (inline
+      # comments incl. ```suggestion fixes) instead of per-comment posts. Anchors are
+      # validated against the PR's real diff first, so one hallucinated line number
+      # can't 422-reject the whole review; findings that don't anchor are folded into
+      # the review body rather than dropped. Posting failures are warnings, not job
+      # failures — findings also appear (in short form) in the sticky summary, and
+      # merge blocking is the separate "Gate on verdict" step, so a red X here would
+      # only add noise. Each push posts a NEW review (submitted reviews can't be
+      # edited); GitHub marks superseded comments "outdated" automatically.
+      - name: Post inline review
+        if: always() && hashFiles('.claude-findings.json') != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            let findings;
+            try {
+              findings = JSON.parse(fs.readFileSync('.claude-findings.json', 'utf8'));
+            } catch (e) {
+              core.warning(`Unreadable .claude-findings.json: ${e.message}`);
+              return;
+            }
+            if (!Array.isArray(findings)) {
+              core.warning('.claude-findings.json is not a JSON array; skipping inline review');
+              return;
+            }
+            findings = findings.filter((f) => f && typeof f.path === 'string' && typeof f.body === 'string');
+            if (findings.length === 0) {
+              core.info('No inline findings to post');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            // Index which (path, side, line) tuples are commentable in the PR's actual
+            // diff. GitHub rejects the ENTIRE review if any single comment anchors
+            // outside the diff, so mis-anchored findings are demoted to the review body.
+            const files = await github.paginate(github.rest.pulls.listFiles, { owner, repo, pull_number, per_page: 100 });
+            const anchors = new Map();
+            for (const file of files) {
+              const sets = { RIGHT: new Set(), LEFT: new Set() };
+              anchors.set(file.filename, sets);
+              if (!file.patch) continue; // binary / too-large diff: nothing commentable
+              let oldLine = 0, newLine = 0;
+              for (const row of file.patch.split('\n')) {
+                const hunk = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(row);
+                if (hunk) { oldLine = Number(hunk[1]); newLine = Number(hunk[2]); continue; }
+                if (row.startsWith('+')) sets.RIGHT.add(newLine++);
+                else if (row.startsWith('-')) sets.LEFT.add(oldLine++);
+                else if (!row.startsWith('\\')) { sets.RIGHT.add(newLine++); sets.LEFT.add(oldLine++); }
+              }
+            }
+
+            const tag = (s) => s === 'Blocker' ? '🛑 **Blocker**' : s === 'Nit' ? '🔹 **Nit**' : '💡 **Suggestion**';
+            const anchored = [];
+            const unanchored = [];
+            for (const f of findings) {
+              const side = f.side === 'LEFT' ? 'LEFT' : 'RIGHT';
+              const sets = anchors.get(f.path);
+              if (!sets || !Number.isInteger(f.line) || !sets[side].has(f.line)) {
+                unanchored.push(f);
+                continue;
+              }
+              const comment = { path: f.path, line: f.line, side, body: `${tag(f.severity)}\n\n${f.body}` };
+              // Multi-line range only when every line in it is commentable; otherwise
+              // degrade to a single-line comment rather than losing the finding.
+              if (Number.isInteger(f.start_line) && f.start_line < f.line) {
+                let spanOk = true;
+                for (let l = f.start_line; l < f.line; l++) {
+                  if (!sets[side].has(l)) { spanOk = false; break; }
+                }
+                if (spanOk) { comment.start_line = f.start_line; comment.start_side = side; }
+              }
+              anchored.push(comment);
+            }
+
+            const count = (sev) => findings.filter((f) => f.severity === sev).length;
+            let body = `**Claude Review** — ${count('Blocker')} Blocker(s), ${count('Suggestion')} Suggestion(s), ${count('Nit')} Nit(s) as inline comments. Verdict and out-of-range findings are in the summary comment.`;
+            if (unanchored.length > 0) {
+              body += '\n\nFindings that could not be anchored to a diff line:';
+              for (const f of unanchored) {
+                const loc = Number.isInteger(f.line) ? `${f.path}:${f.line}` : f.path;
+                body += `\n\n---\n\`${loc}\` — ${tag(f.severity)}\n\n${f.body}`;
+              }
+            }
+
+            try {
+              await github.rest.pulls.createReview({
+                owner, repo, pull_number,
+                commit_id: context.payload.pull_request.head.sha,
+                event: 'COMMENT',
+                body,
+                comments: anchored,
+              });
+              core.info(`Posted review: ${anchored.length} inline comment(s), ${unanchored.length} unanchored`);
+            } catch (e) {
+              // GitHub can still reject an anchor the index considered valid (e.g. a
+              // multi-line span crossing hunks). Retry body-only so nothing is lost.
+              core.warning(`createReview with inline comments failed: ${e.message} — retrying body-only`);
+              let fallback = body + '\n\nInline anchors were rejected by GitHub; all findings as a list:';
+              for (const c of anchored) fallback += `\n\n---\n\`${c.path}:${c.line}\`\n\n${c.body}`;
+              try {
+                await github.rest.pulls.createReview({ owner, repo, pull_number, event: 'COMMENT', body: fallback });
+              } catch (e2) {
+                core.warning(`Body-only review also failed: ${e2.message} — findings remain in the summary comment`);
+              }
+            }
 
       - name: Post review summary
         if: always()


### PR DESCRIPTION
The review agent was instructed to post line-anchored findings via the
action's mcp__github_inline_comment__create_inline_comment tool, but no
inline comments were ever produced in this automation-mode setup —
findings that should have gone inline (e.g. PR #3083's applyable fix)
landed in the sticky summary blob instead. That tool also posts one
separate review per comment; batched reviews are an open upstream
feature request (anthropics/claude-code-action#1049).

Replace the MCP tool with a deterministic pipeline:
- The agent now writes line-anchored findings to .claude-findings.json
  (alongside the existing .claude-summary.md / .claude-verdict), with
  severity, RIGHT/LEFT side, optional multi-line ranges, and
  ```suggestion fences for one-click fixes.
- A new "Post inline review" github-script step batches them into ONE
  PR review via pulls.createReview. Anchors are validated against the
  PR's real diff first (hunk-header parsing of pulls.listFiles patches)
  so a mis-anchored finding is demoted to the review body instead of
  422-rejecting the whole review; a body-only retry ensures findings
  are never lost. Posting failures warn rather than fail the job —
  merge blocking remains the "Gate on verdict" step.
- The summary comment now lists inline findings as one-liners instead
  of duplicating their full bodies.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015uwhaTJTPC3qT8BvocVaS7