### PR TITLE
test: add dead-pid and format_mfa edge-path tests for beamtalk_repl_ops_watch

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_watch.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_watch.erl
@@ -31,6 +31,10 @@ receive the live metrics map; `handle/4` is the WebSocket-edge JSON wrapper.
 
 -export([handle/4, handle_term/4, describe_ops/0]).
 
+-ifdef(TEST).
+-export([pid_stats/1, format_mfa/1]).
+-endif.
+
 -doc "WebSocket-edge wrapper: encodes the term result to JSON (BT-2402).".
 -spec handle(binary(), map(), beamtalk_repl_protocol:protocol_msg(), pid()) -> binary().
 handle(Op, Params, Msg, SessionPid) ->

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_watch_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_watch_tests.erl
@@ -113,7 +113,7 @@ handle_term_pid_stats_live_actor_returns_value_map_test() ->
     end.
 
 %%====================================================================
-%% pid_stats/1 — dead pid returns dead-stats map (line 91 / dead_stats body)
+%% pid_stats/1 — dead pid returns dead-stats map (dead_stats/1 body)
 %%====================================================================
 
 pid_stats_dead_pid_returns_dead_stats_map_test() ->
@@ -140,7 +140,7 @@ pid_stats_dead_pid_returns_dead_stats_map_test() ->
     ?assertEqual(PidBin, maps:get(<<"pid">>, Stats)).
 
 %%====================================================================
-%% format_mfa/1 — undefined and catch-all clauses (lines 106, 110)
+%% format_mfa/1 — undefined and catch-all clauses
 %%====================================================================
 
 format_mfa_undefined_returns_nil_test() ->

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_watch_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_watch_tests.erl
@@ -111,3 +111,42 @@ handle_term_pid_stats_live_actor_returns_value_map_test() ->
         catch gen_server:stop(ActorPid),
         catch gen_server:stop(RegistryPid)
     end.
+
+%%====================================================================
+%% pid_stats/1 — dead pid returns dead-stats map (line 91 / dead_stats body)
+%%====================================================================
+
+pid_stats_dead_pid_returns_dead_stats_map_test() ->
+    %% Spawn a process, capture its pid, then kill it. Calling pid_stats/1
+    %% directly (bypassing the actor registry) exercises the
+    %% `is_process_alive -> false` branch and the dead_stats/1 helper.
+    Pid = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    PidBin = list_to_binary(pid_to_list(Pid)),
+    Ref = erlang:monitor(process, Pid),
+    exit(Pid, kill),
+    receive
+        {'DOWN', Ref, process, Pid, _} -> ok
+    after 1000 ->
+        error(timeout_waiting_for_process_death)
+    end,
+    Stats = beamtalk_repl_ops_watch:pid_stats(Pid),
+    ?assert(is_map(Stats)),
+    ?assertEqual(false, maps:get(<<"alive">>, Stats)),
+    ?assertEqual(<<"dead">>, maps:get(<<"status">>, Stats)),
+    ?assertEqual(PidBin, maps:get(<<"pid">>, Stats)).
+
+%%====================================================================
+%% format_mfa/1 — undefined and catch-all clauses (lines 106, 110)
+%%====================================================================
+
+format_mfa_undefined_returns_nil_test() ->
+    ?assertEqual(nil, beamtalk_repl_ops_watch:format_mfa(undefined)).
+
+format_mfa_catch_all_returns_nil_test() ->
+    %% Non-MFA atoms and tuples with wrong types both hit the catch-all clause.
+    ?assertEqual(nil, beamtalk_repl_ops_watch:format_mfa(not_a_mfa)),
+    ?assertEqual(nil, beamtalk_repl_ops_watch:format_mfa({erlang, apply, not_integer})).


### PR DESCRIPTION
## Summary

- `beamtalk_repl_ops_watch` had 72.2% line coverage (13/18 executable lines) per CI artifact from run 29868036418 (2026-07-21).
- Adds a `-ifdef(TEST)` export block for `pid_stats/1` and `format_mfa/1` (matching the pattern in `beamtalk_build_worker.erl`).
- Adds 3 new EUnit tests covering the dead-pid path and `format_mfa` edge clauses.

## Coverage gap closed

| Line | Code | Status |
|------|------|--------|
| 73 | `dead_stats` (TOCTOU: `process_info` → `undefined` after alive check) | Skipped — genuinely unreachable race (per testing-strategy.md) |
| 91 | `dead_stats(PidBin)` — `is_process_alive` false branch | ✅ Covered by `pid_stats_dead_pid_returns_dead_stats_map_test` |
| 96 | `dead_stats/1` helper body | ✅ Covered (called from line 91) |
| 106 | `format_mfa(undefined) -> nil` | ✅ Covered by `format_mfa_undefined_returns_nil_test` |
| 110 | `format_mfa(_) -> nil` catch-all | ✅ Covered by `format_mfa_catch_all_returns_nil_test` |

Expected coverage: 72.2% → ~94.4% (17/18 lines).

## Test plan

- [x] `rebar3 eunit --module=beamtalk_repl_ops_watch_tests` — 8 tests, 0 failures
- [x] Pre-push CI hook passed (build, clippy, fmt-check, dialyzer, stdlib tests)
- [x] erlfmt clean on both changed files

## Notes

Linear issue was not filed — the Linear MCP connector was not enabled in this automated session. The work is self-contained and the PR description captures all context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ybqKajqYM4XZB9udAqnMS

---
_Generated by [Claude Code](https://claude.ai/code/session_018ybqKajqYM4XZB9udAqnMS)_