### PR TITLE
ci: pin claude-review.yml's checkout action to a SHA

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,7 +30,7 @@ jobs:
       issues: write         # upsert the sticky summary comment
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

- Pins `claude-review.yml`'s `actions/checkout` step to the exact commit SHA every other workflow in the repo already uses, instead of the mutable `v7.0.1` tag. A repointed tag would silently run different code with `pull-requests: write`, `issues: write`, and access to `CLAUDE_CODE_OAUTH_TOKEN`. Flagged by review on #3148.

## ⚠️ Expected check failure on this PR

GitHub Actions skips a workflow-gate job when a PR's own copy of that job's workflow file differs from the default branch (an anti-tampering measure), and this repo's `Claude BeamTalk Review` gate fails closed when no verdict is produced. Since this PR's only change *is* to `claude-review.yml`, that check will show red on this PR for exactly that structural reason — not because of an actual review finding. This is a known limitation specific to PRs touching this one file; the check will behave normally again once this merges. Merging despite the red check here is intentional.

## Test plan

- N/A — single-line workflow-file change, no code affected. `cargo fmt --check` passes (untouched by this diff).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGMonGJyXj5Gtz24cp2Tec)_