### PR TITLE
refactor: consolidate escape_erlang_string into beamtalk-core

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -86,28 +86,7 @@ fn is_runtime_unavailable_error(err: &miette::Report) -> bool {
     msg.starts_with(RUNTIME_UNAVAILABLE_PREFIX)
 }
 
-/// Escapes a string for use in an Erlang string literal.
-///
-/// This escapes backslashes, quotes, and control characters to prevent
-/// injection attacks and ensure valid Erlang term syntax when constructing
-/// Erlang terms from file paths and other user-supplied strings.
-///
-/// Handles: `\`, `"`, `\n`, `\r`, `\t`, `\0`.
-pub(crate) fn escape_erlang_string(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '\\' => result.push_str("\\\\"),
-            '"' => result.push_str("\\\""),
-            '\n' => result.push_str("\\n"),
-            '\r' => result.push_str("\\r"),
-            '\t' => result.push_str("\\t"),
-            '\0' => result.push_str("\\0"),
-            _ => result.push(c),
-        }
-    }
-    result
-}
+pub(crate) use beamtalk_core::codegen::core_erlang::escape_erlang_string;
 
 /// Validates that a module name contains only safe identifier characters.
 ///
@@ -1239,55 +1218,6 @@ end
         // Check that output directory was created and compilation succeeded
         assert!(output_dir.exists());
         result.expect("compile_batch should succeed when escript is available");
-    }
-
-    // Tests for escape_erlang_string
-    #[test]
-    fn test_escape_erlang_string_empty() {
-        assert_eq!(escape_erlang_string(""), "");
-    }
-
-    #[test]
-    fn test_escape_erlang_string_no_special_chars() {
-        assert_eq!(escape_erlang_string("hello"), "hello");
-        assert_eq!(escape_erlang_string("foo_bar"), "foo_bar");
-        assert_eq!(escape_erlang_string("path/to/file"), "path/to/file");
-    }
-
-    #[test]
-    fn test_escape_erlang_string_backslashes() {
-        assert_eq!(escape_erlang_string("a\\b"), "a\\\\b");
-        assert_eq!(escape_erlang_string("\\\\"), "\\\\\\\\");
-    }
-
-    #[test]
-    fn test_escape_erlang_string_quotes() {
-        assert_eq!(escape_erlang_string("a\"b"), "a\\\"b");
-        assert_eq!(escape_erlang_string("\"test\""), "\\\"test\\\"");
-    }
-
-    #[test]
-    fn test_escape_erlang_string_newlines() {
-        assert_eq!(escape_erlang_string("line1\nline2"), "line1\\nline2");
-        assert_eq!(escape_erlang_string("\r\n"), "\\r\\n");
-    }
-
-    #[test]
-    fn test_escape_erlang_string_tabs() {
-        assert_eq!(escape_erlang_string("col1\tcol2"), "col1\\tcol2");
-    }
-
-    #[test]
-    fn test_escape_erlang_string_null_byte() {
-        assert_eq!(escape_erlang_string("\0"), "\\0");
-    }
-
-    #[test]
-    fn test_escape_erlang_string_combined() {
-        assert_eq!(
-            escape_erlang_string("path\\to\\\"file\"\n"),
-            "path\\\\to\\\\\\\"file\\\"\\n"
-        );
     }
 
     // Tests for is_valid_module_name

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -111,6 +111,7 @@ mod variable_context;
 
 // Re-export utility functions for IDE queries
 pub use util::escape_atom_chars;
+pub use util::escape_erlang_string;
 pub use util::to_module_name;
 
 use crate::ast::{Block, Expression, MessageSelector, Module, WellKnownSelector};

--- a/crates/beamtalk-core/src/codegen/core_erlang/util.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/util.rs
@@ -90,7 +90,7 @@ pub(super) fn escape_core_erlang_string(s: &str) -> String {
 /// embed between `"..."` in generated Erlang source (e.g. `-eval` arguments,
 /// path strings passed to `erlc`, `.app` descriptions).
 ///
-/// This is distinct from [`escape_core_erlang_string`], which is a lighter
+/// This is distinct from `escape_core_erlang_string`, which is a lighter
 /// variant for Core Erlang `.core` output.
 #[must_use]
 pub fn escape_erlang_string(s: &str) -> String {

--- a/crates/beamtalk-core/src/codegen/core_erlang/util.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/util.rs
@@ -84,6 +84,31 @@ pub(super) fn escape_core_erlang_string(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
+/// Escapes special characters for embedding in an Erlang string literal.
+///
+/// Handles `\`, `"`, `\n`, `\r`, `\t`, and `\0` so the result is safe to
+/// embed between `"..."` in generated Erlang source (e.g. `-eval` arguments,
+/// path strings passed to `erlc`, `.app` descriptions).
+///
+/// This is distinct from [`escape_core_erlang_string`], which is a lighter
+/// variant for Core Erlang `.core` output.
+#[must_use]
+pub fn escape_erlang_string(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => result.push_str("\\\\"),
+            '"' => result.push_str("\\\""),
+            '\n' => result.push_str("\\n"),
+            '\r' => result.push_str("\\r"),
+            '\t' => result.push_str("\\t"),
+            '\0' => result.push_str("\\0"),
+            _ => result.push(c),
+        }
+    }
+    result
+}
+
 /// Escapes special characters in an atom name for Core Erlang.
 ///
 /// Replaces `\` with `\\` and `'` with `\'` so the result is safe to embed
@@ -547,6 +572,54 @@ mod tests {
         assert_eq!(
             escape_core_erlang_string("C:\\Users\\foo\\bar.bt"),
             "C:\\\\Users\\\\foo\\\\bar.bt"
+        );
+    }
+
+    #[test]
+    fn test_escape_erlang_string_empty() {
+        assert_eq!(escape_erlang_string(""), "");
+    }
+
+    #[test]
+    fn test_escape_erlang_string_no_special_chars() {
+        assert_eq!(escape_erlang_string("hello"), "hello");
+        assert_eq!(escape_erlang_string("foo_bar"), "foo_bar");
+        assert_eq!(escape_erlang_string("path/to/file"), "path/to/file");
+    }
+
+    #[test]
+    fn test_escape_erlang_string_backslashes() {
+        assert_eq!(escape_erlang_string("a\\b"), "a\\\\b");
+        assert_eq!(escape_erlang_string("\\\\"), "\\\\\\\\");
+    }
+
+    #[test]
+    fn test_escape_erlang_string_quotes() {
+        assert_eq!(escape_erlang_string("a\"b"), "a\\\"b");
+        assert_eq!(escape_erlang_string("\"test\""), "\\\"test\\\"");
+    }
+
+    #[test]
+    fn test_escape_erlang_string_newlines() {
+        assert_eq!(escape_erlang_string("line1\nline2"), "line1\\nline2");
+        assert_eq!(escape_erlang_string("\r\n"), "\\r\\n");
+    }
+
+    #[test]
+    fn test_escape_erlang_string_tabs() {
+        assert_eq!(escape_erlang_string("col1\tcol2"), "col1\\tcol2");
+    }
+
+    #[test]
+    fn test_escape_erlang_string_null_byte() {
+        assert_eq!(escape_erlang_string("\0"), "\\0");
+    }
+
+    #[test]
+    fn test_escape_erlang_string_combined() {
+        assert_eq!(
+            escape_erlang_string("path\\to\\\"file\"\n"),
+            "path\\\\to\\\\\\\"file\\\"\\n"
         );
     }
 

--- a/crates/beamtalk-core/src/ffi_type_specs.rs
+++ b/crates/beamtalk-core/src/ffi_type_specs.rs
@@ -26,6 +26,7 @@
 //! [`collect_project_dependency_ebin_dirs`] to resolve those directories from
 //! a project root; `beamtalk-cli` additionally wraps this via `BuildLayout`.
 
+use crate::codegen::core_erlang::escape_erlang_string;
 use crate::semantic_analysis::type_checker::{
     NativeTypeRegistry, is_specs_line, is_specs_result_error, is_specs_result_ok, parse_specs_line,
 };
@@ -218,28 +219,6 @@ pub fn has_beam_files(dir: &Path) -> bool {
             })
             .unwrap_or(false)
 }
-/// Escapes a string for safe embedding in an Erlang string literal, used
-/// when sending `.beam` file paths to the `beamtalk_build_worker` node.
-///
-/// Duplicates `beam_compiler::escape_erlang_string` (a pure, dependency-free
-/// utility unlikely to change) rather than sharing it, so this module doesn't
-/// need to depend on the CLI binary's `beam_compiler` module.
-fn escape_erlang_string(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '\\' => result.push_str("\\\\"),
-            '"' => result.push_str("\\\""),
-            '\n' => result.push_str("\\n"),
-            '\r' => result.push_str("\\r"),
-            '\t' => result.push_str("\\t"),
-            '\0' => result.push_str("\\0"),
-            _ => result.push(c),
-        }
-    }
-    result
-}
-
 // ---------------------------------------------------------------------------
 // Type cache: persists spec extraction results per Erlang module (ADR 0075)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `escape_erlang_string` was defined twice — once in `beamtalk-cli/src/beam_compiler.rs` and once in `beamtalk-core/src/ffi_type_specs.rs`, with a comment in the latter explicitly acknowledging the duplication
- Moves the canonical implementation to `beamtalk-core/src/codegen/core_erlang/util.rs` (alongside the related `escape_core_erlang_string` and `escape_atom_chars`)
- The CLI re-exports via `pub(crate) use beamtalk_core::codegen::core_erlang::escape_erlang_string` so all 6+ existing call sites are unchanged
- Tests relocated from `beam_compiler.rs` to `util.rs` in beamtalk-core

## Changes

- `crates/beamtalk-core/src/codegen/core_erlang/util.rs` — add `pub fn escape_erlang_string` + 8 tests
- `crates/beamtalk-core/src/codegen/core_erlang/mod.rs` — add `pub use util::escape_erlang_string`
- `crates/beamtalk-core/src/ffi_type_specs.rs` — remove local duplicate, add import from core
- `crates/beamtalk-cli/src/beam_compiler.rs` — replace 21-line body with re-export, remove tests

Net change: ~17 lines deleted (76 added, 93 removed across 4 files). No logic changes, no API surface changes, no behavioral changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_015WGeqrzWfRV1KXdKg1qAf7)_