### PR TITLE
test: tighten placeholder assertions in hot_reload_actors.btscript

### DIFF
--- a/tests/repl-protocol/cases/hot_reload_actors.btscript
+++ b/tests/repl-protocol/cases/hot_reload_actors.btscript
@@ -40,7 +40,7 @@ c getValue
 
 // Replace increment to add 10 instead of 1
 Counter >> increment => self.value := self.value + 10
-// => _
+// => Counter>>increment
 
 // Existing actor 'c' should use the NEW increment (not old +1)
 c increment
@@ -57,7 +57,7 @@ c getValue
 // ===========================================================================
 
 Counter >> increment => self.value := self.value * 2
-// => _
+// => Counter>>increment
 
 // Same actor, now uses multiplication
 c increment
@@ -71,7 +71,7 @@ c increment
 // ===========================================================================
 
 Counter >> reset => self.value := 0
-// => _
+// => Counter>>reset
 
 // Existing actor can call the brand new method
 c reset
@@ -79,7 +79,7 @@ c reset
 
 // Restore additive increment and verify from clean state
 Counter >> increment => self.value := self.value + 5
-// => _
+// => Counter>>increment
 
 c increment
 // => 5


### PR DESCRIPTION
## Summary

Replace four `// => _` placeholder assertions in `tests/repl-protocol/cases/hot_reload_actors.btscript` with the concrete deterministic values that method-definition expressions (`ClassName >> selector => body`) actually return.

## What changed

The `>>` operator returns a `ClassName>>selector` string. This is already the established pattern in the sister file `inline_class.btscript` (lines 32–33, 55–56):

```
InlineCounter >> getValue => self.value
// => InlineCounter>>getValue

InlineCounter >> increment => self.value := self.value + 10
// => InlineCounter>>increment
```

`hot_reload_actors.btscript` had four such expressions all using `// => _` instead:

| Expression | Before | After |
|-----------|--------|-------|
| `Counter >> increment => self.value := self.value + 10` | `// => _` | `// => Counter>>increment` |
| `Counter >> increment => self.value := self.value * 2` | `// => _` | `// => Counter>>increment` |
| `Counter >> reset => self.value := 0` | `// => _` | `// => Counter>>reset` |
| `Counter >> increment => self.value := self.value + 5` | `// => _` | `// => Counter>>increment` |

## Why it's safe

- Does not change test intent — the method definitions still execute and the surrounding value-assertions (`c increment // => 12`, `c increment // => 44`, etc.) still prove the patch takes effect on the running actor
- All four wildcards are for the same deterministic expression type; the concrete return value is confirmed by `inline_class.btscript`
- `just test-repl-protocol` passes with the change

---
_Generated by [Claude Code](https://claude.ai/code/session_01P16i9DPkLvmzwUkU6hjkuy)_