### PR TITLE
Seed cross-file type aliases in manifest-less --stdlib-mode builds (BT-2965)

### DIFF
--- a/crates/beamtalk-cli/src/commands/build.rs
+++ b/crates/beamtalk-cli/src/commands/build.rs
@@ -241,7 +241,8 @@ pub fn build(path: &str, options: &beamtalk_core::CompilerOptions, force: bool) 
     // — they're gated on `current_package: Some(_)` and silently emit zero
     // diagnostics otherwise. `None` for single-file/manifest-less builds,
     // which have no package boundary to enforce.
-    options.current_package = env.pkg_manifest().map(|m| m.name.clone());
+    options.current_package =
+        package_identity(env.pkg_manifest(), options.stdlib_mode).map(str::to_owned);
     let options = &options;
 
     let dep_ctx = resolve_and_validate_dependencies(&env, options)?;
@@ -258,6 +259,34 @@ pub fn build(path: &str, options: &beamtalk_core::CompilerOptions, force: bool) 
     post_process_package_artifacts(&env, &dep_ctx, &passes)?;
 
     Ok(())
+}
+
+/// The name of the package this build is compiling, or `None` when the build
+/// has no package boundary at all.
+///
+/// Normally that's just the manifest's package name — a single-file or
+/// manifest-less directory build compiles a loose pile of sources with nothing
+/// to enforce a boundary against.
+///
+/// BT-2965: `--stdlib-mode` is the exception. The stdlib carries no
+/// `beamtalk.toml`, but every file in the build set belongs to one package, so
+/// `beamtalk build --stdlib-mode <dir>` (what `just dialyzer-specs` runs over a
+/// flat copy of `stdlib/src/*.bt` in a bare temp dir) reports the same identity
+/// `build_stdlib::stdlib_compiler_options` (BT-2964) and the LSP's
+/// [`STDLIB_PACKAGE_MARKER`](beamtalk_core::language_service::STDLIB_PACKAGE_MARKER)
+/// use. Both callers below depend on the two agreeing: `build` stamps it onto
+/// `CompilerOptions::current_package` (the boundary
+/// `AliasRegistry::add_pre_loaded` enforces) and `build_class_index` stamps it
+/// onto each collected `AliasInfo::package` (the side that boundary is checked
+/// against). A mismatch would silently drop every `internal` stdlib alias
+/// instead of seeding it.
+fn package_identity(
+    pkg_manifest: Option<&manifest::PackageManifest>,
+    stdlib_mode: bool,
+) -> Option<&str> {
+    pkg_manifest
+        .map(|pkg| pkg.name.as_str())
+        .or_else(|| stdlib_mode.then_some(beamtalk_core::language_service::STDLIB_PACKAGE_MARKER))
 }
 
 /// Phase 1-3: Discover source files, resolve the project root and manifest,
@@ -520,9 +549,22 @@ fn build_class_index(
 
     // BT-2928 / BT-2910: Same-package cross-file protocol and type-alias
     // resolution, merged with dependency-exported protocols/aliases. Only
-    // runs for manifest-based package builds (matching `pre_loaded_classes`'s
-    // existing scope) — a manifest-less directory/single-file build has no
-    // package boundary and keeps today's same-file-only resolution.
+    // runs for package builds (matching `pre_loaded_classes`'s existing
+    // scope) — a manifest-less directory/single-file build has no package
+    // boundary and keeps today's same-file-only resolution.
+    //
+    // BT-2965: `--stdlib-mode` is the exception (see `package_identity`).
+    // `beamtalk build --stdlib-mode <dir>` — what `just dialyzer-specs` runs,
+    // over a flat copy of `stdlib/src/*.bt` in a bare temp dir — has no
+    // manifest but *is* one coherent package. Without it, `field: restart ::
+    // RestartStrategy = #temporary` in `SupervisionSpec.bt` couldn't see
+    // `type RestartStrategy = ...` declared over in `Actor.bt`, and
+    // `check_state_defaults` reported a false "declared as RestartStrategy,
+    // default is #temporary" mismatch against the unexpanded alias name.
+    // `just build-stdlib` never hit this: `build_stdlib.rs` seeds its own
+    // `pre_loaded_aliases` from a live same-run pre-pass (BT-2935). There are
+    // no dependencies to merge in stdlib mode, so the dep-side vectors are
+    // empty and the merge helpers are pass-throughs.
     //
     // Protocols and aliases are extracted together in one uncached scan
     // (`collect_project_protocol_and_alias_infos`) rather than two separate
@@ -530,17 +572,18 @@ fn build_class_index(
     // here, on top of `build_class_module_index`'s own (incrementally
     // cached) scan for classes, was doing up to three full parses of every
     // file per build.
-    let (all_protocol_infos, all_alias_infos) = match pkg_manifest {
-        Some(pkg) => {
-            let (source_protocol_infos, source_alias_infos) =
-                collect_project_protocol_and_alias_infos(&env.source_files, &pkg.name);
-            (
-                collect_all_protocol_infos(&[&source_protocol_infos, &dep_protocol_infos]),
-                collect_all_alias_infos(&[&source_alias_infos, &dep_alias_infos]),
-            )
-        }
-        None => (Vec::new(), Vec::new()),
-    };
+    let (all_protocol_infos, all_alias_infos) =
+        match package_identity(pkg_manifest, options.stdlib_mode) {
+            Some(name) => {
+                let (source_protocol_infos, source_alias_infos) =
+                    collect_project_protocol_and_alias_infos(&env.source_files, name);
+                (
+                    collect_all_protocol_infos(&[&source_protocol_infos, &dep_protocol_infos]),
+                    collect_all_alias_infos(&[&source_alias_infos, &dep_alias_infos]),
+                )
+            }
+            None => (Vec::new(), Vec::new()),
+        };
 
     Ok(ClassIndexResult {
         class_module_index,
@@ -3539,6 +3582,190 @@ mod tests {
                 .all(|d| !d.message.contains("Duplicate type alias")),
             "Expected no false duplicate-alias diagnostic when a file's own \
              alias is also present in pre_loaded_aliases, got: {diagnostics:?}"
+        );
+    }
+
+    /// BT-2965: `package_identity` is the single source of truth for "which
+    /// package is this build compiling", consumed by `build` (for
+    /// `CompilerOptions::current_package`) and `build_class_index` (for the
+    /// `AliasInfo::package` stamp). Those two must agree or
+    /// `AliasRegistry::add_pre_loaded`'s seeding-boundary check silently drops
+    /// every `internal` alias, so pin the mapping directly.
+    #[test]
+    fn package_identity_names_stdlib_for_manifest_less_stdlib_mode() {
+        let manifest = manifest::PackageManifest {
+            name: "my_pkg".to_string(),
+            version: "0.1.0".to_string(),
+            description: None,
+            licenses: None,
+            strict_deps: false,
+        };
+
+        // A manifest always wins — `--stdlib-mode` never renames a real package.
+        assert_eq!(package_identity(Some(&manifest), false), Some("my_pkg"));
+        assert_eq!(package_identity(Some(&manifest), true), Some("my_pkg"));
+
+        // Manifest-less: only `--stdlib-mode` has a package boundary, and it is
+        // named the same way `build_stdlib::stdlib_compiler_options` (BT-2964)
+        // and the LSP's `STDLIB_PACKAGE_MARKER` name it.
+        assert_eq!(
+            package_identity(None, true),
+            Some(beamtalk_core::language_service::STDLIB_PACKAGE_MARKER)
+        );
+        assert_eq!(package_identity(None, false), None);
+    }
+
+    /// BT-2965 regression: `beamtalk build --stdlib-mode <dir>` over a bare
+    /// directory (no `beamtalk.toml`) must still collect cross-file type
+    /// aliases. This is exactly what `just dialyzer-specs` does — it copies
+    /// `stdlib/src/*.bt` flat into a temp dir and builds it — and before the
+    /// fix `build_class_index` returned an empty `all_alias_infos` for every
+    /// manifest-less build, so `SupervisionSpec.bt`'s `field: restart ::
+    /// RestartStrategy = #temporary` never saw `Actor.bt`'s `type
+    /// RestartStrategy = ...` and drew a false state-default type mismatch.
+    #[test]
+    fn stdlib_mode_manifest_less_build_collects_cross_file_aliases() {
+        let temp = TempDir::new().unwrap();
+        let project_path = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+
+        // Flat layout with no `beamtalk.toml` and no `src/`, mirroring
+        // `dialyzer-specs`' temp dir.
+        write_test_file(
+            &project_path.join("Actor.bt"),
+            "type RestartStrategy = #permanent | #transient | #temporary\n\
+             typed Value subclass: Policy\n  \
+             default -> RestartStrategy => #temporary\n",
+        );
+        write_test_file(
+            &project_path.join("SupervisionSpec.bt"),
+            "typed Value subclass: Spec\n  \
+             field: restart :: RestartStrategy = #temporary\n",
+        );
+
+        let env = setup_build_environment(project_path.as_str()).unwrap();
+        assert!(
+            env.pkg_manifest().is_none(),
+            "test fixture must stay manifest-less to exercise the fixed path"
+        );
+        let dep_ctx = DependencyContext {
+            resolved_deps: Vec::new(),
+            has_native_deps: false,
+        };
+
+        let stdlib_options = beamtalk_core::CompilerOptions {
+            stdlib_mode: true,
+            ..default_options()
+        };
+        let index = build_class_index(&env, &dep_ctx, &stdlib_options, true).unwrap();
+        let restart_alias = index
+            .all_alias_infos
+            .iter()
+            .find(|a| a.name == "RestartStrategy")
+            .expect("stdlib-mode build should collect cross-file aliases");
+        assert_eq!(
+            restart_alias.package.as_deref(),
+            Some(beamtalk_core::language_service::STDLIB_PACKAGE_MARKER),
+            "the alias stamp must match the `current_package` `build` sets, or \
+             `add_pre_loaded`'s boundary check drops internal stdlib aliases"
+        );
+
+        // Control: the same manifest-less directory *without* `--stdlib-mode`
+        // keeps the pre-existing same-file-only behaviour — this fix widens
+        // the scope for the stdlib build only.
+        let plain_index = build_class_index(&env, &dep_ctx, &default_options(), true).unwrap();
+        assert!(
+            plain_index.all_alias_infos.is_empty(),
+            "a plain manifest-less directory build has no package boundary and \
+             must keep same-file-only alias resolution"
+        );
+    }
+
+    /// BT-2965 regression, symptom level: with cross-file aliases seeded, a
+    /// `field: x :: SomeAlias = <member>` default whose alias is declared in
+    /// *another* file draws no "Type mismatch: state ... declared as ...,
+    /// default is ..." warning. The negative control (no `pre_loaded_aliases`)
+    /// reproduces the original false positive, proving the assertion is load
+    /// bearing.
+    #[test]
+    fn state_default_with_cross_file_alias_draws_no_type_mismatch() {
+        let temp = TempDir::new().unwrap();
+        let project_path = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let src_path = project_path.join("src");
+        fs::create_dir_all(&src_path).unwrap();
+
+        write_test_file(
+            &src_path.join("a.bt"),
+            "type RestartStrategy = #permanent | #transient | #temporary\n\
+             typed Value subclass: Policy\n  \
+             default -> RestartStrategy => #temporary\n",
+        );
+        write_test_file(
+            &src_path.join("b.bt"),
+            "typed Value subclass: Spec\n  \
+             field: restart :: RestartStrategy = #temporary\n",
+        );
+
+        let build_dir = project_path.join("_build/dev/ebin");
+        fs::create_dir_all(&build_dir).unwrap();
+
+        let source_files = vec![src_path.join("a.bt"), src_path.join("b.bt")];
+        let (class_module_index, class_superclass_index, all_class_infos, _extensions, _cached) =
+            build_class_module_index(&source_files, Some(&src_path), "test_pkg").unwrap();
+        let all_alias_infos = collect_project_alias_infos(&source_files, "test_pkg");
+
+        let options = default_options();
+        let diagnostics = compile_file(
+            &src_path.join("b.bt"),
+            "bt@test_pkg@b",
+            &build_dir.join("bt@test_pkg@b.core"),
+            &options,
+            &CompileContext {
+                hierarchy: ClassHierarchyContext {
+                    class_module_index: class_module_index.clone(),
+                    class_superclass_index: class_superclass_index.clone(),
+                    pre_loaded_classes: all_class_infos.clone(),
+                    pre_loaded_aliases: all_alias_infos,
+                    ..ClassHierarchyContext::default()
+                },
+                ..CompileContext::default()
+            },
+            None,
+        )
+        .expect("state default typed with a cross-file alias should compile");
+        assert!(
+            diagnostics
+                .iter()
+                .all(|d| !d.message.contains("Type mismatch: state")),
+            "Expected no false state-default mismatch once cross-file aliases \
+             are seeded, got: {diagnostics:?}"
+        );
+
+        // Negative control: without `pre_loaded_aliases`, `RestartStrategy`
+        // stays an opaque name and the original false positive returns.
+        let diagnostics_unfixed = compile_file(
+            &src_path.join("b.bt"),
+            "bt@test_pkg@b_unfixed",
+            &build_dir.join("bt@test_pkg@b_unfixed.core"),
+            &options,
+            &CompileContext {
+                hierarchy: ClassHierarchyContext {
+                    class_module_index,
+                    class_superclass_index,
+                    pre_loaded_classes: all_class_infos,
+                    ..ClassHierarchyContext::default()
+                },
+                ..CompileContext::default()
+            },
+            None,
+        )
+        .expect("Compile should still succeed (warning, not error)");
+        assert!(
+            diagnostics_unfixed.iter().any(|d| {
+                d.message.contains("Type mismatch: state `restart`")
+                    && d.message.contains("RestartStrategy")
+            }),
+            "Expected the negative control (no pre_loaded_aliases) to reproduce \
+             the false positive, got: {diagnostics_unfixed:?}"
         );
     }
 

--- a/crates/beamtalk-cli/src/commands/build.rs
+++ b/crates/beamtalk-cli/src/commands/build.rs
@@ -269,17 +269,25 @@ pub fn build(path: &str, options: &beamtalk_core::CompilerOptions, force: bool) 
 /// to enforce a boundary against.
 ///
 /// BT-2965: `--stdlib-mode` is the exception. The stdlib carries no
-/// `beamtalk.toml`, but every file in the build set belongs to one package, so
-/// `beamtalk build --stdlib-mode <dir>` (what `just dialyzer-specs` runs over a
-/// flat copy of `stdlib/src/*.bt` in a bare temp dir) reports the same identity
+/// `beamtalk.toml`, but every file it compiles belongs to one package, so any
+/// manifest-less `--stdlib-mode` build — in practice `beamtalk build
+/// --stdlib-mode <dir>`, what `just dialyzer-specs` runs over a flat copy of
+/// `stdlib/src/*.bt` in a bare temp dir — reports the same identity
 /// `build_stdlib::stdlib_compiler_options` (BT-2964) and the LSP's
 /// [`STDLIB_PACKAGE_MARKER`](beamtalk_core::language_service::STDLIB_PACKAGE_MARKER)
-/// use. Both callers below depend on the two agreeing: `build` stamps it onto
-/// `CompilerOptions::current_package` (the boundary
+/// use. (`test_internal_alias_resolves_cross_file_within_stdlib` pins
+/// `build_stdlib`'s hardcoded literal to that constant so the two stdlib
+/// compile paths cannot drift apart.)
+///
+/// Both callers below depend on the manifest and stdlib answers being the same
+/// one: `build` stamps it onto `CompilerOptions::current_package` (the boundary
 /// `AliasRegistry::add_pre_loaded` enforces) and `build_class_index` stamps it
 /// onto each collected `AliasInfo::package` (the side that boundary is checked
 /// against). A mismatch would silently drop every `internal` stdlib alias
 /// instead of seeding it.
+///
+/// A manifest always wins: `--stdlib-mode` is about how to compile, not about
+/// renaming a package that already named itself.
 fn package_identity(
     pkg_manifest: Option<&manifest::PackageManifest>,
     stdlib_mode: bool,

--- a/crates/beamtalk-cli/src/commands/build_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/build_stdlib.rs
@@ -1890,6 +1890,23 @@ mod tests {
         let pre_loaded_aliases = stdlib_pre_loaded_aliases(&alias_sources);
         assert_eq!(pre_loaded_aliases[0].package.as_deref(), Some("stdlib"));
 
+        // BT-2965: `build.rs`'s `package_identity` names the *other* stdlib
+        // compile path — manifest-less `beamtalk build --stdlib-mode <dir>`,
+        // what `just dialyzer-specs` runs — with `STDLIB_PACKAGE_MARKER`. The
+        // literal hardcoded here and that constant must stay the same string,
+        // or the two paths would disagree about stdlib's package identity and
+        // only one of them would seed `internal` aliases.
+        assert_eq!(
+            pre_loaded_aliases[0].package.as_deref(),
+            Some(beamtalk_core::language_service::STDLIB_PACKAGE_MARKER),
+            "stdlib_pre_loaded_aliases' stamp must match STDLIB_PACKAGE_MARKER"
+        );
+        assert_eq!(
+            stdlib_compiler_options(false).current_package.as_deref(),
+            Some(beamtalk_core::language_service::STDLIB_PACKAGE_MARKER),
+            "stdlib_compiler_options' current_package must match STDLIB_PACKAGE_MARKER"
+        );
+
         // The exact options `build_stdlib()` runs with — crucially with
         // `current_package: Some("stdlib")` matching the stamp above.
         let options = stdlib_compiler_options(false);


### PR DESCRIPTION
Fixes [BT-2965](https://linear.app/beamtalk/issue/BT-2965)

## Problem

`just dialyzer-specs` emitted one false Type warning:

```
× Type mismatch: state `restart` declared as RestartStrategy, default is #temporary
  ╭─[SupervisionSpec.bt:46:3]
  46 │   field: restart :: RestartStrategy = #temporary
  help: Default value type #temporary is not compatible with RestartStrategy
```

`#temporary` *is* a member of `type RestartStrategy = #permanent | #transient | #temporary` — but that alias is declared in `stdlib/src/Actor.bt`, i.e. cross-file from `SupervisionSpec.bt`.

## Root cause

Not in the type checker. `check_state_defaults` has been alias-aware since ADR 0108 / BT-2895 — it just had nothing to resolve against.

`build_class_index` gated its cross-file protocol/alias scan on `pkg_manifest`:

```rust
let (all_protocol_infos, all_alias_infos) = match pkg_manifest {
    Some(pkg) => { /* scan project sources */ }
    None => (Vec::new(), Vec::new()),
};
```

`just dialyzer-specs` copies `stdlib/src/*.bt` flat into a bare temp dir (no `beamtalk.toml`) and runs `beamtalk build --stdlib-mode` on it, so `all_alias_infos` came back empty and `RestartStrategy` stayed an opaque name.

`just build-stdlib` never hit this — `build_stdlib.rs` seeds its own `pre_loaded_aliases` from a live same-run pre-pass (BT-2935). The two stdlib compile paths simply hadn't converged.

## Fix

The stdlib has no manifest but *is* one coherent package, so `--stdlib-mode` now reports a package identity. New `package_identity` helper is the single source of truth for the two consumers that must agree on it:

- `build` → `CompilerOptions::current_package`, the boundary `AliasRegistry::add_pre_loaded` enforces
- `build_class_index` → the `AliasInfo::package` stamp that boundary is checked against

It names the stdlib the same way `build_stdlib::stdlib_compiler_options` (BT-2964) and the LSP's `STDLIB_PACKAGE_MARKER` do. A mismatch would silently drop every `internal` stdlib alias, so `test_internal_alias_resolves_cross_file_within_stdlib` now pins `build_stdlib`'s hardcoded literal to that constant too.

A manifest always wins — `--stdlib-mode` says how to compile, not what the package is called.

## Scope

Unchanged for everything else: plain manifest-less directory and single-file builds still have no package boundary and keep same-file-only resolution. `--stdlib-mode` has exactly one consumer in the tree (`Justfile:716`), and every other `build()` caller passes `stdlib_mode: false`.

## Verification

| | before | after |
|---|---|---|
| `beamtalk build --stdlib-mode` over `stdlib/src` | 1 Type warning | 0 |
| `just dialyzer-specs` | 1 Type warning, 1183 specs valid | 0 warnings, 1183 specs valid |

Measured against the same binary/fixture, with the stdlib ebin present so FFI specs resolve.

## Tests

- `package_identity_names_stdlib_for_manifest_less_stdlib_mode` — pins the manifest/stdlib/neither mapping
- `stdlib_mode_manifest_less_build_collects_cross_file_aliases` — drives `build_class_index` over a bare flat dir, asserts the alias is collected and stamped; **control** asserts a non-stdlib-mode manifest-less build still collects nothing
- `state_default_with_cross_file_alias_draws_no_type_mismatch` — symptom-level, with a **negative control** (no `pre_loaded_aliases`) that reproduces the original false positive
- `test_internal_alias_resolves_cross_file_within_stdlib` — extended with the drift guard

`just ci` green.

## Follow-up filed

[BT-3034](https://linear.app/beamtalk/issue/BT-3034) — review Pass 2 found `build_stdlib.rs` never seeds `pre_loaded_protocols`, so stdlib's own cross-file `:: Printable` annotations (`Console.bt`, `Json.bt`) degrade quietly; `UnresolvedClass` is on the warnings-as-errors exclusion list, so `just build-stdlib` doesn't catch it. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9RhZkTXTDtNxTmM2UQS8A

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9RhZkTXTDtNxTmM2UQS8A)_