### PR TITLE
ci: use Sonnet 5 for Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -77,7 +77,10 @@ jobs:
           # Config-only PRs get the cheaper Haiku model; anything touching code OR docs
           # (incl. ADRs under docs/, whose review is valuable) stays on Sonnet. Unknown
           # extensions default to Sonnet — never silently downgrade a substantive change.
-          model='claude-sonnet-4-6'
+          # Sonnet 5 uses a new tokenizer (~30% more tokens for the same text than
+          # Sonnet 4.6) — the pre-computed diffs and -U20 context above are what keep
+          # that in check, so don't widen them without re-checking review cost.
+          model='claude-sonnet-5'
           files="$(git diff --name-only "${FULL_RANGE}")"
           # A file is "config" if it matches this pattern. If grep finds any changed file
           # that does NOT match (and is non-empty), the PR touches code/docs → Sonnet.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Run Claude review
         id: review
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@c96dd0a84e0232ab86947fca5fe34f1caae8792f # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The reviewer never mutates the repo directly: it reads code, runs
@@ -155,7 +155,7 @@ jobs:
         id: review_retry
         if: always() && hashFiles('.claude-verdict') == ''
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@c96dd0a84e0232ab86947fca5fe34f1caae8792f # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--max-turns 50 --model ${{ steps.model.outputs.model }} --allowedTools "Read,Grep,Glob,Write,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git status:*),Bash(cat:*),Bash(ls:*),Bash(find:*)"'
@@ -185,7 +185,7 @@ jobs:
       # automatically.
       - name: Post PR review
         if: always() && (hashFiles('.claude-verdict') != '' || hashFiles('.claude-findings.json') != '')
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const fs = require('fs');
@@ -317,7 +317,7 @@ jobs:
 
       - name: Post review summary
         if: always()
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
Bumps the Claude Review job's non-config model from `claude-sonnet-4-6` to `claude-sonnet-5`.

```diff
-          model='claude-sonnet-4-6'
+          model='claude-sonnet-5'
```

## Why

- Sonnet 5's gains over 4.6 are concentrated in **coding and agentic work** — which is exactly what this job does.
- It **follows instructions more literally** than 4.6. The review prompt is a long list of explicit rules (severity classes, the DO-NOT-FLAG list, the accepted-tradeoff check), so literal adherence works in our favour: fewer findings the prompt already ruled out.
- `effort` now reaches `xhigh` on the Sonnet tier (4.6 had no `xhigh`), so there's headroom if reviews come back shallow. Not used here yet — the job passes no `effort`.

The **Haiku path is unchanged**: `claude-haiku-4-5` is still the current Haiku, so config-only PRs keep the cheaper model.

## Cost

Auth here is the OAuth subscription token, so per-token API rates don't produce a bill — this draws on the subscription's limits. Worth knowing anyway: Sonnet 5 lists at the same $3/$15 per MTok as Sonnet 4.6, but it uses a **new tokenizer that produces roughly 30% more tokens for the same text**. An equivalent review therefore consumes noticeably more quota at an unchanged per-token rate.

That's why the diff-narrowing in the "Compute diff ranges" step matters more now than it did — the pre-computed `.claude-review-full.diff` / `.claude-review-incr.diff` and the `-U20` context bound what the agent reads. I left a comment next to the model selection so those don't get widened later without re-checking cost.

## Caveat worth knowing (probably doesn't apply here)

Anthropic's migration guidance flags that **code-review harnesses can show lower measured recall on Sonnet 5**: when a review prompt says "only report high-severity issues" or "be conservative", Sonnet 5 obeys more faithfully than 4.6 did — it still finds the bugs, then declines to report ones below the stated bar. Precision rises; measured recall can fall even though bug-finding improved.

Our prompt shouldn't trip this — it explicitly asks for Blockers **and** Suggestions **and** Nits rather than filtering by severity. Flagging it because if finding volume drops noticeably after this merge, that's the first thing to look at rather than assuming a capability regression.

## Rollout

This is the first of eight repos. The seven satellite repos (`beamtalk-collections`, `-exdura`, `-http`, `-registry`, `-symphony`, `-watcher`, `-yaml`) carry the same workflow and will get the same one-line change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDVMbNkfiJDqDtSM8y6Hxt)_