### PR TITLE
test(codegen): add spawn.rs coverage for abstract actor stubs, instance registration, and map validation

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -3434,8 +3434,9 @@ fn test_actor_spawn_registers_instance_for_hot_reload() {
     let spawn1_start = code
         .find("'spawn'/1 = fun (InitArgs) ->")
         .expect("spawn/1 must be generated");
+    let spawn1_end = code.find("'new'/0 = fun () ->").unwrap_or(code.len());
     let spawn0_body = &code[spawn0_start..spawn1_start];
-    let spawn1_body = &code[spawn1_start..];
+    let spawn1_body = &code[spawn1_start..spawn1_end];
     assert!(
         spawn0_body.contains("let _InstReg = try call 'beamtalk_object_instances':'register'("),
         "spawn/0 ok-branch must register the instance. Got spawn/0 body:\n{spawn0_body}"

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -3434,7 +3434,10 @@ fn test_actor_spawn_registers_instance_for_hot_reload() {
     let spawn1_start = code
         .find("'spawn'/1 = fun (InitArgs) ->")
         .expect("spawn/1 must be generated");
-    let spawn1_end = code.find("'new'/0 = fun () ->").unwrap_or(code.len());
+    let spawn1_end = code[spawn1_start..]
+        .find("'new'/0 = fun () ->")
+        .map(|offset| spawn1_start + offset)
+        .unwrap_or(code.len());
     let spawn0_body = &code[spawn0_start..spawn1_start];
     let spawn1_body = &code[spawn1_start..spawn1_end];
     assert!(

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -3373,7 +3373,7 @@ fn test_abstract_actor_spawn_raises_instantiation_error() {
         "Abstract actor spawn/0 must have arity-0 fun signature. Got:\n{code}"
     );
     assert!(
-        !code.contains("beamtalk_actor':'safe_spawn'"),
+        !code.contains("'beamtalk_actor':'safe_spawn'"),
         "Abstract actor spawn must NOT call safe_spawn. Got:\n{code}"
     );
     assert!(

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -3412,6 +3412,10 @@ fn test_actor_spawn_registers_instance_for_hot_reload() {
     // BT-572: spawn/0 and spawn/1 ok-branches must register the new pid with
     // beamtalk_object_instances:register/2, wrapped in try-catch so a missing
     // registry (e.g. in stdlib unit tests) does not crash the spawn.
+    //
+    // Module::new with no classes relies on the empty-module-defaults-to-actor
+    // fallback in is_actor_class (else { true }). The module name "counter"
+    // synthesises the class atom 'Counter' via the module-name heuristic.
     use crate::ast::*;
 
     let module = Module::new(vec![], Span::new(0, 0));
@@ -3437,6 +3441,11 @@ fn test_actor_spawn_registers_instance_for_hot_reload() {
     let spawn1_end = code[spawn1_start..]
         .find("'new'/0 = fun () ->")
         .map_or(code.len(), |offset| spawn1_start + offset);
+    // spawn/0 and spawn/1 are emitted in that order, before new/0, in the generated module.
+    assert!(
+        spawn0_start < spawn1_start,
+        "spawn/0 must appear before spawn/1 in generated code"
+    );
     let spawn0_body = &code[spawn0_start..spawn1_start];
     let spawn1_body = &code[spawn1_start..spawn1_end];
     assert!(

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -3400,6 +3400,11 @@ fn test_abstract_actor_spawn_raises_instantiation_error() {
         2,
         "Both spawn/0 and spawn/1 stubs must include the abstract-class hint. Got:\n{code}"
     );
+    // Abstract stubs must never emit an instance-registration call.
+    assert!(
+        !code.contains("beamtalk_object_instances':'register'"),
+        "Abstract actor spawn stubs must not register instances. Got:\n{code}"
+    );
 }
 
 #[test]
@@ -3414,10 +3419,6 @@ fn test_actor_spawn_registers_instance_for_hot_reload() {
         generate_module(&module, CodegenOptions::new("counter")).expect("codegen should succeed");
 
     assert!(
-        code.contains("let _InstReg = try call 'beamtalk_object_instances':'register'("),
-        "spawn must register instance for hot-reload tracking. Got:\n{code}"
-    );
-    assert!(
         code.contains("of _RegOk -> _RegOk"),
         "instance registration success arm must return the ok value. Got:\n{code}"
     );
@@ -3425,10 +3426,23 @@ fn test_actor_spawn_registers_instance_for_hot_reload() {
         code.contains("catch <_RegT, _RegE, _RegS> -> 'ok'"),
         "instance registration must swallow errors when registry is absent. Got:\n{code}"
     );
-    assert_eq!(
-        code.matches("_InstReg").count(),
-        2,
-        "Both spawn/0 and spawn/1 ok-branches must register the instance. Got:\n{code}"
+    // Check each spawn function independently so a missing registration in one
+    // is reported precisely rather than as a count mismatch.
+    let spawn0_start = code
+        .find("'spawn'/0 = fun () ->")
+        .expect("spawn/0 must be generated");
+    let spawn1_start = code
+        .find("'spawn'/1 = fun (InitArgs) ->")
+        .expect("spawn/1 must be generated");
+    let spawn0_body = &code[spawn0_start..spawn1_start];
+    let spawn1_body = &code[spawn1_start..];
+    assert!(
+        spawn0_body.contains("let _InstReg = try call 'beamtalk_object_instances':'register'("),
+        "spawn/0 ok-branch must register the instance. Got spawn/0 body:\n{spawn0_body}"
+    );
+    assert!(
+        spawn1_body.contains("let _InstReg = try call 'beamtalk_object_instances':'register'("),
+        "spawn/1 ok-branch must register the instance. Got spawn/1 body:\n{spawn1_body}"
     );
 }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -3436,8 +3436,7 @@ fn test_actor_spawn_registers_instance_for_hot_reload() {
         .expect("spawn/1 must be generated");
     let spawn1_end = code[spawn1_start..]
         .find("'new'/0 = fun () ->")
-        .map(|offset| spawn1_start + offset)
-        .unwrap_or(code.len());
+        .map_or(code.len(), |offset| spawn1_start + offset);
     let spawn0_body = &code[spawn0_start..spawn1_start];
     let spawn1_body = &code[spawn1_start..spawn1_end];
     assert!(

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -3410,8 +3410,8 @@ fn test_actor_spawn_registers_instance_for_hot_reload() {
     use crate::ast::*;
 
     let module = Module::new(vec![], Span::new(0, 0));
-    let code = generate_module(&module, CodegenOptions::new("counter"))
-        .expect("codegen should succeed");
+    let code =
+        generate_module(&module, CodegenOptions::new("counter")).expect("codegen should succeed");
 
     assert!(
         code.contains("let _InstReg = try call 'beamtalk_object_instances':'register'("),
@@ -3440,8 +3440,8 @@ fn test_spawn_with_args_validates_map_argument() {
     use crate::ast::*;
 
     let module = Module::new(vec![], Span::new(0, 0));
-    let code = generate_module(&module, CodegenOptions::new("counter"))
-        .expect("codegen should succeed");
+    let code =
+        generate_module(&module, CodegenOptions::new("counter")).expect("codegen should succeed");
 
     assert!(
         code.contains("case call 'erlang':'is_map'(InitArgs)"),
@@ -3459,9 +3459,8 @@ fn test_spawn_with_args_validates_map_argument() {
         code.contains("call 'beamtalk_error':'with_selector'(TypeErr0, 'spawnWith:')"),
         "type_error must name selector 'spawnWith:'. Got:\n{code}"
     );
-    let dict_hint = CoreErlangGenerator::binary_string_literal(
-        "spawnWith: expects a Dictionary argument",
-    );
+    let dict_hint =
+        CoreErlangGenerator::binary_string_literal("spawnWith: expects a Dictionary argument");
     assert!(
         code.contains(dict_hint.as_str()),
         "type_error must include the Dictionary hint. Got:\n{code}"

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -3324,3 +3324,146 @@ fn test_class_method_self_send_long_selector_uses_hashed_atom() {
         "class method self-send must use hashed call target 'class_kw_<hex>'. Got:\n{code}"
     );
 }
+
+// ─── gen_server/spawn.rs coverage ────────────────────────────────────────────
+
+#[test]
+fn test_abstract_actor_spawn_raises_instantiation_error() {
+    // BT-105: Abstract Actor subclasses must emit spawn/0 and spawn/1 as
+    // instantiation_error stubs — not real safe_spawn calls.
+    use crate::ast::*;
+
+    let class = ClassDefinition {
+        name: Identifier::new("AbstractQueue", Span::new(0, 0)),
+        superclass: Some(Identifier::new("Actor", Span::new(0, 0))),
+        superclass_package: None,
+        class_kind: ClassKind::Actor,
+        is_abstract: true,
+        is_sealed: false,
+        is_typed: false,
+        is_internal: false,
+        supervisor_kind: None,
+        state: vec![],
+        methods: vec![],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        superclass_type_args: vec![],
+        comments: CommentAttachment::default(),
+        doc_comment: None,
+        backing_module: None,
+        handle_scope: None,
+        span: Span::new(0, 0),
+    };
+    let module = Module {
+        classes: vec![class],
+        type_aliases: Vec::new(),
+        expressions: vec![],
+        method_definitions: vec![],
+        protocols: Vec::new(),
+        span: Span::new(0, 0),
+        file_leading_comments: vec![],
+        file_trailing_comments: Vec::new(),
+    };
+    let code = generate_module(&module, CodegenOptions::new("bt@abstract_queue"))
+        .expect("codegen should succeed");
+
+    assert!(
+        code.contains("'spawn'/0 = fun () ->"),
+        "Abstract actor spawn/0 must have arity-0 fun signature. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("beamtalk_actor':'safe_spawn'"),
+        "Abstract actor spawn must NOT call safe_spawn. Got:\n{code}"
+    );
+    assert!(
+        code.contains("call 'beamtalk_error':'new'('instantiation_error', 'AbstractQueue')"),
+        "Abstract actor spawn must raise instantiation_error for the class. Got:\n{code}"
+    );
+    assert!(
+        code.contains("call 'beamtalk_error':'with_selector'(Error0, 'spawn')"),
+        "spawn/0 error stub must name selector 'spawn'. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'spawn'/1 = fun (_InitArgs) ->"),
+        "Abstract actor spawn/1 must discard InitArgs (_InitArgs). Got:\n{code}"
+    );
+    assert!(
+        code.contains("call 'beamtalk_error':'with_selector'(Error0, 'spawnWith:')"),
+        "spawn/1 error stub must name selector 'spawnWith:'. Got:\n{code}"
+    );
+    let abstract_hint = CoreErlangGenerator::binary_string_literal(
+        "Abstract classes cannot be instantiated. Subclass it first.",
+    );
+    assert_eq!(
+        code.matches(abstract_hint.as_str()).count(),
+        2,
+        "Both spawn/0 and spawn/1 stubs must include the abstract-class hint. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_actor_spawn_registers_instance_for_hot_reload() {
+    // BT-572: spawn/0 and spawn/1 ok-branches must register the new pid with
+    // beamtalk_object_instances:register/2, wrapped in try-catch so a missing
+    // registry (e.g. in stdlib unit tests) does not crash the spawn.
+    use crate::ast::*;
+
+    let module = Module::new(vec![], Span::new(0, 0));
+    let code = generate_module(&module, CodegenOptions::new("counter"))
+        .expect("codegen should succeed");
+
+    assert!(
+        code.contains("let _InstReg = try call 'beamtalk_object_instances':'register'("),
+        "spawn must register instance for hot-reload tracking. Got:\n{code}"
+    );
+    assert!(
+        code.contains("of _RegOk -> _RegOk"),
+        "instance registration success arm must return the ok value. Got:\n{code}"
+    );
+    assert!(
+        code.contains("catch <_RegT, _RegE, _RegS> -> 'ok'"),
+        "instance registration must swallow errors when registry is absent. Got:\n{code}"
+    );
+    assert_eq!(
+        code.matches("_InstReg").count(),
+        2,
+        "Both spawn/0 and spawn/1 ok-branches must register the instance. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_spawn_with_args_validates_map_argument() {
+    // BT-473: spawn/1 must guard InitArgs with erlang:is_map before calling
+    // safe_spawn. A non-map raises type_error with the 'spawnWith:' selector
+    // and a descriptive hint.
+    use crate::ast::*;
+
+    let module = Module::new(vec![], Span::new(0, 0));
+    let code = generate_module(&module, CodegenOptions::new("counter"))
+        .expect("codegen should succeed");
+
+    assert!(
+        code.contains("case call 'erlang':'is_map'(InitArgs)"),
+        "spawn/1 must guard InitArgs with erlang:is_map. Got:\n{code}"
+    );
+    assert!(
+        code.contains("<'false'> when 'true' ->"),
+        "spawn/1 must have a false branch for non-map InitArgs. Got:\n{code}"
+    );
+    assert!(
+        code.contains("call 'beamtalk_error':'new'('type_error', 'Counter')"),
+        "spawn/1 false-branch must raise type_error for the class. Got:\n{code}"
+    );
+    assert!(
+        code.contains("call 'beamtalk_error':'with_selector'(TypeErr0, 'spawnWith:')"),
+        "type_error must name selector 'spawnWith:'. Got:\n{code}"
+    );
+    let dict_hint = CoreErlangGenerator::binary_string_literal(
+        "spawnWith: expects a Dictionary argument",
+    );
+    assert!(
+        code.contains(dict_hint.as_str()),
+        "type_error must include the Dictionary hint. Got:\n{code}"
+    );
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs
@@ -3402,7 +3402,7 @@ fn test_abstract_actor_spawn_raises_instantiation_error() {
     );
     // Abstract stubs must never emit an instance-registration call.
     assert!(
-        !code.contains("beamtalk_object_instances':'register'"),
+        !code.contains("'beamtalk_object_instances':'register'"),
         "Abstract actor spawn stubs must not register instances. Got:\n{code}"
     );
 }
@@ -3412,13 +3412,40 @@ fn test_actor_spawn_registers_instance_for_hot_reload() {
     // BT-572: spawn/0 and spawn/1 ok-branches must register the new pid with
     // beamtalk_object_instances:register/2, wrapped in try-catch so a missing
     // registry (e.g. in stdlib unit tests) does not crash the spawn.
-    //
-    // Module::new with no classes relies on the empty-module-defaults-to-actor
-    // fallback in is_actor_class (else { true }). The module name "counter"
-    // synthesises the class atom 'Counter' via the module-name heuristic.
     use crate::ast::*;
 
-    let module = Module::new(vec![], Span::new(0, 0));
+    let class = ClassDefinition {
+        name: Identifier::new("Counter", Span::new(0, 0)),
+        superclass: Some(Identifier::new("Actor", Span::new(0, 0))),
+        superclass_package: None,
+        class_kind: ClassKind::Actor,
+        is_abstract: false,
+        is_sealed: false,
+        is_typed: false,
+        is_internal: false,
+        supervisor_kind: None,
+        state: vec![],
+        methods: vec![],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        superclass_type_args: vec![],
+        comments: CommentAttachment::default(),
+        doc_comment: None,
+        backing_module: None,
+        handle_scope: None,
+        span: Span::new(0, 0),
+    };
+    let module = Module {
+        classes: vec![class],
+        method_definitions: Vec::new(),
+        protocols: Vec::new(),
+        type_aliases: Vec::new(),
+        expressions: Vec::new(),
+        span: Span::new(0, 0),
+        file_leading_comments: vec![],
+        file_trailing_comments: Vec::new(),
+    };
     let code =
         generate_module(&module, CodegenOptions::new("counter")).expect("codegen should succeed");
 
@@ -3465,7 +3492,38 @@ fn test_spawn_with_args_validates_map_argument() {
     // and a descriptive hint.
     use crate::ast::*;
 
-    let module = Module::new(vec![], Span::new(0, 0));
+    let class = ClassDefinition {
+        name: Identifier::new("Counter", Span::new(0, 0)),
+        superclass: Some(Identifier::new("Actor", Span::new(0, 0))),
+        superclass_package: None,
+        class_kind: ClassKind::Actor,
+        is_abstract: false,
+        is_sealed: false,
+        is_typed: false,
+        is_internal: false,
+        supervisor_kind: None,
+        state: vec![],
+        methods: vec![],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        superclass_type_args: vec![],
+        comments: CommentAttachment::default(),
+        doc_comment: None,
+        backing_module: None,
+        handle_scope: None,
+        span: Span::new(0, 0),
+    };
+    let module = Module {
+        classes: vec![class],
+        method_definitions: Vec::new(),
+        protocols: Vec::new(),
+        type_aliases: Vec::new(),
+        expressions: Vec::new(),
+        span: Span::new(0, 0),
+        file_leading_comments: vec![],
+        file_trailing_comments: Vec::new(),
+    };
     let code =
         generate_module(&module, CodegenOptions::new("counter")).expect("codegen should succeed");
 


### PR DESCRIPTION
## Summary

Adds 3 unit tests to `crates/beamtalk-core/src/codegen/core_erlang/tests/dispatch.rs` targeting the uncovered paths in `gen_server/spawn.rs` (CI: 60%):

- **`test_abstract_actor_spawn_raises_instantiation_error`** — builds a `ClassKind::Actor` + `is_abstract: true` module and asserts `spawn/0`/`spawn/1` emit `instantiation_error` stubs (not real `safe_spawn` calls), with correct selectors and the "Abstract classes cannot be instantiated" hint (BT-105, covers `generate_abstract_spawn_error_method` / `generate_abstract_spawn_with_args_error_method`).

- **`test_actor_spawn_registers_instance_for_hot_reload`** — asserts the try-catch `beamtalk_object_instances:register/2` block appears in both `spawn/0` and `spawn/1` ok-branches (BT-572, covers `instance_registration_doc`).

- **`test_spawn_with_args_validates_map_argument`** — asserts `spawn/1` guards `InitArgs` with `erlang:is_map` and raises `type_error` with selector `'spawnWith:'` and the Dictionary hint when the guard fails (BT-473, covers the false-branch of `generate_spawn_with_args_function`).

No production code changes — pure test additions.

Closes #3109

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqVuVPiKiPHk6ZPygqy9tG)_