### PR TITLE
Stop mangling non-ASCII in Erlang binary literals (BT-3026)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -59,6 +59,13 @@ stamp_matches() {
 echo "🔍 Running lint-rust..."
 just lint-rust
 
+# Non-ASCII in Erlang binary literals is silently truncated to a control
+# character (BT-3026). Unstamped: it covers *.escript as well as *.erl/*.hrl,
+# and at ~1s it is cheap enough to run every push rather than track a fourth
+# fingerprint.
+echo "🔍 Running lint-binary-literal-encoding..."
+just lint-binary-literal-encoding
+
 ERLANG_FP="$(fingerprint '*.erl' '*.hrl')"
 if stamp_matches "$ERLANG_STAMP" "$ERLANG_FP"; then
   echo "⏭️  lint-erlang: no Erlang changes since last lint, skipping"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,10 @@ jobs:
         # On Windows, fmt-check skips Erlang/JS checks (platform-agnostic, Linux covers them).
         # lint-workaround-comments (BT-2347 ratchet) is a no-op on Windows and enforces
         # the same allowlist gate here that `just ci` enforces locally (BT-2841).
-        run: just build clippy fmt-check test-rust lint-workaround-comments
+        # lint-binary-literal-encoding (BT-3026) likewise no-ops on Windows; it rejects
+        # non-ASCII in Erlang binary literals lacking /utf8, which the compiler silently
+        # truncates to a control character.
+        run: just build clippy fmt-check test-rust lint-workaround-comments lint-binary-literal-encoding
 
       - name: Surface parity drift check (BT-2082)
         # Verifies REPL ops × CLI × MCP × LSP coverage matches

--- a/Justfile
+++ b/Justfile
@@ -539,7 +539,23 @@ bench:
 lint-elixir: fmt-check-elixir
 
 # Run all linting and formatting checks
-lint: lint-rust lint-erlang lint-js lint-elixir lint-beamtalk lint-workaround-comments
+lint: lint-rust lint-erlang lint-js lint-elixir lint-beamtalk lint-workaround-comments lint-binary-literal-encoding
+
+# Lint: reject non-ASCII inside Erlang binary literals that lack /utf8 (BT-3026).
+# Binary literals are bytes, so `<<"—">>` truncates U+2014 to 0x14 (a DC4 control
+# character) with no compiler warning, and the mangled text reaches the user.
+#
+# To clear a failure: rewrite the literal in ASCII (use `;` where an em-dash
+# joined two clauses), or append `/utf8` when the character is genuinely needed.
+# Unix-only (the escript shells out to `git ls-files`); Linux CI covers it, so
+# the Windows variant is a no-op, consistent with the other lint splits.
+[unix]
+lint-binary-literal-encoding:
+    @escript scripts/ci/lint-binary-literal-encoding.escript
+
+[windows]
+lint-binary-literal-encoding:
+    @echo "lint-binary-literal-encoding: skipped on Windows (covered by Linux CI)"
 
 # Ratchet lint: flag workaround/limitation comments lacking a BT-NNNN tracking
 # reference (BT-2347). Ships with an allowlist snapshot of pre-existing offenders

--- a/docs/development/erlang-guidelines.md
+++ b/docs/development/erlang-guidelines.md
@@ -494,6 +494,35 @@ to the tag are not recognized by the spec reader.
 <<First:8, Rest/binary>> = <<"hello">>
 ```
 
+#### Keep binary literals ASCII (BT-3026)
+
+Binary literals have **byte** semantics. A non-ASCII character is silently
+truncated to its low 8 bits — no compiler warning — so the mangled text reaches
+the user:
+
+```erlang
+%% ❌ WRONG - U+2014 truncates to 0x14, a DC4 control character
+<<"List is empty — guard with `isEmpty` before indexing">>
+
+%% ✅ RIGHT - ASCII; use `;` where an em-dash joined two clauses
+<<"List is empty; guard with `isEmpty` before indexing">>
+
+%% ✅ RIGHT - /utf8 when the character is genuinely needed (arrows, test data)
+<<"Actor → Inspector"/utf8>>
+```
+
+Prefer ASCII for error messages and hints: they are also consumed by tests, the
+JSON protocol, and log backends. Reach for `/utf8` only when the character
+carries meaning that ASCII cannot (the inspector's `→`/`↩`, Unicode test
+fixtures).
+
+Plain (non-binary) strings are unaffected — they are lists of codepoints, so
+`?LOG_ERROR("a — b")` and `-doc "a — b"` are fine.
+
+`just lint-binary-literal-encoding` enforces this across all tracked Erlang
+sources. It tokenises with `erl_scan` rather than grepping, so it sees through
+comments, escapes, and binaries spanning multiple lines.
+
 ### Exception Handling
 
 ```erlang

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
@@ -636,7 +636,7 @@ classRemoveFromSystemByName(ClassName) ->
                                 iolist_to_binary([
                                     <<"Cannot remove class '">>,
                                     atom_to_binary(ClassName, utf8),
-                                    <<"' — it has subclasses">>
+                                    <<"'; it has subclasses">>
                                 ])
                             ),
                             Error2 = beamtalk_error:with_hint(
@@ -681,7 +681,7 @@ classReload(Self) ->
             Error0 = beamtalk_error:new(no_source_file, ClassName),
             Msg = iolist_to_binary([
                 atom_to_binary(ClassName, utf8),
-                <<" has no source file — stdlib classes cannot be reloaded">>
+                <<" has no source file; stdlib classes cannot be reloaded">>
             ]),
             beamtalk_error:raise(beamtalk_error:with_message(Error0, Msg));
         SourcePath ->
@@ -729,7 +729,7 @@ classReload(Self) ->
                     beamtalk_error:raise(
                         beamtalk_error:with_message(
                             Error0,
-                            <<"Workspace not available — reload requires a running workspace">>
+                            <<"Workspace not available; reload requires a running workspace">>
                         )
                     )
             end
@@ -801,7 +801,7 @@ do_compile_source(Self, Selector, Source, Intent) ->
                 beamtalk_error:with_message(
                     Error0,
                     <<
-                        "Workspace not available — live method editing requires a "
+                        "Workspace not available; live method editing requires a "
                         "running workspace"
                     >>
                 )
@@ -858,7 +858,7 @@ classPrecheckCompileSource(Self, Selector, Source) ->
                 beamtalk_error:with_message(
                     Error0,
                     <<
-                        "Workspace not available — pre-save precheck requires a "
+                        "Workspace not available; pre-save precheck requires a "
                         "running workspace"
                     >>
                 )

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
@@ -134,7 +134,7 @@ handle_class_self_call(Selector) ->
             <<
                 "' from inside one of its own class methods would deadlock "
                 "(gen_server:call to self). This usually means a block passed to a "
-                "class method is messaging that same class again — read what you "
+                "class method is messaging that same class again; read what you "
                 "need before the call, or hold the resource yourself instead of "
                 "using the block form."
             >>

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
@@ -269,7 +269,7 @@ lookup_in_class_chain(Selector, Args, Self, State, ClassName) ->
                     does_not_understand,
                     ClassName,
                     Selector,
-                    <<"Hierarchy depth limit exceeded — possible cycle in class hierarchy">>
+                    <<"Hierarchy depth limit exceeded; possible cycle in class hierarchy">>
                 )};
         not_found ->
             %% Unreachable: class_chain_step/6 always resolves to

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_error.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_error.erl
@@ -429,7 +429,7 @@ maybe_enrich_dnu_hint(#beamtalk_error{class = Class, selector = Selector} = Erro
             Hint = iolist_to_binary([
                 <<"'">>,
                 SelBin,
-                <<"' is a class-side message — use 'class ">>,
+                <<"' is a class-side message; use 'class ">>,
                 SelBin,
                 <<"' to send it to an instance's class">>
             ]),

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_inspector.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_inspector.erl
@@ -1355,7 +1355,7 @@ actor_eval_unsupported_error() ->
         actor_eval_unsupported,
         'Inspector',
         'evaluate:',
-        <<"evaluate: runs against values; actor evaluate-in-context is not in v1 — drill with at:">>
+        <<"evaluate: runs against values; actor evaluate-in-context is not in v1; drill with at:">>
     ).
 
 %% A value `evaluate:` whose expression failed to compile or evaluate.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_message_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_message_dispatch.erl
@@ -100,7 +100,7 @@ send({beamtalk_supervisor, ClassName, _Module, Pid} = _Self, stop, []) ->
                 runtime_error,
                 ClassName,
                 stop,
-                <<"supervisor is not running — the handle is stale">>
+                <<"supervisor is not running; the handle is stale">>
             ),
             beamtalk_exception_handler:reraise(Error)
     end;
@@ -238,7 +238,7 @@ reraise_actor_dead(ClassName, Selector) ->
         actor_dead,
         ClassName,
         Selector,
-        <<"Actor process is not available — class may not be fully registered">>
+        <<"Actor process is not available; class may not be fully registered">>
     ),
     beamtalk_exception_handler:reraise(Error).
 

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_primitive.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_primitive.erl
@@ -717,7 +717,7 @@ their slots in the underlying map and support read-only reflection (BT-924).
 """.
 -spec is_ivar_method(atom()) -> {true, binary()} | false.
 is_ivar_method('fieldAt:put:') ->
-    {true, <<"Cannot modify slot on value type — use withSlot: to create a new instance">>};
+    {true, <<"Cannot modify slot on value type; use withSlot: to create a new instance">>};
 is_ivar_method(_) ->
     false.
 

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_supervisor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_supervisor.erl
@@ -369,7 +369,7 @@ terminate_child_stale_handle(SupClass) ->
             stale_handle,
             SupClass,
             'terminateChild:',
-            <<"supervisor is not running — the handle is stale">>
+            <<"supervisor is not running; the handle is stale">>
         )}.
 
 %% Shared outcome dispatcher for both static and dynamic terminateChild paths.
@@ -1074,7 +1074,7 @@ stale_handle_error(ClassName, Selector) ->
         stale_handle,
         ClassName,
         Selector,
-        <<"supervisor is not running — the handle is stale">>
+        <<"supervisor is not running; the handle is stale">>
     ),
     {error, Error}.
 

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_file.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_file.erl
@@ -583,7 +583,7 @@ check_regular(PathStr, Selector, Path) ->
                 beamtalk_error:with_hint(
                     Error3,
                     <<
-                        "File handles are for regular files — a directory, FIFO or device "
+                        "File handles are for regular files; a directory, FIFO or device "
                         "cannot be read to end-of-file"
                     >>
                 )}
@@ -1079,7 +1079,7 @@ open(_Path, _Other) ->
     %% anyone reading the record's selector field. The message names both.
     Error0 = beamtalk_error:new(type_error, 'File'),
     Error1 = beamtalk_error:with_message(
-        Error0, <<"File 'open:' — second argument is neither a Block nor a mode Symbol">>
+        Error0, <<"File 'open:': second argument is neither a Block nor a mode Symbol">>
     ),
     beamtalk_error:raise(
         beamtalk_error:with_hint(

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_file_handle.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_file_handle.erl
@@ -423,7 +423,7 @@ closed_error_record(Handle, Selector) ->
     Error2 = beamtalk_error:with_message(Error1, <<"FileHandle is closed">>),
     Error3 = beamtalk_error:with_details(Error2, #{path => path_of(Handle)}),
     beamtalk_error:with_hint(
-        Error3, <<"The handle was already closed — reopen it with 'File open:mode:'">>
+        Error3, <<"The handle was already closed; reopen it with 'File open:mode:'">>
     ).
 
 -spec mode_error(map(), atom(), mode(), binary()) -> beamtalk_result:t().

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_string.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_string.erl
@@ -455,7 +455,7 @@ raise_url_decode_error() ->
     Error1 = beamtalk_error:with_selector(Error0, 'urlDecoded'),
     Error2 = beamtalk_error:with_hint(
         Error1,
-        <<"Malformed percent-encoding — a '%' must be followed by two hex digits">>
+        <<"Malformed percent-encoding; a '%' must be followed by two hex digits">>
     ),
     beamtalk_error:raise(Error2).
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
@@ -1453,7 +1453,7 @@ field_change_note(ClassNameBin, {retyped, Name, OldType, NewType}, AmbiguousWith
     OtherNamesBin = retyped_names_bin(AmbiguousWith),
     <<"state field `", Name/binary, "` retyped by the reload of ", ClassNameBin/binary, " (",
         OldType/binary, " -> ", NewType/binary,
-        ") — ambiguous: could also be caused by the retyping of ", OtherNamesBin/binary>>.
+        "); ambiguous: could also be caused by the retyping of ", OtherNamesBin/binary>>.
 
 -spec retyped_names_bin([shape_field_change()]) -> binary().
 retyped_names_bin(FieldChanges) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_docs.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_docs.erl
@@ -330,7 +330,7 @@ format_metaclass_docs() ->
         <<"== Metaclass ==\n">>,
         <<"The terminal sentinel of the class hierarchy.\n\n">>,
         <<"Every class object is an instance of its metaclass, and every metaclass\n">>,
-        <<"is an instance of Metaclass. Metaclass is its own class — the tower\n">>,
+        <<"is an instance of Metaclass. Metaclass is its own class; the tower\n">>,
         <<"terminates here.\n\n">>,
         <<"Common class-side methods:\n">>,
         <<"  new              Create a new instance\n">>,
@@ -855,7 +855,7 @@ format_see_also(Entries) ->
     Lines = [
         case Desc of
             <<>> -> iolist_to_binary([<<"  ">>, atom_to_binary(Name, utf8)]);
-            _ -> iolist_to_binary([<<"  ">>, atom_to_binary(Name, utf8), <<" — ">>, Desc])
+            _ -> iolist_to_binary([<<"  ">>, atom_to_binary(Name, utf8), <<" - ">>, Desc])
         end
      || {Name, Desc} <- Entries
     ],

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_loader.erl
@@ -1515,7 +1515,7 @@ validate_target_path(TargetPath) ->
                             iolist_to_binary([
                                 <<"newClass:at: target is outside the project source tree: ">>,
                                 list_to_binary(TargetPath),
-                                <<" — new classes must be created inside the current project">>
+                                <<"; new classes must be created inside the current project">>
                             ]),
                             TargetPath
                         )}
@@ -1530,7 +1530,7 @@ validate_target_path(TargetPath) ->
                     iolist_to_binary([
                         <<"newClass:at: target already exists on disk: ">>,
                         list_to_binary(TargetPath),
-                        <<" — use compile:source: against the existing class, or choose a new path">>
+                        <<"; use compile:source: against the existing class, or choose a new path">>
                     ]),
                     TargetPath
                 )}
@@ -1561,7 +1561,7 @@ declared_class_name(ClassNames) when length(ClassNames) > 1 ->
             iolist_to_binary([
                 <<"newClass:at: source declares multiple classes (">>,
                 lists:join(<<", ">>, Names),
-                <<") — one class per file (ADR 0040)">>
+                <<"); one class per file (ADR 0040)">>
             ]),
             undefined
         )}.
@@ -1602,7 +1602,7 @@ validate_new_class(DeclaredName, TargetPath, Loaded) ->
                         Expected,
                         <<"' of ">>,
                         list_to_binary(TargetPath),
-                        <<" — either rename the class to match the basename, or use a path with basename ">>,
+                        <<"; either rename the class to match the basename, or use a path with basename ">>,
                         DeclaredName,
                         <<".bt or ">>,
                         list_to_binary(DeclaredSnake),
@@ -1617,7 +1617,7 @@ validate_new_class(DeclaredName, TargetPath, Loaded) ->
                     iolist_to_binary([
                         <<"newClass:at: class ">>,
                         DeclaredName,
-                        <<" is already loaded — use compile:source: against it, or remove it first">>
+                        <<" is already loaded; use compile:source: against it, or remove it first">>
                     ]),
                     TargetPath
                 )};
@@ -2160,10 +2160,10 @@ mark_stale_finding(ClassNameBin, Finding) ->
 %% stale" is accurate and reason-agnostic for all three causes.
 -spec stale_note(binary(), binary() | undefined) -> binary().
 stale_note(ClassNameBin, undefined) ->
-    <<"not re-checked against the latest reload of ", ClassNameBin/binary, " — may be stale">>;
+    <<"not re-checked against the latest reload of ", ClassNameBin/binary, "; may be stale">>;
 stale_note(ClassNameBin, PrevNote) ->
-    <<PrevNote/binary, " — not re-checked against the latest reload of ", ClassNameBin/binary,
-        " — may be stale">>.
+    <<PrevNote/binary, "; not re-checked against the latest reload of ", ClassNameBin/binary,
+        "; may be stale">>.
 
 %% Log + broadcast the outcome of one `maybe_trigger_recheck/4` call — but
 %% only when a live surface has something to act on: either a dependent

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
@@ -212,7 +212,7 @@ flush_kinds(_Other) ->
 classify_kinds([]) ->
     {error,
         filter_error(<<
-            "flushKinds: requires at least one kind Symbol — use Workspace flush to flush "
+            "flushKinds: requires at least one kind Symbol; use Workspace flush to flush "
             "every pending durable change"
         >>)};
 classify_kinds(Kinds) ->
@@ -277,7 +277,7 @@ normalise_filter(#beamtalk_object{class = ClassNameAtom}) when is_atom(ClassName
         false ->
             {error,
                 filter_error(
-                    <<"flush: argument is an Object but not a Class — pass a class, a Symbol, or a Dictionary">>
+                    <<"flush: argument is an Object but not a Class; pass a class, a Symbol, or a Dictionary">>
                 )}
     end;
 normalise_filter(ClassName) when is_atom(ClassName) ->
@@ -524,7 +524,7 @@ prepare_file(File, Entries) ->
                     Entries,
                     <<
                         "Cannot flush a new-class entry alongside other patches in the "
-                        "same operation — flush the new-class entry first, then re-flush "
+                        "same operation; flush the new-class entry first, then re-flush "
                         "to apply method patches against the newly created file"
                     >>
                 )};
@@ -573,7 +573,7 @@ prepare_new_class(File, Entries, Entry) ->
             %% other than enoent (e.g. eacces, eloop).
             {conflict,
                 conflict_map(File, <<"target_exists">>, Entries, <<
-                    "newClass:at: target already exists on disk — choose a different path "
+                    "newClass:at: target already exists on disk; choose a different path "
                     "or clear the pending entry"
                 >>)}
     end.
@@ -688,7 +688,7 @@ splice_with_prev(Body, Entry, Start, End, PrevBody) ->
                             (integer_to_binary(End))/binary,
                             " is outside the current ",
                             (integer_to_binary(byte_size(Body)))/binary,
-                            "-byte file — the file changed externally"
+                            "-byte file; the file changed externally"
                         >>
                     ])
                 )};
@@ -874,7 +874,7 @@ complete_flush(Files, Renamed, Failed, Seqs) ->
                 detail => iolist_to_binary([
                     <<
                         "Files were written to disk but the ChangeLog could not "
-                        "mark the entries as flushed — they still appear in "
+                        "mark the entries as flushed; they still appear in "
                         "`Workspace changes` and will conflict on re-flush. "
                         "Detail: "
                     >>,

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl
@@ -371,7 +371,7 @@ revert_method(ClassNameBin, SelectorBin) when
                         },
                         #{domain => [beamtalk, runtime]}
                     ),
-                    {error, revert_state_error(<<"revert: internal error — see node logs">>)}
+                    {error, revert_state_error(<<"revert: internal error; see node logs">>)}
             end;
         error ->
             %% No atom exists for this selector, so no method by that name has
@@ -384,7 +384,7 @@ revert_method(ClassNameBin, SelectorBin) when
                         ClassNameBin,
                         <<">>">>,
                         SelectorBin,
-                        <<" — nothing to revert">>
+                        <<"; nothing to revert">>
                     ])
                 )}
     end.
@@ -434,7 +434,7 @@ extract_revert_target_from_map(M) ->
             {error,
                 revert_type_error(
                     <<
-                        "revert: ChangeEntry is missing className/selector fields — pass an "
+                        "revert: ChangeEntry is missing className/selector fields; pass an "
                         "entry obtained from `Workspace changes do:` or `select:`"
                     >>
                 )}
@@ -464,7 +464,7 @@ do_revert(ClassNameBin, SelectorAtom) ->
                         ClassNameBin,
                         <<">>">>,
                         atom_to_binary(SelectorAtom, utf8),
-                        <<" — nothing to revert">>
+                        <<"; nothing to revert">>
                     ])
                 )
             );
@@ -495,7 +495,7 @@ revert_side(Other) ->
             iolist_to_binary([
                 <<"revert: cannot revert a ">>,
                 atom_to_binary(Other, utf8),
-                <<" entry as a method patch — use `Workspace changes clear` to discard it">>
+                <<" entry as a method patch; use `Workspace changes clear` to discard it">>
             ])
         )
     ).
@@ -896,7 +896,7 @@ do_start_supervisor(ClassName, Module) ->
                     raise_start_supervisor_error(
                         iolist_to_binary([
                             NameBin,
-                            <<" is already running — stop it first, then attach to the workspace">>
+                            <<" is already running; stop it first, then attach to the workspace">>
                         ])
                     )
             end;

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
@@ -995,8 +995,8 @@ field_change_note_retyped_unambiguous_names_the_field_test() ->
 
 field_change_note_retyped_with_ambiguous_candidates_renders_all_names_test() ->
     ?assertEqual(
-        <<"state field `count` retyped by the reload of ReCheckCounter (Integer -> String) ",
-            "— ambiguous: could also be caused by the retyping of `label`, `flag`">>,
+        <<"state field `count` retyped by the reload of ReCheckCounter (Integer -> String)",
+            "; ambiguous: could also be caused by the retyping of `label`, `flag`">>,
         beamtalk_recheck:field_change_note(
             <<"ReCheckCounter">>,
             {retyped, <<"count">>, <<"Integer">>, <<"String">>},

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_docs_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_docs_tests.erl
@@ -247,8 +247,8 @@ format_see_also_single_no_desc_test() ->
 format_see_also_with_desc_test() ->
     Result = beamtalk_repl_docs:format_see_also([{'Value', <<"immutable data">>}]),
     ?assert(binary:match(Result, <<"See also:">>) =/= nomatch),
-    %% Should contain the em dash separator
-    ?assert(binary:match(Result, <<" — ">>) =/= nomatch),
+    %% Should contain the ASCII separator (BT-3026: no non-ASCII in binary literals)
+    ?assert(binary:match(Result, <<" - ">>) =/= nomatch),
     ?assert(binary:match(Result, <<"immutable data">>) =/= nomatch).
 
 %%====================================================================

--- a/scripts/ci/lint-binary-literal-encoding.escript
+++ b/scripts/ci/lint-binary-literal-encoding.escript
@@ -1,0 +1,158 @@
+#!/usr/bin/env escript
+%% -*- erlang -*-
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%% Lint: reject non-ASCII characters inside Erlang binary literals that lack a
+%% UTF-8 type specifier.
+%%
+%% Rationale (BT-3026): binary string literals have *byte* semantics, so
+%% `<<"—">>` truncates U+2014 (8212) to its low 8 bits — 0x14, a DC4 control
+%% character. The compiler emits no warning, so every error hint written with a
+%% typographic dash reached the user silently mangled. Adding `/utf8` (or
+%% `/utf16`, `/utf32`) encodes the character properly:
+%%
+%%     <<"a — b">>          %% BROKEN: em-dash becomes 0x14
+%%     <<"a — b"/utf8>>     %% OK:     encoded as UTF-8 bytes
+%%     <<"a; b">>           %% OK:     ASCII only
+%%
+%% Plain (non-binary) strings are unaffected — they are lists of codepoints, so
+%% `?LOG_ERROR("a — b")` and `-doc "a — b"` are fine and are not flagged.
+%%
+%% ── How to clear a failure ──────────────────────────────────────────────────
+%% Either rewrite the literal in ASCII (preferred for error messages and hints;
+%% use `;` where an em-dash joined two clauses), or append `/utf8` when the
+%% character is genuinely needed (arrows in the inspector, Unicode test data).
+%%
+%% This lint tokenises with `erl_scan` rather than grepping, so it is exact:
+%% it sees through comments, escapes, and binaries spanning multiple lines.
+%%
+%% Usage:
+%%   escript scripts/ci/lint-binary-literal-encoding.escript
+
+-mode(compile).
+
+main(_Args) ->
+    %% Offender snippets are printed verbatim, so both devices must speak Unicode.
+    io:setopts(standard_io, [{encoding, unicode}]),
+    io:setopts(standard_error, [{encoding, unicode}]),
+    Files = erlang_sources(),
+    Offenders = lists:flatmap(fun scan_file/1, Files),
+    io:format("🔍 Linting ~b Erlang source file(s) for non-ASCII in binary literals...~n", [
+        length(Files)
+    ]),
+    case Offenders of
+        [] ->
+            io:format("✅ No non-ASCII binary literals missing /utf8.~n"),
+            halt(0);
+        _ ->
+            io:format(standard_error, "~n❌ Non-ASCII character(s) in binary literal without /utf8:~n~n", []),
+            lists:foreach(fun report/1, Offenders),
+            io:format(
+                standard_error,
+                "~nBinary literals are bytes: a non-ASCII character is truncated to its low 8~n"
+                "bits and reaches the user as a control character.~n~n"
+                "Fix: rewrite the literal in ASCII (use `;` where an em-dash joined two~n"
+                "     clauses), or append /utf8 when the character is genuinely needed.~n"
+                "     See the header of this script for details.~n",
+                []
+            ),
+            halt(1)
+    end.
+
+report({File, Line, Chars, Snippet}) ->
+    Described = lists:join(", ", [describe(C) || C <- Chars]),
+    io:format(standard_error, "  ~ts:~b: ~ts~n      contains ~ts~n", [
+        File, Line, Snippet, Described
+    ]).
+
+describe(C) ->
+    lists:flatten(io_lib:format("U+~4.16.0B '~ts'", [C, [C]])).
+
+%% ── File discovery ──────────────────────────────────────────────────────────
+
+%% Tracked files plus untracked-but-not-ignored ones, so a new offender is
+%% caught before it is committed.
+erlang_sources() ->
+    Tracked = git(["ls-files", "*.erl", "*.hrl", "*.escript"]),
+    Untracked = git(["ls-files", "--others", "--exclude-standard", "*.erl", "*.hrl", "*.escript"]),
+    lists:usort(Tracked ++ Untracked).
+
+git(Args) ->
+    Cmd = "git " ++ lists:join(" ", [quote(A) || A <- Args]),
+    Out = os:cmd(Cmd),
+    [L || L <- string:lexemes(Out, "\n"), L =/= ""].
+
+quote(A) -> "'" ++ A ++ "'".
+
+%% ── Scanning ────────────────────────────────────────────────────────────────
+
+scan_file(File) ->
+    case file:read_file(File) of
+        {ok, Bin} ->
+            case unicode:characters_to_list(Bin, utf8) of
+                Chars when is_list(Chars) ->
+                    scan_tokens(File, Chars);
+                _ ->
+                    %% Not valid UTF-8; leave it to the compiler to complain.
+                    []
+            end;
+        {error, _} ->
+            []
+    end.
+
+scan_tokens(File, Chars) ->
+    case erl_scan:string(Chars, 1) of
+        {ok, Tokens, _} -> walk(Tokens, 0, File, []);
+        {error, _, _} -> []
+    end.
+
+%% Walk the token stream tracking binary-literal nesting depth. Inside a binary
+%% (`Depth > 0`), a string or character token holding a non-ASCII codepoint is an
+%% offender unless its type-specifier list names a Unicode encoding.
+walk([], _Depth, _File, Acc) ->
+    lists:reverse(Acc);
+walk([{'<<', _} | Rest], Depth, File, Acc) ->
+    walk(Rest, Depth + 1, File, Acc);
+walk([{'>>', _} | Rest], Depth, File, Acc) ->
+    walk(Rest, max(0, Depth - 1), File, Acc);
+walk([Tok | Rest], Depth, File, Acc) when Depth > 0 ->
+    case literal_codepoints(Tok) of
+        none ->
+            walk(Rest, Depth, File, Acc);
+        {Line, Cps, Snippet} ->
+            NonAscii = [C || C <- Cps, C > 127],
+            case NonAscii =/= [] andalso not unicode_spec(Rest) of
+                true -> walk(Rest, Depth, File, [{File, Line, NonAscii, Snippet} | Acc]);
+                false -> walk(Rest, Depth, File, Acc)
+            end
+    end;
+walk([_ | Rest], Depth, File, Acc) ->
+    walk(Rest, Depth, File, Acc).
+
+literal_codepoints({string, Anno, S}) ->
+    {erl_anno:line(Anno), S, ["\"", S, "\""]};
+literal_codepoints({char, Anno, C}) ->
+    {erl_anno:line(Anno), [C], ["$", [C]]};
+literal_codepoints(_) ->
+    none.
+
+%% A segment's type specifiers follow as `/ Spec ('-' Spec)*`. Any of the
+%% `utf8`/`utf16`/`utf32` types encodes codepoints correctly.
+unicode_spec([{'/', _} | Rest]) -> specs_have_unicode(Rest);
+unicode_spec(_) -> false.
+
+specs_have_unicode([{atom, _, Type} | Rest]) ->
+    case lists:member(Type, [utf8, utf16, utf32]) of
+        true -> true;
+        false -> continue_specs(Rest)
+    end;
+%% `unit:8` and friends arrive as separate tokens; keep walking the spec list.
+specs_have_unicode([{integer, _, _} | Rest]) ->
+    continue_specs(Rest);
+specs_have_unicode(_) ->
+    false.
+
+continue_specs([{'-', _} | Rest]) -> specs_have_unicode(Rest);
+continue_specs([{':', _} | Rest]) -> specs_have_unicode(Rest);
+continue_specs(_) -> false.

--- a/scripts/ci/lint-binary-literal-encoding.escript
+++ b/scripts/ci/lint-binary-literal-encoding.escript
@@ -47,12 +47,12 @@ main(_Args) ->
             io:format(standard_error, "❌ No Erlang sources found under the repository root.~n", []),
             halt(1)
         end,
-    Results = [scan_file(F) || F <- Files],
-    Offenders = lists:append([O || {ok, O} <- Results]),
-    Skipped = [{F, Why} || {skipped, F, Why} <- Results],
     io:format("🔍 Linting ~b Erlang source file(s) for non-ASCII in binary literals...~n", [
         length(Files)
     ]),
+    Results = [scan_file(F) || F <- Files],
+    Offenders = lists:append([O || {ok, O} <- Results]),
+    Skipped = [{F, Why} || {skipped, F, Why} <- Results],
     %% A file this lint could not parse is not a file this lint has checked. Say
     %% so rather than letting it pass silently, but do not fail the build: an
     %% intentionally-malformed fixture is legitimate, and a real syntax error

--- a/scripts/ci/lint-binary-literal-encoding.escript
+++ b/scripts/ci/lint-binary-literal-encoding.escript
@@ -36,11 +36,35 @@ main(_Args) ->
     %% Offender snippets are printed verbatim, so both devices must speak Unicode.
     io:setopts(standard_io, [{encoding, unicode}]),
     io:setopts(standard_error, [{encoding, unicode}]),
+    %% Anchor at the repo root so paths are stable regardless of cwd, and so a
+    %% git failure is caught here rather than surfacing as bogus "files" later
+    %% (os:cmd folds stderr into its output, so an error message would otherwise
+    %% be mistaken for a filename and the lint would report a false pass).
+    ok = goto_repo_root(),
     Files = erlang_sources(),
-    Offenders = lists:flatmap(fun scan_file/1, Files),
+    Files =:= [] andalso
+        begin
+            io:format(standard_error, "❌ No Erlang sources found under the repository root.~n", []),
+            halt(1)
+        end,
+    Results = [scan_file(F) || F <- Files],
+    Offenders = lists:append([O || {ok, O} <- Results]),
+    Skipped = [{F, Why} || {skipped, F, Why} <- Results],
     io:format("🔍 Linting ~b Erlang source file(s) for non-ASCII in binary literals...~n", [
         length(Files)
     ]),
+    %% A file this lint could not parse is not a file this lint has checked. Say
+    %% so rather than letting it pass silently, but do not fail the build: an
+    %% intentionally-malformed fixture is legitimate, and a real syntax error
+    %% fails the compile anyway.
+    Skipped =:= [] orelse
+        begin
+            io:format(standard_error, "~n⚠️  ~b file(s) could not be parsed and were NOT checked:~n", [
+                length(Skipped)
+            ]),
+            [io:format(standard_error, "  ~ts (~p)~n", [F, W]) || {F, W} <- Skipped],
+            io:format(standard_error, "~n", [])
+        end,
     case Offenders of
         [] ->
             io:format("✅ No non-ASCII binary literals missing /utf8.~n"),
@@ -71,17 +95,28 @@ describe(C) ->
 
 %% ── File discovery ──────────────────────────────────────────────────────────
 
+goto_repo_root() ->
+    case git(["rev-parse", "--show-toplevel"]) of
+        [Root] ->
+            file:set_cwd(Root);
+        _ ->
+            io:format(standard_error, "❌ Not a git repository - cannot enumerate sources.~n", []),
+            halt(1)
+    end.
+
 %% Tracked files plus untracked-but-not-ignored ones, so a new offender is
 %% caught before it is committed.
 erlang_sources() ->
-    Tracked = git(["ls-files", "*.erl", "*.hrl", "*.escript"]),
-    Untracked = git(["ls-files", "--others", "--exclude-standard", "*.erl", "*.hrl", "*.escript"]),
+    Pats = ["*.erl", "*.hrl", "*.escript"],
+    Tracked = git(["ls-files" | Pats]),
+    Untracked = git(["ls-files", "--others", "--exclude-standard" | Pats]),
     lists:usort(Tracked ++ Untracked).
 
+%% stderr is discarded rather than folded into the result: os:cmd merges it into
+%% stdout, where a git diagnostic would be indistinguishable from a filename.
 git(Args) ->
-    Cmd = "git " ++ lists:join(" ", [quote(A) || A <- Args]),
-    Out = os:cmd(Cmd),
-    [L || L <- string:lexemes(Out, "\n"), L =/= ""].
+    Cmd = "git " ++ lists:join(" ", [quote(A) || A <- Args]) ++ " 2>/dev/null",
+    [L || L <- string:lexemes(os:cmd(Cmd), "\n"), L =/= ""].
 
 quote(A) -> "'" ++ A ++ "'".
 
@@ -94,17 +129,16 @@ scan_file(File) ->
                 Chars when is_list(Chars) ->
                     scan_tokens(File, Chars);
                 _ ->
-                    %% Not valid UTF-8; leave it to the compiler to complain.
-                    []
+                    {skipped, File, not_utf8}
             end;
-        {error, _} ->
-            []
+        {error, Reason} ->
+            {skipped, File, Reason}
     end.
 
 scan_tokens(File, Chars) ->
     case erl_scan:string(Chars, 1) of
-        {ok, Tokens, _} -> walk(Tokens, 0, File, []);
-        {error, _, _} -> []
+        {ok, Tokens, _} -> {ok, walk(Tokens, 0, File, [])};
+        {error, {_, _, Reason}, _} -> {skipped, File, Reason}
     end.
 
 %% Walk the token stream tracking binary-literal nesting depth. Inside a binary


### PR DESCRIPTION
Fixes BT-3026.

## The bug

Erlang binary literals have **byte** semantics, so a non-ASCII character is truncated to its low 8 bits with no compiler warning. Every error hint written with a typographic em-dash reached the user with U+2014 collapsed to `0x14`, a DC4 control character that renders as nothing:

```
Hint: List is empty  guard with `isEmpty` before indexing
```

## Scope was larger than the issue estimated: 42 sites, not ~30

The sweep in the issue body, `grep -rnP '<<"[^"]*\xe2\x80\x94'`, is line-local, so it misses offenders inside binary literals that span multiple lines. Twelve of the 42 look like this:

```erlang
<<
    "Workspace not available — live method editing requires a "
    "running workspace"
>>
```

The `<<` is on a previous line, so no single line matches. Files affected that the issue's table does not list: `beamtalk_class_dispatch.erl`, `beamtalk_recheck.erl`, and five more sites in `beamtalk_workspace_flush.erl`. All 42 were U+2014; no other non-ASCII character appeared in a binary literal.

## Approach

Replaced with `;`, following the BT-3021 convention. Two sites took different punctuation because `;` was grammatically wrong:

- `beamtalk_file.erl` — `File 'open:':` names a selector rather than joining two clauses, so a colon reads correctly.
- `beamtalk_repl_docs.erl` — the `See also:` listing uses ` — ` as a *display separator* between name and description, not a clause join; it became ` - `.

A strict "ASCII-only in binary literals" rule is not achievable: the inspector's `→`/`↩` and the Unicode test fixtures (`café`, `世界`) legitimately need non-ASCII. So the enforced rule is **non-ASCII requires `/utf8`**, which both options the issue proposed satisfy.

## The lint tokenises rather than greps

`scripts/ci/lint-binary-literal-encoding.escript` uses `erl_scan`, tracking `<<`/`>>` nesting depth and inspecting each segment's type-specifier list. A grep-based check would have shipped with the same blind spot that hid 12 of these sites. It also catches `<<$—>>` char literals, and ignores comments, escapes, and plain (non-binary) strings — the latter are codepoint lists and are unaffected by this bug, so the 74 em-dashes in `-doc` attributes and log format strings are left alone.

Reviewing the lint turned up two paths where it could report success without checking anything, both fixed in `d5895a3`:

- A file that could not be read or tokenised was dropped silently, so an unparseable source counted as clean. Such files are now listed as NOT checked — a warning rather than a failure, since an intentionally-malformed fixture is legitimate and a real syntax error fails the compile anyway.
- `os:cmd` folds stderr into stdout, so outside a git repository `fatal: not a git repository` became a one-element file list. Not empty, so the empty-list guard never fired and the lint exited 0 reporting no offenders. Discovery now anchors at the repo root up front and discards git's stderr.

Wired into `just lint` (so `just ci` / `just ci-changed`), the cross-platform CI lint step, and `.githooks/pre-push`. No allowlist needed — all offenders are fixed, so it starts clean.

## Verification

- `just ci-changed` passes; runtime suites green (223 stdlib, 3037 BUnit, 7184 EUnit).
- Lint verified against single-line, multi-line, and `$—` forms, with `/utf8`, plain strings, comments and docs all still passing. Also verified clean from the repo root, identical from a subdirectory with repo-relative paths, and hard-failing outside a repository.
- `.escript` files confirmed scanned — the shebang does not break `erl_scan`.
- Spot-checked four rendered messages against the built runtime: all now carry zero control bytes, e.g. `Value - immutable data` where the dash previously vanished.
- Checked that nothing splits or pattern-matches on the changed separators; all remaining em-dash hits in the tree are comment/doc text, not parsing logic.

Two tests asserted on the mangled text and were updated in lockstep (`beamtalk_recheck_tests.erl`, `beamtalk_repl_docs_tests.erl`). One would have gained a stray space from naive replacement, since its expected value is built from concatenated fragments.