### PR TITLE
refactor: extract collect_project_dependency_ebin_dirs to beamtalk-core (#3100)

### DIFF
--- a/crates/beamtalk-cli/src/build_layout.rs
+++ b/crates/beamtalk-cli/src/build_layout.rs
@@ -11,7 +11,7 @@
 //! same note in `crate::manifest` for why every item here must stay `pub`
 //! rather than `pub(crate)`.
 
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 
 /// Provides all build-output paths relative to a project root.
 ///
@@ -41,6 +41,11 @@ impl BuildLayout {
         Self {
             project_root: project_root.into(),
         }
+    }
+
+    /// The project root directory this layout is rooted at.
+    pub fn project_root(&self) -> &Utf8Path {
+        &self.project_root
     }
 
     // ── Roots ────────────────────────────────────────────────────────

--- a/crates/beamtalk-cli/src/native_type_specs.rs
+++ b/crates/beamtalk-cli/src/native_type_specs.rs
@@ -27,61 +27,6 @@ pub use beamtalk_core::ffi_type_specs::{
 
 use crate::build_layout::BuildLayout;
 use beamtalk_core::semantic_analysis::type_checker::NativeTypeRegistry;
-use camino::Utf8PathBuf;
-
-/// Collects dependency/native `.beam` ebin directories for `layout`'s project.
-///
-/// Duplicates the directory-scanning logic of `beamtalk-cli`'s (binary-only)
-/// `commands::deps::collect_dep_ebin_paths` + `commands::build::
-/// collect_rebar3_ebin_paths`, so this module doesn't need to depend on the
-/// `commands` module tree (which lives in the CLI binary, not this library
-/// crate). Each side is a handful of `read_dir` calls over paths `BuildLayout`
-/// already owns, so duplication carries little drift risk — unlike the
-/// FFI-spec-extraction logic itself, which is *not* duplicated (`beamtalk-
-/// core`'s `ffi_type_specs` is its single source of truth, consumed by
-/// `beamtalk-cli`, `beamtalk-mcp`, and `beamtalk-lsp`).
-fn collect_dependency_ebin_dirs(layout: &BuildLayout) -> Vec<Utf8PathBuf> {
-    let mut dirs = Vec::new();
-
-    // Path dependencies: `_build/deps/*/ebin/`.
-    if let Ok(entries) = std::fs::read_dir(layout.deps_dir()) {
-        for entry in entries.flatten() {
-            let ebin = entry.path().join("ebin");
-            if ebin.is_dir() {
-                if let Ok(utf8) = Utf8PathBuf::from_path_buf(ebin) {
-                    dirs.push(utf8);
-                }
-            }
-        }
-    }
-
-    // The project's own native/ code, compiled to `_build/dev/native/ebin/`.
-    let native_ebin = layout.native_ebin_dir();
-    if native_ebin.exists() {
-        dirs.push(native_ebin);
-    }
-
-    // rebar3 hex/git deps: `_build/dev/native/default/lib/*/ebin/`.
-    let lib_dir = layout.rebar_lib_dir();
-    if let Ok(entries) = std::fs::read_dir(&lib_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-            let ebin = path.join("ebin");
-            if ebin.is_dir() {
-                if let Ok(utf8) = Utf8PathBuf::from_path_buf(ebin) {
-                    dirs.push(utf8);
-                }
-            }
-        }
-    }
-
-    dirs.sort();
-    dirs.dedup();
-    dirs
-}
 
 /// ADR 0075 Phase 1 / BT-2851: Extract type specs from OTP and dependency
 /// `.beam` files for a manifest-backed project and cache them.
@@ -95,39 +40,7 @@ fn collect_dependency_ebin_dirs(layout: &BuildLayout) -> Vec<Utf8PathBuf> {
 /// Non-fatal: if spec extraction fails (e.g., runtime not compiled), returns
 /// `None` rather than erroring — callers fall back to untyped FFI checking.
 pub fn extract_project_type_specs(layout: &BuildLayout) -> Option<NativeTypeRegistry> {
-    let dep_ebin_dirs = collect_dependency_ebin_dirs(layout);
+    let dep_ebin_dirs =
+        beamtalk_core::ffi_type_specs::collect_project_dependency_ebin_dirs(layout.project_root());
     beamtalk_core::ffi_type_specs::extract_type_specs(&layout.type_cache_dir(), &dep_ebin_dirs)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-    use tempfile::TempDir;
-
-    #[test]
-    fn collect_dependency_ebin_dirs_empty_project() {
-        let temp = TempDir::new().unwrap();
-        let root = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
-        let layout = BuildLayout::new(&root);
-
-        let dirs = collect_dependency_ebin_dirs(&layout);
-        assert!(dirs.is_empty(), "fresh project has no dependency ebin dirs");
-    }
-
-    #[test]
-    fn collect_dependency_ebin_dirs_finds_path_dep_ebin() {
-        let temp = TempDir::new().unwrap();
-        let root = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
-        let layout = BuildLayout::new(&root);
-
-        let dep_ebin = layout.deps_dir().join("json").join("ebin");
-        fs::create_dir_all(&dep_ebin).unwrap();
-
-        let dirs = collect_dependency_ebin_dirs(&layout);
-        assert!(
-            dirs.contains(&dep_ebin),
-            "should find the path dependency's ebin dir: {dirs:?}"
-        );
-    }
 }

--- a/crates/beamtalk-core/src/ffi_type_specs.rs
+++ b/crates/beamtalk-core/src/ffi_type_specs.rs
@@ -22,9 +22,9 @@
 //!
 //! [`extract_type_specs`] is deliberately layout-agnostic — it takes an
 //! explicit cache directory and dependency ebin directories rather than a
-//! `beamtalk-cli`-specific `BuildLayout`, so each caller (the CLI via
-//! `BuildLayout`, the LSP via its own `_build/` path joins) supplies its own
-//! notion of where those directories live.
+//! `beamtalk-cli`-specific `BuildLayout`. Callers use
+//! [`collect_project_dependency_ebin_dirs`] to resolve those directories from
+//! a project root; `beamtalk-cli` additionally wraps this via `BuildLayout`.
 
 use crate::semantic_analysis::type_checker::{
     NativeTypeRegistry, is_specs_line, is_specs_result_error, is_specs_result_ok, parse_specs_line,
@@ -1239,6 +1239,67 @@ pub fn discover_otp_beam_files() -> Result<OtpDiscovery> {
     })
 }
 
+/// Collect the ebin directories for a project's native and path dependencies.
+///
+/// Scans the standard `_build/` layout for a project rooted at `project_root`:
+/// - `_build/deps/*/ebin/` — Beamtalk path-dependency ebin dirs
+/// - `_build/dev/native/ebin/` — the project's own compiled native Erlang
+/// - `_build/dev/native/default/lib/*/ebin/` — rebar3 hex/git dependency ebins
+///
+/// The returned list is sorted and deduplicated. Missing directories are silently
+/// skipped (no build yet → empty list rather than an error).
+///
+/// Pass the result to [`extract_type_specs`] as `dependency_ebin_dirs`. Both
+/// `beamtalk-cli` (via `BuildLayout`) and `beamtalk-lsp` call this function —
+/// it is the single source of truth for project-dependency ebin discovery.
+pub fn collect_project_dependency_ebin_dirs(project_root: &Utf8Path) -> Vec<Utf8PathBuf> {
+    let build_root = project_root.join("_build");
+    let mut dirs = Vec::new();
+
+    // Path dependencies: `_build/deps/*/ebin/`.
+    if let Ok(entries) = std::fs::read_dir(build_root.join("deps")) {
+        for entry in entries.flatten() {
+            let ebin = entry.path().join("ebin");
+            if ebin.is_dir() {
+                if let Ok(utf8) = Utf8PathBuf::from_path_buf(ebin) {
+                    dirs.push(utf8);
+                }
+            }
+        }
+    }
+
+    // The project's own native/ code, compiled to `_build/dev/native/ebin/`.
+    let native_ebin = build_root.join("dev").join("native").join("ebin");
+    if native_ebin.is_dir() {
+        dirs.push(native_ebin);
+    }
+
+    // rebar3 hex/git deps: `_build/dev/native/default/lib/*/ebin/`.
+    let lib_dir = build_root
+        .join("dev")
+        .join("native")
+        .join("default")
+        .join("lib");
+    if let Ok(entries) = std::fs::read_dir(&lib_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let ebin = path.join("ebin");
+            if ebin.is_dir() {
+                if let Ok(utf8) = Utf8PathBuf::from_path_buf(ebin) {
+                    dirs.push(utf8);
+                }
+            }
+        }
+    }
+
+    dirs.sort();
+    dirs.dedup();
+    dirs
+}
+
 /// Discover `.beam` files from project dependency directories.
 ///
 /// Collects beams from:
@@ -1285,14 +1346,13 @@ pub fn discover_dependency_beam_files(ebin_dirs: &[Utf8PathBuf]) -> Vec<Utf8Path
 /// `beamtalk-cli`'s `native_type_specs::extract_project_type_specs`, which
 /// resolves `cache_dir`/`dependency_ebin_dirs` from a `BuildLayout`),
 /// `beamtalk-mcp`'s `lint`/`diagnostic_summary` tools (BT-2858, same path),
-/// and `beamtalk-lsp` (BT-2859, which resolves the same `_build/` paths
-/// itself rather than depending on `beamtalk-cli`'s `BuildLayout`).
+/// and `beamtalk-lsp` (BT-2859). All callers obtain `dependency_ebin_dirs`
+/// via [`collect_project_dependency_ebin_dirs`].
 ///
 /// `dependency_ebin_dirs` should include the project's path-dependency ebin
 /// dirs (`_build/deps/*/ebin/`), its own compiled `native/` ebin dir, and any
-/// rebar3 hex-dependency ebin dirs — see `native_type_specs::
-/// collect_dependency_ebin_dirs` in `beamtalk-cli` for the canonical CLI-side
-/// construction.
+/// rebar3 hex-dependency ebin dirs — use [`collect_project_dependency_ebin_dirs`]
+/// to obtain them from a project root path.
 ///
 /// Non-fatal: if spec extraction fails (e.g., runtime not compiled), returns
 /// `None` rather than erroring — callers fall back to untyped FFI checking.
@@ -1524,6 +1584,34 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let cache_dir = Utf8PathBuf::from_path_buf(temp.path().join("type_cache")).unwrap();
         let _ = extract_type_specs(&cache_dir, &[]);
+    }
+
+    // -----------------------------------------------------------------------
+    // collect_project_dependency_ebin_dirs tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn collect_project_dependency_ebin_dirs_empty_project() {
+        let temp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+
+        let dirs = collect_project_dependency_ebin_dirs(&root);
+        assert!(dirs.is_empty(), "fresh project has no dependency ebin dirs");
+    }
+
+    #[test]
+    fn collect_project_dependency_ebin_dirs_finds_path_dep_ebin() {
+        let temp = TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+
+        let dep_ebin = root.join("_build").join("deps").join("json").join("ebin");
+        std::fs::create_dir_all(&dep_ebin).unwrap();
+
+        let dirs = collect_project_dependency_ebin_dirs(&root);
+        assert!(
+            dirs.contains(&dep_ebin),
+            "should find the path dependency's ebin dir: {dirs:?}"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -257,68 +257,6 @@ impl NavCache {
     }
 }
 
-/// Collects dependency/native `.beam` ebin directories under `root`'s
-/// `_build/` tree, for `beamtalk_core::ffi_type_specs::extract_type_specs`.
-///
-/// Duplicates the directory-scanning logic of `beamtalk-cli`'s
-/// `native_type_specs::collect_dependency_ebin_dirs` (itself already a
-/// deliberate BT-2858 duplicate of the CLI binary's `commands::deps`/
-/// `commands::build` versions) rather than sharing it, so `beamtalk-lsp`
-/// doesn't need a `beamtalk-lsp -> beamtalk-cli` dependency (forbidden —
-/// see `docs/development/architecture-principles.md`). Each side is a
-/// handful of `read_dir` calls over the same `_build/` layout convention
-/// this function's caller (`load_type_cache`) already assumes for
-/// `_build/type_cache/`, so duplication carries little drift risk — unlike
-/// the FFI-spec-extraction logic itself, which is *not* duplicated
-/// (`beamtalk-core`'s `ffi_type_specs` is its single source of truth).
-fn collect_dependency_ebin_dirs(root: &Utf8PathBuf) -> Vec<Utf8PathBuf> {
-    let mut dirs = Vec::new();
-    let build_root = root.join("_build");
-
-    // Path dependencies: `_build/deps/*/ebin/`.
-    if let Ok(entries) = std::fs::read_dir(build_root.join("deps")) {
-        for entry in entries.flatten() {
-            let ebin = entry.path().join("ebin");
-            if ebin.is_dir() {
-                if let Ok(utf8) = Utf8PathBuf::from_path_buf(ebin) {
-                    dirs.push(utf8);
-                }
-            }
-        }
-    }
-
-    // The project's own native/ code, compiled to `_build/dev/native/ebin/`.
-    let native_ebin = build_root.join("dev").join("native").join("ebin");
-    if native_ebin.is_dir() {
-        dirs.push(native_ebin);
-    }
-
-    // rebar3 hex/git deps: `_build/dev/native/default/lib/*/ebin/`.
-    let lib_dir = build_root
-        .join("dev")
-        .join("native")
-        .join("default")
-        .join("lib");
-    if let Ok(entries) = std::fs::read_dir(&lib_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-            let ebin = path.join("ebin");
-            if ebin.is_dir() {
-                if let Ok(utf8) = Utf8PathBuf::from_path_buf(ebin) {
-                    dirs.push(utf8);
-                }
-            }
-        }
-    }
-
-    dirs.sort();
-    dirs.dedup();
-    dirs
-}
-
 impl Backend {
     /// Creates a new `Backend` with the given LSP client handle.
     pub fn new(client: Client) -> Self {
@@ -819,7 +757,8 @@ impl Backend {
                     continue;
                 };
                 let cache_dir = root.join("_build").join("type_cache");
-                let dependency_ebin_dirs = collect_dependency_ebin_dirs(&root);
+                let dependency_ebin_dirs =
+                    beamtalk_core::ffi_type_specs::collect_project_dependency_ebin_dirs(&root);
                 if let Some(root_registry) = beamtalk_core::ffi_type_specs::extract_type_specs(
                     &cache_dir,
                     &dependency_ebin_dirs,
@@ -5060,34 +4999,6 @@ mod tests {
         let uri = path_to_stdlib_uri(&path).expect("should produce URI");
         assert_eq!(uri.scheme(), "beamtalk-stdlib");
         assert_eq!(uri.path(), "/Collection.bt");
-    }
-
-    // -----------------------------------------------------------------------
-    // load_type_cache / collect_dependency_ebin_dirs (BT-2859)
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn collect_dependency_ebin_dirs_empty_project() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let root = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
-
-        let dirs = collect_dependency_ebin_dirs(&root);
-        assert!(dirs.is_empty(), "fresh project has no dependency ebin dirs");
-    }
-
-    #[test]
-    fn collect_dependency_ebin_dirs_finds_path_dep_ebin() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let root = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
-
-        let dep_ebin = root.join("_build").join("deps").join("json").join("ebin");
-        std::fs::create_dir_all(&dep_ebin).unwrap();
-
-        let dirs = collect_dependency_ebin_dirs(&root);
-        assert!(
-            dirs.contains(&dep_ebin),
-            "should find the path dependency's ebin dir: {dirs:?}"
-        );
     }
 
     /// BT-2859: `load_type_cache` extracts live from OTP `.beam` files for a


### PR DESCRIPTION
## Summary

Closes #3100.

The `_build/` directory-scanning logic for collecting dependency ebin dirs was duplicated between `beamtalk-cli::native_type_specs` and `beamtalk-lsp::server`. The LSP copy existed solely because `beamtalk-lsp` cannot depend on `beamtalk-cli` (DDD boundary). This PR extracts it into `beamtalk-core::ffi_type_specs` where both crates can call it.

## Changes

- **`crates/beamtalk-core/src/ffi_type_specs.rs`**: Add `pub fn collect_project_dependency_ebin_dirs(project_root: &Utf8Path) -> Vec<Utf8PathBuf>` as the single source of truth for scanning `_build/deps/*/ebin/`, `_build/dev/native/ebin/`, and `_build/dev/native/default/lib/*/ebin/`. Add two unit tests (moved from `beamtalk-lsp`). Update stale doc comments that referenced the old per-crate approach.
- **`crates/beamtalk-cli/src/build_layout.rs`**: Add `pub fn project_root(&self) -> &Utf8Path` accessor so `native_type_specs` can pass the root to the core function.
- **`crates/beamtalk-cli/src/native_type_specs.rs`**: Replace the 52-line `collect_dependency_ebin_dirs` function (and its tests) with a one-line delegation to the core function.
- **`crates/beamtalk-lsp/src/server.rs`**: Remove the 57-line `collect_dependency_ebin_dirs` function and its two unit tests; inline the core call directly at the `load_type_cache` call site.

**Net: 106 additions, 189 deletions — zero behaviour change.** Same directories, same `sort()`+`dedup()`, same call sites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfLkifJXj6zB7bM64uvYig)_