### PR TITLE
docs: ADR 0097 — Desktop Attach Client (Tauri) + implementation plan

### DIFF
--- a/docs/ADR/0097-desktop-attach-client-node-per-workspace.md
+++ b/docs/ADR/0097-desktop-attach-client-node-per-workspace.md
@@ -592,8 +592,22 @@ three small front-side additions (`ensure_distributed/0` sname seed,
 `config/runtime.exs` `BT_ATTACH_BIND_IP`, a `/readiness` router + controller),
 CI release lanes. **Not** affected: the wire/RPC/eval layer, the Rust toolchain.
 
+## Implementation Tracking
+
+**Epic:** BT-2982
+**Issues:**
+- BT-2983 — Front-side attach hooks (sname seed, `BT_ATTACH_BIND_IP`, `/readiness`)
+- BT-2984 — Spike: settle shell (Tauri vs no-shell coordinator), window model, single-instance policy
+- BT-2985 — Desktop broker core (discovery, spawn, two-stage readiness, reaping)
+- BT-2986 — Desktop picker UI (workspace list, attach/detach, first-run empty state)
+- BT-2987 — Packaging: Linux + macOS build lane, signing/notarization
+- BT-2988 — Packaging: Windows support
+- BT-2989 — E2E validation + user docs
+
+**Status:** Planned
+
 ## References
-- Related issues: BT-XXX (to be filed via `/plan-adr`)
+- Related issues: BT-2982 (Epic), BT-2983–BT-2989 (see Implementation Tracking above)
 - Related ADRs:
   [ADR 0017](0017-browser-connectivity-to-running-workspaces.md) (LiveView IDE),
   [ADR 0091](0091-remote-workspace-access-phoenix-authenticated-front.md) (Attach topology + cookie boundary),

--- a/docs/ADR/0097-desktop-attach-client-node-per-workspace.md
+++ b/docs/ADR/0097-desktop-attach-client-node-per-workspace.md
@@ -21,12 +21,18 @@ their dock, not a `localhost:4000` URL they have to remember to start by hand.
 The shaping discussion converged on two constraints that narrow the design
 sharply:
 
-1. **Connect to live workspaces; do not spawn the Rust toolchain.** The desktop
-   app should *attach* to workspaces the user has already started
-   (`beamtalk workspace create … --background --persistent`), discovered from
-   `~/.beamtalk/workspaces/`. It is a client, not a process manager for the
-   language runtime. This removes cross-platform bundling and lifecycle
-   supervision of the Rust `beamtalk` binary — the most painful packaging slice.
+1. **Attach to live workspaces; do not bundle or supervise the Rust
+   toolchain.** The desktop app *attaches* to workspaces discovered from
+   `~/.beamtalk/workspaces/`, typically started with
+   `beamtalk workspace create … --background --persistent`. It is a client, not
+   a process supervisor for the language runtime: it never ships the Rust
+   `beamtalk` binary and never babysits its lifecycle — the most painful
+   packaging slice. The constraint is on **bundling, not invoking**: the broker
+   already shells out to the *installed* CLI for liveness (`workspace status`),
+   and invoking that same CLI for `workspace create`/`stop` costs no additional
+   packaging — `--background --persistent` daemonizes the workspace, so no
+   supervision follows. In-scope lifecycle is "invoke the user's CLI";
+   out-of-scope is shipping or supervising it.
 
 2. **Multiple workspaces, switchable at runtime.** A developer typically has
    more than one workspace alive. The desktop app's reason to exist (over just
@@ -179,9 +185,16 @@ untouched.
    BEAMs are orphaned — the reaping mechanism (process group, parent-death
    watch, or PID-file sweep on next start) must be specified in the spike, since
    crash-reaping is cited below as a load-bearing argument for the Tauri shell.
+5. **Create / stop, via the installed CLI** — the picker's empty state and
+   lifecycle buttons shell out to the user's installed `beamtalk` CLI
+   (`workspace create … --background --persistent`, `workspace stop`) — never a
+   bundled copy (constraint 1). If the CLI can't be resolved (GUI-app `PATH`,
+   §1), the picker degrades to setup instructions: the first-run experience
+   must not be a blank window with an unstated terminal prerequisite.
 
-**Local-only posture (security).** Three things the broker must pin, none of
-which the remote-shaped release does for it:
+**Local-only posture (security).** Three things the broker must pin — none of
+which the remote-shaped release does for it — and one it deliberately leaves
+ephemeral:
 
 - **Loopback bind.** The prod endpoint hardcodes `ip: {0,0,0,0,0,0,0,0}`
   (`runtime.exs:74`) with **no env hook today**, so "the broker passes a bind
@@ -202,16 +215,22 @@ which the remote-shaped release does for it:
   derives from `PORT`, so the origin *likely* matches `http://localhost:<port>`
   already — but it is load-bearing and must be pinned explicitly and validated
   in the spike (§6d), not assumed.
-- **Stable, locked-down secret.** Provision a **stable `SECRET_KEY_BASE` per
-  workspace** (rather than inheriting `bin/server`'s ephemeral-per-boot key) so a
-  front crash + respawn doesn't invalidate the user's live session cookies. This
-  secret signs session cookies — a forged cookie is RCE-equivalent — so it is
-  stored `0600` under the (already `0700`) workspace dir; the same "get it wrong
-  and you expose the workspace" failure-mode framing applies as to the bind.
+- **Ephemeral `SECRET_KEY_BASE` per boot — deliberately.** The broker inherits
+  `bin/server`'s ephemeral-per-boot key rather than provisioning a stable
+  per-workspace secret. In the unauthenticated localhost lane there is no login
+  session worth preserving across a front restart: LiveView state lives in the
+  front's *processes*, which the restart destroyed anyway — the browser
+  remounts fresh whether or not the old session cookie still verifies. A
+  stable secret would add an RCE-adjacent artifact (a forged session cookie ≈
+  eval) with an unspecified writer inside a directory whose lifecycle the Rust
+  CLI owns, for no user-visible benefit. If the remote/OIDC topology (future
+  ADR) ever needs durable sessions, that ADR owns the decision.
 
 ### What this is NOT
 
-- It does **not** spawn or supervise the Rust `beamtalk` workspace runtime.
+- It does **not** bundle or supervise the Rust `beamtalk` workspace runtime —
+  creating/stopping workspaces happens by invoking the user's *installed* CLI
+  (Broker §5), which daemonizes workspaces itself.
 - It does **not** introduce a new wire protocol — the front still speaks the
   same `:rpc` it does today.
 - It does **not** add per-session node targeting to `workspace.ex` (the
@@ -250,10 +269,12 @@ at-URL). That shared surface is the natural seam at which a future
 "desktop remote attach + OIDC" ADR would extend this one — it does not require
 revisiting any decision here.
 
-### Decided sub-decisions
+### Open sub-decisions (deferred to implementation spike)
 
-- **Shell: Tauri.** The desktop shell is a **Tauri (Rust) app**, not Electron.
-  Three reasons. First, **language coherence**: the Beamtalk compiler/CLI is
+- **Shell: Tauri (recommendation, spike-confirmed).** Recommendation: a
+  **Tauri (Rust) app**, not Electron — a *recommendation the spike must
+  confirm*, not a settled decision; the CI build lane (§5) waits for its
+  verdict. Three reasons. First, **language coherence**: the Beamtalk compiler/CLI is
   already Rust, so a Rust shell keeps the toolchain in one language — the broker
   logic (discovery, spawn, port allocation, child reaping) is ordinary Rust
   process handling, reviewable by the same people who own `beamtalk-cli`.
@@ -273,12 +294,9 @@ revisiting any decision here.
   still lets the browser/OS consume `Ctrl/Cmd-W` (it closes the PWA window), and
   the page still cannot `preventDefault` it — so editor-grade key ownership is a
   concrete capability that tips the spike's shell decision toward Tauri.
-  Caveat: the spike (Implementation §6) builds the no-shell coordinator
-  alternative alongside and must confirm the Rust shell earns its keep over it
-  before the CI build lane is committed.
-
-### Open sub-decisions (deferred to implementation spike)
-
+  The spike (Implementation §6) builds the no-shell coordinator alternative
+  alongside; its exit criteria (a)–(g) — including webview keybinding and
+  rendering parity, which cut *against* Tauri on Linux — decide the shell.
 - **Window model: window-per-workspace vs tabbed.** Recommendation:
   **window-per-workspace**. It falls straight out of one-BEAM-per-workspace and
   keeps crash isolation visible to the user (a dead workspace = one greyed
@@ -328,11 +346,13 @@ cookie-bearing dist nodes.
 - **End-user developer (uses the IDE).** Opens a native app, sees a list of
   live workspaces, clicks one, gets a window. No `localhost:4000` to remember,
   no `mix`/Elixir on their machine (ERTS is bundled). Mental model:
-  one window = one workspace.
+  one window = one workspace. First run with no workspaces is a real state:
+  the picker offers "create a workspace" via the installed CLI (Broker §5), or
+  setup instructions if the CLI isn't found — never a silent empty list.
 - **IDE contributor.** `workspace.ex` is untouched, so the from-source
   `just web` flow and its tests are unaffected. The new surface is a small
-  shell + a free-`PORT` per instance and (optionally) a one-line self-node-name
-  seeding in `ensure_distributed/0`. Low blast radius.
+  shell + a free-`PORT` per instance and a small self-node-name seeding
+  (id + entropy) in `ensure_distributed/0`. Low blast radius.
 - **Operator / security.** The cookie boundary (ADR 0091) is *strengthened* on
   the isolation axis: each front node carries exactly one workspace's cookie, so
   a compromise or crash is contained to one workspace. (A single node *could*
@@ -430,8 +450,8 @@ code. **This is the real 80/20 challenger**: it delivers discovery + a
 dock icon + pick-a-workspace without Tauri, a Rust broker, or a new CI build
 lane. **Not rejected outright** — instead, the spike (Implementation §6) must
 build this *first* and justify the Tauri shell against it. The Tauri case rests
-on things the coordinator can't easily do: enforcing the loopback/no-OIDC
-posture and `SECRET_KEY_BASE` provisioning *outside* the BEAM (a coordinator
+on things the coordinator can't easily do: enforcing the
+loopback/no-OIDC/`check_origin` posture *outside* the BEAM (a coordinator
 front would have to spawn children with the same care anyway), true per-window
 OS integration, **ownership of OS-reserved keybindings** (`Ctrl/Cmd-W` etc. as
 IDE actions — see "Shell: Tauri"; a PWA window still cedes these to the browser),
@@ -439,12 +459,26 @@ and reaping orphaned child processes on crash. If those don't
 prove load-bearing in the spike, the coordinator wins and this ADR's
 shell choice should flip.
 
-### Desktop app spawns the Rust workspace too
-Bundle and supervise `beamtalk workspace create` from the shell. **Rejected**
-per the framing constraint: it reintroduces cross-platform bundling of the Rust
-toolchain and lifecycle supervision of a second, less-well-behaved process —
-the most expensive and platform-fragile slice — for no benefit to the "attach
-to what's already running" use case.
+### Desktop app bundles and supervises the Rust workspace runtime
+Ship the Rust toolchain inside the app and supervise workspace processes from
+the shell. **Rejected** per the framing constraint: it reintroduces
+cross-platform bundling of the Rust toolchain and lifecycle supervision of a
+second, less-well-behaved process — the most expensive and platform-fragile
+slice. What is *not* rejected: invoking the user's already-installed CLI to
+create/stop workspaces (Broker §5). An earlier "attach-only" framing conflated
+bundling with invoking; the rejection applies to bundling only.
+
+### `beamtalk workspace open <id>` — CLI-only launcher, no desktop app
+Add a CLI command that spawns a front for the workspace (free port, loopback
+bind) and opens the browser/PWA at it; discovery is `beamtalk workspace list`.
+Zero new artifacts, no CI lane, no GUI-`PATH` problem (the CLI *is* the entry
+point), and it fits ADR 0099's CLI application story. **Rejected as a
+replacement, cheap as a complement**: it delivers launch but none of the
+connection-broker UX — no persistent picker, no window management, no
+post-attach monitoring or orphan reaping (stray fronts accumulate with no
+owner) — and it inherits the PWA path's inability to own OS-reserved
+keybindings. Worth shipping *independently* of this ADR as a CLI affordance;
+the spike's no-shell coordinator comparison effectively subsumes it.
 
 ## Consequences
 
@@ -452,7 +486,7 @@ to what's already running" use case.
 - **Small, additive front changes — the attach client's core is untouched.**
   Reuses the shipped boot-time global-env model and `bin/server` discovery; the
   RPC/eval path is unchanged. The new front-side work is three small, additive
-  pieces (Impl §1): a one-line sname seed, a `BT_ATTACH_BIND_IP` env hook in
+  pieces (Impl §1): an id+entropy sname seed, a `BT_ATTACH_BIND_IP` env hook in
   `config/runtime.exs`, and a minimal `/readiness` endpoint.
 - **Blast-radius and crash isolation** — one workspace's cookie per process, one
   window per front.
@@ -480,19 +514,20 @@ to what's already running" use case.
   the front refuses or warns on mismatch.
 - **The broker inherits security-critical responsibilities the BEAM release
   won't enforce for it:** forcing a loopback bind (the prod default is
-  all-interfaces), refusing OIDC config, and provisioning a stable
-  `SECRET_KEY_BASE`. Get any wrong and you either expose the IDE to the LAN or
-  break the user's session on every restart. These are the price of reusing the
-  remote-shaped release as a local tool.
+  all-interfaces), refusing OIDC config, and pinning `check_origin`. Get one
+  wrong and you expose an unauthenticated eval surface to the LAN (or to
+  drive-by-localhost pages). These are the price of reusing the remote-shaped
+  release as a local tool.
 
 ### Neutral
 - Does not foreclose a later move to single-node per-session targeting; the
   broker can collapse if that refactor lands.
-- Shell is **Tauri (Rust)** (language coherence with the compiler/CLI),
-  *contingent on the spike* showing the broker's loopback/no-OIDC/secret +
-  crash-reaping duties need to live outside the BEAM; if not, the no-shell
-  coordinator front wins and the shell choice flips. The window model
-  (per-workspace vs tabbed) is likewise deferred to the spike.
+- Shell **recommendation is Tauri (Rust)** (language coherence with the
+  compiler/CLI) — an open sub-decision the spike settles: it must show the
+  broker's loopback/no-OIDC/`check_origin` + crash-reaping duties need to live
+  outside the BEAM; if not, the no-shell coordinator front wins and the shell
+  choice flips. The window model (per-workspace vs tabbed) and single-instance
+  policy are likewise deferred to the spike.
 
 ## Implementation
 
@@ -515,7 +550,8 @@ to what's already running" use case.
    then `GET /readiness` for true workspace reachability — distribution starts
    lazily, so HTTP-up alone is not enough), child-exit reaping. (~M)
 3. **Picker / launcher UI** — native list of live workspaces, attach/detach,
-   disconnected-state handling. (~M)
+   disconnected-state handling, the first-run empty state, and create/stop via
+   the installed CLI (Broker §5). (~M)
 4. **Window-per-workspace wiring** — one window per attached front. (~S)
 5. **Packaging** — bundle the `bt_attach` release into the shell; CI release
    lane mirroring `liveview-release.yml`. Three named costs the "reuse
@@ -563,7 +599,8 @@ CI release lanes. **Not** affected: the wire/RPC/eval layer, the Rust toolchain.
   [ADR 0091](0091-remote-workspace-access-phoenix-authenticated-front.md) (Attach topology + cookie boundary),
   [ADR 0058](0058-platform-security-model.md) (Trusted Developer Tool stance),
   [ADR 0046](0046-vscode-live-workspace-sidebar.md) (per-connection client precedent),
-  [ADR 0020](0020-connection-security.md) (transport/cookie machinery)
+  [ADR 0020](0020-connection-security.md) (transport/cookie machinery),
+  [ADR 0099](0099-cli-application-story.md) (CLI application story — the `workspace open` alternative)
 - Documentation: `editors/liveview/README.md`,
   `editors/liveview/rel/overlays/bin/server`,
   `docs/research/phoenix-topology-spike.md`,

--- a/docs/ADR/0097-desktop-attach-client-node-per-workspace.md
+++ b/docs/ADR/0097-desktop-attach-client-node-per-workspace.md
@@ -67,6 +67,16 @@ The release is already self-contained (ERTS-embedded `mix release`), and `PORT`
 browser mount (`connect/0` → `ensure_distributed/0`), not at boot. Discovery
 data (`metadata.json` + `cookie`) already lives on disk in a stable layout.
 
+One invariant to state rather than assume: the front's lazy
+`:net_kernel.start/1` — unlike `erl -sname` boot — does **not** auto-start
+epmd; it fails if none is listening. The design therefore assumes
+"workspace running ⇒ epmd listening on loopback 4369", which holds today
+because the workspace's own boot daemonizes epmd. If workspace lifecycle ever
+adopts the pinned-dist-port / **epmdless** direction ADR 0091 floats for its
+private-network posture, the front's name-resolution path breaks with no
+fallback — a known future incompatibility, and why `/readiness` should report
+*epmd absent* as its own failure mode (Impl §1c).
+
 ### Constraints
 
 - **Don't regress `workspace.ex`.** It is the attach client shared with the
@@ -111,9 +121,14 @@ PORT=<free-port> bin/server <id>
   `RELEASE_NODE` override is needed. One caveat (Implementation §1): that
   integer is `System.unique_integer/1`, which is per-VM, so two *separate* front
   processes could in principle generate the same sname and collide on epmd.
-  Seeding the name with the workspace id — a one-line change to
-  `ensure_distributed/0` (or a `BT_ATTACH_NODE_SUFFIX` env it reads) — makes it
-  collision-free across processes. This is the smallest of the front-side
+  Seeding the name with the workspace id **plus per-process entropy** (e.g.
+  `bt_attach_<id>_<os_pid>@localhost`, via a `BT_ATTACH_NODE_SUFFIX` env
+  `ensure_distributed/0` reads) makes it collision-free across processes.
+  An id-*only* seed would invert the bug: two fronts attached to the **same**
+  workspace — a second window, a second broker instance, or a crash→respawn
+  racing the dying front's epmd deregistration — would collide
+  *deterministically*, in exactly the scenarios the spike (§6b) probes.
+  This is the smallest of the front-side
   touches; the design also needs a `BT_ATTACH_BIND_IP` hook in
   `config/runtime.exs` and a minimal `/readiness` endpoint (both below) — all
   small and additive, but not literally "one line."
@@ -130,7 +145,17 @@ untouched.
 ### Broker responsibilities (desktop main process)
 
 1. **Discover** — enumerate `~/.beamtalk/workspaces/*/metadata.json`; liveness
-   via `beamtalk workspace status` (or a dist ping).
+   via the installed `beamtalk` CLI (`workspace status`) or a direct epmd query
+   (TCP 4369 `NAMES`) — a *dist ping* is **not** available to a non-BEAM broker
+   without implementing the distribution handshake, so it is not a fallback.
+   Two contracts this surfaces: (a) GUI apps launched from Finder/the dock do
+   not inherit the user's shell `PATH`, so the CLI path must be resolved
+   explicitly (configurable, with sane defaults) if the CLI route is used;
+   (b) the broker parses `metadata.json` with a real JSON parser (not
+   `bin/server`'s `sed` extraction), and an independently-updating desktop app
+   coupling to a file layout owned by the Rust CLI needs a stated compat
+   contract (additive-only fields, or a version field) — today that layout is
+   stable by convention, not by contract.
 2. **Attach** — pick a free port, spawn the node as above pinned to a **loopback
    bind** and the **unauthenticated cookie-only** path (see local-only posture
    below), then probe for readiness before opening the window. Note the probe is
@@ -142,7 +167,18 @@ untouched.
    on the user's first eval. That endpoint does **not** exist today; it is a
    small, explicit addition to the front's router + a thin controller (see
    Implementation §1) — not free, but contained.
-3. **Detach / quit** — terminate that node's child process; the window closes.
+3. **Monitor** — the readiness probe runs once, before the window opens;
+   attachment health after that is not free. The broker re-polls `/readiness`
+   periodically post-attach to drive window state (the "dead workspace = greyed
+   window" UX needs this mechanism — a dead workspace does *not* kill the front,
+   whose RPCs just start returning `{:badrpc, :nodedown}`), and the front should
+   retry `connect/0` on `:nodedown` so OS sleep/resume — which drops dist
+   connections — self-heals.
+4. **Detach / quit** — terminate that node's child process; the window closes.
+   If the *broker* dies uncleanly (SIGKILL, logout), N cookie-bearing front
+   BEAMs are orphaned — the reaping mechanism (process group, parent-death
+   watch, or PID-file sweep on next start) must be specified in the spike, since
+   crash-reaping is cited below as a load-bearing argument for the Tauri shell.
 
 **Local-only posture (security).** Three things the broker must pin, none of
 which the remote-shaped release does for it:
@@ -159,6 +195,13 @@ which the remote-shaped release does for it:
   localhost lane (ADR 0091 §"Local dev stays zero-config"), not a place to
   silently half-enforce remote auth. (`runtime.exs:32` runs `IdeConfig.load!()`
   for every non-test boot, so a stray config would otherwise take effect.)
+- **Origin pinning.** The front is an *unauthenticated, eval-capable* LiveView
+  websocket on a dynamic port — exactly the surface where `check_origin` is the
+  remaining defense against drive-by-localhost / DNS-rebinding eval (the threat
+  ADR 0091 reasons about for its remote posture). The endpoint's `url` config
+  derives from `PORT`, so the origin *likely* matches `http://localhost:<port>`
+  already — but it is load-bearing and must be pinned explicitly and validated
+  in the spike (§6d), not assumed.
 - **Stable, locked-down secret.** Provision a **stable `SECRET_KEY_BASE` per
   workspace** (rather than inheriting `bin/server`'s ephemeral-per-boot key) so a
   front crash + respawn doesn't invalidate the user's live session cookies. This
@@ -240,6 +283,11 @@ revisiting any decision here.
   **window-per-workspace**. It falls straight out of one-BEAM-per-workspace and
   keeps crash isolation visible to the user (a dead workspace = one greyed
   window, not a dead tab in a shared shell).
+- **Single-instance policy and attach-twice semantics.** Is the broker a
+  single-instance app (Tauri single-instance plugin / lockfile), and what does
+  attaching twice to the same workspace mean — focus the existing window, or
+  spawn a second front? Both interact with the sname seed (two fronts on one
+  workspace must not collide) and port bookkeeping; decide in the spike.
 
 ## Prior Art
 
@@ -294,8 +342,12 @@ cookie-bearing dist nodes.
   path by default, so a naïve "just run `bin/server`" would *regress* 0091 by
   exposing an unauthenticated IDE to the LAN. The broker must force loopback and
   reject OIDC config. Given that, no new remote surface is added, and the app
-  cannot escalate privilege — it only reaches workspaces whose cookies are
-  already readable on disk by this user.
+  cannot escalate privilege *on a single-user machine* — it only reaches
+  workspaces whose cookies are already readable on disk by this user. On a
+  **shared host**, loopback ≠ single-user: any local user or process can open
+  `http://localhost:<port>` and eval as the workspace owner. That is ADR 0058's
+  trusted-developer-tool stance, accepted — but it is a stance, not an absence
+  of surface.
 - **BEAM veteran.** "One dist node per trust domain" reads as obviously correct;
   they'd be wary of the alternative concentrating several workspaces' cookies in
   one VM. `observer`/`recon` work per-front-node exactly as today.
@@ -417,6 +469,15 @@ to what's already running" use case.
 - **Per-instance port (and sname-uniqueness) management** is new surface the
   broker owns — including reusing a port and re-registering the same sname after
   a front crashes (epmd must have dropped the dead registration first).
+- **The desktop artifact introduces version skew for the first time.** Today
+  `just web` builds front and workspace from the same tree, so skew cannot
+  occur. A bundled `bt_attach` (+ its ERTS/OTP) updates on the app's cadence
+  while the workspace runs whatever runtime the user installed — and the front
+  RPCs into workspace-internal modules by name (`beamtalk_repl_ops` etc.), a
+  private surface with no versioned protocol; the dist protocol itself must
+  also stay OTP-compatible across the gap. The `/readiness` handshake (Impl
+  §1c) is the mitigation: the workspace reports a runtime/protocol version and
+  the front refuses or warns on mismatch.
 - **The broker inherits security-critical responsibilities the BEAM release
   won't enforce for it:** forcing a loopback bind (the prod default is
   all-interfaces), refusing OIDC config, and provisioning a stable
@@ -436,13 +497,18 @@ to what's already running" use case.
 ## Implementation
 
 1. **Front-side hooks (three small, additive changes).** (a) seed
-   `ensure_distributed/0`'s sname with the workspace id (or a
-   `BT_ATTACH_NODE_SUFFIX` env) so two front processes can't collide on epmd;
+   `ensure_distributed/0`'s sname with the workspace id **plus per-process
+   entropy** (e.g. `bt_attach_<id>_<os_pid>`, via a `BT_ATTACH_NODE_SUFFIX`
+   env) so two front processes can't collide on epmd — id-only would collide
+   deterministically when two fronts attach to the same workspace;
    (b) read `BT_ATTACH_BIND_IP` in `config/runtime.exs` (default = today's
    all-interfaces) so the broker can pin loopback; (c) add a `/readiness`
    endpoint (router + thin controller) that forces `connect/0` + one cheap RPC
-   and returns 200 only when the workspace is actually reachable. Confirm `PORT`
-   passthrough. (~S)
+   and returns 200 only when the workspace is actually reachable — including a
+   **version handshake** (workspace reports its runtime/protocol version; the
+   front refuses or warns on mismatch) and a failure taxonomy that
+   distinguishes *epmd absent* from *bad cookie* from *dead workspace*.
+   Confirm `PORT` passthrough. (~S)
 2. **Broker core (desktop main process)** — discovery of
    `~/.beamtalk/workspaces/*`, free-port selection, spawn with `PORT` +
    `BT_ATTACH_BIND_IP` + cookie env, **two-stage readiness probe** (HTTP port up,
@@ -452,16 +518,35 @@ to what's already running" use case.
    disconnected-state handling. (~M)
 4. **Window-per-workspace wiring** — one window per attached front. (~S)
 5. **Packaging** — bundle the `bt_attach` release into the shell; CI release
-   lane mirroring `liveview-release.yml`. (~M)
+   lane mirroring `liveview-release.yml`. Three named costs the "reuse
+   `bin/server`" framing hides: (a) an ERTS-embedded release is per-OS/per-arch,
+   so this is a **build matrix** (macOS arm64 + x86_64, Linux x86_64, Windows —
+   ADR 0027 makes Windows a supported platform), not one artifact; (b)
+   `bin/server` is a POSIX `sh` script with no Windows counterpart — on Windows
+   the broker must set the env and invoke `bin/bt_attach` itself; (c) macOS
+   notarization requires signing every nested Mach-O in the release
+   (`beam.smp`, NIFs, epmd) — Livebook treats this as a substantial ongoing
+   surface, not a one-off. (~L, was ~M)
 6. **Spike first**, and make it decide the shell question. Validate: (a)
    two-instance boot (distinct snames + ports); (b) **crash → respawn of the
    *same* workspace** — same seeded sname must re-register cleanly after epmd
    drops the dead one, and the freed port must be reusable; (c) the attach-health
    probe catching a dead-workspace/bad-cookie before the window opens; (d) the
-   loopback-bind + no-OIDC posture actually takes. Build the **no-shell
-   coordinator** (Alternatives) alongside and only commit to the Tauri shell +
-   CI lane (§5) if the broker responsibilities prove they need to live outside
-   the BEAM. (~M, was ~S — this is the load-bearing spike, not a warm-up.)
+   loopback-bind + no-OIDC + pinned-`check_origin` posture actually takes;
+   (e) **webview parity**: OS-reserved keybinding interception (`Cmd/Ctrl-W`
+   etc.) actually works in the Tauri webview on all three platforms — the
+   keybinding argument for Tauri is asserted from *browser* behavior, not yet
+   demonstrated in WebKitGTK/WebView2/WKWebView — and WebKitGTK's
+   rendering/websocket performance is adequate for an editor-grade LiveView
+   UI (a known Tauri-on-Linux risk that cuts *against* the shell as surely as
+   the keybinding argument cuts for it); (f) post-attach lifecycle: workspace
+   killed while attached → greyed window (not a wall of LiveView errors), and
+   sleep/resume → reconnect; (g) the orphan-reaping mechanism on broker crash,
+   concretely. Build the **no-shell coordinator** (Alternatives) alongside and
+   only commit to the Tauri shell + CI lane (§5) if the broker responsibilities
+   prove they need to live outside the BEAM — the spike's exit criteria are
+   (a)–(g), decided per-duty, not vibes. (~M, was ~S — this is the load-bearing
+   spike, not a warm-up.)
 
 Rough total: ~2 weeks, low risk — the front changes are small and additive; the
 attach client's RPC/eval core is untouched.

--- a/docs/ADR/0097-desktop-attach-client-node-per-workspace.md
+++ b/docs/ADR/0097-desktop-attach-client-node-per-workspace.md
@@ -44,9 +44,9 @@ The `bt_attach` front is hardwired to a **single** workspace, fixed at boot:
 | Mechanism | Where | Behaviour |
 |-----------|-------|-----------|
 | Target node | `workspace.ex:54` (`node_name/0`) | reads `BT_WORKSPACE_NODE` env **once**, module-global |
-| Cookie | `workspace.ex:951` `set_cookie/0` | reads `BT_WORKSPACE_COOKIE` env, calls `Node.set_cookie(node_name(), token)` — the **per-peer** arity (`erlang:set_cookie(Node, Cookie)`), scoped to the one target node |
-| Self node name | `workspace.ex:936` `ensure_distributed/0` | the front starts its *own* distribution via `:net_kernel.start([:"bt_attach_#{System.unique_integer([:positive])}@localhost", :shortnames])` — it does **not** use `RELEASE_NODE` |
-| Every RPC | `workspace.ex:966` `rpc/3` | `:rpc.call(node_name(), …)` — always the one global target |
+| Cookie | `workspace.ex:1966` `set_cookie/0` | reads `BT_WORKSPACE_COOKIE` env, calls `Node.set_cookie(node_name(), token)` — the **per-peer** arity (`erlang:set_cookie(Node, Cookie)`), scoped to the one target node |
+| Self node name | `workspace.ex:1951` `ensure_distributed/0` | the front starts its *own* distribution via `:net_kernel.start([:"bt_attach_#{System.unique_integer([:positive])}@localhost", :shortnames])` — it does **not** use `RELEASE_NODE` |
+| Every RPC | `workspace.ex:1981` `rpc/3` | `:rpc.call(node_name(), …)` — always the one global target |
 | Launcher | `rel/overlays/bin/server <id>` | resolves `node_name` from `~/.beamtalk/workspaces/<id>/metadata.json` + the sibling `cookie` file, exports the two env vars, runs `bin/bt_attach start` |
 
 So today: **one front node, bound to one workspace, for the life of the
@@ -82,7 +82,7 @@ data (`metadata.json` + `cookie`) already lives on disk in a stable layout.
   Two facts about the **prod** release make this an active requirement, not a
   given: (1) `config/runtime.exs:74` binds the endpoint to **all interfaces**
   (`{0,0,0,0,0,0,0,0}`), not loopback — a desktop front left at that default is
-  reachable from the LAN; and (2) `runtime.exs:31` runs `IdeConfig.load!()` for
+  reachable from the LAN; and (2) `runtime.exs:32` runs `IdeConfig.load!()` for
   every non-test boot, so a stray `~/.beamtalk/ide.toml` (or `BT_OIDC_*`) makes
   each spawned front enforce OIDC login. The broker must pin both: bind loopback
   and run the unauthenticated cookie-only path.
@@ -157,7 +157,7 @@ which the remote-shaped release does for it:
 - **No OIDC.** Refuse to spawn, with a clear error, if OIDC config is present
   (`~/.beamtalk/ide.toml` / `BT_OIDC_*`) — the desktop tool is the single-user
   localhost lane (ADR 0091 §"Local dev stays zero-config"), not a place to
-  silently half-enforce remote auth. (`runtime.exs:31` runs `IdeConfig.load!()`
+  silently half-enforce remote auth. (`runtime.exs:32` runs `IdeConfig.load!()`
   for every non-test boot, so a stray config would otherwise take effect.)
 - **Stable, locked-down secret.** Provision a **stable `SECRET_KEY_BASE` per
   workspace** (rather than inheriting `bin/server`'s ephemeral-per-boot key) so a


### PR DESCRIPTION
## Summary

- Adds ADR 0097: a desktop wrapper for the LiveView IDE (`bt_attach`), built as a Tauri-shelled **connection broker** — one dedicated front BEAM node per attached workspace, giving process-level cookie/blast-radius isolation instead of a single multiplexed node.
- Hardens the ADR from a three-pass review (structural/factual, reasoning, and an adversarial pass by an independent agent): fixed stale code line references, corrected the sname-seeding spec (id-only seeding was a deterministic self-collision bug), added `check_origin` pinning and a shared-host caveat to the security posture, named version-skew as a consequence with a `/readiness` version handshake, re-scoped packaging cost for a real per-platform build matrix (Windows has no POSIX `bin/server` equivalent; macOS notarization must sign nested Mach-O binaries), and specified post-attach lifecycle (workspace death, sleep/resume, orphan reaping on broker crash).
- Resolved three open design questions: (1) reframed "attach-only" as bundle-vs-invoke — creating/stopping workspaces via the user's installed CLI is now in scope, with an honest first-run empty-state and a `beamtalk workspace open` alternative documented; (2) dropped the proposed stable per-workspace `SECRET_KEY_BASE` in favor of keeping the existing ephemeral-per-boot key, since there's no session worth preserving in the unauthenticated localhost lane; (3) demoted "Shell: Tauri" from a Decided sub-decision to an Open sub-decision — a spike-confirmed recommendation, not a settled choice, so the CI build lane doesn't start before the spike's verdict.
- Runs `/plan-adr`: creates Epic **BT-2982** and 7 phased, dependency-ordered, agent-ready child issues (BT-2983–BT-2989) covering front-side hooks, the shell-choice spike, broker core, picker UI, Linux/macOS + Windows packaging, and e2e validation + docs. The ADR now carries an Implementation Tracking section linking back to the epic.

## Test plan

- [x] Docs-only change; no code paths touched — `just ci` is not required for this diff
- [x] All ADR code/line-number references re-verified against the current `editors/liveview` source (`workspace.ex`, `config/runtime.exs`, `bin/server`, `keyboard_shortcuts.js`) during review
- [x] All 7 child Linear issues created with acceptance criteria, file lists, and blocking relationships (`BT-2983 → BT-2984 → BT-2985 → BT-2986 → {BT-2987, BT-2989}`, `BT-2987 → BT-2988 → BT-2989`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163GbojmCBrHjHS92KzV99m