### PR TITLE
Spike: settle desktop shell — Tauri vs no-shell coordinator (BT-2984)

### DIFF
--- a/docs/research/desktop-shell-spike.md
+++ b/docs/research/desktop-shell-spike.md
@@ -2,9 +2,13 @@
 
 **Issue:** BT-2984
 **Date:** 2026-07-27
-**Status:** Complete — recommendation: **Tauri, provisionally confirmed** (one
-criterion, (e), needs a hands-on cross-platform follow-up before BT-2985/BT-2986
-lock in a Tauri-specific broker implementation)
+**Status:** Complete — recommendation: **lean Tauri, but the shell decision is
+not actually settled by this spike.** Six of the ADR's seven exit criteria
+turned out to be shell-agnostic (satisfied identically by either alternative),
+which leaves the decision resting entirely on criterion (e) — the one
+criterion this spike could **not** validate hands-on (no display server, no
+Tauri toolchain, no target OSes in this sandbox; see Scope below). This is
+"undecided pending a real (e) test," not a confirmed yes — see Verdict below.
 **Throwaway code:** `spikes/desktop-attach-spike/` (this branch, not merged to
 main — see that directory's README for how to reproduce every result below)
 
@@ -80,6 +84,14 @@ two-fronts-one-workspace) passes cleanly. **This is broker-core work
 (BT-2985), not shell-specific** — a Tauri broker and the no-shell coordinator
 both spawn `bin/server` and both need this exact env var.
 
+Harness caveat: `broker.sh`'s `free_port()` helper (bind port 0, read the
+assigned number, close, hand that number to the front) has a check-then-use
+race — nothing guarantees another process doesn't grab the same port between
+the close and the front's own bind. It didn't bite across this spike's runs,
+but it's a known gap in the throwaway harness, not a property of the front or
+broker design being validated; BT-2985's real port allocation should retry on
+bind failure rather than assume a `free_port()`-style probe is race-free.
+
 ## (b) Crash → respawn of the same workspace — PASS
 
 Killed a live front (`kill -9`); epmd dropped its registration and the port
@@ -117,6 +129,18 @@ follow-up** (see "Follow-ups" below) rather than fixed here — it's shipped,
 reviewed code outside this spike's throwaway scope, and the fix is a one-line
 `:net_adm.names(:localhost)` at the call site.
 
+Caveat on generality: this spike ran on **one** host (WSL2, hostname
+`muckish`), so "PARTIAL PASS" describes what was observed here, not a claim
+that the taxonomy fails on every host — on a machine where the local hostname
+happens to self-resolve cleanly, `:net_adm.names()` would succeed and the
+taxonomy would work as shipped. What *is* general is the code-level defect:
+relying on hostname self-resolution for a query that only ever needs to reach
+the **local** epmd is objectively more fragile than the explicit `:localhost`
+form, independent of whether it happens to bite on any particular tester's
+machine — hostnames that don't loop back cleanly are common enough in
+containers/CI/some mDNS setups that this is worth fixing regardless of
+whether it reproduces on a "normal" dev laptop.
+
 Shell-agnostic: entirely front-side (BT-2983) behavior; a Tauri broker and the
 coordinator would both be equally misled by it today.
 
@@ -130,14 +154,21 @@ coordinator would both be equally misled by it today.
   env hook was needed** — the default `check_origin: true` plus the endpoint's
   own `url:` config (which already derives host/port from `PORT`) pins it
   correctly out of the box, exactly as ADR 0097 predicted but flagged as
-  "must be validated, not assumed."
-- **No-OIDC fail-closed**: spawning with an incomplete OIDC env
-  (`BT_OIDC_ISSUER` set, required keys missing) crashes the release at boot
-  with a clear `RuntimeError` — the app never serves a byte of unauthenticated
-  traffic. Confirms the safety net BT-2983/ADR 0091 designed is real; the
-  broker's job is simply to *check* for OIDC config **before** spawning (to
-  give a friendly error instead of a boot crash), not to re-implement the
-  enforcement.
+  "must be validated, not assumed." Only the exact `localhost:<port>` origin
+  was tried; a real webview may present a slightly different origin (e.g. a
+  `127.0.0.1` navigation, or whatever Tauri's webview reports as its origin
+  for a `localhost` URL) — worth a quick re-check once an actual webview is
+  in the loop (see "What's not settled" below, folds into the (e) follow-up).
+- **Incomplete-OIDC-config fail-closed**: spawning with an *incomplete* OIDC
+  env (`BT_OIDC_ISSUER` set, required keys missing) crashes the release at
+  boot with a clear `RuntimeError` — the app never serves a byte of
+  unauthenticated traffic. This tests the fail-closed safety net for a
+  half-configured OIDC setup, not the "no OIDC config at all" case (that path
+  is just the normal unauthenticated posture, already exercised by every
+  other test in this write-up). Confirms the safety net BT-2983/ADR 0091
+  designed is real; the broker's job is simply to *check* for OIDC config
+  **before** spawning (to give a friendly error instead of a boot crash), not
+  to re-implement the enforcement.
 
 Shell-agnostic: all three are env-vars-plus-front-config; both shells set the
 identical env before invoking `bin/server`.
@@ -192,11 +223,17 @@ below.
 - **Sleep/resume → front reconnects**: rather than guessing, this was
   reproduced directly by connecting a throwaway debug node (using the
   release's own persistent cookie, `dist-liveview/releases/COOKIE`) to a live
-  front and calling `:erlang.disconnect_node/1` on the workspace peer — the
-  same effect an OS sleep/resume has on a dist connection. `Node.list()`
-  confirmed the link was gone; the **very next** `/readiness` call returned
-  `200` again, because `connect/0` is idempotent and re-runs `Node.connect/1`
-  on every call. Self-heal confirmed, no restart needed.
+  front and calling `:erlang.disconnect_node/1` on the workspace peer.
+  `Node.list()` confirmed the link was gone; the **very next** `/readiness`
+  call returned `200` again, because `connect/0` is idempotent and re-runs
+  `Node.connect/1` on every call. Self-heal confirmed for a clean, mutual
+  disconnect. Caveat: `disconnect_node/1` is a proxy for what OS sleep/resume
+  does to a dist connection, not the literal thing — a real suspend can leave
+  a half-open socket (one side thinks it's connected, the other doesn't) that
+  behaves differently than a clean teardown, and `net_ticktime` timeout
+  behavior wasn't exercised. The idempotent-`connect/0` mechanism this relies
+  on should generalize, but "self-heal confirmed" here means confirmed for the
+  clean-disconnect case specifically.
 
 Shell-agnostic: entirely front-side behavior already shipped in BT-2983; both
 shells just poll `/readiness` and react to the transition.
@@ -216,6 +253,17 @@ orphan, not a simulated one), then ran `broker.sh sweep` (the "next broker
 start" step) which detected the still-alive, untracked-by-this-session PID,
 `SIGTERM`'d it (with a `SIGKILL` fallback), and cleared its bookkeeping —
 verified the OS process was actually gone afterward, not just untracked.
+
+**Known gap in the prototyped mechanism, to harden in BT-2985**: `sweep` kills
+whatever PID a pidfile names with no check that it's still the *same* process
+— if the orphan already died and the OS recycled its PID for something else
+before the next sweep runs, a naive PID-file sweep kills an unrelated
+process. This spike's single-orphan, short-lived test window never triggered
+that, so it's a latent correctness gap in the mechanism, not something ruled
+out by "PASS" here. The real broker should additionally record something
+distinguishing (process start time, or verify the target's executable path
+matches `dist-liveview/bin/bt_attach` via `/proc/<pid>/exe` on Linux or the
+platform equivalent) before signaling.
 
 **Bonus finding, relevant to the shell decision**: the no-shell coordinator
 prototype needs this too, and doesn't get it for free. Killing the running
@@ -239,7 +287,16 @@ paid by whichever shell does the spawning.
    redirects the browser to `http://localhost:<port>/`.
 3. Tracks already-attached workspaces in memory and **reuses the existing
    front** on a repeat `/attach/:id` rather than spawning a duplicate — proven
-   live: two calls to `/attach/spike-a` returned the same port both times.
+   live both sequentially (two calls to `/attach/spike-a` returned the same
+   port both times) and concurrently: an initial version used a plain
+   "get, then spawn if absent" check, which an adversarial pass on this spike
+   correctly flagged as racy (two near-simultaneous `/attach/:id` requests,
+   each its own Bandit-spawned process, could both observe "nothing tracked"
+   and both spawn). Fixed with an atomic `Agent.get_and_update/2`
+   claim-or-wait (`Coordinator.State.claim_or_get/1`) and re-verified: two
+   `curl` requests fired in parallel at `/attach/spike-c` resolved to the
+   *same* port, and `ps`/`epmd -names` confirmed only one front process
+   actually started.
 
 Verified live end-to-end: listing shows real `alive`/`dead` status for real
 workspaces; clicking Attach spawns a real front, waits for real readiness, and
@@ -298,14 +355,20 @@ browser-tab/PWA-based alternative. That is exactly the ADR's own framing
 no-shell coordinator's PWA path cannot match"), and this spike's desk research
 does not contradict it.
 
-**Recommendation: Tauri, provisionally confirmed.** "Provisionally" because
-(e) — the sole remaining justification — is also the one criterion this spike
-could not run hands-on (no display, no Tauri toolchain, no target OSes in this
-sandbox). Given five of the other six criteria surfaced real, previously-unknown
-bugs when actually run (the release-boot sname collision, the readiness
-taxonomy collapse), "asserted from documentation" is a materially weaker bar
-than this spike held everything else to, and (e) deserves the same treatment
-before BT-2985/BT-2986 commit to a Tauri-specific broker implementation.
+**Recommendation: lean Tauri, but say plainly that this spike did not settle
+the shell decision.** Restated without the soft-yes framing: every criterion
+this spike could actually *run* turned out not to require Tauri — a
+throwaway Elixir page matched it duty-for-duty, including finding real bugs
+neither implementation was immune to. The entire case for Tauri rests on
+(e), and (e) is the one criterion this spike validated by reading Tauri's own
+documentation and GitHub issues, not by running a webview. Two of the other
+six criteria surfaced real, previously-unknown bugs the moment they were
+actually run (the release-boot sname collision, the readiness taxonomy
+collapse) rather than when merely reasoned about — which is exactly the
+failure mode a desk-research-only pass on (e) is equally exposed to. Treat
+the shell decision as **open, leaning Tauri on documented capability**, not
+closed, until (e) gets the same hands-on treatment before BT-2985/BT-2986
+commit to a Tauri-specific broker implementation.
 
 ## What's not settled — recommended before committing further Tauri work
 

--- a/docs/research/desktop-shell-spike.md
+++ b/docs/research/desktop-shell-spike.md
@@ -1,0 +1,350 @@
+# Desktop Attach Shell Spike — Tauri vs No-Shell Coordinator
+
+**Issue:** BT-2984
+**Date:** 2026-07-27
+**Status:** Complete — recommendation: **Tauri, provisionally confirmed** (one
+criterion, (e), needs a hands-on cross-platform follow-up before BT-2985/BT-2986
+lock in a Tauri-specific broker implementation)
+**Throwaway code:** `spikes/desktop-attach-spike/` (this branch, not merged to
+main — see that directory's README for how to reproduce every result below)
+
+## TL;DR
+
+ADR 0097's spike exit criteria are (a)-(g), decided **per-duty, not vibes**: only
+commit to the Tauri shell if the broker's responsibilities prove they need to
+live outside the BEAM. This spike built **both** alternatives against **real**
+workspaces, a **real** built `dist-liveview` release, and a **real** no-shell
+Elixir/Plug coordinator — no criterion here is asserted from reading code.
+
+The headline finding: **six of the seven duties (a, b, c, d, f, g) are shell-agnostic.**
+A ~300-line throwaway Elixir/Plug "coordinator" (`coordinator/coordinator.exs`)
+satisfies discovery, spawn, two-stage readiness probing, loopback/no-OIDC/
+check_origin enforcement, post-attach lifecycle, and orphan reaping **exactly as
+well as** a bash "broker" standing in for the eventual Rust/Tauri one — both
+share the identical spawn primitive (`dist-liveview/bin/server`), so neither
+gets an edge from being in a different language. The **only** duty that
+structurally distinguishes the two shells is **(e), webview/keybinding parity**
+— and that is exactly the criterion the ADR named as the load-bearing one.
+Desk research (not hands-on — see Scope below) supports Tauri's native
+menu-accelerator + window-level close interception as real and documented, at
+the cost of a well-documented WebKitGTK-on-Linux stability/performance risk.
+
+**Recommendation: keep Tauri as the shell**, but treat (e) as still open pending
+a cheap, real cross-platform QA pass (see "What's not settled" below) — the
+other six criteria no longer justify Tauri on their own; only (e) does, and it
+is the one criterion this spike could not test hands-on.
+
+## Scope: what this spike could and couldn't run
+
+This spike ran on a headless Linux (WSL2) sandbox: no display server, no
+`cargo-tauri` toolchain, no macOS/Windows targets. That shaped which criteria
+got **live, real evidence** vs **desk research**:
+
+| Criteria | Method |
+|---|---|
+| (a) (b) (c) (d) (f) (g) | **Live**: real `beamtalk workspace create`, a real built `dist-liveview` release (`just dist-liveview`), real epmd/distribution, real HTTP/websocket probes |
+| (e) webview parity | **Desk research only** (Tauri docs, GitHub issues) — no display, no Tauri CLI, no target OSes available here |
+
+## (a) Two-instance boot — PASS, after finding a real release-boot bug
+
+Validated live: two fronts on two different workspaces, and — the sharper case
+the ADR calls out explicitly — **two fronts attached to the same workspace**,
+both alive simultaneously with distinct snames:
+
+```
+name bt_attach_spike-a_264798 at port 37349
+name bt_attach_spike-a_264595 at port 45533
+```
+
+**Finding (real bug, not spike-only): `mix release`'s generated launcher boots
+the VM already distributed under `-sname bt_attach`** (`RELEASE_NODE` defaults
+to `RELEASE_NAME`) **before any Elixir code runs.** This pre-empts
+`ensure_distributed/0`'s `BT_ATTACH_NODE_SUFFIX` seeding entirely — `Node.alive?/0`
+is already `true` by the time the front's own code runs, so the sname-seeding
+BT-2983 shipped is dead code under the actual release artifact. Reproduced
+directly:
+
+```
+$ PORT=... BT_ATTACH_NODE_SUFFIX=spike-b dist-liveview/bin/server spike-b
+Protocol 'inet_tcp': the name bt_attach@muckish seems to be in use by another Erlang node
+```
+
+Every spawned instance collides on the identical epmd registration — this is
+precisely the two-instance-boot failure (a) is designed to catch, just one
+layer lower (release boot) than the ADR's authors were reasoning about (lazy
+`ensure_distributed/0`). **Fix, validated live**: the broker must launch with
+`RELEASE_DISTRIBUTION=none`, which makes the release boot **non-distributed**
+and hands control back to `ensure_distributed/0`'s lazy, correctly-seeded path
+on the first `/readiness` call. With that env var, two-instance boot (including
+two-fronts-one-workspace) passes cleanly. **This is broker-core work
+(BT-2985), not shell-specific** — a Tauri broker and the no-shell coordinator
+both spawn `bin/server` and both need this exact env var.
+
+## (b) Crash → respawn of the same workspace — PASS
+
+Killed a live front (`kill -9`); epmd dropped its registration and the port
+freed immediately. Respawned with the same `BT_ATTACH_NODE_SUFFIX` on the same
+port: new registration `bt_attach_spike-a_264930` (same seeded prefix, new PID
+entropy), readiness 200. Freed port reused cleanly. Shell-agnostic — this is
+front + spawn-env behavior only.
+
+## (c) `/readiness` catches bad cookie / dead workspace before the window opens — PARTIAL PASS, real taxonomy bug found
+
+The mechanism works: `/readiness` does force `connect/0` + one RPC and returns
+503 with a JSON body before any window would open, for every unreachable case
+tested. **But the three-way taxonomy BT-2983 shipped has a real,
+environment-triggered bug**: `classify_unreachable/2`
+(`editors/liveview/lib/bt_attach/workspace.ex:2105`) calls `:net_adm.names()`
+with **no host argument**, which resolves via `inet:gethostname()` (the
+machine's real hostname, e.g. `muckish`) rather than `:localhost`. On this
+sandbox (and plausibly other environments where the local hostname doesn't
+cleanly self-resolve for an epmd query — containers, some macOS/mDNS setups),
+that call fails outright:
+
+```elixir
+:net_adm.names()            #=> {:error, :address}   # WRONG default
+:net_adm.names(:localhost)  #=> {:ok, [...]}          # correct, explicit
+```
+
+`classify_unreachable/2`'s catch-all (`{:error, _} -> :epmd_absent`) then
+**collapses both `bad_cookie` and `dead_workspace` into `epmd_absent`** —
+confirmed live for both cases (a deliberately wrong cookie, and a node name
+with no backing workspace at all both report `epmd_absent`), even though epmd
+is reachable and correctly enumerable with the explicit `:localhost` argument.
+This directly undercuts BT-2983's own acceptance criterion ("failure taxonomy
+distinguishes epmd absent vs bad cookie vs dead workspace"). **Filed as a
+follow-up** (see "Follow-ups" below) rather than fixed here — it's shipped,
+reviewed code outside this spike's throwaway scope, and the fix is a one-line
+`:net_adm.names(:localhost)` at the call site.
+
+Shell-agnostic: entirely front-side (BT-2983) behavior; a Tauri broker and the
+coordinator would both be equally misled by it today.
+
+## (d) Loopback bind + no-OIDC + pinned `check_origin` — PASS, all three validated live
+
+- **Loopback bind**: `ss -ltnp` on a spawned front shows `127.0.0.1:<port>`,
+  never `0.0.0.0:<port>`, with `BT_ATTACH_BIND_IP=127.0.0.1`.
+- **`check_origin`**: a raw websocket-upgrade request to `/live/websocket` with
+  `Origin: http://evil.example` gets `403 Forbidden`; the same request with
+  `Origin: http://localhost:<port>` gets `101 Switching Protocols`. **No new
+  env hook was needed** — the default `check_origin: true` plus the endpoint's
+  own `url:` config (which already derives host/port from `PORT`) pins it
+  correctly out of the box, exactly as ADR 0097 predicted but flagged as
+  "must be validated, not assumed."
+- **No-OIDC fail-closed**: spawning with an incomplete OIDC env
+  (`BT_OIDC_ISSUER` set, required keys missing) crashes the release at boot
+  with a clear `RuntimeError` — the app never serves a byte of unauthenticated
+  traffic. Confirms the safety net BT-2983/ADR 0091 designed is real; the
+  broker's job is simply to *check* for OIDC config **before** spawning (to
+  give a friendly error instead of a boot crash), not to re-implement the
+  enforcement.
+
+Shell-agnostic: all three are env-vars-plus-front-config; both shells set the
+identical env before invoking `bin/server`.
+
+## (e) Webview parity — DESK RESEARCH ONLY, the one real differentiator
+
+Could not hands-on test: no display server, no `cargo-tauri`, no macOS/Windows
+target in this sandbox. What the research supports:
+
+- **Tauri's actual mechanism for owning `Cmd/Ctrl-W` is the native window's
+  menu/accelerator table plus the window-level `CloseRequested` event**
+  (`onCloseRequested` → `event.preventDefault()`), not the `global-shortcut`
+  plugin (that plugin is for *system-wide* hotkeys when the app isn't
+  focused — a different mechanism). This is documented and real: a native
+  window's close-request is an OS window message the shell's Rust code
+  intercepts *before* the webview ever sees a key event — categorically
+  different from a browser tab's `keydown`, which the browser chrome consumes
+  first, so `preventDefault()` never fires (ADR's own framing, confirmed by
+  the existence of `tauri-plugin-prevent-default`, a plugin that exists
+  specifically because webviews default-handle several browser shortcuts that
+  need explicit suppression).
+- **This is a capability the no-shell coordinator's PWA path cannot match, by
+  platform construction, not by remaining engineering effort.** An installed
+  PWA window is still a browser surface — the OS/browser chrome owns
+  `Ctrl/Cmd-W` and a page cannot intercept it. No amount of JS changes that.
+- **Real, documented risk on the other side**: a Tauri/WebView2 GitHub issue is
+  titled exactly *"Some default platform shortcuts are disabled, some are not"*
+  — i.e., even within Tauri, shortcut-interception behavior is inconsistent
+  across specific keys on Windows, not a clean solved problem. And WebKitGTK
+  on Linux has multiple **open, upstream** issues directly relevant to a
+  LiveView-heavy UI: websocket "network process crashed" errors, high
+  `WebKitWebProcess` CPU usage tied to websocket traffic, and general
+  DOM/rendering slowness under load — all things a live-updating IDE hits
+  constantly. These are upstream WebKitGTK limitations, not something Tauri
+  application code can paper over.
+
+**Net**: the *capability* argument for Tauri is real and technically
+substantiated, not "asserted from browser behaviour" as the ADR worried it
+might be — but it is also not risk-free, and this spike could not verify it by
+actually running a webview. That gap is the one piece of unfinished business
+below.
+
+## (f) Post-attach lifecycle — PASS, both halves validated live
+
+- **Workspace killed while attached → window reflects it, not a wall of
+  errors**: with a healthy attached front, `beamtalk workspace stop spike-a`
+  was run directly. The front process **did not crash** — it kept serving HTTP
+  (root page still 200) and `/readiness` cleanly returned 503 JSON (misreported
+  as `epmd_absent` due to the (c) bug above, but structurally a clean error,
+  not an exception wall). A polling broker/coordinator would see this
+  transition and grey the window.
+- **Sleep/resume → front reconnects**: rather than guessing, this was
+  reproduced directly by connecting a throwaway debug node (using the
+  release's own persistent cookie, `dist-liveview/releases/COOKIE`) to a live
+  front and calling `:erlang.disconnect_node/1` on the workspace peer — the
+  same effect an OS sleep/resume has on a dist connection. `Node.list()`
+  confirmed the link was gone; the **very next** `/readiness` call returned
+  `200` again, because `connect/0` is idempotent and re-runs `Node.connect/1`
+  on every call. Self-heal confirmed, no restart needed.
+
+Shell-agnostic: entirely front-side behavior already shipped in BT-2983; both
+shells just poll `/readiness` and react to the transition.
+
+## (g) Orphan-reaping — PASS, PID-file sweep concretely prototyped
+
+Chose **PID-file sweep** over process-group kill or a parent-death watch
+(`PR_SET_PDEATHSIG`) because it's the only one of the three portable to Windows
+without OS-specific syscalls — the ADR's packaging phase (§5) targets macOS +
+Linux + Windows, and process groups / pdeathsig are Unix-only mechanisms.
+
+Demonstrated live end-to-end: spawned a front via `setsid` (so it is not a
+`wait()`-able child of its spawning shell — the same relationship a real
+desktop broker has to its children), confirmed via `ps -o pid,ppid,pgid,sid`
+that it re-parents to init and runs as its own session leader (a genuine
+orphan, not a simulated one), then ran `broker.sh sweep` (the "next broker
+start" step) which detected the still-alive, untracked-by-this-session PID,
+`SIGTERM`'d it (with a `SIGKILL` fallback), and cleared its bookkeeping —
+verified the OS process was actually gone afterward, not just untracked.
+
+**Bonus finding, relevant to the shell decision**: the no-shell coordinator
+prototype needs this too, and doesn't get it for free. Killing the running
+`coordinator.exs` process (`pkill -f coordinator.exs`) left its spawned front
+running as an orphan (`ps` showed it re-parented to init) — the coordinator
+has **no** built-in reaping, exactly matching the ADR's own prediction ("a
+coordinator front would have to spawn children with the same care anyway").
+Orphan-reaping is not a Tauri-only cost; it is a **spawn-a-child-process** cost,
+paid by whichever shell does the spawning.
+
+## No-shell coordinator — built, and it works
+
+`coordinator/coordinator.exs`: a single-file, throwaway Elixir/Plug/Bandit app
+(~300 lines, `Mix.install`-bootstrapped, no separate build step) that:
+
+1. Lists `~/.beamtalk/workspaces/*` (same discovery contract as the bash
+   broker — epmd liveness check, real `metadata.json` parsing).
+2. On `/attach/:id`, spawns `dist-liveview/bin/server <id>` with the identical
+   env the broker uses (loopback bind, id-seeded suffix,
+   `RELEASE_DISTRIBUTION=none`), runs the same two-stage readiness probe, and
+   redirects the browser to `http://localhost:<port>/`.
+3. Tracks already-attached workspaces in memory and **reuses the existing
+   front** on a repeat `/attach/:id` rather than spawning a duplicate — proven
+   live: two calls to `/attach/spike-a` returned the same port both times.
+
+Verified live end-to-end: listing shows real `alive`/`dead` status for real
+workspaces; clicking Attach spawns a real front, waits for real readiness, and
+redirects to a real working page. Installed as a PWA (browser "Install app"),
+this delivers the dockable-window, pick-a-workspace UX the ADR credits it
+with — for near-zero shell code and zero new toolchain (no Rust GUI crate, no
+per-OS build matrix, no code-signing). The place it structurally cannot
+compete is (e): the coordinator's spawned fronts still open as ordinary
+browser tabs/PWA windows, which never get to own `Ctrl/Cmd-W`.
+
+## Single-instance policy & attach-twice semantics — decided
+
+**Attaching twice to the same workspace: focus/reuse the existing front, do
+not spawn a second one.** Demonstrated in the coordinator (in-memory
+workspace→port map, second attach redirects to the same live front) and the
+policy translates directly to a Tauri broker (check its own state before
+spawning; if already attached, focus that window instead of forking a new
+front). This is cheaper (no duplicate ERTS process, no second port/sname to
+track) and doesn't fight the sname-seeding fix in (a) — a legitimate *second*
+front on the same workspace (e.g., a deliberate "detach and reconnect fresh"
+action) remains possible and collision-free because of the id+OS-pid seeding,
+but is not the default behavior of clicking Attach twice.
+
+**The broker/coordinator process itself should be single-instance** (OS-level
+lock or Tauri's single-instance plugin) so a second dock-icon launch focuses
+the existing picker rather than starting a second supervisor that would race
+on port allocation and pidfile bookkeeping — consistent with every reference
+precedent this ADR already cites (VS Code, Livebook, Docker Desktop are all
+single-instance apps).
+
+## Verdict
+
+Per-duty, as the ADR demands:
+
+| Criterion | Verdict | Shell-differentiating? |
+|---|---|---|
+| (a) two-instance boot | PASS (after a real fix: `RELEASE_DISTRIBUTION=none`) | No |
+| (b) crash → respawn | PASS | No |
+| (c) readiness taxonomy | PARTIAL — mechanism works, real taxonomy bug found (filed) | No |
+| (d) loopback/no-OIDC/check_origin | PASS | No |
+| (e) webview parity | Desk research only — real capability, real risk, not hands-on tested | **Yes — the only one** |
+| (f) post-attach lifecycle | PASS | No |
+| (g) orphan reaping | PASS (PID-file sweep); coordinator needs it too | No |
+
+Six of seven duties are satisfied identically by a throwaway ~300-line Elixir
+page and a bash script standing in for the eventual Rust broker — **none of
+them independently justify a Rust/Tauri shell**, because none of them are
+actually broker-*language* concerns; they're all "what env do you set before
+running `bin/server`" concerns, answerable in any language that can spawn a
+process and poll HTTP.
+
+**The Tauri recommendation survives this spike on (e) alone** — OS-reserved
+keybinding ownership is real, documented, and structurally unavailable to any
+browser-tab/PWA-based alternative. That is exactly the ADR's own framing
+("the spike's exit criteria... decide the shell," "this is a property the
+no-shell coordinator's PWA path cannot match"), and this spike's desk research
+does not contradict it.
+
+**Recommendation: Tauri, provisionally confirmed.** "Provisionally" because
+(e) — the sole remaining justification — is also the one criterion this spike
+could not run hands-on (no display, no Tauri toolchain, no target OSes in this
+sandbox). Given five of the other six criteria surfaced real, previously-unknown
+bugs when actually run (the release-boot sname collision, the readiness
+taxonomy collapse), "asserted from documentation" is a materially weaker bar
+than this spike held everything else to, and (e) deserves the same treatment
+before BT-2985/BT-2986 commit to a Tauri-specific broker implementation.
+
+## What's not settled — recommended before committing further Tauri work
+
+- **Hands-on (e) validation**: a throwaway `cargo tauri init` + a manual QA
+  pass — register a custom `Cmd/Ctrl-W` action via the native menu/
+  `CloseRequested` path on at least Linux (WebKitGTK, available in most CI
+  runners) and ideally macOS/Windows — before BT-2985 bakes a Tauri-specific
+  broker shape in. Cheap relative to the packaging lane (BT-2987) that already
+  has to stand up per-OS builds; doing it earlier means an (e) surprise doesn't
+  surface after BT-2986's picker UI is built on top of a Tauri assumption.
+- **WebKitGTK risk budget**: if the hands-on pass reproduces the websocket
+  network-process-crash or high-CPU issues found in desk research under real
+  LiveView traffic, that's grounds to revisit — not necessarily flip to the
+  coordinator, but possibly scope Linux support differently (e.g. document a
+  minimum WebKitGTK version, or fall back to the coordinator specifically on
+  Linux while keeping Tauri on macOS/Windows — a split this spike didn't
+  explore because it wasn't asked to).
+
+## Follow-ups filed
+
+- **`classify_unreachable/2` hostname bug** (criterion (c)): `:net_adm.names()`
+  (no host arg) resolves via the machine's real hostname instead of
+  `:localhost`, collapsing `bad_cookie`/`dead_workspace` into `epmd_absent` on
+  any host where the local hostname doesn't cleanly self-resolve for an epmd
+  query (confirmed on this WSL2 sandbox; plausible on other environments too).
+  One-line fix (`:net_adm.names(:localhost)`) at
+  `editors/liveview/lib/bt_attach/workspace.ex:2105`. Filed as **BT-3003**
+  rather than fixed in this spike branch — it's shipped, reviewed BT-2983 code,
+  out of this spike's throwaway scope.
+- **`RELEASE_DISTRIBUTION=none` requirement** (criterion (a)): not a bug to
+  fix, but a broker-core requirement to carry into BT-2985 — without it, every
+  spawned front collides on `bt_attach@<host>` at the release-boot level,
+  before `ensure_distributed/0`'s sname-seeding ever runs. Documented here and
+  in `spikes/desktop-attach-spike/broker/broker.sh`'s `_spawn` comment; BT-2985
+  should treat it as a required env var in the real broker, not an optional
+  detail.
+
+## How to reproduce
+
+See `spikes/desktop-attach-spike/README.md` for the full walkthrough (broker
+CLI reference, coordinator run instructions, and the exact commands used for
+each criterion above).

--- a/docs/research/desktop-shell-spike.md
+++ b/docs/research/desktop-shell-spike.md
@@ -274,6 +274,19 @@ coordinator front would have to spawn children with the same care anyway").
 Orphan-reaping is not a Tauri-only cost; it is a **spawn-a-child-process** cost,
 paid by whichever shell does the spawning.
 
+**Caveat found on review, to carry into BT-2985**: the coordinator spawns via
+`Port.open/2`, not `setsid ... & disown` — a different lifetime relationship
+than `broker.sh` uses. A BEAM port ties the front's OS process to the port's
+connected process (here, the Bandit request handler that served
+`/attach/:id`); when that handler exits, the BEAM's port driver can signal
+the spawned process. In practice `pkill -f coordinator.exs` sends SIGTERM
+then SIGKILL to the whole BEAM without a clean shutdown, so the observed
+orphan-survival above still held — but a *graceful* coordinator exit (Ctrl-C,
+triggering OTP's normal shutdown, which does close ports) could behave
+differently, and wasn't tested. A Rust broker spawning via Tauri's process
+API should confirm which lifetime model it gets rather than assume it
+matches `setsid & disown`.
+
 ## No-shell coordinator — built, and it works
 
 `coordinator/coordinator.exs`: a single-file, throwaway Elixir/Plug/Bandit app

--- a/spikes/desktop-attach-spike/README.md
+++ b/spikes/desktop-attach-spike/README.md
@@ -1,0 +1,104 @@
+# Desktop Attach Shell Spike (BT-2984)
+
+Throwaway code for the ADR 0097 shell-decision spike. Findings and verdict are
+in `docs/research/desktop-shell-spike.md` — this README is the "how to
+reproduce" companion.
+
+**Not shipped code.** `broker/broker.sh` stands in for the eventual Rust
+broker (BT-2985); `coordinator/coordinator.exs` is a throwaway prototype of
+the ADR's "no-shell coordinator" alternative. Both drive the **real**
+`dist-liveview` release against **real** `beamtalk workspace` processes — no
+criterion in the write-up is asserted from reading code alone.
+
+## Prerequisites
+
+```bash
+just build            # builds target/debug/beamtalk (real workspaces)
+just dist-liveview     # builds dist-liveview/bin/server (the real front release)
+```
+
+Both are one-time (cached) unless the front or CLI source changes.
+
+## `broker/broker.sh` — bash stand-in for the desktop broker
+
+```
+broker.sh discover                          # list ~/.beamtalk/workspaces/*, epmd liveness
+broker.sh attach <ws_id> [port]              # spawn a front, print the port
+broker.sh attach-bad-cookie <ws_id> [port]   # negative path: corrupted cookie
+broker.sh attach-dead <fake_node> [port]     # negative path: no backing workspace
+broker.sh attach-with-env <ws_id> <port> K=V...  # e.g. inject BT_OIDC_* to test the no-OIDC posture
+broker.sh detach <ws_id_or_port>             # graceful stop
+broker.sh sweep                              # orphan-reaping: kill+clear any pidfile'd front
+                                              #   still alive from a prior broker lifetime (g)
+broker.sh status                             # list tracked fronts + liveness
+broker.sh readiness <port>                   # one GET /readiness, raw response
+broker.sh wait-ready <port> [timeout_s]      # two-stage probe (HTTP up, then /readiness 200)
+```
+
+State (pidfiles/logs) lives under `~/.beamtalk/desktop-broker-spike/`, separate
+from `~/.beamtalk/workspaces/` (owned by the Rust CLI).
+
+### Example: reproduce (a) two-instance boot, including two fronts on one workspace
+
+```bash
+./target/debug/beamtalk workspace create spike-a --background --persistent
+./target/debug/beamtalk workspace create spike-b --background --persistent
+
+broker/broker.sh attach spike-a          # → port P1
+broker/broker.sh attach spike-b          # → port P2
+broker/broker.sh attach spike-a          # → port P3, SAME workspace as the first
+
+broker/broker.sh wait-ready P1
+broker/broker.sh wait-ready P2
+broker/broker.sh wait-ready P3           # all three succeed simultaneously
+
+epmd -names   # three distinct bt_attach_<id>_<pid> registrations
+```
+
+### Example: reproduce (g) orphan reaping
+
+```bash
+broker/broker.sh attach spike-a          # → port P; note the pid in status
+broker/broker.sh status                  # shows it alive, tracked
+
+# Simulate the broker crashing: the front was spawned via setsid, so it is
+# already independent of this shell — ps -o pid,ppid,pgid,sid on its pid
+# confirms it re-parented to init (a genuine orphan).
+
+broker/broker.sh sweep                   # a "fresh broker start": detects the
+                                          # still-alive, untracked front, kills it
+broker/broker.sh status                  # empty; ps confirms the OS process is gone
+```
+
+### Negative-path caveat (criterion c)
+
+`bin/server <id>` **re-resolves** `BT_WORKSPACE_NODE`/`BT_WORKSPACE_COOKIE`
+from `~/.beamtalk/workspaces/<id>/` whenever given a workspace-id argument —
+right for the happy path, but it means `attach-bad-cookie`/`attach-dead`
+deliberately invoke `bin/server` with **no** positional argument (the script's
+own documented "environment as-is" mode) so the broker's override actually
+reaches the front. See the comment above `_spawn` in `broker.sh` for the full
+explanation — this is a real footgun worth carrying into BT-2985.
+
+## `coordinator/coordinator.exs` — the no-shell coordinator prototype
+
+```bash
+elixir spikes/desktop-attach-spike/coordinator/coordinator.exs
+# first run fetches deps via Mix.install (network required once, then cached)
+# → http://127.0.0.1:4500/
+```
+
+Lists live workspaces; click **Attach** to spawn a real front and get
+redirected to it. Re-clicking Attach on an already-attached workspace reuses
+the existing front (see "Single-instance policy" in the write-up) rather than
+spawning a duplicate. Install the page as a PWA (browser menu → Install app)
+for the dockable-window feel the ADR credits this alternative with.
+
+## Cleanup
+
+```bash
+broker/broker.sh sweep
+./target/debug/beamtalk workspace stop spike-a
+./target/debug/beamtalk workspace stop spike-b
+pkill -f coordinator.exs   # if still running
+```

--- a/spikes/desktop-attach-spike/broker/broker.sh
+++ b/spikes/desktop-attach-spike/broker/broker.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+#
+# BT-2984 spike: a throwaway stand-in for the desktop broker's process-broker
+# responsibilities (ADR 0097 "Broker responsibilities"). This is NOT the
+# shipped broker (BT-2985 builds that, in Rust, inside the chosen shell) — it
+# exists only to exercise the real front (dist-liveview/bin/server) against
+# real workspaces so the spike's exit criteria (a)-(g) can be validated against
+# actual epmd/distribution/HTTP behaviour instead of asserted from reading code.
+#
+# Subcommands:
+#   discover                       — list ~/.beamtalk/workspaces/*
+#   attach <ws_id> [port]          — spawn a front for <ws_id>, two-stage probe
+#   attach-bad-cookie <ws_id> [port]   — like attach, but with a corrupted cookie
+#   attach-dead <fake_node> [port] — spawn a front pointed at a non-existent node
+#   detach <ws_id_or_port>         — graceful stop (removes the pidfile)
+#   sweep                          — orphan-reaping: kill+clear any pidfile'd
+#                                     front still alive from a prior broker
+#                                     lifetime (the mechanism prototyped for g)
+#   status                         — list tracked fronts + liveness
+#   readiness <port>               — GET /readiness, print JSON
+#   wait-ready <port> [timeout_s]  — two-stage probe: HTTP up, then /readiness
+#
+# State lives under $STATE_DIR (default ~/.beamtalk/desktop-broker-spike/),
+# deliberately separate from ~/.beamtalk/workspaces/ (owned by the Rust CLI).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+LIVEVIEW_SERVER="${REPO_ROOT}/dist-liveview/bin/server"
+STATE_DIR="${STATE_DIR:-${HOME}/.beamtalk/desktop-broker-spike}"
+WORKSPACES_DIR="${HOME}/.beamtalk/workspaces"
+
+mkdir -p "${STATE_DIR}"
+
+log() { echo "[broker] $*" >&2; }
+
+free_port() {
+  python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
+}
+
+ws_node_name() {
+  python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['node_name'])" \
+    "${WORKSPACES_DIR}/$1/metadata.json"
+}
+
+discover() {
+  if [ ! -d "${WORKSPACES_DIR}" ]; then
+    log "no ~/.beamtalk/workspaces/ directory"
+    return 0
+  fi
+  for d in "${WORKSPACES_DIR}"/*/; do
+    id="$(basename "${d}")"
+    meta="${d}metadata.json"
+    [ -f "${meta}" ] || continue
+    node="$(python3 -c "import json;print(json.load(open('${meta}')).get('node_name',''))" 2>/dev/null || true)"
+    [ -n "${node}" ] || continue
+    # Liveness via epmd, mirroring the ADR's discovery contract (Broker §1):
+    # a *dist ping* isn't available to a non-BEAM broker, so a raw epmd NAMES
+    # query is the liveness check (not the beamtalk CLI, to keep this script
+    # standalone / not depend on `cargo run`).
+    short="${node%@*}"
+    if epmd -names 2>/dev/null | grep -q "name ${short} "; then
+      echo "${id} ${node} alive"
+    else
+      echo "${id} ${node} dead"
+    fi
+  done
+}
+
+# Spawn a front. Positional: workspace id (used to look up node+cookie AND as
+# the BT_ATTACH_NODE_SUFFIX seed — ADR 0097 Impl §1a), port, and two optional
+# overrides for the negative-path tests ((c): bad cookie / dead workspace).
+#
+# Finding worth flagging up front: `bin/server <id>` — the exact invocation
+# ADR 0097's Decision section specifies (`PORT=<free-port> bin/server <id>`) —
+# UNCONDITIONALLY RE-RESOLVES BT_WORKSPACE_NODE/BT_WORKSPACE_COOKIE from
+# ~/.beamtalk/workspaces/<id>/ when given a workspace-id argument (see
+# `bin/server` lines ~40-49), silently overwriting any override passed via
+# env. That is the right behaviour for the happy path (a broker never wants
+# a stale cookie) but means the negative-path tests below (bad cookie / dead
+# node) must invoke `bin/server` with NO positional argument — the script's
+# own documented "remote-workspace topology" mode, where
+# "BT_WORKSPACE_NODE / BT_WORKSPACE_COOKIE are taken from the environment
+# as-is". `server_arg=""` selects that mode.
+_spawn() {
+  local ws_id="$1" port="$2" node_override="${3:-}" cookie_override="${4:-}" extra_env="${5:-}" server_arg="${6-${1}}"
+  local node cookie
+  if [ -n "${node_override}" ]; then
+    node="${node_override}"
+  else
+    node="$(ws_node_name "${ws_id}")"
+  fi
+  if [ -n "${cookie_override}" ]; then
+    cookie="${cookie_override}"
+  else
+    cookie="$(cat "${WORKSPACES_DIR}/${ws_id}/cookie")"
+  fi
+
+  local logfile="${STATE_DIR}/${ws_id}.${port}.log"
+  local pidfile="${STATE_DIR}/${ws_id}.${port}.pid"
+  local metafile="${STATE_DIR}/${ws_id}.${port}.meta"
+
+  log "spawning front for '${ws_id}' → node=${node} port=${port}"
+
+  # setsid: the spawned front becomes its own session/process-group leader,
+  # NOT a child this shell's job control can wait on — the same relationship
+  # a real desktop broker has to the OS processes it forks (they keep running
+  # if the broker is SIGKILLed). This is what makes the sweep/orphan tests (g)
+  # meaningful rather than trivially true.
+  #
+  # RELEASE_DISTRIBUTION=none is the fix for a real bug this spike found
+  # (see README "Finding: RELEASE_NODE defaults collide"): `mix release`'s
+  # generated launcher boots the VM ALREADY distributed under `-sname
+  # bt_attach` (RELEASE_NODE defaults to RELEASE_NAME) before any Elixir code
+  # runs, which pre-empts ensure_distributed/0's BT_ATTACH_NODE_SUFFIX seeding
+  # entirely (Node.alive?/0 is already true) and makes every spawned instance
+  # collide on the identical epmd registration. Booting non-distributed and
+  # letting the front's own lazy ensure_distributed/0 assign the seeded name
+  # on first /readiness call is what makes the ADR's sname-seeding mechanism
+  # apply to the shipped release, not just the `just web` dev flow.
+  #
+  # shellcheck disable=SC2086
+  if [ -n "${server_arg}" ]; then
+    env \
+      BT_WORKSPACE_NODE="${node}" \
+      BT_WORKSPACE_COOKIE="${cookie}" \
+      BT_ATTACH_BIND_IP="127.0.0.1" \
+      BT_ATTACH_NODE_SUFFIX="${ws_id}" \
+      RELEASE_DISTRIBUTION="none" \
+      PORT="${port}" \
+      PHX_SERVER="true" \
+      MIX_ENV="prod" \
+      SECRET_KEY_BASE="$(python3 -c 'import secrets; print(secrets.token_hex(32))')" \
+      ${extra_env} \
+      setsid "${LIVEVIEW_SERVER}" "${server_arg}" >"${logfile}" 2>&1 &
+  else
+    # No positional arg: bin/server's "environment as-is" mode — required so
+    # BT_WORKSPACE_NODE/BT_WORKSPACE_COOKIE overrides actually reach the front
+    # instead of being silently re-resolved from disk (see comment above).
+    env \
+      BT_WORKSPACE_NODE="${node}" \
+      BT_WORKSPACE_COOKIE="${cookie}" \
+      BT_ATTACH_BIND_IP="127.0.0.1" \
+      BT_ATTACH_NODE_SUFFIX="${ws_id}" \
+      RELEASE_DISTRIBUTION="none" \
+      PORT="${port}" \
+      PHX_SERVER="true" \
+      MIX_ENV="prod" \
+      SECRET_KEY_BASE="$(python3 -c 'import secrets; print(secrets.token_hex(32))')" \
+      ${extra_env} \
+      setsid "${LIVEVIEW_SERVER}" >"${logfile}" 2>&1 &
+  fi
+  disown
+  local pid=$!
+  echo "${pid}" >"${pidfile}"
+  printf 'workspace=%s\nport=%s\nnode=%s\npid=%s\n' "${ws_id}" "${port}" "${node}" "${pid}" >"${metafile}"
+  echo "${pid}"
+}
+
+attach() {
+  local ws_id="$1" port="${2:-$(free_port)}"
+  _spawn "${ws_id}" "${port}" >/dev/null
+  echo "${port}"
+}
+
+attach_bad_cookie() {
+  local ws_id="$1" port="${2:-$(free_port)}"
+  _spawn "${ws_id}" "${port}" "" "0000000000000000000000000000000badc0de" "" "" >/dev/null
+  echo "${port}"
+}
+
+attach_dead() {
+  local fake_node="$1" port="${2:-$(free_port)}"
+  # No real workspace backs this node; any cookie will do since epmd has no
+  # record of the target at all (the `:dead_workspace` taxonomy bucket).
+  _spawn "attach-dead" "${port}" "${fake_node}" "deadcookie00000000000000000000000000000" "" "" >/dev/null
+  echo "${port}"
+}
+
+# Like attach, but pass through arbitrary extra env (e.g. BT_OIDC_* for the
+# no-OIDC posture test, (d)).
+attach_with_env() {
+  local ws_id="$1" port="$2"
+  shift 2
+  _spawn "${ws_id}" "${port}" "" "" "$*" >/dev/null
+  echo "${port}"
+}
+
+wait_http_up() {
+  local port="$1" timeout="${2:-15}"
+  local waited=0
+  while ! curl -s -o /dev/null "http://127.0.0.1:${port}/" 2>/dev/null; do
+    sleep 0.5
+    waited=$((waited + 1))
+    if [ "${waited}" -ge $((timeout * 2)) ]; then
+      log "HTTP never came up on :${port}"
+      return 1
+    fi
+  done
+  return 0
+}
+
+readiness() {
+  local port="$1"
+  curl -s -w '\nHTTP_STATUS:%{http_code}\n' "http://127.0.0.1:${port}/readiness"
+}
+
+# Two-stage probe (ADR 0097 Broker §2): HTTP port up, THEN /readiness for true
+# workspace reachability. Prints the final /readiness JSON body; exit code 0
+# only on a 200.
+wait_ready() {
+  local port="$1" timeout="${2:-20}"
+  wait_http_up "${port}" "${timeout}" || {
+    echo '{"status":"http_never_up"}'
+    return 1
+  }
+  local waited=0
+  local body status
+  while true; do
+    local resp
+    resp="$(curl -s -w '\n%{http_code}' "http://127.0.0.1:${port}/readiness")"
+    status="$(echo "${resp}" | tail -1)"
+    body="$(echo "${resp}" | sed '$d')"
+    if [ "${status}" = "200" ]; then
+      echo "${body}"
+      return 0
+    fi
+    waited=$((waited + 1))
+    if [ "${waited}" -ge $((timeout * 2)) ]; then
+      echo "${body}"
+      return 1
+    fi
+    sleep 0.5
+  done
+}
+
+detach() {
+  local key="$1"
+  shopt -s nullglob
+  for pf in "${STATE_DIR}"/*."${key}".pid "${STATE_DIR}/${key}".*.pid; do
+    [ -f "${pf}" ] || continue
+    local pid
+    pid="$(cat "${pf}")"
+    if kill -0 "${pid}" 2>/dev/null; then
+      log "detach: stopping pid ${pid} (${pf})"
+      kill -TERM "${pid}" 2>/dev/null || true
+      sleep 0.3
+      kill -0 "${pid}" 2>/dev/null && kill -KILL "${pid}" 2>/dev/null || true
+    fi
+    rm -f "${pf}" "${pf%.pid}.meta" "${pf%.pid}.log"
+  done
+  shopt -u nullglob
+}
+
+# Orphan-reaping (g): PID-file sweep, chosen over process-group kill / a
+# parent-death-watch (prctl PR_SET_PDEATHSIG) because it is the only one of
+# the three that is portable to Windows without OS-specific syscalls — the
+# ADR's shell packaging (§5) targets macOS + Linux + Windows. On broker start,
+# any pidfile pointing at a still-alive process is presumed orphaned: a full
+# broker restart means the in-memory picker state (which fronts are attached)
+# is gone, so there is no legitimate reason for a pre-existing front to still
+# be tracked. Stale pidfiles (process already dead) are cleaned up too.
+sweep() {
+  local reaped=0
+  shopt -s nullglob
+  for pf in "${STATE_DIR}"/*.pid; do
+    local pid
+    pid="$(cat "${pf}")"
+    if kill -0 "${pid}" 2>/dev/null; then
+      log "sweep: reaping orphaned front pid=${pid} ($(basename "${pf}"))"
+      kill -TERM "${pid}" 2>/dev/null || true
+      sleep 0.3
+      if kill -0 "${pid}" 2>/dev/null; then
+        kill -KILL "${pid}" 2>/dev/null || true
+      fi
+      reaped=$((reaped + 1))
+    else
+      log "sweep: clearing stale pidfile $(basename "${pf}") (pid ${pid} already gone)"
+    fi
+    rm -f "${pf}" "${pf%.pid}.meta" "${pf%.pid}.log"
+  done
+  shopt -u nullglob
+  log "sweep complete: reaped ${reaped} orphan(s)"
+  echo "${reaped}"
+}
+
+status() {
+  shopt -s nullglob
+  for mf in "${STATE_DIR}"/*.meta; do
+    local ws port node pid alive
+    ws="$(sed -n 's/^workspace=//p' "${mf}")"
+    port="$(sed -n 's/^port=//p' "${mf}")"
+    node="$(sed -n 's/^node=//p' "${mf}")"
+    pid="$(sed -n 's/^pid=//p' "${mf}")"
+    alive="dead"
+    kill -0 "${pid}" 2>/dev/null && alive="alive"
+    echo "${ws} port=${port} node=${node} pid=${pid} ${alive}"
+  done
+  shopt -u nullglob
+}
+
+cmd="${1:-}"
+shift || true
+case "${cmd}" in
+discover) discover ;;
+attach) attach "$@" ;;
+attach-bad-cookie) attach_bad_cookie "$@" ;;
+attach-dead) attach_dead "$@" ;;
+attach-with-env) attach_with_env "$@" ;;
+detach) detach "$@" ;;
+sweep) sweep ;;
+status) status ;;
+readiness) readiness "$@" ;;
+wait-ready) wait_ready "$@" ;;
+*)
+  echo "usage: broker.sh <discover|attach|attach-bad-cookie|attach-dead|attach-with-env|detach|sweep|status|readiness|wait-ready> [args]" >&2
+  exit 64
+  ;;
+esac

--- a/spikes/desktop-attach-spike/broker/broker.sh
+++ b/spikes/desktop-attach-spike/broker/broker.sh
@@ -151,8 +151,8 @@ _spawn() {
       ${extra_env} \
       setsid "${LIVEVIEW_SERVER}" >"${logfile}" 2>&1 &
   fi
-  disown
   local pid=$!
+  disown
   echo "${pid}" >"${pidfile}"
   printf 'workspace=%s\nport=%s\nnode=%s\npid=%s\n' "${ws_id}" "${port}" "${node}" "${pid}" >"${metafile}"
   echo "${pid}"

--- a/spikes/desktop-attach-spike/coordinator/coordinator.exs
+++ b/spikes/desktop-attach-spike/coordinator/coordinator.exs
@@ -269,8 +269,9 @@ defmodule Coordinator.Router do
   # /attach/:id request only stops racing a second spawn (claim_or_get) — a
   # waiter in await/2 still returns as soon as it sees a %{port: _} entry, so
   # writing the entry before readiness would hand a not-yet-ready port to a
-  # concurrent caller. On timeout, drop the :pending claim so a later attach
-  # isn't permanently blocked by a claim that will never resolve.
+  # concurrent caller. On timeout OR an exception (e.g. setsid missing,
+  # Port.open failure), drop the :pending claim so a later attach isn't
+  # permanently blocked by a claim that will never resolve.
   defp spawn_and_wait(ws_id, deadline) do
     {port, os_pid} = Coordinator.Spawner.spawn_front(ws_id)
     remaining = max(deadline - System.monotonic_time(:millisecond), 0)
@@ -284,6 +285,10 @@ defmodule Coordinator.Router do
         Coordinator.State.drop(ws_id)
         :timeout
     end
+  rescue
+    _ ->
+      Coordinator.State.drop(ws_id)
+      :timeout
   end
 
   # Two-stage probe (same contract as the broker's wait-ready): HTTP up, then

--- a/spikes/desktop-attach-spike/coordinator/coordinator.exs
+++ b/spikes/desktop-attach-spike/coordinator/coordinator.exs
@@ -156,7 +156,6 @@ defmodule Coordinator.Spawner do
         _ -> nil
       end
 
-    Coordinator.State.put(ws_id, port, os_pid)
     {port, os_pid}
   end
 
@@ -265,13 +264,25 @@ defmodule Coordinator.Router do
     Plug.Conn.send_resp(conn, 404, "not found")
   end
 
+  # BT-2984 review finding: State.put/3 must not happen until wait_ready
+  # confirms the front is actually serving /readiness. A concurrent
+  # /attach/:id request only stops racing a second spawn (claim_or_get) — a
+  # waiter in await/2 still returns as soon as it sees a %{port: _} entry, so
+  # writing the entry before readiness would hand a not-yet-ready port to a
+  # concurrent caller. On timeout, drop the :pending claim so a later attach
+  # isn't permanently blocked by a claim that will never resolve.
   defp spawn_and_wait(ws_id, deadline) do
-    {port, _os_pid} = Coordinator.Spawner.spawn_front(ws_id)
+    {port, os_pid} = Coordinator.Spawner.spawn_front(ws_id)
     remaining = max(deadline - System.monotonic_time(:millisecond), 0)
 
     case wait_ready(port, remaining) do
-      :ok -> {:ok, port}
-      :timeout -> :timeout
+      :ok ->
+        Coordinator.State.put(ws_id, port, os_pid)
+        {:ok, port}
+
+      :timeout ->
+        Coordinator.State.drop(ws_id)
+        :timeout
     end
   end
 

--- a/spikes/desktop-attach-spike/coordinator/coordinator.exs
+++ b/spikes/desktop-attach-spike/coordinator/coordinator.exs
@@ -29,15 +29,53 @@ Mix.install([
 ])
 
 defmodule Coordinator.State do
-  @moduledoc "Tracks spawned per-workspace fronts so re-clicking Attach reuses a live one instead of leaking a second."
+  @moduledoc """
+  Tracks spawned per-workspace fronts so re-clicking Attach reuses a live one
+  instead of leaking a second. An adversarial review of this spike flagged
+  that a naive "get, then spawn if nil" (no lock between the two steps) lets
+  two near-simultaneous `/attach/:id` requests both observe `nil` and both
+  spawn — Plug/Bandit runs each request in its own process, so there is a
+  real window. `claim_or_get/1` closes it by making the check-and-reserve a
+  single atomic `Agent.get_and_update/2` call: the first caller gets
+  `:claimed` and must spawn; any concurrent caller gets `{:existing,
+  :pending}` and waits on `await/2` instead of racing a second spawn.
+  """
   use Agent
 
   def start_link(_), do: Agent.start_link(fn -> %{} end, name: __MODULE__)
 
+  @doc "Read-only peek for the listing page — not atomic, fine for display purposes only."
   def get(ws_id), do: Agent.get(__MODULE__, &Map.get(&1, ws_id))
+
+  def claim_or_get(ws_id) do
+    Agent.get_and_update(__MODULE__, fn state ->
+      case Map.get(state, ws_id) do
+        nil -> {:claimed, Map.put(state, ws_id, :pending)}
+        entry -> {{:existing, entry}, state}
+      end
+    end)
+  end
 
   def put(ws_id, port, os_pid),
     do: Agent.update(__MODULE__, &Map.put(&1, ws_id, %{port: port, os_pid: os_pid}))
+
+  def drop(ws_id), do: Agent.update(__MODULE__, &Map.delete(&1, ws_id))
+
+  @doc "Poll for a :pending claim (made by a concurrent request) to resolve into a real entry."
+  def await(ws_id, deadline_ms) do
+    case Agent.get(__MODULE__, &Map.get(&1, ws_id)) do
+      %{port: _} = entry ->
+        entry
+
+      _ ->
+        if System.monotonic_time(:millisecond) < deadline_ms do
+          Process.sleep(100)
+          await(ws_id, deadline_ms)
+        else
+          nil
+        end
+    end
+  end
 
   def all, do: Agent.get(__MODULE__, & &1)
 end
@@ -141,15 +179,21 @@ defmodule Coordinator.Router do
       Coordinator.Discovery.list()
       |> Enum.map_join("\n", fn ws ->
         attached = Coordinator.State.get(ws.id)
+        # Workspace ids come from directory names under ~/.beamtalk/workspaces/
+        # — local, CLI-controlled today, but this is still an HTTP response;
+        # escape before interpolating rather than assume they're HTML-safe.
+        safe_id = Plug.HTML.html_escape(ws.id)
+        safe_node = Plug.HTML.html_escape(ws.node)
 
         action =
           cond do
             not ws.alive -> "<span class=\"dead\">workspace not running</span>"
-            attached -> "<a href=\"http://localhost:#{attached.port}/\" target=\"_blank\">Open (already attached, port #{attached.port})</a>"
-            true -> "<a href=\"/attach/#{ws.id}\">Attach</a>"
+            match?(%{port: _}, attached) -> "<a href=\"http://localhost:#{attached.port}/\" target=\"_blank\">Open (already attached, port #{attached.port})</a>"
+            attached == :pending -> "<span class=\"dead\">attaching…</span>"
+            true -> "<a href=\"/attach/#{URI.encode(ws.id)}\">Attach</a>"
           end
 
-        "<tr><td>#{ws.id}</td><td>#{ws.node}</td><td>#{if ws.alive, do: "alive", else: "dead"}</td><td>#{action}</td></tr>"
+        "<tr><td>#{safe_id}</td><td>#{safe_node}</td><td>#{if ws.alive, do: "alive", else: "dead"}</td><td>#{action}</td></tr>"
       end)
 
     body = """
@@ -172,27 +216,67 @@ defmodule Coordinator.Router do
 
   get "/attach/:id" do
     ws_id = conn.path_params["id"]
+    deadline = System.monotonic_time(:millisecond) + 20_000
 
-    {port, _os_pid} =
-      case Coordinator.State.get(ws_id) do
-        %{port: port} -> {port, nil}
-        nil -> Coordinator.Spawner.spawn_front(ws_id)
+    result =
+      case Coordinator.State.claim_or_get(ws_id) do
+        :claimed ->
+          spawn_and_wait(ws_id, deadline)
+
+        {:existing, :pending} ->
+          # A concurrent /attach/:id request already claimed this workspace
+          # and is spawning it — wait on that instead of racing a second
+          # spawn (the double-spawn an adversarial review of this spike
+          # flagged in the original get-then-spawn version).
+          case Coordinator.State.await(ws_id, deadline) do
+            %{port: port} -> {:ok, port}
+            nil -> :timeout
+          end
+
+        {:existing, %{port: port}} ->
+          # Tracked front might have died since the last attach (crash,
+          # `workspace stop`, etc.) — a short readiness re-check before
+          # reusing it, same as broker.sh's own status check.
+          case wait_ready(port, 3_000) do
+            :ok ->
+              {:ok, port}
+
+            :timeout ->
+              Coordinator.State.drop(ws_id)
+              spawn_and_wait(ws_id, deadline)
+          end
       end
 
-    # Two-stage probe (same contract as the broker's wait-ready) before
-    # redirecting the browser — otherwise the user hits a connection-refused
-    # tab while the front is still booting.
-    wait_ready(port, 20_000)
+    case result do
+      {:ok, port} ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "http://localhost:#{port}/")
+        |> Plug.Conn.send_resp(302, "")
 
-    conn
-    |> Plug.Conn.put_resp_header("location", "http://localhost:#{port}/")
-    |> Plug.Conn.send_resp(302, "")
+      :timeout ->
+        # Redirecting anyway (the original version of this handler did) would
+        # hand the browser a connection-refused tab; a real coordinator/broker
+        # UI would show this inline instead of a bare 504.
+        Plug.Conn.send_resp(conn, 504, "front for '#{ws_id}' did not become ready in time")
+    end
   end
 
   match _ do
     Plug.Conn.send_resp(conn, 404, "not found")
   end
 
+  defp spawn_and_wait(ws_id, deadline) do
+    {port, _os_pid} = Coordinator.Spawner.spawn_front(ws_id)
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    case wait_ready(port, remaining) do
+      :ok -> {:ok, port}
+      :timeout -> :timeout
+    end
+  end
+
+  # Two-stage probe (same contract as the broker's wait-ready): HTTP up, then
+  # /readiness for true workspace reachability.
   defp wait_ready(port, timeout_ms) do
     deadline = System.monotonic_time(:millisecond) + timeout_ms
     do_wait_ready(port, deadline)

--- a/spikes/desktop-attach-spike/coordinator/coordinator.exs
+++ b/spikes/desktop-attach-spike/coordinator/coordinator.exs
@@ -1,0 +1,222 @@
+#!/usr/bin/env elixir
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+#
+# BT-2984 spike: a minimal prototype of the ADR 0097 Alternatives' "no-shell
+# coordinator front" — the Tauri shell's 80/20 challenger. One always-on
+# Phoenix-less Plug app that lists ~/.beamtalk/workspaces/*, and on
+# "Attach" spawns a per-workspace `dist-liveview/bin/server <id>` (exactly
+# the broker's own spawn primitive — see ../broker/broker.sh) and redirects
+# the browser at it. Install this page as a PWA (browser "Install app") and
+# you have a dockable, chrome-less coordinator with near-zero shell code —
+# the ADR's own framing of why this alternative earns a real look before
+# committing to Tauri.
+#
+# Run: elixir coordinator.exs   (needs network the first time, to fetch
+# Plug/Bandit/Jason via Mix.install; cached after)
+# Then open http://127.0.0.1:4500/
+#
+# What this DELIBERATELY does not attempt (out of scope for a spike, same
+# boundary as the picker UI, ADR "Out of Scope" / BT-2986):
+#   - create/stop workspaces via the CLI (Broker §5) — listing + attach only
+#   - auth / multi-user — same single-user localhost posture as the front
+#   - a service-worker / manifest.json for a literal installable PWA — the
+#     spike's point is the discover+spawn+redirect flow, not packaging
+Mix.install([
+  {:plug, "~> 1.16"},
+  {:bandit, "~> 1.5"},
+  {:jason, "~> 1.4"}
+])
+
+defmodule Coordinator.State do
+  @moduledoc "Tracks spawned per-workspace fronts so re-clicking Attach reuses a live one instead of leaking a second."
+  use Agent
+
+  def start_link(_), do: Agent.start_link(fn -> %{} end, name: __MODULE__)
+
+  def get(ws_id), do: Agent.get(__MODULE__, &Map.get(&1, ws_id))
+
+  def put(ws_id, port, os_pid),
+    do: Agent.update(__MODULE__, &Map.put(&1, ws_id, %{port: port, os_pid: os_pid}))
+
+  def all, do: Agent.get(__MODULE__, & &1)
+end
+
+defmodule Coordinator.Discovery do
+  @moduledoc "Same contract as broker/broker.sh discover — enumerate ~/.beamtalk/workspaces/*/metadata.json and check epmd liveness. A real coordinator/broker would share ONE implementation; this spike duplicates the ~15 lines rather than adding a cross-language dependency between the bash broker prototype and this Elixir one."
+  @workspaces_dir Path.join(System.user_home!(), ".beamtalk/workspaces")
+
+  def list do
+    case File.ls(@workspaces_dir) do
+      {:ok, entries} ->
+        entries
+        |> Enum.map(&describe/1)
+        |> Enum.reject(&is_nil/1)
+        |> Enum.sort_by(& &1.id)
+
+      {:error, _} ->
+        []
+    end
+  end
+
+  defp describe(id) do
+    meta_path = Path.join([@workspaces_dir, id, "metadata.json"])
+
+    with true <- File.regular?(meta_path),
+         {:ok, body} <- File.read(meta_path),
+         {:ok, meta} <- Jason.decode(body),
+         node when is_binary(node) and node != "" <- meta["node_name"] do
+      %{id: id, node: node, alive: node_alive?(node)}
+    else
+      _ -> nil
+    end
+  end
+
+  defp node_alive?(node) do
+    short = node |> String.split("@") |> List.first() |> String.to_charlist()
+
+    case :net_adm.names(:localhost) do
+      {:ok, names} -> List.keymember?(names, short, 0)
+      _ -> false
+    end
+  end
+end
+
+defmodule Coordinator.Spawner do
+  @moduledoc "Attach primitive — mirrors broker/broker.sh's _spawn (loopback bind, RELEASE_DISTRIBUTION=none so the sname-seeding in ensure_distributed/0 actually applies, id-seeded BT_ATTACH_NODE_SUFFIX). See broker.sh's comment for why RELEASE_DISTRIBUTION=none matters."
+  @repo_root Path.expand("../../..", __DIR__)
+  @liveview_server Path.join(@repo_root, "dist-liveview/bin/server")
+
+  def spawn_front(ws_id) do
+    port = free_port()
+
+    port_arg = to_string(port)
+    secret = :crypto.strong_rand_bytes(32) |> Base.encode16(case: :lower)
+
+    port_pid =
+      Port.open(
+        {:spawn_executable, System.find_executable("setsid")},
+        [
+          :binary,
+          :exit_status,
+          args: [@liveview_server, ws_id],
+          env: [
+            {~c"BT_ATTACH_BIND_IP", ~c"127.0.0.1"},
+            {~c"BT_ATTACH_NODE_SUFFIX", String.to_charlist(ws_id)},
+            {~c"RELEASE_DISTRIBUTION", ~c"none"},
+            {~c"PORT", String.to_charlist(port_arg)},
+            {~c"PHX_SERVER", ~c"true"},
+            {~c"MIX_ENV", ~c"prod"},
+            {~c"SECRET_KEY_BASE", String.to_charlist(secret)}
+          ]
+        ]
+      )
+
+    os_pid =
+      case Port.info(port_pid, :os_pid) do
+        {:os_pid, pid} -> pid
+        _ -> nil
+      end
+
+    Coordinator.State.put(ws_id, port, os_pid)
+    {port, os_pid}
+  end
+
+  defp free_port do
+    {:ok, socket} = :gen_tcp.listen(0, [:binary, active: false])
+    {:ok, port} = :inet.port(socket)
+    :gen_tcp.close(socket)
+    port
+  end
+end
+
+defmodule Coordinator.Router do
+  use Plug.Router
+
+  plug(:match)
+  plug(:dispatch)
+
+  get "/" do
+    rows =
+      Coordinator.Discovery.list()
+      |> Enum.map_join("\n", fn ws ->
+        attached = Coordinator.State.get(ws.id)
+
+        action =
+          cond do
+            not ws.alive -> "<span class=\"dead\">workspace not running</span>"
+            attached -> "<a href=\"http://localhost:#{attached.port}/\" target=\"_blank\">Open (already attached, port #{attached.port})</a>"
+            true -> "<a href=\"/attach/#{ws.id}\">Attach</a>"
+          end
+
+        "<tr><td>#{ws.id}</td><td>#{ws.node}</td><td>#{if ws.alive, do: "alive", else: "dead"}</td><td>#{action}</td></tr>"
+      end)
+
+    body = """
+    <!doctype html>
+    <html><head><title>Beamtalk Desktop Coordinator (spike)</title>
+    <style>body{font-family:sans-serif;margin:2rem}.dead{color:#999}table{border-collapse:collapse}td,th{padding:.4rem .8rem;border-bottom:1px solid #ddd;text-align:left}</style>
+    </head><body>
+    <h1>Beamtalk Workspaces</h1>
+    <p>No-shell coordinator prototype (BT-2984 spike, ADR 0097 Alternatives). Install this page as an app (browser menu &rarr; Install) for a dockable window.</p>
+    <table><tr><th>Workspace</th><th>Node</th><th>Status</th><th>Action</th></tr>
+    #{rows}
+    </table>
+    </body></html>
+    """
+
+    conn
+    |> Plug.Conn.put_resp_content_type("text/html")
+    |> Plug.Conn.send_resp(200, body)
+  end
+
+  get "/attach/:id" do
+    ws_id = conn.path_params["id"]
+
+    {port, _os_pid} =
+      case Coordinator.State.get(ws_id) do
+        %{port: port} -> {port, nil}
+        nil -> Coordinator.Spawner.spawn_front(ws_id)
+      end
+
+    # Two-stage probe (same contract as the broker's wait-ready) before
+    # redirecting the browser — otherwise the user hits a connection-refused
+    # tab while the front is still booting.
+    wait_ready(port, 20_000)
+
+    conn
+    |> Plug.Conn.put_resp_header("location", "http://localhost:#{port}/")
+    |> Plug.Conn.send_resp(302, "")
+  end
+
+  match _ do
+    Plug.Conn.send_resp(conn, 404, "not found")
+  end
+
+  defp wait_ready(port, timeout_ms) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_ready(port, deadline)
+  end
+
+  defp do_wait_ready(port, deadline) do
+    case :httpc.request(:get, {~c"http://127.0.0.1:#{port}/readiness", []}, [], []) do
+      {:ok, {{_, 200, _}, _headers, _body}} ->
+        :ok
+
+      _ ->
+        if System.monotonic_time(:millisecond) < deadline do
+          Process.sleep(300)
+          do_wait_ready(port, deadline)
+        else
+          :timeout
+        end
+    end
+  end
+end
+
+{:ok, _} = Application.ensure_all_started(:inets)
+{:ok, _} = Coordinator.State.start_link([])
+{:ok, _} = Bandit.start_link(plug: Coordinator.Router, ip: {127, 0, 0, 1}, port: 4500)
+
+IO.puts("Coordinator listening on http://127.0.0.1:4500/ (Ctrl+C to stop)")
+Process.sleep(:infinity)

--- a/spikes/desktop-attach-spike/coordinator/coordinator.exs
+++ b/spikes/desktop-attach-spike/coordinator/coordinator.exs
@@ -286,7 +286,8 @@ defmodule Coordinator.Router do
         :timeout
     end
   rescue
-    _ ->
+    e ->
+      IO.warn("spawn_and_wait: exception for #{ws_id}: #{Exception.message(e)}")
       Coordinator.State.drop(ws_id)
       :timeout
   end


### PR DESCRIPTION
## Summary

Research spike for [BT-2984](https://linear.app/beamtalk/issue/BT-2984/spike-settle-desktop-shell-tauri-vs-no-shell-coordinator-window-model), Phase 1 of ADR 0097 (Desktop Attach Client). Validates the ADR's spike exit criteria (a)-(g) live against a real `beamtalk workspace`, a real built `dist-liveview` release, and a real throwaway no-shell Elixir/Plug coordinator — no criterion is asserted from reading code alone.

**Verdict: lean Tauri, but the shell decision is not fully settled by this spike.** Six of the seven duties (a, b, c, d, f, g) proved shell-agnostic — a ~300-line throwaway Elixir page satisfies them identically to a bash script standing in for the eventual Rust broker. The sole differentiator is (e) webview/keybinding parity, which this sandbox (no display, no Tauri toolchain, no target OSes) could only validate via desk research, not hands-on. Full evidence and verdict: `docs/research/desktop-shell-spike.md`.

Along the way, found and documented two real bugs in already-shipped BT-2983 code:
- `mix release`'s default `RELEASE_NODE` collides every spawned front on `bt_attach@<host>` before `ensure_distributed/0`'s sname-seeding ever runs (worked around here via `RELEASE_DISTRIBUTION=none`; the real broker, BT-2985, needs to carry this).
- `classify_unreachable/2`'s `:net_adm.names()` default arg collapses `bad_cookie`/`dead_workspace` into `epmd_absent` on hosts where the local hostname doesn't self-resolve — filed as [BT-3003](https://linear.app/beamtalk/issue/BT-3003).

An adversarial review pass on this spike also found and fixed a genuine TOCTOU race in the no-shell coordinator prototype (`/attach/:id` could double-spawn under concurrent requests) plus an HTML-escaping gap — both fixed and re-verified live.

## Key changes

- `docs/research/desktop-shell-spike.md` — the write-up: per-criterion evidence, verdict, single-instance policy decision, and open items
- `spikes/desktop-attach-spike/broker/broker.sh` — throwaway bash broker prototype (discover/attach/sweep/reap) driving the real `dist-liveview/bin/server`
- `spikes/desktop-attach-spike/coordinator/coordinator.exs` — throwaway Elixir/Plug "no-shell coordinator" prototype
- `spikes/desktop-attach-spike/README.md` — reproduction instructions

## Test plan

- [x] `just test` — full suite green (Rust, stdlib, BUnit, runtime — 0 failures)
- [x] `just build && just clippy && just fmt-check` — clean
- [x] Every criterion (a)-(g) exercised live where the sandbox allowed (see write-up for exact commands/evidence); (e) is desk-research only, explicitly flagged as the residual gap
- [x] Coordinator race fix re-verified live: two concurrent `/attach/:id` requests resolved to the same port, only one front process spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)