### PR TITLE
Refactor: extract duplicated find_project_root() into shared CLI util

### DIFF
--- a/crates/beamtalk-cli/src/commands/clean.rs
+++ b/crates/beamtalk-cli/src/commands/clean.rs
@@ -23,6 +23,7 @@ use miette::{Context, IntoDiagnostic, Result};
 use tracing::{debug, info};
 
 use super::build_layout::BuildLayout;
+use super::util::find_project_root;
 
 /// What `clean` is allowed to remove.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -186,28 +187,6 @@ fn remove_path(path: &Utf8Path) -> Result<()> {
             .into_diagnostic()
             .wrap_err_with(|| format!("Failed to remove file '{path}'"))
     }
-}
-
-/// Find the project root by requiring a `beamtalk.toml` in the current
-/// directory.
-fn find_project_root() -> Result<Utf8PathBuf> {
-    let cwd = std::env::current_dir()
-        .into_diagnostic()
-        .wrap_err("Failed to determine current directory")?;
-
-    let project_root = Utf8PathBuf::from_path_buf(cwd).map_err(|p| {
-        miette::miette!("Current directory path is not valid UTF-8: {}", p.display())
-    })?;
-
-    let manifest_path = project_root.join("beamtalk.toml");
-    if !manifest_path.exists() {
-        miette::bail!(
-            "No beamtalk.toml found in current directory.\n  \
-             Run this command from a Beamtalk project root, or create one with `beamtalk new`."
-        );
-    }
-
-    Ok(project_root)
 }
 
 #[cfg(test)]

--- a/crates/beamtalk-cli/src/commands/deps/cli.rs
+++ b/crates/beamtalk-cli/src/commands/deps/cli.rs
@@ -16,6 +16,7 @@ use std::collections::BTreeMap;
 use tracing::info;
 
 use crate::commands::manifest::{self, format_name_error, validate_package_name};
+use crate::commands::util::find_project_root;
 
 use super::git;
 use super::lockfile::{LockEntry, Lockfile};
@@ -470,31 +471,6 @@ fn update_single_git_dep(
     }
 
     Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Find the project root by looking for `beamtalk.toml` in the current directory.
-fn find_project_root() -> Result<Utf8PathBuf> {
-    let cwd = std::env::current_dir()
-        .into_diagnostic()
-        .wrap_err("Failed to determine current directory")?;
-
-    let project_root = Utf8PathBuf::from_path_buf(cwd).map_err(|p| {
-        miette::miette!("Current directory path is not valid UTF-8: {}", p.display())
-    })?;
-
-    let manifest_path = project_root.join("beamtalk.toml");
-    if !manifest_path.exists() {
-        miette::bail!(
-            "No beamtalk.toml found in current directory.\n  \
-             Run this command from a Beamtalk project root, or create one with `beamtalk new`."
-        );
-    }
-
-    Ok(project_root)
 }
 
 #[cfg(test)]

--- a/crates/beamtalk-cli/src/commands/util.rs
+++ b/crates/beamtalk-cli/src/commands/util.rs
@@ -7,7 +7,7 @@
 
 use beamtalk_core::file_walker::FileWalker;
 use camino::{Utf8Path, Utf8PathBuf};
-use miette::Result;
+use miette::{Context, IntoDiagnostic, Result};
 use std::fs;
 use std::time::SystemTime;
 
@@ -37,6 +37,30 @@ pub(crate) enum Expected {
 /// Read the modification time of a file, returning `None` on any error.
 pub(super) fn mtime_of(path: &Utf8Path) -> Option<SystemTime> {
     fs::metadata(path).ok()?.modified().ok()
+}
+
+/// Find the project root by requiring a `beamtalk.toml` in the current directory.
+///
+/// Returns the current working directory as a [`Utf8PathBuf`] if a manifest is
+/// present, or an error telling the user to run from a Beamtalk project root.
+pub(crate) fn find_project_root() -> Result<Utf8PathBuf> {
+    let cwd = std::env::current_dir()
+        .into_diagnostic()
+        .wrap_err("Failed to determine current directory")?;
+
+    let project_root = Utf8PathBuf::from_path_buf(cwd).map_err(|p| {
+        miette::miette!("Current directory path is not valid UTF-8: {}", p.display())
+    })?;
+
+    let manifest_path = project_root.join("beamtalk.toml");
+    if !manifest_path.exists() {
+        miette::bail!(
+            "No beamtalk.toml found in current directory.\n  \
+             Run this command from a Beamtalk project root, or create one with `beamtalk new`."
+        );
+    }
+
+    Ok(project_root)
 }
 
 /// Find files matching the given extensions in a path.


### PR DESCRIPTION
## Summary

`find_project_root()` was copy-pasted identically into both `commands/clean.rs` and `commands/deps/cli.rs`. This PR moves it to the existing `commands/util.rs` shared helpers module and updates both callers to import from there.

- Define `pub(crate) fn find_project_root()` once in `crates/beamtalk-cli/src/commands/util.rs`
- Remove the duplicate from `commands/clean.rs` and update its import
- Remove the duplicate from `commands/deps/cli.rs` and update its import
- Zero behaviour change — the function body is byte-for-byte identical across all copies

Closes #3183

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGiJmFr6brDb9g3ThUGT7U)_