### PR TITLE
Support subdirectories under stdlib/src/

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -648,8 +648,11 @@ dialyzer-specs: build-stdlib
     # Compile stdlib to Core Erlang (preserves .core files)
     CORE_DIR=$(mktemp -d)
     trap 'rm -rf "$CORE_DIR"' EXIT
-    # Copy .bt sources and build in temp dir to get .core files
-    cp stdlib/src/*.bt "$CORE_DIR/"
+    # Copy .bt sources and build in temp dir to get .core files.
+    # Flattened on purpose: stdlib module names come from the file stem, so any
+    # stdlib/src/ subdirectories are irrelevant here (and unique stems are
+    # enforced by build-stdlib's duplicate-stem check).
+    find stdlib/src -type f -name '*.bt' -exec cp {} "$CORE_DIR/" \;
     cargo run --bin beamtalk --quiet -- build --stdlib-mode "$CORE_DIR/"
     # Run spec validation on the generated .core files
     escript scripts/validate_specs.escript "$CORE_DIR/build/"
@@ -1302,10 +1305,15 @@ install PREFIX="/usr/local": build-release build-stdlib
     install -m 755 "runtime/tools/rebar3" "${PREFIX}/lib/beamtalk/tools/rebar3"
 
     # Stdlib sources for LSP/tooling navigation
+    # Mirrors the source tree (including any subdirectories) so LSP
+    # goto-definition resolves to the same relative layout as the repo.
     STDLIB_SOURCE_SRC="stdlib/src"
-    if [ -d "${STDLIB_SOURCE_SRC}" ] && compgen -G "${STDLIB_SOURCE_SRC}/*.bt" > /dev/null; then
-        install -d "${PREFIX}/share/beamtalk/stdlib/src"
-        install -m 644 "${STDLIB_SOURCE_SRC}"/*.bt "${PREFIX}/share/beamtalk/stdlib/src/"
+    if [ -d "${STDLIB_SOURCE_SRC}" ]; then
+        find "${STDLIB_SOURCE_SRC}" -type f -name '*.bt' | while read -r bt; do
+            rel="${bt#"${STDLIB_SOURCE_SRC}"/}"
+            install -d "${PREFIX}/share/beamtalk/stdlib/src/$(dirname "${rel}")"
+            install -m 644 "${bt}" "${PREFIX}/share/beamtalk/stdlib/src/${rel}"
+        done
     fi
 
     echo "✅ Installed beamtalk to ${PREFIX}"
@@ -1404,7 +1412,7 @@ dist: build-release build-stdlib
     Copy-Item target/release/beamtalk-exec.exe dist/bin/
     $appCount = 0; foreach ($ebinDir in (Get-ChildItem -Directory "runtime/_build/default/lib/*/ebin" -ErrorAction SilentlyContinue)) { $app = $ebinDir.Parent.Name; $appRoot = $ebinDir.Parent.FullName; if (!(Get-ChildItem "$($ebinDir.FullName)/*.beam" -ErrorAction SilentlyContinue)) { continue }; New-Item -ItemType Directory -Force -Path "dist/lib/beamtalk/lib/$app/ebin" | Out-Null; Copy-Item "$($ebinDir.FullName)/*.beam" "dist/lib/beamtalk/lib/$app/ebin/" -ErrorAction Stop; if (Get-ChildItem "$($ebinDir.FullName)/*.app" -ErrorAction SilentlyContinue) { Copy-Item "$($ebinDir.FullName)/*.app" "dist/lib/beamtalk/lib/$app/ebin/" -ErrorAction Stop }; $privSrc = Join-Path $appRoot "priv"; if (Test-Path $privSrc) { New-Item -ItemType Directory -Force -Path "dist/lib/beamtalk/lib/$app/priv" | Out-Null; Copy-Item "$privSrc/*" "dist/lib/beamtalk/lib/$app/priv/" -Recurse }; $appCount++ }; if ($appCount -eq 0) { Write-Error "No OTP apps found in runtime/_build/default/lib/. Run 'just build-erlang' first."; exit 1 }
     if (!(Test-Path "runtime/tools/rebar3")) { Write-Error "Bundled rebar3 not found at runtime/tools/rebar3."; exit 1 }; New-Item -ItemType Directory -Force -Path "dist/lib/beamtalk/tools" | Out-Null; Copy-Item "runtime/tools/rebar3" "dist/lib/beamtalk/tools/rebar3"
-    if (Test-Path "stdlib/src/*.bt") { New-Item -ItemType Directory -Force -Path "dist/share/beamtalk/stdlib/src" | Out-Null; Copy-Item "stdlib/src/*.bt" "dist/share/beamtalk/stdlib/src/" }
+    if (Test-Path "stdlib/src") { $stdlibRoot = (Resolve-Path "stdlib/src").Path; foreach ($bt in (Get-ChildItem -Path "stdlib/src" -Recurse -File -Filter *.bt)) { $rel = $bt.FullName.Substring($stdlibRoot.Length).TrimStart('\', '/'); $dest = Join-Path "dist/share/beamtalk/stdlib/src" $rel; New-Item -ItemType Directory -Force -Path (Split-Path $dest -Parent) | Out-Null; Copy-Item $bt.FullName $dest } }
     just dist-vscode
     @echo "✅ Distribution ready in dist/"
     @echo "   Run: dist\bin\beamtalk.exe repl"

--- a/crates/beamtalk-cli/src/commands/build_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/build_stdlib.rs
@@ -56,7 +56,7 @@ pub fn build_stdlib(quiet: bool, warnings_as_errors: bool) -> Result<()> {
         return Ok(());
     }
 
-    check_duplicate_stems(&source_files)?;
+    check_duplicate_module_names(&source_files)?;
 
     // Incremental build: skip if all outputs are newer than all inputs
     if is_stdlib_up_to_date(&ebin_dir, &source_files) {
@@ -380,23 +380,27 @@ fn find_stdlib_files(lib_dir: &Utf8Path) -> Result<Vec<Utf8PathBuf>> {
     beamtalk_core::file_walker::FileWalker::source_files().walk(lib_dir)
 }
 
-/// Reject two stdlib sources whose file stems collide.
+/// Reject two stdlib sources that would compile to the same module.
 ///
 /// Module names come from the file stem alone, so `collections/Array.bt` and
-/// `legacy/Array.bt` would both compile to `bt@stdlib@array` — the second
-/// silently clobbering the first in `ebin/`. Flat layouts got this for free
-/// from the filesystem; nested ones have to check.
-fn check_duplicate_stems(source_files: &[Utf8PathBuf]) -> Result<()> {
-    let mut seen: std::collections::HashMap<&str, &Utf8Path> = std::collections::HashMap::new();
+/// `legacy/Array.bt` both become `bt@stdlib@array` — the second silently
+/// clobbering the first in `ebin/`. Flat layouts got uniqueness for free from
+/// the filesystem; nested ones have to check.
+///
+/// Keyed on the *derived module name*, not the raw stem, because
+/// [`module_name_from_path`] case-folds: `BEAMError.bt` and `Beamerror.bt` are
+/// distinct filenames that both produce `bt@stdlib@beamerror`. Comparing stems
+/// would wave that collision straight through.
+fn check_duplicate_module_names(source_files: &[Utf8PathBuf]) -> Result<()> {
+    let mut seen: std::collections::HashMap<String, &Utf8Path> = std::collections::HashMap::new();
     for file in source_files {
-        let Some(stem) = file.file_stem() else {
-            continue;
-        };
-        if let Some(first) = seen.insert(stem, file.as_path()) {
+        let module = module_name_from_path(file)?;
+        if let Some(first) = seen.insert(module.clone(), file.as_path()) {
             miette::bail!(
-                "Duplicate stdlib class file name '{stem}.bt': '{first}' and '{file}' would both \
-                 compile to the same module. Stdlib module names come from the file stem only, \
-                 so class file names must be unique across all subdirectories."
+                "Stdlib sources '{first}' and '{file}' both compile to module '{module}'. \
+                 Module names come from the file stem alone (case-folded), and subdirectories \
+                 do not namespace them, so stdlib class file names must be unique across all \
+                 subdirectories. Rename one of the two files."
             );
         }
     }
@@ -1086,6 +1090,7 @@ fn format_stdlib_class_entry(m: &ClassMeta) -> String {
 }
 
 /// Format stdlib class metadata entries joined with the given separator.
+///
 /// Sorted by class name so the generated `.app`/`.app.src` content depends
 /// only on *which* classes exist, never on the order the source tree happened
 /// to be walked in. Without this, moving a class into a `stdlib/src/`
@@ -2552,27 +2557,54 @@ mod tests {
     }
 
     #[test]
-    fn check_duplicate_stems_accepts_unique_names_across_subdirectories() {
+    fn check_duplicate_module_names_accepts_unique_names_across_subdirectories() {
         let files = vec![
             Utf8PathBuf::from("stdlib/src/Object.bt"),
             Utf8PathBuf::from("stdlib/src/collections/Array.bt"),
             Utf8PathBuf::from("stdlib/src/numeric/Integer.bt"),
         ];
-        assert!(check_duplicate_stems(&files).is_ok());
+        assert!(check_duplicate_module_names(&files).is_ok());
     }
 
     #[test]
-    fn check_duplicate_stems_rejects_colliding_names() {
-        // Both would compile to `bt@stdlib@array`, silently clobbering in ebin/.
+    fn check_duplicate_module_names_rejects_same_stem_in_two_subdirectories() {
+        // Both compile to `bt@stdlib@array`, silently clobbering in ebin/.
         let files = vec![
             Utf8PathBuf::from("stdlib/src/collections/Array.bt"),
             Utf8PathBuf::from("stdlib/src/legacy/Array.bt"),
         ];
 
-        let err = check_duplicate_stems(&files).unwrap_err().to_string();
+        let err = check_duplicate_module_names(&files)
+            .unwrap_err()
+            .to_string();
         assert!(
-            err.contains("Array.bt") && err.contains("legacy/Array.bt"),
-            "Error must name both colliding files. Got: {err}"
+            err.contains("stdlib/src/collections/Array.bt")
+                && err.contains("stdlib/src/legacy/Array.bt"),
+            "Error must name both colliding paths in full, so the user knows \
+             which two files to rename. Got: {err}"
+        );
+        assert!(
+            err.contains("bt@stdlib@array"),
+            "Error should name the module they collide on. Got: {err}"
+        );
+    }
+
+    #[test]
+    fn check_duplicate_module_names_catches_case_folded_collision() {
+        // `to_module_name` lowercases, so these distinct filenames both yield
+        // `bt@stdlib@beamerror`. A raw-stem comparison would miss it — and
+        // `BEAMError.bt` is a real stdlib class, so the shape is not academic.
+        let files = vec![
+            Utf8PathBuf::from("stdlib/src/BEAMError.bt"),
+            Utf8PathBuf::from("stdlib/src/errors/Beamerror.bt"),
+        ];
+
+        let err = check_duplicate_module_names(&files)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("bt@stdlib@beamerror"),
+            "Case-folded collision must be rejected. Got: {err}"
         );
     }
 }

--- a/crates/beamtalk-cli/src/commands/build_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/build_stdlib.rs
@@ -17,7 +17,6 @@ use crate::beam_compiler::{
 };
 use crate::commands::app_file;
 use crate::commands::build::build_alias_metadata;
-use crate::commands::util;
 use beamtalk_core::semantic_analysis::alias_registry::AliasRegistry;
 use beamtalk_core::semantic_analysis::type_checker::NativeTypeRegistry;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -56,6 +55,8 @@ pub fn build_stdlib(quiet: bool, warnings_as_errors: bool) -> Result<()> {
         println!("No .bt source files found in '{lib_dir}'");
         return Ok(());
     }
+
+    check_duplicate_stems(&source_files)?;
 
     // Incremental build: skip if all outputs are newer than all inputs
     if is_stdlib_up_to_date(&ebin_dir, &source_files) {
@@ -369,9 +370,37 @@ fn oldest_mtime_in_dir(dir: &Utf8Path, ext: &str) -> Option<SystemTime> {
     oldest
 }
 
-/// Find all `.bt` files in the stdlib source directory.
+/// Find all `.bt` files in the stdlib source directory, recursively.
+///
+/// Recursive so `stdlib/src/` can be grouped into subdirectories
+/// (`collections/`, `actors/`, …) without silently dropping classes from the
+/// build. Subdirectories are purely editorial — they do *not* affect module
+/// names; see [`module_name_from_path`].
 fn find_stdlib_files(lib_dir: &Utf8Path) -> Result<Vec<Utf8PathBuf>> {
-    util::find_files(lib_dir, &["bt"])
+    beamtalk_core::file_walker::FileWalker::source_files().walk(lib_dir)
+}
+
+/// Reject two stdlib sources whose file stems collide.
+///
+/// Module names come from the file stem alone, so `collections/Array.bt` and
+/// `legacy/Array.bt` would both compile to `bt@stdlib@array` — the second
+/// silently clobbering the first in `ebin/`. Flat layouts got this for free
+/// from the filesystem; nested ones have to check.
+fn check_duplicate_stems(source_files: &[Utf8PathBuf]) -> Result<()> {
+    let mut seen: std::collections::HashMap<&str, &Utf8Path> = std::collections::HashMap::new();
+    for file in source_files {
+        let Some(stem) = file.file_stem() else {
+            continue;
+        };
+        if let Some(first) = seen.insert(stem, file.as_path()) {
+            miette::bail!(
+                "Duplicate stdlib class file name '{stem}.bt': '{first}' and '{file}' would both \
+                 compile to the same module. Stdlib module names come from the file stem only, \
+                 so class file names must be unique across all subdirectories."
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Extract the module name from a `.bt` file path.
@@ -379,6 +408,17 @@ fn find_stdlib_files(lib_dir: &Utf8Path) -> Result<Vec<Utf8PathBuf>> {
 /// ADR 0016: All stdlib classes use `bt@stdlib@{snake_case}` prefix.
 /// The `@` separator is legal in unquoted Erlang atoms and follows
 /// the Gleam convention (`gleam@list`, `gleam@string`).
+///
+/// Only the file *stem* is used — a subdirectory under `stdlib/src/` never
+/// becomes part of the module name. This deliberately diverges from user
+/// packages, where `src/util/math.bt` becomes `util@math`
+/// (`build::compute_relative_module`). Stdlib keeps the flat mapping because
+/// it is a closed-form function of the class name: `compiled_module_name`,
+/// `PrimitiveBindingTable::runtime_module_for_class` and
+/// `beamtalk_primitive:module_for_value/1` all derive `bt@stdlib@{snake}`
+/// with no path and no lookup table available. Folding directories into the
+/// atom would couple that hot dispatch path to a purely cosmetic layout
+/// choice.
 fn module_name_from_path(path: &Utf8Path) -> Result<String> {
     let stem = path
         .file_stem()
@@ -1046,12 +1086,31 @@ fn format_stdlib_class_entry(m: &ClassMeta) -> String {
 }
 
 /// Format stdlib class metadata entries joined with the given separator.
+/// Sorted by class name so the generated `.app`/`.app.src` content depends
+/// only on *which* classes exist, never on the order the source tree happened
+/// to be walked in. Without this, moving a class into a `stdlib/src/`
+/// subdirectory reshuffles a checked-in generated file for no semantic reason.
 fn format_stdlib_classes_list(class_metadata: &[ClassMeta], separator: &str) -> String {
-    class_metadata
-        .iter()
+    let mut sorted: Vec<&ClassMeta> = class_metadata.iter().collect();
+    sorted.sort_by(|a, b| a.class_name.cmp(&b.class_name));
+    sorted
+        .into_iter()
         .map(format_stdlib_class_entry)
         .collect::<Vec<_>>()
         .join(separator)
+}
+
+/// Format a sorted, quoted Erlang atom list (`'a', 'b', …`).
+///
+/// Same layout-independence rationale as [`format_stdlib_classes_list`].
+fn format_sorted_atom_list(names: &[String]) -> String {
+    let mut sorted = names.to_vec();
+    sorted.sort();
+    sorted
+        .iter()
+        .map(|m| format!("'{m}'"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Generate the `beamtalk_stdlib.app` file in the ebin directory.
@@ -1080,21 +1139,13 @@ fn generate_app_file(
         .map(|f| module_name_from_path(f))
         .collect::<Result<_>>()?;
 
-    let modules_list = module_names
-        .iter()
-        .map(|m| format!("'{m}'"))
-        .collect::<Vec<_>>()
-        .join(", ");
+    let modules_list = format_sorted_atom_list(&module_names);
 
     // ADR 0070 Phase 4: Generate extended class hierarchy entries for env
     let classes_list = format_stdlib_classes_list(class_metadata, ",\n                    ");
 
     // BT-1766: Protocol-only modules need to be loaded separately during stdlib init
-    let protocol_modules_list = protocol_modules
-        .iter()
-        .map(|m| format!("'{m}'"))
-        .collect::<Vec<_>>()
-        .join(", ");
+    let protocol_modules_list = format_sorted_atom_list(protocol_modules);
 
     // BT-2938: same `{type_aliases, [...]}` entry the ordinary `beamtalk
     // build` pipeline emits (`app_file::format_type_aliases_entry`) — empty
@@ -1140,11 +1191,7 @@ fn generate_app_src_file(
     let classes_list = format_stdlib_classes_list(class_metadata, ",\n            ");
 
     // BT-1766: Protocol-only modules need to be loaded separately during stdlib init
-    let protocol_modules_list = protocol_modules
-        .iter()
-        .map(|m| format!("'{m}'"))
-        .collect::<Vec<_>>()
-        .join(", ");
+    let protocol_modules_list = format_sorted_atom_list(protocol_modules);
 
     // BT-2938: see `generate_app_file`'s doc.
     let type_aliases_entry = app_file::format_type_aliases_entry(alias_metadata);
@@ -2462,6 +2509,70 @@ mod tests {
         assert!(
             code.contains("is_internal: true"),
             "Should emit is_internal: true for an internal method. Got: {code}"
+        );
+    }
+
+    // --- stdlib/src/ subdirectory support ---
+
+    #[test]
+    fn find_stdlib_files_recurses_into_subdirectories() {
+        let (_temp, dir) = temp_utf8_dir();
+        fs::create_dir_all(dir.join("collections")).unwrap();
+        fs::create_dir_all(dir.join("actors/supervision")).unwrap();
+        fs::write(dir.join("Object.bt"), "Object subclass: Object\n").unwrap();
+        fs::write(dir.join("collections/Array.bt"), "Object subclass: Array\n").unwrap();
+        fs::write(
+            dir.join("actors/supervision/Supervisor.bt"),
+            "Object subclass: Supervisor\n",
+        )
+        .unwrap();
+
+        let files = find_stdlib_files(&dir).unwrap();
+
+        let mut stems: Vec<&str> = files.iter().filter_map(|f| f.file_stem()).collect();
+        stems.sort_unstable();
+        assert_eq!(
+            stems,
+            vec!["Array", "Object", "Supervisor"],
+            "Nested classes must be found at any depth. Got: {files:?}"
+        );
+    }
+
+    #[test]
+    fn module_name_ignores_subdirectory() {
+        // Subdirectories are editorial only — `bt@stdlib@array` regardless of
+        // where the file sits. Deliberately unlike user packages, where
+        // `src/util/math.bt` becomes `util@math`.
+        let flat = module_name_from_path(Utf8Path::new("stdlib/src/Array.bt")).unwrap();
+        let nested =
+            module_name_from_path(Utf8Path::new("stdlib/src/collections/Array.bt")).unwrap();
+
+        assert_eq!(flat, "bt@stdlib@array");
+        assert_eq!(nested, flat, "Subdirectory must not change the module name");
+    }
+
+    #[test]
+    fn check_duplicate_stems_accepts_unique_names_across_subdirectories() {
+        let files = vec![
+            Utf8PathBuf::from("stdlib/src/Object.bt"),
+            Utf8PathBuf::from("stdlib/src/collections/Array.bt"),
+            Utf8PathBuf::from("stdlib/src/numeric/Integer.bt"),
+        ];
+        assert!(check_duplicate_stems(&files).is_ok());
+    }
+
+    #[test]
+    fn check_duplicate_stems_rejects_colliding_names() {
+        // Both would compile to `bt@stdlib@array`, silently clobbering in ebin/.
+        let files = vec![
+            Utf8PathBuf::from("stdlib/src/collections/Array.bt"),
+            Utf8PathBuf::from("stdlib/src/legacy/Array.bt"),
+        ];
+
+        let err = check_duplicate_stems(&files).unwrap_err().to_string();
+        assert!(
+            err.contains("Array.bt") && err.contains("legacy/Array.bt"),
+            "Error must name both colliding files. Got: {err}"
         );
     }
 }

--- a/crates/beamtalk-cli/src/commands/doc/extractor.rs
+++ b/crates/beamtalk-cli/src/commands/doc/extractor.rs
@@ -11,8 +11,6 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use tracing::{debug, warn};
 
-use crate::commands::util;
-
 /// Information about a documented class.
 pub struct ClassInfo {
     /// The class name (e.g., `Counter`).
@@ -44,9 +42,13 @@ pub struct MethodInfo {
     pub is_sealed: bool,
 }
 
-/// Find all `.bt` source files in a path.
+/// Find all `.bt` source files in a path, recursing into subdirectories.
+///
+/// Matches `build::find_source_files`, so `beamtalk doc` documents every class
+/// that `beamtalk build` compiles — including classes in `src/` subdirectories
+/// (user packages) or `stdlib/src/` subdirectories.
 pub(super) fn find_source_files(path: &Utf8Path) -> Result<Vec<Utf8PathBuf>> {
-    util::find_files(path, &["bt"])
+    beamtalk_core::file_walker::FileWalker::source_files().walk(path)
 }
 
 /// Parse a `.bt` source file and extract class documentation info.

--- a/crates/beamtalk-cli/src/commands/doc/extractor.rs
+++ b/crates/beamtalk-cli/src/commands/doc/extractor.rs
@@ -47,8 +47,15 @@ pub struct MethodInfo {
 /// Matches `build::find_source_files`, so `beamtalk doc` documents every class
 /// that `beamtalk build` compiles — including classes in `src/` subdirectories
 /// (user packages) or `stdlib/src/` subdirectories.
+///
+/// Build/VCS directories are excluded. `build::find_source_files` avoids them
+/// by preferring the package's `src/` subdirectory, but `doc` walks whatever
+/// path it is handed — so pointing it at a package root would otherwise pull
+/// in every dependency's classes from `_build/deps/`.
 pub(super) fn find_source_files(path: &Utf8Path) -> Result<Vec<Utf8PathBuf>> {
-    beamtalk_core::file_walker::FileWalker::source_files().walk(path)
+    beamtalk_core::file_walker::FileWalker::source_files()
+        .exclude_dirs(&[".git", "target", "node_modules", "_build"])
+        .walk(path)
 }
 
 /// Parse a `.bt` source file and extract class documentation info.

--- a/crates/beamtalk-cli/src/commands/doc/mod.rs
+++ b/crates/beamtalk-cli/src/commands/doc/mod.rs
@@ -332,6 +332,24 @@ mod tests {
     }
 
     #[test]
+    fn test_find_source_files_skips_build_directories() {
+        // Recursion must not turn `beamtalk doc <package-root>` into "document
+        // every dependency too" — `_build/deps/**` classes are not this
+        // package's API.
+        let temp = TempDir::new().unwrap();
+        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        fs::create_dir_all(dir.join("_build/deps/http/src")).unwrap();
+        fs::create_dir_all(dir.join("target")).unwrap();
+        fs::write(dir.join("Mine.bt"), "// stub").unwrap();
+        fs::write(dir.join("_build/deps/http/src/HTTPClient.bt"), "// stub").unwrap();
+        fs::write(dir.join("target/Stale.bt"), "// stub").unwrap();
+
+        let files = find_source_files(&dir).unwrap();
+        assert_eq!(files.len(), 1, "Only the package's own class: {files:?}");
+        assert!(files[0].as_str().ends_with("Mine.bt"));
+    }
+
+    #[test]
     fn test_parse_class_info() {
         let temp = TempDir::new().unwrap();
         let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();

--- a/crates/beamtalk-cli/src/commands/doc/mod.rs
+++ b/crates/beamtalk-cli/src/commands/doc/mod.rs
@@ -313,6 +313,25 @@ mod tests {
     }
 
     #[test]
+    fn test_find_source_files_recurses_into_subdirectories() {
+        // Matches `beamtalk build`, so every class that compiles also gets
+        // documented — whether it lives in `src/` or `src/collections/`.
+        let temp = TempDir::new().unwrap();
+        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        fs::create_dir_all(dir.join("collections/ordered")).unwrap();
+        fs::write(dir.join("Object.bt"), "// stub").unwrap();
+        fs::write(dir.join("collections/Array.bt"), "// stub").unwrap();
+        fs::write(dir.join("collections/ordered/List.bt"), "// stub").unwrap();
+
+        let files = find_source_files(&dir).unwrap();
+        assert_eq!(
+            files.len(),
+            3,
+            "Nested classes must be documented: {files:?}"
+        );
+    }
+
+    #[test]
     fn test_parse_class_info() {
         let temp = TempDir::new().unwrap();
         let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();

--- a/crates/beamtalk-core/build.rs
+++ b/crates/beamtalk-core/build.rs
@@ -69,11 +69,22 @@ fn generate_stdlib_types(lib_dir: &Path) {
 /// Those are editorial only — the class name is the file stem regardless of
 /// depth, matching `build_stdlib::module_name_from_path`. Recursing keeps
 /// `is_known_stdlib_type()` from silently missing nested classes.
+///
+/// Symlinks are skipped, matching `FileWalker`'s default (the walker
+/// `build_stdlib` uses over the same tree). Beyond keeping the two in sync,
+/// it stops a symlinked directory cycle from recursing until the build script
+/// blows its stack.
 fn collect_stdlib_class_names(dir: &Path, out: &mut Vec<String>) {
     let entries = fs::read_dir(dir).expect("Failed to read stdlib source directory");
     for entry in entries {
-        let path = entry.expect("Failed to read directory entry").path();
-        if path.is_dir() {
+        let entry = entry.expect("Failed to read directory entry");
+        // `file_type()` does not traverse symlinks, unlike `Path::is_dir()`.
+        let file_type = entry.file_type().expect("Failed to read file type");
+        if file_type.is_symlink() {
+            continue;
+        }
+        let path = entry.path();
+        if file_type.is_dir() {
             collect_stdlib_class_names(&path, out);
         } else if path.extension().is_some_and(|ext| ext == "bt") {
             if let Some(stem) = path.file_stem() {

--- a/crates/beamtalk-core/build.rs
+++ b/crates/beamtalk-core/build.rs
@@ -43,17 +43,7 @@ fn main() {
 
 fn generate_stdlib_types(lib_dir: &Path) {
     let mut class_names: Vec<String> = Vec::new();
-
-    for entry in fs::read_dir(lib_dir).expect("Failed to read lib/ directory") {
-        let entry = entry.expect("Failed to read directory entry");
-        let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "bt") {
-            if let Some(stem) = path.file_stem() {
-                class_names.push(stem.to_string_lossy().to_string());
-            }
-        }
-    }
-
+    collect_stdlib_class_names(lib_dir, &mut class_names);
     class_names.sort();
 
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
@@ -71,4 +61,24 @@ fn generate_stdlib_types(lib_dir: &Path) {
     );
 
     fs::write(dest_path, code).expect("Failed to write stdlib_types.rs");
+}
+
+/// Collect stdlib class names from `dir`, recursing into subdirectories.
+///
+/// `stdlib/src/` may be grouped into subdirectories (`collections/`, …).
+/// Those are editorial only — the class name is the file stem regardless of
+/// depth, matching `build_stdlib::module_name_from_path`. Recursing keeps
+/// `is_known_stdlib_type()` from silently missing nested classes.
+fn collect_stdlib_class_names(dir: &Path, out: &mut Vec<String>) {
+    let entries = fs::read_dir(dir).expect("Failed to read stdlib source directory");
+    for entry in entries {
+        let path = entry.expect("Failed to read directory entry").path();
+        if path.is_dir() {
+            collect_stdlib_class_names(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "bt") {
+            if let Some(stem) = path.file_stem() {
+                out.push(stem.to_string_lossy().to_string());
+            }
+        }
+    }
 }

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitive_bindings.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitive_bindings.rs
@@ -204,6 +204,7 @@ pub fn build_binding_table<'a>(
 /// Parsing errors are silently ignored — files that fail to parse simply
 /// contribute no bindings. This is safe because the binding table is used
 /// as an optimization hint, not a correctness requirement.
+///
 /// Subdirectories are walked too, so grouping `stdlib/src/` into
 /// `collections/`, `actors/`, … does not silently drop `@primitive` bindings
 /// for the classes that move.
@@ -213,15 +214,26 @@ pub fn load_from_directory(lib_dir: &std::path::Path) -> PrimitiveBindingTable {
     table
 }
 
+/// Symlinks are skipped, matching `FileWalker`'s default (the walker
+/// `build_stdlib` uses over the same tree) and stopping a symlinked directory
+/// cycle from recursing forever.
 fn load_into_table(dir: &std::path::Path, table: &mut PrimitiveBindingTable) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
 
     for entry in entries.flatten() {
+        // `file_type()` does not traverse symlinks, unlike `Path::is_dir()`.
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+
         let path = entry.path();
 
-        if path.is_dir() {
+        if file_type.is_dir() {
             load_into_table(&path, table);
             continue;
         }
@@ -637,6 +649,33 @@ mod tests {
                 selector: "size".to_string(),
             }),
             "Two levels deep must be found"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_load_from_directory_does_not_follow_symlinked_directory_cycle() {
+        // A symlink pointing back at an ancestor would recurse forever if
+        // directory detection followed links. Matches `FileWalker`'s
+        // skip-symlinks default over the same tree.
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir_all(root.join("numeric")).unwrap();
+        std::fs::write(
+            root.join("numeric/Integer.bt"),
+            "Value subclass: Integer\n  + other => @primitive\n",
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(root, root.join("numeric/loop")).unwrap();
+
+        // Terminates, and still collects the real file alongside the cycle.
+        let table = load_from_directory(root);
+
+        assert_eq!(
+            table.lookup("Integer", "+"),
+            Some(&PrimitiveBinding::SelectorBased {
+                selector: "+".to_string(),
+            })
         );
     }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitive_bindings.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitive_bindings.rs
@@ -204,15 +204,28 @@ pub fn build_binding_table<'a>(
 /// Parsing errors are silently ignored — files that fail to parse simply
 /// contribute no bindings. This is safe because the binding table is used
 /// as an optimization hint, not a correctness requirement.
+/// Subdirectories are walked too, so grouping `stdlib/src/` into
+/// `collections/`, `actors/`, … does not silently drop `@primitive` bindings
+/// for the classes that move.
 pub fn load_from_directory(lib_dir: &std::path::Path) -> PrimitiveBindingTable {
     let mut table = PrimitiveBindingTable::new();
+    load_into_table(lib_dir, &mut table);
+    table
+}
 
-    let Ok(entries) = std::fs::read_dir(lib_dir) else {
-        return table;
+fn load_into_table(dir: &std::path::Path, table: &mut PrimitiveBindingTable) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
     };
 
     for entry in entries.flatten() {
         let path = entry.path();
+
+        if path.is_dir() {
+            load_into_table(&path, table);
+            continue;
+        }
+
         if path.extension().and_then(|e| e.to_str()) != Some("bt") {
             continue;
         }
@@ -225,8 +238,6 @@ pub fn load_from_directory(lib_dir: &std::path::Path) -> PrimitiveBindingTable {
         let (module, _diagnostics) = crate::source_analysis::parse(tokens);
         table.add_from_module(&module);
     }
-
-    table
 }
 
 #[cfg(test)]
@@ -588,6 +599,44 @@ mod tests {
             Some(&PrimitiveBinding::SelectorBased {
                 selector: "exists:".to_string(),
             })
+        );
+    }
+
+    #[test]
+    fn test_load_from_directory_recurses_into_subdirectories() {
+        // stdlib/src/ may be grouped into subdirectories; `@primitive`
+        // bindings for the classes that move must still be picked up.
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::create_dir_all(root.join("numeric")).unwrap();
+        std::fs::create_dir_all(root.join("collections/ordered")).unwrap();
+
+        std::fs::write(
+            root.join("numeric/Integer.bt"),
+            "Value subclass: Integer\n  + other => @primitive\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("collections/ordered/List.bt"),
+            "Object subclass: List\n  size => @primitive\n",
+        )
+        .unwrap();
+
+        let table = load_from_directory(root);
+
+        assert_eq!(
+            table.lookup("Integer", "+"),
+            Some(&PrimitiveBinding::SelectorBased {
+                selector: "+".to_string(),
+            }),
+            "One level deep must be found"
+        );
+        assert_eq!(
+            table.lookup("List", "size"),
+            Some(&PrimitiveBinding::SelectorBased {
+                selector: "size".to_string(),
+            }),
+            "Two levels deep must be found"
         );
     }
 

--- a/docs/development/common-tasks.md
+++ b/docs/development/common-tasks.md
@@ -55,9 +55,10 @@ cosmetic layout choice, and turn every future file move into an ABI change.
 
 Two consequences:
 
-- **Class file names must be unique across all subdirectories.**
-  `build-stdlib` fails with a duplicate-stem error rather than silently
-  clobbering a module in `ebin/`.
+- **Class file names must be unique across all subdirectories**, and unique
+  *after case-folding* — `to_module_name` lowercases, so `BEAMError.bt` and
+  `Beamerror.bt` both yield `bt@stdlib@beamerror`. `build-stdlib` fails with a
+  duplicate-module error rather than silently clobbering a module in `ebin/`.
 - Moving a class between subdirectories is free at build time, but does
   invalidate any `stdlib/src/...` paths written in docs and comments. Update
   those in the same change.

--- a/docs/development/common-tasks.md
+++ b/docs/development/common-tasks.md
@@ -26,6 +26,41 @@ Step-by-step guides for common tasks in the Beamtalk codebase.
    - Use `@primitive intrinsicName` pragmas for methods backed by runtime dispatch (see [ADR 0007](../ADR/0007-compilable-stdlib-with-primitive-injection.md))
    - Pure Beamtalk methods need no pragma — they compile directly
    - Provide usage examples in comments
+   - Subdirectories under `stdlib/src/` are allowed and purely editorial —
+     see [Stdlib source layout](#stdlib-source-layout) below
+
+### Stdlib source layout
+
+`stdlib/src/` may be grouped into subdirectories (`collections/`, `actors/`, …).
+The build walks it recursively, so a nested class compiles, documents, installs
+and loads exactly like a top-level one — a flat and a nested tree produce
+byte-identical `beamtalk_stdlib.app` output.
+
+**Subdirectories never affect module names.** `stdlib/src/collections/Array.bt`
+compiles to `bt@stdlib@array`, not `bt@stdlib@collections@array`. This
+deliberately diverges from user packages, where `src/util/math.bt` becomes
+`util@math`.
+
+The reason is that stdlib's class→module mapping is a *closed-form function of
+the class name*, with no path and no lookup table involved:
+
+- `value_type_codegen::compiled_module_name` (packages use a two-pass
+  `class_module_index`; stdlib falls through to `bt@stdlib@{snake}`)
+- `PrimitiveBindingTable::runtime_module_for_class`
+- `beamtalk_primitive:module_for_value/1` — dispatches on `is_integer(X)`, so
+  no class name is even available to look up
+
+Folding directories into the atom would couple that hot dispatch path to a
+cosmetic layout choice, and turn every future file move into an ABI change.
+
+Two consequences:
+
+- **Class file names must be unique across all subdirectories.**
+  `build-stdlib` fails with a duplicate-stem error rather than silently
+  clobbering a module in `ebin/`.
+- Moving a class between subdirectories is free at build time, but does
+  invalidate any `stdlib/src/...` paths written in docs and comments. Update
+  those in the same change.
 
 2. **Implement runtime support** (for primitive methods only)
    - Add dispatch clause in the appropriate runtime module (e.g., `runtime/apps/beamtalk_runtime/src/beamtalk_primitive.erl`)


### PR DESCRIPTION
`stdlib/src/` has grown to 104 classes in one flat directory. Grouping it
into subdirectories (`collections/`, `actors/`, …) previously would have
silently dropped classes: four separate file-discovery sites assumed a flat
tree and enumerated it non-recursively, each failing quietly rather than
erroring.

This makes the tree layout-agnostic without moving any files, so classes can
be regrouped later — one group at a time, alongside work already touching
that area — instead of as one large cosmetic change.

Discovery sites made recursive:

- `build_stdlib::find_stdlib_files` — `util::find_files` is explicitly
  `recursive(false)`; nested classes would never compile.
- `beamtalk-core/build.rs::generate_stdlib_types` — `STDLIB_CLASS_NAMES`
  would lose entries, making `is_known_stdlib_type()` wrong.
- `primitive_bindings::load_from_directory` — `@primitive` bindings would
  vanish for nested classes.
- `doc::extractor::find_source_files` — `beamtalk doc` and the docs site
  would drop classes. Now matches `build::find_source_files`, which already
  recurses, so `doc` documents everything `build` compiles.

Justfile recipes that globbed `stdlib/src/*.bt`: `dialyzer-specs` (flattens
into a temp dir on purpose — module names are stem-based), plus `install`
and the Windows `dist` recipe, which now mirror the source tree so LSP
goto-definition resolves against the same relative layout as the repo.

Module names are unchanged and deliberately stay stem-only:
`stdlib/src/collections/Array.bt` compiles to `bt@stdlib@array`, not
`bt@stdlib@collections@array`. Stdlib's class→module mapping is a
closed-form function of the class name — `compiled_module_name` (packages
use a two-pass `class_module_index`; stdlib falls through to the formula),
`runtime_module_for_class`, and `beamtalk_primitive:module_for_value/1`,
which dispatches on `is_integer(X)` and has no class name to look up.
Folding directories into the atom would couple that dispatch path to a
cosmetic layout choice and turn every future file move into an ABI change.

Because stems alone determine module names, `build-stdlib` now rejects two
class files sharing a stem rather than silently clobbering a module in
`ebin/`. Flat layouts got that guarantee from the filesystem.

Generated `.app`/`.app.src` module, class and protocol lists are now sorted
rather than emitted in walk order, so output depends only on which classes
exist. Verified byte-identical `.app` and `.app.src` between a flat build
and one with four classes moved into `collections/`; the sort is a no-op on
the current flat tree (`.app.src` unchanged).

Documented the package divergence and the unique-stem constraint in
docs/development/common-tasks.md.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0114NvQ5vCGxFmCRaHi2ZgN8