### PR TITLE
Route unknown mode Symbols to open:mode: instead of raising (BT-2975 follow-up)

### DIFF
--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_file.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_file.erl
@@ -1006,16 +1006,19 @@ appendBinary(Path, Contents) -> 'appendBinary:contents:'(Path, Contents).
 lines(Path) -> 'lines:'(Path).
 %% `open:do:` and `open:mode:` both lower to the arity-2 shim (the shim name is
 %% the first keyword), so they are told apart by their second argument: a Block
-%% is a fun, a mode is one of the four mode Symbols. Anything else is a typo in
-%% one of the two selectors and we cannot tell which — guessing would report
-%% "Mode must be #read, ..." for a call that said `do:` (`nil` and the booleans
-%% are atoms too), so name both candidates instead.
+%% is a fun, a mode is a Symbol.
+%%
+%% Every atom goes to `open:mode:`, not just the four valid modes. A misspelled
+%% mode is the common mistake, and `open:mode:` answers it with a `Result
+%% error:` naming all four — far better than a raise claiming the Symbol you
+%% passed is not a Symbol. The cost is that `File open: p do: nil` (nil and the
+%% booleans are atoms too) is reported against `open:mode:`, but passing a
+%% non-Block as a block is the rarer and more obviously broken call, and the
+%% message still names what a valid mode looks like.
 -spec open(binary(), Do :: fun((map()) -> term()) | atom()) -> beamtalk_result:t().
 open(Path, Block) when is_function(Block, 1) ->
     'open:do:'(Path, Block);
-open(Path, Mode) when
-    Mode =:= read; Mode =:= write; Mode =:= append; Mode =:= readWrite
-->
+open(Path, Mode) when is_atom(Mode) ->
     'open:mode:'(Path, Mode);
 open(_Path, _Other) ->
     %% Deliberately no selector on the error: we cannot tell which of
@@ -1057,8 +1060,9 @@ handleLines(Handle) -> handle_lines(Handle).
 -doc """
 Return a lazy Stream of lines from a FileHandle.
 
-Used within File open:do: blocks. The Stream reads lines from the
-already-open file handle. The handle's lifetime is managed by open:do:.
+The Stream reads lines from the already-open file handle, so it is bounded by
+that handle's lifetime — the enclosing block for `open:do:` / `open:mode:do:`,
+or the caller's `close` for a handle from `open:mode:`.
 """.
 -spec handle_lines(file_handle()) -> beamtalk_stream:t().
 handle_lines(#{'$beamtalk_class' := 'FileHandle', fd := Fd} = Handle) ->

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_file_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_file_tests.erl
@@ -2521,16 +2521,34 @@ open_mode_do_non_block_raises_test() ->
     ).
 
 open_shim_rejects_ambiguous_second_argument_test() ->
-    %% open/2 backs both open:do: and open:mode:; nil is neither a Block nor a
-    %% mode, and guessing would report the wrong selector's error. The error
-    %% carries no selector at all — naming a made-up 'open:' would mislead
-    %% anyone reading the record — and names both candidates in the message.
+    %% open/2 backs both open:do: and open:mode:; a non-atom, non-Block second
+    %% argument fits neither, and guessing would report the wrong selector's
+    %% error. The error carries no selector at all — naming a made-up 'open:'
+    %% would mislead anyone reading the record — and names both candidates.
     ?assertError(
         #{
             '$beamtalk_class' := _,
             error := #beamtalk_error{kind = type_error, selector = undefined}
         },
-        beamtalk_file:open(<<"x.txt">>, nil)
+        beamtalk_file:open(<<"x.txt">>, 42)
+    ).
+
+open_shim_routes_unknown_mode_symbol_to_open_mode_test() ->
+    %% A misspelled mode is the common mistake: it must reach 'open:mode:' and
+    %% come back as a Result naming the four valid modes, not a raise claiming
+    %% the Symbol you passed is not a Symbol.
+    R = beamtalk_file:open(<<"x.txt">>, notAMode),
+    ?assertMatch(
+        #{
+            '$beamtalk_class' := 'Result',
+            'isOk' := false,
+            'errReason' := #{
+                error := #beamtalk_error{
+                    kind = type_error, class = 'File', selector = 'open:mode:'
+                }
+            }
+        },
+        R
     ).
 
 open_shim_routes_mode_atoms_test() ->


### PR DESCRIPTION
Follow-up to #3159, fixing a regression that PR introduced during its own review cycle.

## The bug

`open/2` is the FFI shim backing **both** `File open:do:` and `File open:mode:` — they collide because the shim name is the first keyword, so they're told apart by the second argument's type.

In #3159 I narrowed the mode guard from `is_atom(Mode)` to the four valid mode atoms. That fixed `File open: p do: nil` being reported against `open:mode:` (`nil` and the booleans are atoms), but broke the far more common mistake:

```beamtalk
File open: "x.txt" mode: #bogus
```

`#bogus` no longer matched the mode clause, so it fell to the catch-all and **raised** *"second argument is neither a Block nor a mode Symbol"* — about a value that is plainly a Symbol — instead of returning the structured `Result error:` naming all four valid modes. `open:mode:do:` was unaffected; it goes through the arity-3 shim.

Caught by the review bot on #3159 after it had already merged.

## The fix

Route every atom to `open:mode:`, which answers a misspelled mode with a proper Result. Non-atom, non-Block values keep the both-candidates raise.

The accepted cost is that `File open: p do: nil` is once again reported against `open:mode:`. That's the right trade: passing a non-Block as a block is the rarer and more obviously broken call, and the message still names what a valid mode looks like. The reasoning is recorded in the comment so the guard doesn't get re-narrowed.

Also refreshes `handle_lines/1`'s docstring, which still claimed the handle's lifetime is managed by `open:do:` — it's now equally reachable from `open:mode:`, where the caller's `close` is the bound.

## Testing

`just ci-changed` green; runtime EUnit 1706 → 1707.

- `open_shim_routes_unknown_mode_symbol_to_open_mode_test` — new; locks in that a misspelled mode returns a Result against `open:mode:` rather than raising
- `open_shim_rejects_ambiguous_second_argument_test` — retargeted from `nil` to `42`, so it still covers the catch-all now that atoms route through

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDzUiTCxbL2pxTXUm6xhvo)_