### PR TITLE
fix(deps): detect structural dep type-swaps via a graph snapshot BT-3009

### DIFF
--- a/crates/beamtalk-cli/src/build_layout.rs
+++ b/crates/beamtalk-cli/src/build_layout.rs
@@ -114,6 +114,19 @@ impl BuildLayout {
         self.build_root().join("deps")
     }
 
+    /// `_build/deps/.dep-graph.json` — snapshot of the effective dependency
+    /// graph recorded after the last successful resolve (BT-3009).
+    ///
+    /// Compared against the currently declared graph so a *structural* change
+    /// — most importantly a dependency's source type swapping between git and
+    /// path in an intermediate manifest — is detected as stale, which no
+    /// mtime, lockfile, or ebin-presence check catches. The leading dot keeps
+    /// it out of the way of the per-dependency directories that share
+    /// `_build/deps/` (and that `clean_stale_deps` scans).
+    pub fn dep_graph_path(&self) -> Utf8PathBuf {
+        self.deps_dir().join(".dep-graph.json")
+    }
+
     /// `_build/deps/<name>/` — checkout directory for a single dependency.
     pub fn dep_checkout_dir(&self, name: &str) -> Utf8PathBuf {
         self.deps_dir().join(name)

--- a/crates/beamtalk-cli/src/build_layout.rs
+++ b/crates/beamtalk-cli/src/build_layout.rs
@@ -120,9 +120,13 @@ impl BuildLayout {
     /// Compared against the currently declared graph so a *structural* change
     /// — most importantly a dependency's source type swapping between git and
     /// path in an intermediate manifest — is detected as stale, which no
-    /// mtime, lockfile, or ebin-presence check catches. The leading dot keeps
-    /// it out of the way of the per-dependency directories that share
-    /// `_build/deps/` (and that `clean_stale_deps` scans).
+    /// mtime, lockfile, or ebin-presence check catches.
+    ///
+    /// Sharing `_build/deps/` with the per-dependency directories is safe
+    /// because every consumer filters to directories: `clean_stale_deps`
+    /// skips non-directory entries outright, and `collect_dep_ebin_paths`
+    /// only accepts `<entry>/ebin`. The leading dot is convention, not what
+    /// makes it safe — a dotless name would be equally well protected.
     pub fn dep_graph_path(&self) -> Utf8PathBuf {
         self.deps_dir().join(".dep-graph.json")
     }

--- a/crates/beamtalk-cli/src/commands/deps/mod.rs
+++ b/crates/beamtalk-cli/src/commands/deps/mod.rs
@@ -22,6 +22,7 @@ pub mod graph;
 pub mod lockfile;
 pub mod path;
 pub mod registry;
+mod snapshot;
 
 // Re-export commonly used items
 pub use path::collect_dep_ebin_paths;
@@ -45,6 +46,9 @@ use crate::commands::manifest;
 /// Staleness triggers (any one causes full re-resolution + compilation):
 /// - `beamtalk.toml` has dependencies but no lockfile exists and git deps are present
 /// - `beamtalk.toml` was modified after the lockfile
+/// - The transitive dependency graph changed shape since the last successful
+///   resolve — e.g. an intermediate manifest swapped a dependency between a
+///   git and a path source (BT-3009)
 /// - Any dependency's `_build/deps/{name}/ebin/` directory is missing or empty
 ///
 /// Always returns `ResolvedDependency` structs with class module indexes
@@ -69,7 +73,13 @@ pub fn ensure_deps_resolved(
         collect_fresh_deps(project_root, &parsed)?
     } else {
         info!("Dependencies need resolution, resolving...");
-        graph::resolve_dependency_graph(project_root, options)?
+        let resolved = graph::resolve_dependency_graph(project_root, options)?;
+        // Record the graph we just resolved as the baseline the next build's
+        // structural freshness check compares against (BT-3009). Discovery is
+        // re-run *after* resolution so every git/registry checkout and every
+        // transitive manifest is on disk and the recorded graph is complete.
+        record_dep_graph_snapshot(project_root, &parsed);
+        resolved
     };
 
     clean_stale_deps(project_root, &resolved)?;
@@ -412,6 +422,9 @@ fn locked_deps_match(
 ///    path dependencies (which don't use a lockfile)
 /// 3. Every git/registry dep's locked version or reference still matches
 ///    what its declaring manifest (root or transitive) currently requests
+/// 4. The transitive graph's shape (names, declaring chains, declared
+///    sources) still matches the snapshot recorded by the last successful
+///    resolve — see [`snapshot`] (BT-3009)
 fn deps_are_fresh(project_root: &Utf8Path, manifest: &manifest::ParsedManifest) -> bool {
     use beamtalk_core::compilation::DependencySource;
 
@@ -429,6 +442,19 @@ fn deps_are_fresh(project_root: &Utf8Path, manifest: &manifest::ParsedManifest) 
             return false;
         }
     };
+
+    // Structural check (BT-3009): compare the graph's *shape* — every dep's
+    // name, declaring chain, and declared source — against what the last
+    // successful resolve recorded. This is the only check that notices a
+    // dependency's source type swapping (a git dep becoming a path dep of the
+    // same name, or vice versa) in an intermediate manifest: the root mtime
+    // guard stays silent, `locked_deps_match` no longer sees the dep as
+    // git/registry, and the stale `ebin/` from the old source is still sitting
+    // at the same path, so every value-based check below is satisfied.
+    if let snapshot::SnapshotStatus::Stale(reason) = snapshot::check(project_root, &all_deps) {
+        debug!(%reason, "Dependency graph changed since last resolve — deps are stale");
+        return false;
+    }
 
     // Registry deps resolve into git checkouts and are pinned in the lockfile
     // just like git deps, so they carry the same lockfile requirement —
@@ -532,6 +558,22 @@ fn deps_are_fresh(project_root: &Utf8Path, manifest: &manifest::ParsedManifest) 
     }
 
     true
+}
+
+/// Record the just-resolved dependency graph so the next build's structural
+/// freshness check has a baseline to compare against (BT-3009).
+///
+/// Best-effort by design: discovery or writing failing here must not fail a
+/// build that has already resolved and compiled successfully. A missing
+/// snapshot simply makes the next `deps_are_fresh` return `false`, which
+/// re-resolves and tries again.
+fn record_dep_graph_snapshot(project_root: &Utf8Path, manifest: &manifest::ParsedManifest) {
+    match discover_all_dep_roots(project_root, manifest) {
+        Ok(all_deps) => snapshot::write(project_root, &all_deps),
+        Err(e) => {
+            debug!(error = %e, "Failed to discover dep roots — dependency-graph snapshot not recorded");
+        }
+    }
 }
 
 /// Check if any `.bt` source file in a path dependency is newer than the
@@ -645,6 +687,23 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    /// `deps_are_fresh` with the BT-3009 dependency-graph snapshot pre-seeded
+    /// from the graph currently on disk — i.e. as if the last successful
+    /// resolve had produced exactly this graph.
+    ///
+    /// Every freshness test other than the structural ones below is about a
+    /// *value* changing (an mtime, a locked version, a provenance stamp) while
+    /// the graph's shape stays put, so seeding the snapshot keeps those
+    /// assertions testing what they name rather than passing vacuously on a
+    /// missing snapshot.
+    fn deps_are_fresh_with_snapshot(
+        root: &camino::Utf8Path,
+        parsed: &manifest::ParsedManifest,
+    ) -> bool {
+        record_dep_graph_snapshot(root, parsed);
+        deps_are_fresh(root, parsed)
+    }
+
     fn create_dep_ebin_with_beam(project_root: &std::path::Path, dep_name: &str) {
         let root_utf8 = camino::Utf8PathBuf::from_path_buf(project_root.to_path_buf()).unwrap();
         let layout = BuildLayout::new(&root_utf8);
@@ -711,7 +770,7 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&manifest_path).unwrap();
 
         // Path deps with compiled ebin should be fresh
-        assert!(deps_are_fresh(&root, &parsed));
+        assert!(deps_are_fresh_with_snapshot(&root, &parsed));
     }
 
     #[test]
@@ -743,7 +802,10 @@ mod tests {
 
         let manifest_path = root.join("beamtalk.toml");
         let parsed = manifest::parse_manifest_full(&manifest_path).unwrap();
-        assert!(deps_are_fresh(&root, &parsed), "should start fresh");
+        assert!(
+            deps_are_fresh_with_snapshot(&root, &parsed),
+            "should start fresh"
+        );
 
         // Forge an older-toolchain stamp: same shape, different version.
         let layout = BuildLayout::new(&root);
@@ -755,7 +817,7 @@ mod tests {
         .unwrap();
 
         assert!(
-            !deps_are_fresh(&root, &parsed),
+            !deps_are_fresh_with_snapshot(&root, &parsed),
             "dep with a mismatched-version stamp should be stale (rebuild, not reuse)"
         );
     }
@@ -781,7 +843,7 @@ mod tests {
         let manifest_path = root.join("beamtalk.toml");
         let parsed = manifest::parse_manifest_full(&manifest_path).unwrap();
 
-        assert!(!deps_are_fresh(&root, &parsed));
+        assert!(!deps_are_fresh_with_snapshot(&root, &parsed));
     }
 
     #[test]
@@ -809,7 +871,7 @@ mod tests {
         let manifest_path = root.join("beamtalk.toml");
         let parsed = manifest::parse_manifest_full(&manifest_path).unwrap();
 
-        assert!(!deps_are_fresh(&root, &parsed));
+        assert!(!deps_are_fresh_with_snapshot(&root, &parsed));
     }
 
     #[test]
@@ -831,7 +893,7 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&manifest_path).unwrap();
 
         // Git deps without lockfile should be stale
-        assert!(!deps_are_fresh(&root, &parsed));
+        assert!(!deps_are_fresh_with_snapshot(&root, &parsed));
     }
 
     #[test]
@@ -868,7 +930,7 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&manifest_path).unwrap();
 
         // Source is newer than beam → stale
-        assert!(!deps_are_fresh(&root, &parsed));
+        assert!(!deps_are_fresh_with_snapshot(&root, &parsed));
     }
 
     #[test]
@@ -951,7 +1013,7 @@ mod tests {
 
         // Should be stale because transitive dep "shared" has no ebin
         assert!(
-            !deps_are_fresh(&root, &parsed),
+            !deps_are_fresh_with_snapshot(&root, &parsed),
             "Should detect missing transitive dep ebin as stale"
         );
     }
@@ -1119,7 +1181,7 @@ mod tests {
 
         // Git dep with lockfile + compiled ebin should be fresh
         assert!(
-            deps_are_fresh(&root, &parsed),
+            deps_are_fresh_with_snapshot(&root, &parsed),
             "Git dep with lockfile and ebin should be fresh"
         );
     }
@@ -1169,7 +1231,7 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&manifest_path).unwrap();
 
         assert!(
-            !deps_are_fresh(&root, &parsed),
+            !deps_are_fresh_with_snapshot(&root, &parsed),
             "Should be stale when manifest is newer than lockfile"
         );
     }
@@ -1222,7 +1284,7 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&manifest_path).unwrap();
 
         assert!(
-            !deps_are_fresh(&root, &parsed),
+            !deps_are_fresh_with_snapshot(&root, &parsed),
             "Should detect transitive manifest change as stale"
         );
     }
@@ -1387,7 +1449,7 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
 
         assert!(
-            deps_are_fresh(&root, &parsed),
+            deps_are_fresh_with_snapshot(&root, &parsed),
             "Registry dep locked at the requested version should be fresh"
         );
     }
@@ -1400,7 +1462,7 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
 
         assert!(
-            !deps_are_fresh(&root, &parsed),
+            !deps_are_fresh_with_snapshot(&root, &parsed),
             "A version bump in beamtalk.toml must force re-resolution"
         );
     }
@@ -1413,7 +1475,7 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
 
         assert!(
-            !deps_are_fresh(&root, &parsed),
+            !deps_are_fresh_with_snapshot(&root, &parsed),
             "Registry deps require a lockfile, like git deps"
         );
     }
@@ -1437,7 +1499,7 @@ mod tests {
 
         let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
         assert!(
-            !deps_are_fresh(&root, &parsed),
+            !deps_are_fresh_with_snapshot(&root, &parsed),
             "An unversioned lock entry should force re-resolution"
         );
     }
@@ -1493,7 +1555,7 @@ mod tests {
 
         let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
         assert!(
-            deps_are_fresh(&root, &parsed),
+            deps_are_fresh_with_snapshot(&root, &parsed),
             "a relative [registry] url must stay fresh regardless of the \
              project's absolute checkout path"
         );
@@ -1525,7 +1587,7 @@ mod tests {
 
         let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
         assert!(
-            !deps_are_fresh(&root, &parsed),
+            !deps_are_fresh_with_snapshot(&root, &parsed),
             "A lock entry from a different registry must force re-resolution"
         );
     }
@@ -1632,7 +1694,7 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
 
         assert!(
-            deps_are_fresh(&root, &parsed),
+            deps_are_fresh_with_snapshot(&root, &parsed),
             "A transitive registry dep locked at the requested version should be fresh"
         );
     }
@@ -1648,7 +1710,7 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
 
         assert!(
-            !deps_are_fresh(&root, &parsed),
+            !deps_are_fresh_with_snapshot(&root, &parsed),
             "A registry dep declared by a transitive path dependency must still require a lockfile"
         );
     }
@@ -1663,7 +1725,7 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
 
         assert!(
-            !deps_are_fresh(&root, &parsed),
+            !deps_are_fresh_with_snapshot(&root, &parsed),
             "A version bump in a transitive dependency's manifest must force re-resolution"
         );
     }
@@ -1739,7 +1801,7 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
 
         assert!(
-            deps_are_fresh(&root, &parsed),
+            deps_are_fresh_with_snapshot(&root, &parsed),
             "A transitive git dep locked at the requested tag should be fresh"
         );
     }
@@ -1755,7 +1817,7 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
 
         assert!(
-            !deps_are_fresh(&root, &parsed),
+            !deps_are_fresh_with_snapshot(&root, &parsed),
             "A git dep declared by a transitive path dependency must still require a lockfile"
         );
     }
@@ -1770,8 +1832,218 @@ mod tests {
         let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
 
         assert!(
-            !deps_are_fresh(&root, &parsed),
+            !deps_are_fresh_with_snapshot(&root, &parsed),
             "A tag bump in a transitive git dependency's manifest must force re-resolution"
+        );
+    }
+
+    // --- Structural freshness checks (BT-3009) ---
+    //
+    // Every check above compares a *value* — an mtime, a locked version, a
+    // provenance stamp. None of them notices a dependency's declared *source
+    // type* changing while its name stays put in an intermediate manifest.
+    // These tests cover that gap, and each one first proves the gap is real by
+    // asserting the swapped graph looks fresh to every other check once the
+    // snapshot is re-recorded to match it.
+
+    /// Rewrite a compiled dependency's ebin so its `.beam` files are newer than
+    /// any manifest the test has just edited — neutralising the
+    /// `manifest_newer_than_ebin` mtime fallback so the assertion isolates the
+    /// structural check.
+    fn recompile_dep(temp: &TempDir, dep_name: &str) {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        create_dep_ebin_with_beam(temp.path(), dep_name);
+    }
+
+    #[test]
+    fn test_intermediate_git_to_path_swap_is_stale() {
+        // root -> middle (path) -> leaf, where middle's manifest swaps leaf
+        // from a git dep to a path dep. The root manifest is never touched.
+        let temp = TempDir::new().unwrap();
+        let root = setup_transitive_git_project(&temp, "v1.0", "v1.0");
+        let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
+
+        // Baseline: the graph as it stands is what the last resolve produced.
+        record_dep_graph_snapshot(&root, &parsed);
+        assert!(deps_are_fresh(&root, &parsed), "should start fresh");
+
+        // The swap: leaf becomes a local path dependency of middle. Its stale
+        // `_build/deps/leaf/ebin/` from the git checkout stays exactly where
+        // it was, and `beamtalk.lock` still pins the old git revision.
+        let leaf_src = temp.path().join("leaf");
+        fs::create_dir_all(&leaf_src).unwrap();
+        write_manifest(&leaf_src, "leaf", "1.0.0", "");
+        write_manifest(
+            &temp.path().join("middle"),
+            "middle",
+            "0.1.0",
+            "[dependencies]\nleaf = { path = \"../leaf\" }\n",
+        );
+        recompile_dep(&temp, "middle");
+        recompile_dep(&temp, "leaf");
+
+        assert!(
+            !deps_are_fresh(&root, &parsed),
+            "A git-to-path swap in an intermediate manifest must be detected as stale"
+        );
+
+        // The gap this closes: with the snapshot re-recorded to match the
+        // swapped graph, every other freshness check is satisfied — nothing
+        // else in `deps_are_fresh` can see the swap at all.
+        assert!(
+            deps_are_fresh_with_snapshot(&root, &parsed),
+            "no non-structural check should be able to detect the swap"
+        );
+    }
+
+    #[test]
+    fn test_intermediate_path_to_git_swap_is_stale() {
+        // The reverse direction: middle declares leaf as a path dep, then
+        // swaps it to a git dep at the same name. There is no lockfile at all
+        // in the starting state, because the graph is pure-path.
+        let temp = TempDir::new().unwrap();
+        let root = camino::Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+
+        let leaf_src = temp.path().join("leaf");
+        fs::create_dir_all(&leaf_src).unwrap();
+        write_manifest(&leaf_src, "leaf", "1.0.0", "");
+        create_dep_ebin_with_beam(temp.path(), "leaf");
+
+        let middle_dir = temp.path().join("middle");
+        fs::create_dir_all(&middle_dir).unwrap();
+        write_manifest(
+            &middle_dir,
+            "middle",
+            "0.1.0",
+            "[dependencies]\nleaf = { path = \"../leaf\" }\n",
+        );
+        recompile_dep(&temp, "middle");
+
+        write_manifest(
+            temp.path(),
+            "my_app",
+            "0.1.0",
+            "[dependencies]\nmiddle = { path = \"middle\" }",
+        );
+
+        let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
+        record_dep_graph_snapshot(&root, &parsed);
+        assert!(deps_are_fresh(&root, &parsed), "should start fresh");
+
+        // The swap. A git dep with no lock entry is already caught by
+        // `locked_deps_match`, so this asserts the structural check agrees
+        // rather than that it is the only thing catching it.
+        write_manifest(
+            &middle_dir,
+            "middle",
+            "0.1.0",
+            "[dependencies]\nleaf = { git = \"https://example.com/leaf\", tag = \"v1.0\" }\n",
+        );
+        recompile_dep(&temp, "middle");
+
+        assert!(
+            !deps_are_fresh(&root, &parsed),
+            "A path-to-git swap in an intermediate manifest must be detected as stale"
+        );
+    }
+
+    #[test]
+    fn test_intermediate_path_dep_moved_is_stale() {
+        // A path dependency's declared *path* moving is the same class of
+        // structural change: same name, different source, artifacts left
+        // behind at `_build/deps/leaf/ebin/`.
+        let temp = TempDir::new().unwrap();
+        let root = camino::Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+
+        for dir in ["leaf", "leaf_v2"] {
+            let src = temp.path().join(dir);
+            fs::create_dir_all(&src).unwrap();
+            write_manifest(&src, "leaf", "1.0.0", "");
+        }
+        create_dep_ebin_with_beam(temp.path(), "leaf");
+
+        write_manifest(
+            temp.path(),
+            "my_app",
+            "0.1.0",
+            "[dependencies]\nleaf = { path = \"leaf\" }",
+        );
+        let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
+        record_dep_graph_snapshot(&root, &parsed);
+        assert!(deps_are_fresh(&root, &parsed), "should start fresh");
+
+        write_manifest(
+            temp.path(),
+            "my_app",
+            "0.1.0",
+            "[dependencies]\nleaf = { path = \"leaf_v2\" }",
+        );
+        let moved = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
+
+        assert!(
+            !deps_are_fresh(&root, &moved),
+            "A path dependency pointed at a different directory must be stale"
+        );
+    }
+
+    #[test]
+    fn test_deps_stale_when_no_graph_snapshot_recorded() {
+        // "Fail toward rebuild", matching ADR 0098's stance on a missing
+        // provenance stamp: with no record of what the last resolve produced,
+        // there is nothing to compare the current graph against.
+        let temp = TempDir::new().unwrap();
+        let root = camino::Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+
+        let dep_dir = temp.path().join("utils");
+        fs::create_dir_all(&dep_dir).unwrap();
+        write_manifest(&dep_dir, "utils", "0.1.0", "");
+        create_dep_ebin_with_beam(temp.path(), "utils");
+        write_manifest(
+            temp.path(),
+            "my_app",
+            "0.1.0",
+            "[dependencies]\nutils = { path = \"utils\" }",
+        );
+
+        let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
+        assert!(
+            !deps_are_fresh(&root, &parsed),
+            "An otherwise-fresh project with no graph snapshot must re-resolve once"
+        );
+
+        record_dep_graph_snapshot(&root, &parsed);
+        assert!(
+            deps_are_fresh(&root, &parsed),
+            "and be fresh once the snapshot has been recorded"
+        );
+    }
+
+    #[test]
+    fn test_deps_stale_when_graph_snapshot_corrupt() {
+        let temp = TempDir::new().unwrap();
+        let root = camino::Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+
+        let dep_dir = temp.path().join("utils");
+        fs::create_dir_all(&dep_dir).unwrap();
+        write_manifest(&dep_dir, "utils", "0.1.0", "");
+        create_dep_ebin_with_beam(temp.path(), "utils");
+        write_manifest(
+            temp.path(),
+            "my_app",
+            "0.1.0",
+            "[dependencies]\nutils = { path = \"utils\" }",
+        );
+
+        let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
+        assert!(
+            deps_are_fresh_with_snapshot(&root, &parsed),
+            "should start fresh"
+        );
+
+        fs::write(BuildLayout::new(&root).dep_graph_path(), "{not json").unwrap();
+        assert!(
+            !deps_are_fresh(&root, &parsed),
+            "A corrupt graph snapshot must force re-resolution"
         );
     }
 }

--- a/crates/beamtalk-cli/src/commands/deps/mod.rs
+++ b/crates/beamtalk-cli/src/commands/deps/mod.rs
@@ -2046,4 +2046,45 @@ mod tests {
             "A corrupt graph snapshot must force re-resolution"
         );
     }
+
+    #[test]
+    fn test_ensure_deps_resolved_records_a_snapshot_that_reads_back_fresh() {
+        // The round trip that matters for build times: the snapshot a real
+        // resolve records must satisfy the *next* freshness check. If the
+        // graph recorded after resolution ever disagreed with the graph
+        // discovered before it, every build would re-resolve from scratch.
+        let temp = TempDir::new().unwrap();
+        let root = camino::Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+
+        let dep_dir = temp.path().join("utils");
+        fs::create_dir_all(&dep_dir).unwrap();
+        write_manifest(&dep_dir, "utils", "0.1.0", "");
+        write_source(
+            &dep_dir,
+            "helper.bt",
+            "Object subclass: Helper\n  greet => \"hi\"\n",
+        );
+        write_manifest(
+            temp.path(),
+            "my_app",
+            "0.1.0",
+            "[dependencies]\nutils = { path = \"utils\" }",
+        );
+
+        let options = beamtalk_core::CompilerOptions::default();
+        let resolved = ensure_deps_resolved(&root, &options).unwrap();
+        assert_eq!(resolved.len(), 1, "utils should have resolved");
+
+        assert!(
+            BuildLayout::new(&root).dep_graph_path().exists(),
+            "a successful resolve must record the dependency-graph snapshot"
+        );
+
+        let parsed = manifest::parse_manifest_full(&root.join("beamtalk.toml")).unwrap();
+        assert!(
+            deps_are_fresh(&root, &parsed),
+            "the recorded snapshot must read back as fresh — otherwise every \
+             build re-resolves"
+        );
+    }
 }

--- a/crates/beamtalk-cli/src/commands/deps/snapshot.rs
+++ b/crates/beamtalk-cli/src/commands/deps/snapshot.rs
@@ -1,0 +1,270 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Dependency-graph snapshot for structural freshness detection (BT-3009).
+//!
+//! **DDD Context:** Build System
+//!
+//! The freshness heuristics in [`super::deps_are_fresh`] are all *value*
+//! comparisons: mtimes, ebin presence, provenance stamps, and (BT-2994) each
+//! git/registry dep's locked version or reference. None of them notice a
+//! **structural** change to the dependency graph — one where a dependency's
+//! declared *source type* changes while its name stays put.
+//!
+//! The motivating case: the root manifest declares only
+//! `utils = { path = "../utils" }`, and `utils/beamtalk.toml` swaps
+//! `yaml = { git = "…", tag = "v1" }` for `yaml = { path = "../yaml" }`.
+//! Afterwards:
+//!
+//! * The root manifest's mtime is unchanged, so the lockfile mtime guard stays
+//!   silent.
+//! * `locked_deps_match` only inspects deps that are *currently* declared as
+//!   git/registry, so `yaml` — now a path dep — is never compared against its
+//!   stale lock entry. (The reverse swap, path → git, *is* caught: the newly
+//!   git dep misses in the lockfile.)
+//! * `_build/deps/yaml/ebin/` still holds the old git checkout's `.beam`
+//!   files, so the ebin-presence check is satisfied too.
+//!
+//! Net effect without this module: the build silently links against artifacts
+//! compiled from a source that is no longer declared anywhere.
+//!
+//! The fix is direction (b) from the issue — record the *effective dependency
+//! graph* (every discovered dep's name, declaring chain, and declared source)
+//! after each successful resolve, and compare the current graph against it on
+//! the next build. That is generic: it catches source-type swaps, a path dep's
+//! declared path moving, and any add/remove/restructure anywhere in the
+//! transitive graph, without adding yet another mtime heuristic.
+//!
+//! The snapshot lives under `_build/` (gitignored) alongside the ADR 0098
+//! provenance stamps, and follows the same "fail toward rebuild" rule: a
+//! missing, corrupt, or unrecognised-schema snapshot is a miss, so the first
+//! build after this ships re-resolves once and then records a baseline.
+
+use camino::Utf8Path;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use tracing::{debug, warn};
+
+use super::DiscoveredDep;
+use crate::commands::build_layout::BuildLayout;
+
+/// Current snapshot schema. Bump when the meaning of [`DepGraphEntry`]
+/// changes; an unrecognised schema is treated as a miss (re-resolve), so a
+/// newer toolchain's snapshot never lets an older binary reuse artifacts it
+/// cannot reason about.
+const SNAPSHOT_SCHEMA: u32 = 1;
+
+/// One dependency as it was declared the last time the graph resolved.
+///
+/// `source` is [`beamtalk_core::compilation::DependencySource`]'s `Display`
+/// form (`path: ../utils`, `git: <url> (tag: v1.0.0)`, `registry: 0.2.1`), so
+/// a type swap, a URL change, a tag bump, or a moved path all show up as a
+/// different string — and the file stays readable when debugging a rebuild.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct DepGraphEntry {
+    /// The dependency's package name.
+    name: String,
+    /// The chain of intermediate dependency names it was reached through
+    /// (empty for a dependency the root manifest declares directly).
+    #[serde(default)]
+    via: Vec<String>,
+    /// How the declaring manifest asked for it.
+    source: String,
+}
+
+/// On-disk snapshot of the effective dependency graph.
+#[derive(Debug, Serialize, Deserialize)]
+struct DepGraphSnapshot {
+    /// Snapshot schema version. An unrecognised value is a miss.
+    schema: u32,
+    /// Every dependency in the transitive graph, ordered by name.
+    deps: Vec<DepGraphEntry>,
+}
+
+/// Result of comparing the current dependency graph against the recorded one.
+pub(super) enum SnapshotStatus {
+    /// The graph is structurally identical to the last successful resolve.
+    Fresh,
+    /// No usable snapshot, or the graph changed shape. Carries a
+    /// human-readable reason for the build log.
+    Stale(String),
+}
+
+/// Project-relative location of the snapshot: `_build/deps/.dep-graph.json`.
+fn snapshot_path(project_root: &Utf8Path) -> camino::Utf8PathBuf {
+    BuildLayout::new(project_root).dep_graph_path()
+}
+
+/// Project the discovered graph into its comparable form, ordered by name.
+///
+/// Dependency names are unique across the graph (`discover_all_dep_roots`
+/// de-duplicates by name), so sorting by name is a total order and makes the
+/// comparison independent of discovery order.
+fn entries_for(all_deps: &[DiscoveredDep]) -> Vec<DepGraphEntry> {
+    let mut entries: Vec<DepGraphEntry> = all_deps
+        .iter()
+        .map(|dep| DepGraphEntry {
+            name: dep.name.clone(),
+            via: dep.via_chain.clone(),
+            source: dep.source.to_string(),
+        })
+        .collect();
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    entries
+}
+
+/// Compare the currently discovered graph against the recorded snapshot.
+///
+/// Returns [`SnapshotStatus::Stale`] when there is no snapshot to compare
+/// against — the same "fail toward rebuild" stance ADR 0098 takes for a
+/// missing provenance stamp.
+pub(super) fn check(project_root: &Utf8Path, all_deps: &[DiscoveredDep]) -> SnapshotStatus {
+    let path = snapshot_path(project_root);
+
+    let Ok(data) = fs::read_to_string(&path) else {
+        return SnapshotStatus::Stale("no dependency-graph snapshot".to_string());
+    };
+
+    let snapshot: DepGraphSnapshot = match serde_json::from_str(&data) {
+        Ok(s) => s,
+        Err(_) => return SnapshotStatus::Stale("corrupt dependency-graph snapshot".to_string()),
+    };
+
+    if snapshot.schema != SNAPSHOT_SCHEMA {
+        return SnapshotStatus::Stale(format!(
+            "unrecognised dependency-graph schema {} (current {SNAPSHOT_SCHEMA})",
+            snapshot.schema
+        ));
+    }
+
+    let current = entries_for(all_deps);
+    if current == snapshot.deps {
+        return SnapshotStatus::Fresh;
+    }
+
+    SnapshotStatus::Stale(describe_difference(&snapshot.deps, &current))
+}
+
+/// Build a short human-readable summary of how the graph changed, for the
+/// build log. Reports the first difference found, scanning by name.
+fn describe_difference(recorded: &[DepGraphEntry], current: &[DepGraphEntry]) -> String {
+    for entry in current {
+        match recorded.iter().find(|r| r.name == entry.name) {
+            Some(previous) if previous.source != entry.source => {
+                return format!(
+                    "dependency '{}' changed source: was '{}', now '{}'",
+                    entry.name, previous.source, entry.source
+                );
+            }
+            Some(previous) if previous.via != entry.via => {
+                return format!(
+                    "dependency '{}' is now reached through a different chain",
+                    entry.name
+                );
+            }
+            Some(_) => {}
+            None => return format!("dependency '{}' is newly declared", entry.name),
+        }
+    }
+
+    for entry in recorded {
+        if !current.iter().any(|c| c.name == entry.name) {
+            return format!("dependency '{}' is no longer declared", entry.name);
+        }
+    }
+
+    "dependency graph changed".to_string()
+}
+
+/// Record the current dependency graph as the baseline for future freshness
+/// checks.
+///
+/// Called **after** a successful resolve, so every checkout and transitive
+/// manifest is on disk and discovery sees the complete graph. Best-effort: an
+/// I/O or serialisation failure is logged but never fails the build (the next
+/// build simply sees a missing snapshot and re-resolves).
+pub(super) fn write(project_root: &Utf8Path, all_deps: &[DiscoveredDep]) {
+    let snapshot = DepGraphSnapshot {
+        schema: SNAPSHOT_SCHEMA,
+        deps: entries_for(all_deps),
+    };
+
+    let data = match serde_json::to_string_pretty(&snapshot) {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(error = %e, "Failed to serialise dependency-graph snapshot");
+            return;
+        }
+    };
+
+    let path = snapshot_path(project_root);
+    match write_atomic(&path, &data) {
+        Ok(()) => debug!("Wrote dependency-graph snapshot to {path}"),
+        Err(e) => warn!(error = %e, "Failed to write dependency-graph snapshot to {path}"),
+    }
+}
+
+/// Write `contents` to `path` atomically: stage in a sibling temp file, then
+/// rename into place (atomic on the same filesystem). The temp name is keyed
+/// by pid so concurrent builders don't clobber each other's staging file.
+fn write_atomic(path: &Utf8Path, contents: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_file_name(format!(".beamtalk-dep-graph.{}.tmp", std::process::id()));
+    fs::write(&tmp, contents)?;
+    fs::rename(&tmp, path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(name: &str, source: &str) -> DepGraphEntry {
+        DepGraphEntry {
+            name: name.to_string(),
+            via: Vec::new(),
+            source: source.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_describe_difference_reports_source_swap() {
+        let recorded = vec![entry(
+            "yaml",
+            "git: https://example.test/yaml (tag: v1.0.0)",
+        )];
+        let current = vec![entry("yaml", "path: ../yaml")];
+
+        let message = describe_difference(&recorded, &current);
+        assert!(message.contains("yaml"), "{message}");
+        assert!(message.contains("changed source"), "{message}");
+    }
+
+    #[test]
+    fn test_describe_difference_reports_added_and_removed() {
+        let recorded = vec![entry("yaml", "path: ../yaml")];
+        let current = vec![entry("json", "path: ../json")];
+
+        assert!(describe_difference(&recorded, &current).contains("newly declared"));
+        assert!(describe_difference(&current, &recorded).contains("newly declared"));
+
+        let both = vec![
+            entry("yaml", "path: ../yaml"),
+            entry("json", "path: ../json"),
+        ];
+        assert!(describe_difference(&both, &recorded).contains("no longer declared"));
+    }
+
+    #[test]
+    fn test_describe_difference_reports_changed_chain() {
+        let recorded = vec![DepGraphEntry {
+            name: "yaml".to_string(),
+            via: vec!["utils".to_string()],
+            source: "path: ../yaml".to_string(),
+        }];
+        let current = vec![entry("yaml", "path: ../yaml")];
+
+        assert!(describe_difference(&recorded, &current).contains("different chain"));
+    }
+}


### PR DESCRIPTION
## Problem

`deps_are_fresh` only ever compared **values** — mtimes, ebin presence, provenance stamps, and (BT-2994) each git/registry dep's locked version or reference. None of those notice a dependency's declared *source type* changing while its name stays put in an **intermediate** manifest.

Concretely: the root declares only `utils = { path = "../utils" }`, and `utils/beamtalk.toml` swaps `yaml = { git = "…", tag = "v1" }` for `yaml = { path = "../yaml" }`.

- The root manifest's mtime is untouched, so the lockfile mtime guard stays silent.
- `locked_deps_match` filters to deps *currently* declared as git/registry, so `yaml` — now a path dep — is never compared against its stale lock entry.
- `_build/deps/yaml/ebin/` still holds the old git checkout's `.beam` files, so the ebin-presence check passes.

Net effect: the build silently links against artifacts compiled from a source that is no longer declared anywhere.

(The reverse swap, path → git, was already caught — the newly-git dep misses in the lockfile.)

## Solution

Direction **(b)** from the issue, chosen over another mtime heuristic because it is generic. After every successful resolve, record the **effective dependency graph** — each dep's name, declaring chain, and declared source (`DependencySource`'s `Display` form) — to `_build/deps/.dep-graph.json`. On the next build, compare the currently discovered graph against it.

That catches source-type swaps at any depth, and also a path dep's declared path moving, a git URL change, and any add/remove/restructure anywhere in the transitive graph.

A missing, corrupt, or unrecognised-schema snapshot is a miss, matching ADR 0098's "fail toward rebuild" stance for a missing provenance stamp: the first build after this ships re-resolves once, then records a baseline.

## Changes

- **`crates/beamtalk-cli/src/commands/deps/snapshot.rs`** (new) — the snapshot's schema, atomic write, and comparison, with a human-readable "what changed" reason for the build log.
- **`crates/beamtalk-cli/src/commands/deps/mod.rs`** — `deps_are_fresh` runs the structural check right after graph discovery; `ensure_deps_resolved` records the snapshot after a successful resolve (best-effort, never fails the build).
- **`crates/beamtalk-cli/src/build_layout.rs`** — `dep_graph_path()`. The leading dot keeps it clear of the per-dependency directories sharing `_build/deps/`; `clean_stale_deps` only removes directories and `collect_dep_ebin_paths` only accepts `<entry>/ebin` directories, so neither is disturbed. `beamtalk clean --deps` removes it along with `_build/deps/`.

## Tests

New:
- `test_intermediate_git_to_path_swap_is_stale` — the issue's exact scenario. Asserts the swap is detected **and** that re-recording the snapshot to match the swapped graph makes it look fresh again, pinning down that no other check in `deps_are_fresh` can see it.
- `test_intermediate_path_to_git_swap_is_stale` — the reverse direction, starting from a pure-path graph with no lockfile at all.
- `test_intermediate_path_dep_moved_is_stale` — same structural class, different trigger.
- `test_deps_stale_when_no_graph_snapshot_recorded` / `..._corrupt` — the fail-toward-rebuild contract.
- `test_ensure_deps_resolved_records_a_snapshot_that_reads_back_fresh` — round-trip guard against a re-resolve loop: drives a real resolve (compilation included) and asserts the next freshness check passes.

Existing freshness tests now seed the snapshot through a `deps_are_fresh_with_snapshot` helper, so each keeps testing the value change it names rather than passing vacuously on a missing snapshot.

`cargo test -p beamtalk-cli --bins` (1056 passed) and `cargo clippy -p beamtalk-cli --all-targets` are clean.

Closes BT-3009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9RhZkTXTDtNxTmM2UQS8A

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9RhZkTXTDtNxTmM2UQS8A)_