### PR TITLE
Fix flaky ETXTBSY failure in desktop-broker launcher-script tests

### DIFF
--- a/crates/beamtalk-desktop-broker/src/spawn.rs
+++ b/crates/beamtalk-desktop-broker/src/spawn.rs
@@ -362,11 +362,36 @@ mod tests {
 
     /// Write an executable shell script to `dir` that ignores its argv
     /// (the workspace id `spawn_front` always appends) and runs `body`.
+    ///
+    /// The returned executable is produced by an out-of-process `cp` rather
+    /// than by writing `dir/name` directly, to avoid `ETXTBSY` ("Text file
+    /// busy") when it is later `exec`'d. A file *this* process has open for
+    /// writing is inherited by any concurrent `fork()` — every other test in
+    /// this binary that calls `Command::spawn` (`reap`'s `sleep` children,
+    /// the sibling launcher tests) forks — and the forked child keeps that
+    /// descriptor open until it `exec`s. The kernel refuses to `exec` a file
+    /// any process holds open for writing, so a sibling fork landing inside
+    /// the write window here makes our own spawn fail. Copying via a child
+    /// process means the launcher inode is never write-open in this process,
+    /// so no sibling fork can ever inherit a writer for it (`chmod` below
+    /// opens nothing).
     #[cfg(unix)]
     fn write_launcher_script(dir: &std::path::Path, name: &str, body: &str) -> PathBuf {
         use std::os::unix::fs::PermissionsExt;
+        let source = dir.join(format!("{name}.source"));
+        std::fs::write(&source, format!("#!/bin/sh\n{body}\n")).unwrap();
+
         let path = dir.join(name);
-        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        let status = Command::new("cp")
+            .arg(&source)
+            .arg(&path)
+            .status()
+            .expect("cp should be runnable");
+        assert!(
+            status.success(),
+            "cp {source:?} -> {path:?} failed: {status}"
+        );
+
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
         path
     }


### PR DESCRIPTION
## Summary

CI on `main` failed in `beamtalk-desktop-broker`:

```
spawn::tests::spawn_front_with_port_retry_recovers_after_transient_conflicts
panicked at crates/beamtalk-desktop-broker/src/spawn.rs:440:50:
should eventually succeed: Io(Os { code: 26, kind: ExecutableFileBusy,
message: "Text file busy" })
```

Not a logic bug — a **fork/exec race between tests in the same binary**.
`write_launcher_script` opened the script with `std::fs::write`. A file this
process holds open for writing is inherited by any concurrent `fork()` — and
several other tests in this binary fork (`reap`'s `sleep` children, the two
sibling launcher tests) — with the forked child keeping that descriptor open
until it `exec`s. The kernel refuses to `exec` a file any process holds open
for writing, so a sibling fork landing inside the write window makes the spawn
under test fail with `ETXTBSY`.

The fix produces the launcher via an out-of-process `cp`: the `.source` file we
write is never `exec`'d, and the `exec`'d inode is never write-open in this
process, so no sibling fork can inherit a writer for it (`chmod` opens
nothing).

Test-only change — no production code is touched.

### Why not the alternatives

- **Retry on `ETXTBSY`** — the `exec` happens *inside* the code under test, and
  the recovery test asserts an exact attempt count, so a retry wrapper can't sit
  at the right level.
- **`std::fs::copy`** — uses this process's own descriptors, so it has the same
  race.
- **Symlink** — `ETXTBSY` is checked per-inode, so it inherits the target's
  problem.

### Checked for the same pattern elsewhere

Both production sites that create executables were reviewed and are **not**
exposed:

- `beam_compiler.rs` writes an escript, then execs the `escript` **interpreter**
  with that file as an *argument*. `ETXTBSY` applies only to the file being
  `exec`'d; opening for reading is unaffected.
- `escript.rs` (`set_executable`) only chmods an artifact run later, out of
  process.

## Test plan

- [x] `cargo test -p beamtalk-desktop-broker --lib` — 98 passed, green on 5
      consecutive runs
- [x] `just build` — clean
- [x] `just clippy` — clean
- [x] `just fmt-check` — clean (Rust, JS/TS, Beamtalk)
- [x] Pre-push hook — passed

Root cause confirmed empirically rather than by inspection. A standalone
reproducer ran both variants against four background forking threads:

| variant | iterations | `ETXTBSY` |
|---|---|---|
| direct `fs::write` (old) | 3,000 | **66** |
| out-of-process `cp` (new) | 3,000 | 0 |
| out-of-process `cp` (new) | 25,000 | 0 |

## Note

The tests' 100 ms `bind_failure_grace` is deliberately left unchanged. On a
heavily loaded runner a `sh` fork→exec→exit could in principle exceed it and
trip the `attempts == 3` assertion, but that is a distinct failure mode from the
one CI hit and there is no evidence of it occurring — raising it here would be
speculative. Happy to bump it as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLnn32xJ2ixTWUV9ABJjme

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLnn32xJ2ixTWUV9ABJjme)_