### PR TITLE
refactor(ast): extract Module::all_methods() to eliminate iteration boilerplate

### DIFF
--- a/crates/beamtalk-core/src/ast/mod.rs
+++ b/crates/beamtalk-core/src/ast/mod.rs
@@ -192,6 +192,20 @@ impl Module {
             file_trailing_comments: Vec::new(),
         }
     }
+
+    /// Iterate every method defined in this module — both inline class methods
+    /// (instance-side and class-side) and standalone Tonel-style definitions.
+    ///
+    /// Use this instead of manually nesting
+    /// `for class in &module.classes { for method in … }` and a separate
+    /// `for standalone in &module.method_definitions { … }` loop when the
+    /// per-method logic does not need the enclosing `ClassDefinition` context.
+    pub fn all_methods(&self) -> impl Iterator<Item = &MethodDefinition> {
+        self.classes
+            .iter()
+            .flat_map(|c| c.methods.iter().chain(c.class_methods.iter()))
+            .chain(self.method_definitions.iter().map(|s| &s.method))
+    }
 }
 
 /// A comment in the source code.

--- a/crates/beamtalk-core/src/ast/mod.rs
+++ b/crates/beamtalk-core/src/ast/mod.rs
@@ -200,7 +200,7 @@ impl Module {
     /// `for class in &module.classes { for method in … }` and a separate
     /// `for standalone in &module.method_definitions { … }` loop when the
     /// per-method logic does not need the enclosing `ClassDefinition` context.
-    pub fn all_methods(&self) -> impl Iterator<Item = &MethodDefinition> {
+    pub(crate) fn all_methods(&self) -> impl Iterator<Item = &MethodDefinition> {
         self.classes
             .iter()
             .flat_map(|c| c.methods.iter().chain(c.class_methods.iter()))

--- a/crates/beamtalk-core/src/lint/inspect_in_string_position.rs
+++ b/crates/beamtalk-core/src/lint/inspect_in_string_position.rs
@@ -34,15 +34,8 @@ pub(crate) struct InspectInStringPositionPass;
 
 impl LintPass for InspectInStringPositionPass {
     fn check(&self, module: &Module, diagnostics: &mut Vec<Diagnostic>) {
-        for class in &module.classes {
-            for method in class.methods.iter().chain(class.class_methods.iter()) {
-                for stmt in &method.body {
-                    walk(&stmt.expression, diagnostics);
-                }
-            }
-        }
-        for standalone in &module.method_definitions {
-            for stmt in &standalone.method.body {
+        for method in module.all_methods() {
+            for stmt in &method.body {
                 walk(&stmt.expression, diagnostics);
             }
         }

--- a/crates/beamtalk-core/src/lint/shadowed_block_param.rs
+++ b/crates/beamtalk-core/src/lint/shadowed_block_param.rs
@@ -39,13 +39,8 @@ impl LintPass for ShadowedBlockParamPass {
         // Top-level expressions (module scope, depth 0)
         check_expr_seq(&module.expressions, &mut scope, diagnostics);
 
-        for class in &module.classes {
-            for method in class.methods.iter().chain(class.class_methods.iter()) {
-                check_method(method, &mut scope, diagnostics);
-            }
-        }
-        for standalone in &module.method_definitions {
-            check_method(&standalone.method, &mut scope, diagnostics);
+        for method in module.all_methods() {
+            check_method(method, &mut scope, diagnostics);
         }
     }
 }

--- a/crates/beamtalk-core/src/lint/sync_send_in_timer_block.rs
+++ b/crates/beamtalk-core/src/lint/sync_send_in_timer_block.rs
@@ -29,15 +29,8 @@ pub(crate) struct SyncSendInTimerBlockPass;
 
 impl LintPass for SyncSendInTimerBlockPass {
     fn check(&self, module: &Module, diagnostics: &mut Vec<Diagnostic>) {
-        for class in &module.classes {
-            for method in class.methods.iter().chain(class.class_methods.iter()) {
-                for stmt in &method.body {
-                    walk_for_timer_sends(&stmt.expression, false, diagnostics);
-                }
-            }
-        }
-        for standalone in &module.method_definitions {
-            for stmt in &standalone.method.body {
+        for method in module.all_methods() {
+            for stmt in &method.body {
                 walk_for_timer_sends(&stmt.expression, false, diagnostics);
             }
         }

--- a/crates/beamtalk-core/src/lint/trailing_caret.rs
+++ b/crates/beamtalk-core/src/lint/trailing_caret.rs
@@ -23,16 +23,8 @@ pub(crate) struct TrailingCaretPass;
 
 impl LintPass for TrailingCaretPass {
     fn check(&self, module: &Module, diagnostics: &mut Vec<Diagnostic>) {
-        for class in &module.classes {
-            for method in &class.methods {
-                check_method(method, diagnostics);
-            }
-            for method in &class.class_methods {
-                check_method(method, diagnostics);
-            }
-        }
-        for standalone in &module.method_definitions {
-            check_method(&standalone.method, diagnostics);
+        for method in module.all_methods() {
+            check_method(method, diagnostics);
         }
     }
 }

--- a/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/lint_validators.rs
@@ -178,18 +178,10 @@ fn empty_body_error(selector: &str, span: Span) -> Diagnostic {
 }
 
 pub(crate) fn check_empty_method_bodies(module: &Module, diagnostics: &mut Vec<Diagnostic>) {
-    for class in &module.classes {
-        for method in class.methods.iter().chain(class.class_methods.iter()) {
-            if method.body.is_empty() {
-                let selector = method.selector.name();
-                diagnostics.push(empty_body_error(&selector, method.span));
-            }
-        }
-    }
-    for standalone in &module.method_definitions {
-        if standalone.method.body.is_empty() {
-            let selector = standalone.method.selector.name();
-            diagnostics.push(empty_body_error(&selector, standalone.method.span));
+    for method in module.all_methods() {
+        if method.body.is_empty() {
+            let selector = method.selector.name();
+            diagnostics.push(empty_body_error(&selector, method.span));
         }
     }
 }


### PR DESCRIPTION
## Summary

The 3-part nested loop for iterating every method in a module was copy-pasted identically across 5 call sites in `beamtalk-core`:

```rust
for class in &module.classes {
    for method in class.methods.iter().chain(class.class_methods.iter()) {
        // per-method work
    }
}
for standalone in &module.method_definitions {
    // same per-method work on standalone.method
}
```

This PR adds `Module::all_methods()` to `ast/mod.rs` and replaces all 5 pure call sites with a single loop.

## Changes

- **`crates/beamtalk-core/src/ast/mod.rs`** — add `pub fn all_methods(&self) -> impl Iterator<Item = &MethodDefinition>` to `impl Module`
- **`src/lint/inspect_in_string_position.rs`** — use `all_methods()`
- **`src/lint/shadowed_block_param.rs`** — use `all_methods()`
- **`src/lint/sync_send_in_timer_block.rs`** — use `all_methods()`
- **`src/lint/trailing_caret.rs`** — use `all_methods()` (replaces two separate instance/class-method loops)
- **`src/semantic_analysis/validators/lint_validators.rs`** — use `all_methods()` in `check_empty_method_bodies`

## Why these 5

All 5 sites delegate directly to a per-method helper with no use of the enclosing `ClassDefinition` (no `class.class_kind`, `class.superclass`, `class.type_params`, etc.), making them mechanical substitutions. Sites that need class context (`cascade_candidate`, `dead_block_assignment`, `structural_validators`, …) are left unchanged.

## Test plan

- [x] `cargo build -p beamtalk-core` — clean
- [x] `cargo test -p beamtalk-core` — 5327 unit + 29 doc tests pass
- [x] `cargo clippy -p beamtalk-core` — clean
- [x] `just ci` — full CI green (pre-push hook ran clippy, dialyzer, fmt, erlfmt, stdlib build)

---
_Generated by [Claude Code](https://claude.ai/code/session_0174vtqnvofDsCi3TxJqnntZ)_