### PR TITLE
LiveView front: desktop-broker attach hooks — sname seed, BT_ATTACH_BIND_IP, /readiness (BT-2983)

### DIFF
--- a/editors/liveview/config/runtime.exs
+++ b/editors/liveview/config/runtime.exs
@@ -64,14 +64,37 @@ if config_env() == :prod do
 
   config :bt_attach, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
+  # ADR 0097 Implementation §1b: the desktop-attach broker needs to pin this
+  # front to a loopback bind (`127.0.0.1`/`::1`) so a spawned front is never
+  # reachable from the LAN — the all-interfaces default below is right for the
+  # existing remote-deploy story (ADR 0091) but wrong for a broker-spawned
+  # local instance. Unset/empty keeps today's all-interfaces default so remote
+  # deploys are unchanged; an unparseable value fails closed (raise) rather
+  # than silently falling back to all-interfaces on a typo'd env.
+  bind_ip =
+    case System.get_env("BT_ATTACH_BIND_IP") do
+      unset when unset in [nil, ""] ->
+        {0, 0, 0, 0, 0, 0, 0, 0}
+
+      addr ->
+        case :inet.parse_address(String.to_charlist(addr)) do
+          {:ok, parsed} ->
+            parsed
+
+          {:error, _reason} ->
+            raise "invalid BT_ATTACH_BIND_IP: #{inspect(addr)} is not a valid IP address"
+        end
+    end
+
   config :bt_attach, BtAttachWeb.Endpoint,
     url: [host: url_host, port: url_port, scheme: url_scheme],
     http: [
-      # Enable IPv6 and bind on all interfaces.
+      # Enable IPv6 and bind on all interfaces by default (see BT_ATTACH_BIND_IP
+      # above for the desktop-attach broker's loopback override).
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
       # See the documentation on https://hexdocs.pm/bandit/Bandit.html#t:options/0
       # for details about using IPv6 vs IPv4 and loopback vs public addresses.
-      ip: {0, 0, 0, 0, 0, 0, 0, 0},
+      ip: bind_ip,
       port: port
     ],
     secret_key_base: secret_key_base

--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -133,6 +133,9 @@ defmodule BtAttach.Workspace do
         {:error, classify_unreachable(node)}
 
       {:error, {:connect_failed, _node, :ignored}} ->
+        # :ignored means this node's own dist went away, not the workspace's —
+        # see the taxonomy doc above. No better bucket exists, so it's folded
+        # into :dead_workspace.
         {:error, :dead_workspace}
     end
   end

--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -102,31 +102,38 @@ defmodule BtAttach.Workspace do
 
   @doc """
   Full connectivity check for the desktop-attach `/readiness` endpoint (ADR
-  0097 Implementation §1c). Forces `connect/0` plus one cheap RPC — the
-  workspace's version report (`beamtalk_version:get/0`, BT-2991) — and
-  classifies failure into the taxonomy the endpoint surfaces:
+  0097 Implementation §1c). Calls `connect/0` (rather than re-implementing its
+  steps, so the two can never drift) plus one cheap RPC — the workspace's
+  version report (`beamtalk_version:get/0`, BT-2991) — and classifies failure
+  into the taxonomy the endpoint surfaces:
 
     * `{:error, :epmd_absent}`   — no local dist name server to publish to.
     * `{:error, :bad_cookie}`    — epmd knows the target node; dist handshake
                                    rejected (mismatched cookie).
-    * `{:error, :dead_workspace}` — epmd has no record of the target node, or
-                                    the workspace died between connect and RPC.
+    * `{:error, :dead_workspace}` — epmd has no record of the target node, the
+                                    workspace died between connect and RPC, or
+                                    (the rare `:ignored` case) this node's own
+                                    distribution unexpectedly went away between
+                                    `connect/0`'s two internal calls — a local
+                                    dist failure, not the target's epmd being
+                                    absent, so it is *not* reported as
+                                    `:epmd_absent`.
 
   Returns `{:ok, version_report}` (see `beamtalk_version:get/0`) on success.
   """
   def readiness do
-    case ensure_distributed() do
+    case connect() do
+      :ok ->
+        readiness_rpc()
+
       {:error, :epmd_absent} = err ->
         err
 
-      :ok ->
-        set_cookie()
+      {:error, {:connect_failed, node, false}} ->
+        {:error, classify_unreachable(node)}
 
-        case Node.connect(node_name()) do
-          true -> readiness_rpc()
-          false -> {:error, classify_unreachable(node_name())}
-          :ignored -> {:error, :epmd_absent}
-        end
+      {:error, {:connect_failed, _node, :ignored}} ->
+        {:error, :dead_workspace}
     end
   end
 

--- a/editors/liveview/lib/bt_attach/workspace.ex
+++ b/editors/liveview/lib/bt_attach/workspace.ex
@@ -45,9 +45,34 @@ defmodule BtAttach.Workspace do
     * `BT_WORKSPACE_NODE`   — e.g. `beamtalk_workspace_spike@localhost`
     * `BT_WORKSPACE_COOKIE` — contents of `~/.beamtalk/workspaces/<id>/vm.args`
                               (`-setcookie <token>`), token only
+
+  ## Self node name (ADR 0097 Implementation §1a)
+
+  `ensure_distributed/0` self-assigns this front's own distribution sname.
+  With no `BT_ATTACH_NODE_SUFFIX` set, it falls back to today's
+  `bt_attach_<unique_integer>@localhost` — fine for the single-workspace
+  `just web` flow, where at most one front runs per dev machine. The desktop
+  broker (BT-2985) sets `BT_ATTACH_NODE_SUFFIX` to the workspace id so a crash
+  → respawn or a second window re-derives a related name; per-process entropy
+  (the OS pid) is *always* appended on top of that id so two separate front
+  processes attached to the **same** workspace can never collide on epmd —
+  an id-only seed would collide deterministically in exactly that scenario.
+
+  ## Readiness handshake (ADR 0097 Implementation §1c)
+
+  `readiness/0` is the RPC target behind the desktop-attach `GET /readiness`
+  endpoint: it forces `connect/0` plus one cheap RPC (`beamtalk_version:get/0`,
+  BT-2991) and distinguishes *why* an unreachable workspace failed —
+  `:epmd_absent` (this node couldn't even publish itself to the local epmd),
+  `:bad_cookie` (epmd knows the target node but the dist handshake was
+  rejected), or `:dead_workspace` (epmd has no record of the target node at
+  all) — so the broker can surface a precise error before opening a window,
+  and the version report lets it warn/refuse on a runtime/protocol mismatch.
   """
 
   require Logger
+
+  @epmd_port 4369
 
   @doc "The configured workspace node name as an atom."
   def node_name do
@@ -58,14 +83,50 @@ defmodule BtAttach.Workspace do
   @doc """
   Ensure this Phoenix node is distributed, shares the workspace cookie, and is
   connected to the workspace node. Idempotent — safe to call on every mount.
+
+  Returns `:ok`, or `{:error, :epmd_absent}` if this node could not even
+  publish itself to the local epmd (ADR 0097 Implementation §1c), or
+  `{:error, {:connect_failed, node, reason}}` if distribution started fine but
+  the target workspace node didn't accept the connection.
   """
   def connect do
-    ensure_distributed()
-    set_cookie()
+    with :ok <- ensure_distributed() do
+      set_cookie()
 
-    case Node.connect(node_name()) do
-      true -> :ok
-      reason -> {:error, {:connect_failed, node_name(), reason}}
+      case Node.connect(node_name()) do
+        true -> :ok
+        reason -> {:error, {:connect_failed, node_name(), reason}}
+      end
+    end
+  end
+
+  @doc """
+  Full connectivity check for the desktop-attach `/readiness` endpoint (ADR
+  0097 Implementation §1c). Forces `connect/0` plus one cheap RPC — the
+  workspace's version report (`beamtalk_version:get/0`, BT-2991) — and
+  classifies failure into the taxonomy the endpoint surfaces:
+
+    * `{:error, :epmd_absent}`   — no local dist name server to publish to.
+    * `{:error, :bad_cookie}`    — epmd knows the target node; dist handshake
+                                   rejected (mismatched cookie).
+    * `{:error, :dead_workspace}` — epmd has no record of the target node, or
+                                    the workspace died between connect and RPC.
+
+  Returns `{:ok, version_report}` (see `beamtalk_version:get/0`) on success.
+  """
+  def readiness do
+    case ensure_distributed() do
+      {:error, :epmd_absent} = err ->
+        err
+
+      :ok ->
+        set_cookie()
+
+        case Node.connect(node_name()) do
+          true -> readiness_rpc()
+          false -> {:error, classify_unreachable(node_name())}
+          :ignored -> {:error, :epmd_absent}
+        end
     end
   end
 
@@ -1948,17 +2009,27 @@ defmodule BtAttach.Workspace do
 
   # ── internals ─────────────────────────────────────────────────────────────
 
+  # Returns `:ok`, or `{:error, :epmd_absent}` if the local epmd isn't
+  # reachable — the lazy `:net_kernel.start/1` this uses (unlike an `erl
+  # -sname` boot) does not auto-start epmd, so probing first turns that
+  # failure into a classifiable error instead of the `raise` below (ADR 0097
+  # Implementation §1c names this failure mode explicitly).
   defp ensure_distributed do
-    unless Node.alive?() do
-      # A unique short name so multiple dev runs don't collide on epmd.
-      name = :"bt_attach_#{System.unique_integer([:positive])}@localhost"
+    if Node.alive?() do
+      :ok
+    else
+      if epmd_reachable?() do
+        name = attach_sname()
 
-      # Two connected mounts can both pass Node.alive?/0 and race here; the
-      # loser sees {:error, {:already_started, _}}, which is fine.
-      case :net_kernel.start([name, :shortnames]) do
-        {:ok, _pid} -> :ok
-        {:error, {:already_started, _pid}} -> :ok
-        {:error, reason} -> raise "failed to start distributed node: #{inspect(reason)}"
+        # Two connected mounts can both pass Node.alive?/0 and race here; the
+        # loser sees {:error, {:already_started, _}}, which is fine.
+        case :net_kernel.start([name, :shortnames]) do
+          {:ok, _pid} -> :ok
+          {:error, {:already_started, _pid}} -> :ok
+          {:error, reason} -> raise "failed to start distributed node: #{inspect(reason)}"
+        end
+      else
+        {:error, :epmd_absent}
       end
     end
   end
@@ -1968,6 +2039,93 @@ defmodule BtAttach.Workspace do
       nil -> Logger.warning("BT_WORKSPACE_COOKIE not set; relying on ~/.erlang.cookie")
       "" -> :ok
       token -> Node.set_cookie(node_name(), String.to_atom(token))
+    end
+  end
+
+  @doc """
+  This front's self-assigned distribution sname (ADR 0097 Implementation
+  §1a). Exposed (not `defp`) purely so its pure naming logic — no
+  distribution/network I/O — is unit-testable in isolation.
+
+  With `suffix` unset/empty, keeps today's collision-avoidance-by-luck
+  behaviour: `bt_attach_<unique_integer>@localhost`. With a suffix (the
+  desktop broker passes the workspace id via `BT_ATTACH_NODE_SUFFIX`),
+  per-process entropy (`os_pid`, defaulting to this VM's OS pid) is always
+  appended — an id-only seed would collide deterministically when two fronts
+  attach to the *same* workspace (a second window, a second broker instance,
+  or a crash→respawn racing the dying front's epmd deregistration).
+  """
+  def attach_sname(
+        suffix \\ System.get_env("BT_ATTACH_NODE_SUFFIX"),
+        os_pid \\ System.pid()
+      )
+
+  def attach_sname(suffix, _os_pid) when suffix in [nil, ""] do
+    :"bt_attach_#{System.unique_integer([:positive])}@localhost"
+  end
+
+  def attach_sname(suffix, os_pid) do
+    :"bt_attach_#{suffix}_#{os_pid}@localhost"
+  end
+
+  # Raw TCP probe of the local epmd port — cheaper and more reliable than
+  # inferring epmd absence from :net_kernel.start/1's opaque error reasons.
+  # Exposed (not `defp`) with injectable host/port so tests can point it at a
+  # throwaway listener/closed port instead of the real system epmd.
+  @doc false
+  def epmd_reachable?(host \\ ~c"localhost", port \\ @epmd_port) do
+    case :gen_tcp.connect(host, port, [:binary, active: false], 500) do
+      {:ok, socket} ->
+        :gen_tcp.close(socket)
+        true
+
+      {:error, _reason} ->
+        false
+    end
+  end
+
+  @doc """
+  Classify why `Node.connect(target_node)` returned `false`, given an
+  `:net_adm.names/0`-shaped result — `:bad_cookie` if epmd still knows about
+  `target_node` (so the dist handshake itself was rejected), `:dead_workspace`
+  if epmd has no record of it at all, `:epmd_absent` if the names query itself
+  failed. Exposed (not `defp`) so the pure classification is unit-testable
+  against a fabricated names list, without a real epmd/workspace.
+  """
+  def classify_unreachable(target_node, epmd_names \\ :net_adm.names())
+
+  def classify_unreachable(_target_node, {:error, _reason}), do: :epmd_absent
+
+  def classify_unreachable(target_node, {:ok, names}) do
+    short_name =
+      target_node
+      |> Atom.to_string()
+      |> String.split("@")
+      |> List.first()
+      |> String.to_charlist()
+
+    if List.keymember?(names, short_name, 0), do: :bad_cookie, else: :dead_workspace
+  end
+
+  # The one cheap RPC behind `readiness/0` — the workspace's version report
+  # (`beamtalk_version:get/0`, BT-2991). A `:badrpc` here (workspace died
+  # between `Node.connect/1` succeeding and this call landing) reports the
+  # same `:dead_workspace` reason as epmd never having heard of the node.
+  defp readiness_rpc do
+    case rpc(:beamtalk_version, :get, []) do
+      {:badrpc, _reason} ->
+        {:error, :dead_workspace}
+
+      report when is_map(report) ->
+        {:ok, report}
+
+      # Defensive catch-all matching the rest of this module's degrade-
+      # gracefully contract (e.g. eval/2's `other -> {:unexpected_reply, _}`):
+      # an older workspace predating beamtalk_version (BT-2991) or a future
+      # shape change should surface as a clean :dead_workspace 503, not crash
+      # the /readiness controller with a CaseClauseError.
+      _other ->
+        {:error, :dead_workspace}
     end
   end
 

--- a/editors/liveview/lib/bt_attach_web/controllers/readiness_controller.ex
+++ b/editors/liveview/lib/bt_attach_web/controllers/readiness_controller.ex
@@ -1,0 +1,45 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.ReadinessController do
+  @moduledoc """
+  `GET /readiness` — the desktop-attach broker's attach-health probe (ADR 0097
+  Implementation §1c).
+
+  An external (non-BEAM) broker can't trigger this front's lazy
+  `connect/0` from outside the VM, so it spawns the front, polls the HTTP port
+  to confirm Phoenix is up, then hits this endpoint to force `connect/0` plus
+  one cheap RPC and get a real answer *before* opening a window — a bad
+  cookie or a dead workspace surfaces here rather than on the user's first
+  eval.
+
+  Responses:
+
+    * `200` — the workspace is reachable. Body includes the version report
+      (`beamtalk_version:get/0`, BT-2991) so the broker can warn/refuse on a
+      runtime/protocol mismatch.
+    * `503` — not reachable, with a machine-readable `reason` distinguishing
+      *epmd absent*, *bad cookie*, and *dead workspace* (`BtAttach.Workspace.
+      readiness/0`'s taxonomy) so the broker can show a precise error instead
+      of a generic "connection failed".
+  """
+  use BtAttachWeb, :controller
+
+  @doc "Force a connect + cheap RPC and report workspace reachability."
+  def show(conn, _params) do
+    case workspace_client().readiness() do
+      {:ok, version_report} ->
+        conn
+        |> put_status(:ok)
+        |> json(%{status: "ok", version: version_report})
+
+      {:error, reason} ->
+        conn
+        |> put_status(:service_unavailable)
+        |> json(%{status: "error", reason: to_string(reason)})
+    end
+  end
+
+  defp workspace_client,
+    do: Application.get_env(:bt_attach, :workspace_client, BtAttach.Workspace)
+end

--- a/editors/liveview/lib/bt_attach_web/router.ex
+++ b/editors/liveview/lib/bt_attach_web/router.ex
@@ -25,6 +25,32 @@ defmodule BtAttachWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :readiness do
+    plug :accepts, ["json"]
+    plug :fetch_session
+    # Load the OIDC session user so :require_auth below can gate on it, same
+    # as the :browser pipeline.
+    plug :fetch_current_user
+  end
+
+  # Desktop-attach health check (ADR 0097 Implementation §1c): the broker
+  # polls this *before* opening a window, when there is no browser session
+  # yet — `:require_auth` is a documented pass-through when OIDC is disabled
+  # (the broker's own posture: it refuses to spawn a front with OIDC config
+  # present), so this is a no-op for the intended caller. It must NOT be
+  # unconditionally public, though: this same `bt_attach` release also serves
+  # OIDC-authenticated remote deployments (ADR 0091), where this endpoint
+  # would otherwise let any unauthenticated internet client force a dist
+  # `connect/0` + RPC to the workspace and read back its version report on
+  # every hit. `:require_auth` closes that: unauthenticated + OIDC-enabled
+  # gets redirected to the IdP (never reaches the controller), exactly like
+  # the IDE route below. No CSRF plug — GET-only, not a form submission.
+  scope "/", BtAttachWeb do
+    pipe_through [:readiness, :require_auth]
+
+    get "/readiness", ReadinessController, :show
+  end
+
   # OIDC login + callback. These must NOT require an authenticated session
   # (they are how you get one). The callback is the only route that legitimately
   # receives a cross-site top-level redirect from the IdP (SameSite handling is

--- a/editors/liveview/test/bt_attach/runtime_config_test.exs
+++ b/editors/liveview/test/bt_attach/runtime_config_test.exs
@@ -1,0 +1,114 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttach.RuntimeConfigTest do
+  @moduledoc """
+  Evaluates `config/runtime.exs` itself (via `Config.Reader.read!/2`, the same
+  mechanism `mix release` uses to run it) with a controlled environment, so the
+  `BT_ATTACH_BIND_IP` hook (ADR 0097 Implementation §1b) and `PORT` passthrough
+  are covered without booting a real endpoint.
+
+  `env: :prod` makes `config_env()` evaluate to `:prod` inside the script
+  (`Config.Reader.read!/2`'s documented purpose), exercising the same branch a
+  release boot takes. `BT_IDE_CONFIG` is pointed at a file that doesn't exist so
+  the unrelated OIDC-load block (`runtime.exs`'s `unless config_env() ==
+  :test`) resolves deterministically to "OIDC not configured" regardless of
+  what the machine running this test happens to have in `~/.beamtalk/ide.toml`
+  or `BT_OIDC_*`.
+  """
+  use ExUnit.Case, async: false
+
+  @runtime_exs Path.expand("../../config/runtime.exs", __DIR__)
+
+  setup do
+    original = %{
+      "SECRET_KEY_BASE" => System.get_env("SECRET_KEY_BASE"),
+      "PORT" => System.get_env("PORT"),
+      "PHX_HOST" => System.get_env("PHX_HOST"),
+      "BT_ATTACH_BIND_IP" => System.get_env("BT_ATTACH_BIND_IP"),
+      "BT_IDE_CONFIG" => System.get_env("BT_IDE_CONFIG")
+    }
+
+    System.put_env("SECRET_KEY_BASE", String.duplicate("a", 64))
+    System.delete_env("PHX_HOST")
+    # A path that cannot exist, so IdeConfig.load! deterministically sees "no
+    # config file" regardless of this machine's real ~/.beamtalk/ide.toml.
+    System.put_env(
+      "BT_IDE_CONFIG",
+      Path.join(
+        System.tmp_dir!(),
+        "bt-2983-nonexistent-ide-#{System.unique_integer([:positive])}.toml"
+      )
+    )
+
+    on_exit(fn ->
+      for {key, value} <- original do
+        case value do
+          nil -> System.delete_env(key)
+          value -> System.put_env(key, value)
+        end
+      end
+    end)
+
+    :ok
+  end
+
+  defp read_prod_endpoint_http! do
+    config = Config.Reader.read!(@runtime_exs, env: :prod, target: :host)
+
+    config
+    |> Keyword.fetch!(:bt_attach)
+    |> Keyword.fetch!(BtAttachWeb.Endpoint)
+    |> Keyword.fetch!(:http)
+  end
+
+  describe "BT_ATTACH_BIND_IP (ADR 0097 Implementation §1b)" do
+    test "unset keeps today's all-interfaces default" do
+      System.delete_env("BT_ATTACH_BIND_IP")
+
+      assert Keyword.fetch!(read_prod_endpoint_http!(), :ip) == {0, 0, 0, 0, 0, 0, 0, 0}
+    end
+
+    test "empty string keeps today's all-interfaces default" do
+      System.put_env("BT_ATTACH_BIND_IP", "")
+
+      assert Keyword.fetch!(read_prod_endpoint_http!(), :ip) == {0, 0, 0, 0, 0, 0, 0, 0}
+    end
+
+    test "127.0.0.1 is accepted for the desktop-attach broker's loopback bind" do
+      System.put_env("BT_ATTACH_BIND_IP", "127.0.0.1")
+
+      assert Keyword.fetch!(read_prod_endpoint_http!(), :ip) == {127, 0, 0, 1}
+    end
+
+    test "::1 is accepted for the desktop-attach broker's loopback bind" do
+      System.put_env("BT_ATTACH_BIND_IP", "::1")
+
+      assert Keyword.fetch!(read_prod_endpoint_http!(), :ip) == {0, 0, 0, 0, 0, 0, 0, 1}
+    end
+
+    test "an invalid address fails closed at boot rather than falling back silently" do
+      System.put_env("BT_ATTACH_BIND_IP", "not-an-ip")
+
+      assert_raise RuntimeError, ~r/invalid BT_ATTACH_BIND_IP/, fn ->
+        read_prod_endpoint_http!()
+      end
+    end
+  end
+
+  describe "PORT passthrough" do
+    test "PORT is read into the endpoint's http port" do
+      System.delete_env("BT_ATTACH_BIND_IP")
+      System.put_env("PORT", "34567")
+
+      assert Keyword.fetch!(read_prod_endpoint_http!(), :port) == 34_567
+    end
+
+    test "defaults to 4000 when PORT is unset" do
+      System.delete_env("BT_ATTACH_BIND_IP")
+      System.delete_env("PORT")
+
+      assert Keyword.fetch!(read_prod_endpoint_http!(), :port) == 4000
+    end
+  end
+end

--- a/editors/liveview/test/bt_attach/workspace_test.exs
+++ b/editors/liveview/test/bt_attach/workspace_test.exs
@@ -366,4 +366,91 @@ defmodule BtAttach.WorkspaceTest do
       end
     end
   end
+
+  describe "attach_sname/2 — self node-name seeding (ADR 0097 Implementation §1a)" do
+    test "with no suffix, falls back to a unique-integer name (today's behaviour)" do
+      name = Workspace.attach_sname(nil, "999")
+      assert Atom.to_string(name) =~ ~r/^bt_attach_\d+@localhost$/
+    end
+
+    test "an empty-string suffix is treated the same as unset" do
+      name = Workspace.attach_sname("", "999")
+      assert Atom.to_string(name) =~ ~r/^bt_attach_\d+@localhost$/
+    end
+
+    test "two unset-suffix calls never collide (System.unique_integer/1)" do
+      refute Workspace.attach_sname(nil, "1") == Workspace.attach_sname(nil, "1")
+    end
+
+    test "a workspace-id suffix is combined with the given OS-pid entropy" do
+      assert Workspace.attach_sname("ws-42", "1234") == :"bt_attach_ws-42_1234@localhost"
+    end
+
+    test "the same suffix with different os_pid values never collides (per-process entropy)" do
+      # This is the exact bug ADR 0097 calls out: an id-only seed would collide
+      # deterministically when two fronts attach to the same workspace.
+      refute Workspace.attach_sname("ws-42", "1") == Workspace.attach_sname("ws-42", "2")
+    end
+  end
+
+  describe "epmd_reachable?/2 — local epmd probe (ADR 0097 Implementation §1c)" do
+    test "true when something is listening on the given host/port" do
+      {:ok, listener} = :gen_tcp.listen(0, [:binary, active: false, ip: {127, 0, 0, 1}])
+      {:ok, port} = :inet.port(listener)
+
+      on_exit(fn -> :gen_tcp.close(listener) end)
+
+      assert Workspace.epmd_reachable?(~c"127.0.0.1", port) == true
+    end
+
+    test "false when nothing is listening on the given host/port" do
+      # Bind port 0 to get a free port, then close it immediately so the OS
+      # frees it back up but nothing is listening there for our probe.
+      {:ok, listener} = :gen_tcp.listen(0, [:binary, active: false, ip: {127, 0, 0, 1}])
+      {:ok, port} = :inet.port(listener)
+      :ok = :gen_tcp.close(listener)
+
+      assert Workspace.epmd_reachable?(~c"127.0.0.1", port) == false
+    end
+  end
+
+  describe "classify_unreachable/2 — readiness failure taxonomy (ADR 0097 Implementation §1c)" do
+    test "epmd_absent when the names query itself failed" do
+      assert Workspace.classify_unreachable(:beamtalk_workspace_spike@localhost, {:error, :x}) ==
+               :epmd_absent
+    end
+
+    test "bad_cookie when epmd still knows about the target node" do
+      names = {:ok, [{~c"beamtalk_workspace_spike", 45678}]}
+
+      assert Workspace.classify_unreachable(:beamtalk_workspace_spike@localhost, names) ==
+               :bad_cookie
+    end
+
+    test "dead_workspace when epmd has no record of the target node" do
+      names = {:ok, [{~c"some_other_node", 45678}]}
+
+      assert Workspace.classify_unreachable(:beamtalk_workspace_spike@localhost, names) ==
+               :dead_workspace
+    end
+
+    test "dead_workspace when epmd's names list is empty" do
+      assert Workspace.classify_unreachable(:beamtalk_workspace_spike@localhost, {:ok, []}) ==
+               :dead_workspace
+    end
+  end
+
+  describe "readiness/0 — full connectivity check against a real workspace (ADR 0097 §1c)" do
+    # No stub here: readiness/0 forces real distribution (`ensure_distributed/0`
+    # + `Node.connect/1`) plus a real RPC, so unlike the pure-logic describes
+    # above this needs an actual workspace node and its cookie — the same
+    # `:workspace`-gated CI job as `workspace_live_test.exs`. Excluded from the
+    # default `mix test` run (see test_helper.exs).
+    @describetag :workspace
+
+    test "reports :ok with a version report when the workspace is reachable" do
+      assert {:ok, report} = Workspace.readiness()
+      assert %{runtime_version: _, protocol_version: _, otp_release: _, erts_version: _} = report
+    end
+  end
 end

--- a/editors/liveview/test/bt_attach_web/controllers/readiness_controller_test.exs
+++ b/editors/liveview/test/bt_attach_web/controllers/readiness_controller_test.exs
@@ -1,0 +1,118 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.ReadinessControllerTest do
+  @moduledoc """
+  `GET /readiness` request/response coverage (ADR 0097 Implementation §1c) —
+  the desktop-attach broker's pre-window health probe.
+
+  Drives the endpoint against small fake workspace clients (the same
+  `Application.put_env(:bt_attach, :workspace_client, ...)` injection point
+  `workspace_live_test.exs` uses via `BtAttachWeb.StubWorkspaceClient`) rather
+  than a real workspace, so each of the four outcomes — reachable, and the
+  three failure-taxonomy reasons — is deterministic and doesn't need real
+  distribution/epmd/a live workspace.
+  """
+  use BtAttachWeb.ConnCase, async: false
+
+  defmodule ReachableClient do
+    @moduledoc false
+    def readiness do
+      {:ok,
+       %{
+         runtime_version: "1.2.3",
+         protocol_version: "2.0",
+         otp_release: "26",
+         erts_version: "14.0"
+       }}
+    end
+  end
+
+  defmodule EpmdAbsentClient do
+    @moduledoc false
+    def readiness, do: {:error, :epmd_absent}
+  end
+
+  defmodule BadCookieClient do
+    @moduledoc false
+    def readiness, do: {:error, :bad_cookie}
+  end
+
+  defmodule DeadWorkspaceClient do
+    @moduledoc false
+    def readiness, do: {:error, :dead_workspace}
+  end
+
+  setup do
+    on_exit(fn -> Application.delete_env(:bt_attach, :workspace_client) end)
+    :ok
+  end
+
+  test "200 with the version report when the workspace is reachable", %{conn: conn} do
+    Application.put_env(:bt_attach, :workspace_client, ReachableClient)
+
+    conn = get(conn, ~p"/readiness")
+
+    assert json_response(conn, 200) == %{
+             "status" => "ok",
+             "version" => %{
+               "runtime_version" => "1.2.3",
+               "protocol_version" => "2.0",
+               "otp_release" => "26",
+               "erts_version" => "14.0"
+             }
+           }
+  end
+
+  test "503 with reason epmd_absent when the front can't publish to epmd", %{conn: conn} do
+    Application.put_env(:bt_attach, :workspace_client, EpmdAbsentClient)
+
+    conn = get(conn, ~p"/readiness")
+
+    assert json_response(conn, 503) == %{"status" => "error", "reason" => "epmd_absent"}
+  end
+
+  test "503 with reason bad_cookie when the dist handshake is rejected", %{conn: conn} do
+    Application.put_env(:bt_attach, :workspace_client, BadCookieClient)
+
+    conn = get(conn, ~p"/readiness")
+
+    assert json_response(conn, 503) == %{"status" => "error", "reason" => "bad_cookie"}
+  end
+
+  test "503 with reason dead_workspace when epmd has no record of the target node", %{
+    conn: conn
+  } do
+    Application.put_env(:bt_attach, :workspace_client, DeadWorkspaceClient)
+
+    conn = get(conn, ~p"/readiness")
+
+    assert json_response(conn, 503) == %{"status" => "error", "reason" => "dead_workspace"}
+  end
+
+  # This front's release is shared with OIDC-authenticated remote deployments
+  # (ADR 0091) as well as the (always-unauthenticated) desktop-attach broker.
+  # An unauthenticated `/readiness` would let any internet client on a remote
+  # deployment force a dist connect + RPC and read the version report — so
+  # when OIDC *is* configured, the endpoint must sit behind the same
+  # `require_auth` gate as the IDE route, not be unconditionally public.
+  test "redirects to the OIDC login route instead of leaking the version report when OIDC is configured",
+       %{conn: conn} do
+    Application.put_env(:bt_attach, :workspace_client, ReachableClient)
+
+    Application.put_env(:bt_attach, :oidc, %{
+      issuer: "https://idp",
+      client_id: "id",
+      redirect_uri: "https://ide/callback",
+      groups_claim: "groups",
+      client_secret: "x",
+      roles: %{"owner" => ["beamtalk-owners"]}
+    })
+
+    on_exit(fn -> Application.delete_env(:bt_attach, :oidc) end)
+
+    conn = get(conn, ~p"/readiness")
+
+    assert redirected_to(conn) == ~p"/oidc/auth"
+  end
+end

--- a/editors/liveview/test/support/stub_workspace_client.ex
+++ b/editors/liveview/test/support/stub_workspace_client.ex
@@ -109,6 +109,20 @@ defmodule BtAttachWeb.StubWorkspaceClient do
 
   def connect, do: :ok
 
+  # ADR 0097: the desktop-attach `/readiness` handshake target. A canned
+  # "always reachable" report — tests exercising the failure taxonomy
+  # (`readiness_controller_test.exs`) use their own small fake clients instead
+  # of this shared stub, since they need to drive distinct error reasons.
+  def readiness do
+    {:ok,
+     %{
+       runtime_version: "stub",
+       protocol_version: "2.0",
+       otp_release: "stub",
+       erts_version: "stub"
+     }}
+  end
+
   def start_session(_session_id, _meta) do
     # Returns a stub pid. Safe only when the caller uses a nil token, which
     # short-circuits SessionRegistry.register/3 before any monitor is set up.


### PR DESCRIPTION
## Summary

Part of ADR 0097 (Desktop Attach Client), Phase 1 of 5. Implements the three small, additive front-side changes ADR 0097 Implementation §1 needs before the desktop broker (BT-2985) can attach — the attach client's RPC/eval core stays untouched.

- **Self node-name seeding** — `ensure_distributed/0` (`editors/liveview/lib/bt_attach/workspace.ex`) now seeds its sname from `BT_ATTACH_NODE_SUFFIX` (the workspace id) plus per-process entropy (OS pid): `bt_attach_<id>_<os_pid>@localhost`. Unset env keeps today's `System.unique_integer` behaviour. An id-only seed would collide deterministically when two fronts attach to the same workspace — the entropy is always appended, never optional.
- **`BT_ATTACH_BIND_IP`** — `config/runtime.exs` reads this env for the endpoint's bind address; default remains today's all-interfaces `{0,0,0,0,0,0,0,0}` so remote deploys are unchanged. `127.0.0.1`/`::1` (or any valid address) parsed via `:inet.parse_address/1`; an invalid value fails closed at boot rather than silently falling back.
- **`GET /readiness`** (new router scope + `BtAttachWeb.ReadinessController`) — forces `connect/0` plus one cheap RPC (`beamtalk_version:get/0`, BT-2991) and returns:
  - `200` with the workspace's version report (runtime/protocol/OTP/ERTS) on success, for the broker's version-mismatch handshake.
  - `503` with a machine-readable `reason` distinguishing `epmd_absent` / `bad_cookie` / `dead_workspace`, so the broker can show a precise error before opening a window instead of a generic failure.
- **Security fix applied during self-review**: `/readiness` is gated behind the existing `require_auth` pipeline. It's a documented no-op when OIDC is disabled (the broker's own posture — it refuses to spawn with OIDC config present), but this `bt_attach` release is also used by OIDC-authenticated remote deployments (ADR 0091); without the gate, any unauthenticated internet client could hit a remote deployment's `/readiness` to force a dist connect + RPC and read back version info on every request.
- `connect/0`'s underlying `ensure_distributed/0` no longer `raise`s when the local epmd is unreachable — it returns a classifiable `{:error, :epmd_absent}` instead, which `connect/0` now propagates via `with` (previously this crashed the LiveView mount).

## Test plan

- [x] `mix test` (editors/liveview): 485 passed, 120 excluded (`:workspace`/`:playwright`-tagged, requiring a real workspace/browser — unchanged exclusion set)
- [x] Pure-logic unit tests for the sname-seeding, epmd-probe, and failure-taxonomy classification (`attach_sname/2`, `epmd_reachable?/2`, `classify_unreachable/2`) — deterministic, no real distribution/epmd needed
- [x] `ReadinessController` request/response tests via injected fake workspace clients covering all four outcomes (reachable, epmd_absent, bad_cookie, dead_workspace) plus the new OIDC-gate redirect test
- [x] `config/runtime.exs` evaluated via `Config.Reader.read!/2` (`env: :prod`) to cover `BT_ATTACH_BIND_IP` (unset/empty/127.0.0.1/::1/invalid) and `PORT` passthrough
- [x] A `:workspace`-tagged integration test added for `Workspace.readiness/0`'s happy path against a real workspace (runs in the existing workspace-gated CI lane)
- [x] `mix format --check-formatted`, `mix compile --warnings-as-errors`: clean
- [x] `just build`, `just clippy`, `just fmt-check`: clean (unaffected Rust/Erlang surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)