### PR TITLE
test: add edge-path tests for beamtalk_test_case.erl (was 78%)

### DIFF
--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_test_case_stdlib_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_test_case_stdlib_tests.erl
@@ -484,19 +484,23 @@ should_raise_matches_exception_map_test() ->
 %% Line 652: {future_rejected, Reason} → recursive delegation → hits line 657
 should_raise_matches_future_rejected_test() ->
     Block = fun() ->
-        error({future_rejected, #beamtalk_error{
-            kind = my_kind, class = 'TestCase', message = <<"m">>
-        }})
+        error(
+            {future_rejected, #beamtalk_error{
+                kind = my_kind, class = 'TestCase', message = <<"m">>
+            }}
+        )
     end,
     ?assertEqual(nil, beamtalk_test_case:should_raise(Block, my_kind)).
 
 %% Line 655: {error, Map} when is_map(Map) → recursive → hits $beamtalk_class clause
 should_raise_matches_error_map_wrapped_test() ->
     Block = fun() ->
-        error({error, #{
-            '$beamtalk_class' => 'RuntimeError',
-            error => #beamtalk_error{kind = my_kind, class = 'TestCase', message = <<"m">>}
-        }})
+        error(
+            {error, #{
+                '$beamtalk_class' => 'RuntimeError',
+                error => #beamtalk_error{kind = my_kind, class = 'TestCase', message = <<"m">>}
+            }}
+        )
     end,
     ?assertEqual(nil, beamtalk_test_case:should_raise(Block, my_kind)).
 

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_test_case_stdlib_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_test_case_stdlib_tests.erl
@@ -452,3 +452,115 @@ run_single_structured_fail_test() ->
     ?assertEqual(1, maps:get(total, Result)),
     ?assertEqual(0, maps:get(passed, Result)),
     ?assertEqual(1, maps:get(failed, Result)).
+
+%%% ============================================================================
+%%% extract_error_kind/1 clauses via should_raise/2
+%%%
+%%% extract_error_kind/1 is private but reachable via the public should_raise/2
+%%% API: Block raises an exception; should_raise calls extract_error_kind on the
+%%% exception value to get the kind to compare against ExpectedKind.
+%%%
+%%% Covers lines 652, 655, 657, 660, 669 of beamtalk_test_case.erl.
+%%% ============================================================================
+
+%% Line 657: #beamtalk_error{kind = Kind} direct record match
+should_raise_matches_beamtalk_error_record_test() ->
+    Block = fun() ->
+        error(#beamtalk_error{kind = my_kind, class = 'TestCase', message = <<"m">>})
+    end,
+    ?assertEqual(nil, beamtalk_test_case:should_raise(Block, my_kind)).
+
+%% Line 660: #{class := 'Exception', error := #beamtalk_error{}} map match
+should_raise_matches_exception_map_test() ->
+    Block = fun() ->
+        error(#{
+            class => 'Exception',
+            '$beamtalk_class' => 'Exception',
+            error => #beamtalk_error{kind = my_kind, class = 'TestCase', message = <<"m">>}
+        })
+    end,
+    ?assertEqual(nil, beamtalk_test_case:should_raise(Block, my_kind)).
+
+%% Line 652: {future_rejected, Reason} → recursive delegation → hits line 657
+should_raise_matches_future_rejected_test() ->
+    Block = fun() ->
+        error({future_rejected, #beamtalk_error{
+            kind = my_kind, class = 'TestCase', message = <<"m">>
+        }})
+    end,
+    ?assertEqual(nil, beamtalk_test_case:should_raise(Block, my_kind)).
+
+%% Line 655: {error, Map} when is_map(Map) → recursive → hits $beamtalk_class clause
+should_raise_matches_error_map_wrapped_test() ->
+    Block = fun() ->
+        error({error, #{
+            '$beamtalk_class' => 'RuntimeError',
+            error => #beamtalk_error{kind = my_kind, class = 'TestCase', message = <<"m">>}
+        }})
+    end,
+    ?assertEqual(nil, beamtalk_test_case:should_raise(Block, my_kind)).
+
+%% Line 669: unknown error shape → catch-all returns atom 'error'
+should_raise_unknown_error_shape_test() ->
+    Block = fun() -> error({some_weird_tuple, not_recognized}) end,
+    ?assertEqual(nil, beamtalk_test_case:should_raise(Block, error)).
+
+%%% ============================================================================
+%%% format_stacktrace/1 edge cases (BT-1743)
+%%%
+%%% format_stacktrace/1 is exported under -ifdef(TEST).
+%%% Covers lines 440, 537–538, 556, 573 of beamtalk_test_case.erl.
+%%% ============================================================================
+
+%% Line 440: empty list → <<>>
+format_stacktrace_empty_test() ->
+    ?assertEqual(<<>>, beamtalk_test_case:format_stacktrace([])).
+
+%% Lines 537–538: anonymous fun name stripping ('-fun_name/N-fun-M-' → 'fun_name')
+format_stacktrace_anon_fun_name_test() ->
+    Frame = {'bt@my_class', '-my_fun/0-fun-0-', 0, [{file, "my_class.erl"}, {line, 42}]},
+    Result = beamtalk_test_case:format_stacktrace([Frame]),
+    ?assertNotEqual(nomatch, binary:match(Result, <<"my_fun">>)).
+
+%% Line 556: malformed frame (not a 4-tuple) filtered out → <<>>
+format_stacktrace_malformed_frame_test() ->
+    Result = beamtalk_test_case:format_stacktrace([bad_frame]),
+    ?assertEqual(<<>>, Result).
+
+%% Line 573: >3 bt@ frames → select_frames returns [first, second, last]
+format_stacktrace_more_than_3_frames_test() ->
+    Frames = [
+        {'bt@a', f, 0, [{file, "a.erl"}, {line, 1}]},
+        {'bt@b', f, 0, [{file, "b.erl"}, {line, 2}]},
+        {'bt@c', f, 0, [{file, "c.erl"}, {line, 3}]},
+        {'bt@d', f, 0, [{file, "d.erl"}, {line, 4}]}
+    ],
+    Result = beamtalk_test_case:format_stacktrace(Frames),
+    ?assert(is_binary(Result)),
+    ?assertNotEqual(<<>>, Result).
+
+%%% ============================================================================
+%%% setUp failure paths in run_test_method/5 outer catch block
+%%%
+%%% The outer try in run_test_method/5 wraps Module:new() and the setUp
+%%% dispatch. Exceptions from setUp bypass the inner catch and land in the
+%%% outer catch clauses at lines 850–871 of beamtalk_test_case.erl.
+%%% ============================================================================
+
+%% Line 853: setUp throws {bunit_skip, Reason} → {skip, MethodName, Reason}
+setup_throws_bunit_skip_test() ->
+    FlatMethods = #{setUp => {'FakeTest', {}}, testPass => {'FakeTest', {}}},
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_setup_skip_helper, testPass, FlatMethods, nil
+    ),
+    ?assertEqual({skip, testPass, <<"skipping in setUp">>}, Result).
+
+%% Lines 868–871: setUp raises generic Erlang error → {fail, MethodName, "setUp failed: ..."}
+setup_raises_generic_error_test() ->
+    FlatMethods = #{setUp => {'FakeTest', {}}, testPass => {'FakeTest', {}}},
+    Result = beamtalk_test_case:run_test_method(
+        'FakeTest', tc_setup_fail_helper, testPass, FlatMethods, nil
+    ),
+    ?assertMatch({fail, testPass, Msg} when is_binary(Msg), Result),
+    {fail, _, Msg} = Result,
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"setUp failed">>)).

--- a/runtime/apps/beamtalk_stdlib/test/tc_setup_fail_helper.erl
+++ b/runtime/apps/beamtalk_stdlib/test/tc_setup_fail_helper.erl
@@ -1,0 +1,21 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%% Helper for setUp-failure paths in beamtalk_test_case_stdlib_tests.
+%% setUp raises a generic Erlang error — exercises the outer catch-all
+%% in run_test_method/5 (lines 868–871 of beamtalk_test_case.erl).
+-module(tc_setup_fail_helper).
+
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+-export([new/0, dispatch/3]).
+
+new() ->
+    #{'$beamtalk_class' => 'FakeTest'}.
+
+dispatch(setUp, [], _Instance) ->
+    error(setup_went_wrong);
+dispatch(testPass, [], _Instance) ->
+    nil;
+dispatch(tearDown, [], _Instance) ->
+    nil.

--- a/runtime/apps/beamtalk_stdlib/test/tc_setup_skip_helper.erl
+++ b/runtime/apps/beamtalk_stdlib/test/tc_setup_skip_helper.erl
@@ -1,0 +1,21 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+%% Helper for setUp-skip path in beamtalk_test_case_stdlib_tests.
+%% setUp throws {bunit_skip, ...} — exercises the throw:{bunit_skip, ...}
+%% outer catch clause in run_test_method/5 (line 853 of beamtalk_test_case.erl).
+-module(tc_setup_skip_helper).
+
+-include_lib("beamtalk_runtime/include/beamtalk.hrl").
+
+-export([new/0, dispatch/3]).
+
+new() ->
+    #{'$beamtalk_class' => 'FakeTest'}.
+
+dispatch(setUp, [], _Instance) ->
+    throw({bunit_skip, <<"skipping in setUp">>});
+dispatch(testPass, [], _Instance) ->
+    nil;
+dispatch(tearDown, [], _Instance) ->
+    nil.


### PR DESCRIPTION
## Summary

`beamtalk_test_case.erl` was at **77.9% line coverage** (271/348 lines) per CI artifact `coverage-reports` from run `30593857209` on 2026-07-31. This PR adds 11 new tests across three groups of previously-uncovered paths.

### Group 1 — `extract_error_kind/1` via `should_raise/2` (lines 652, 655, 657, 660, 669)

`extract_error_kind/1` is private but reachable via the public `should_raise/2` API: the block raises an exception and `should_raise` calls `extract_error_kind` on the exception value. Five new tests cover:

- `#beamtalk_error{kind = K}` direct record match (line 657)
- `#{class := 'Exception', error := #beamtalk_error{}}` map match (line 660)
- `{future_rejected, Reason}` → recursive delegation (line 652)
- `{error, Map} when is_map(Map)` → recursive delegation (line 655)
- catch-all → returns atom `error` (line 669)

### Group 2 — `format_stacktrace/1` edge cases (lines 440, 537–538, 556, 573)

`format_stacktrace/1` is exported under `-ifdef(TEST)`. Four new tests cover:

- Empty list `[]` → `<<>>` (line 440)
- Anonymous-fun name stripping: `'-my_fun/0-fun-0-'` → `"my_fun"` (lines 537–538)
- Malformed frame (not a 4-tuple) filtered out by catch-all `(_) -> false` (line 556)
- More than 3 `bt@` frames → `select_frames` picks `[first, second, last]` (line 573)

### Group 3 — setUp failure outer catch block (lines 853, 868–871)

Two new helper modules trigger the outer catch clauses in `run_test_method/5` when setUp itself fails before the test method runs:

- `tc_setup_skip_helper`: setUp throws `{bunit_skip, ...}` → `{skip, MethodName, Reason}` (line 853)
- `tc_setup_fail_helper`: setUp raises generic Erlang error → `{fail, MethodName, "setUp failed: ..."}` (lines 868–871)

## Files changed

- `runtime/apps/beamtalk_stdlib/test/beamtalk_test_case_stdlib_tests.erl` — +112 lines (11 new tests in 3 groups)
- `runtime/apps/beamtalk_stdlib/test/tc_setup_fail_helper.erl` — new helper (setUp raises generic error)
- `runtime/apps/beamtalk_stdlib/test/tc_setup_skip_helper.erl` — new helper (setUp throws bunit_skip)

No production code changes. All new tests call already-exported functions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xoz4AstdrEYAk8K75LDNfw)_