### PR TITLE
refactor: extract is_valid_selector to beamtalk-core, eliminating MCP/LSP duplication

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/mod.rs
@@ -80,6 +80,38 @@ pub fn is_valid_class_name(name: &str) -> bool {
         && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
+/// Returns `true` if `sel` is a valid Beamtalk selector.
+///
+/// Three shapes are accepted:
+/// - **Unary / keyword**: non-empty, all characters are ASCII alphanumeric,
+///   underscore, or `:` (e.g. `increment`, `at:put:`).
+/// - **Binary operator**: non-empty, all characters are operator characters
+///   from the set `+ - * / < > = ~ % & ? , \` (e.g. `+`, `>=`, `**`).
+///
+/// Mixed shapes (e.g. a string that starts with an operator char but also
+/// contains alphanumerics) are rejected.
+///
+/// This is the canonical definition; tools that validate user-supplied
+/// selectors (LSP, MCP) must delegate their boolean check here so the rule
+/// stays in one place.
+pub fn is_valid_selector(sel: &str) -> bool {
+    fn is_binary_selector_char(c: char) -> bool {
+        matches!(
+            c,
+            '+' | '-' | '*' | '/' | '<' | '>' | '=' | '~' | '%' | '&' | '?' | ',' | '\\'
+        )
+    }
+
+    let mut chars = sel.chars();
+    match chars.next() {
+        None => false,
+        Some(first) if is_binary_selector_char(first) => chars.all(is_binary_selector_char),
+        Some(_) => sel
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == ':'),
+    }
+}
+
 #[cfg(test)]
 mod naming_tests {
     use super::*;
@@ -115,5 +147,40 @@ mod naming_tests {
     #[test]
     fn invalid_digit_start() {
         assert!(!is_valid_class_name("123Foo"));
+    }
+
+    #[test]
+    fn selector_unary() {
+        assert!(is_valid_selector("increment"));
+        assert!(is_valid_selector("size"));
+        assert!(is_valid_selector("printString"));
+    }
+
+    #[test]
+    fn selector_keyword() {
+        assert!(is_valid_selector("at:"));
+        assert!(is_valid_selector("at:put:"));
+        assert!(is_valid_selector("do:separatedBy:"));
+    }
+
+    #[test]
+    fn selector_binary() {
+        assert!(is_valid_selector("+"));
+        assert!(is_valid_selector(">="));
+        assert!(is_valid_selector("**"));
+        assert!(is_valid_selector("~="));
+    }
+
+    #[test]
+    fn selector_empty_is_invalid() {
+        assert!(!is_valid_selector(""));
+    }
+
+    #[test]
+    fn selector_mixed_shapes_invalid() {
+        assert!(!is_valid_selector("+foo"));
+        assert!(!is_valid_selector("foo+"));
+        assert!(!is_valid_selector("has space"));
+        assert!(!is_valid_selector("bad!char"));
     }
 }

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -3616,38 +3616,16 @@ fn validate_class_name(name: &str) -> std::result::Result<(), String> {
 
 /// Validate a Beamtalk selector (unary, keyword, or binary) before splicing
 /// it unescaped into a `#selector` literal in a built expression (ADR 0105
-/// Phase 3, BT-2782's `CMD_PRECHECK_METHOD`) — mirrors `beamtalk-mcp`'s
-/// `validate_selector` (there is no shared crate for this; both surfaces
-/// need the same shape check before string-building an expression).
+/// Phase 3, BT-2782's `CMD_PRECHECK_METHOD`). The canonical shape check is
+/// `beamtalk_core::source_analysis::is_valid_selector`.
 fn validate_selector(sel: &str) -> std::result::Result<(), String> {
-    fn is_binary_selector_char(c: char) -> bool {
-        matches!(
-            c,
-            '+' | '-' | '*' | '/' | '<' | '>' | '=' | '~' | '%' | '&' | '?' | ',' | '\\'
-        )
-    }
-
     if sel.is_empty() {
         return Err("selector must not be empty".to_string());
     }
-
-    let first = sel.chars().next().expect("checked non-empty above");
-    if is_binary_selector_char(first) {
-        return if sel.chars().all(is_binary_selector_char) {
-            Ok(())
-        } else {
-            Err(format!("invalid binary selector: '{sel}'"))
-        };
+    if !beamtalk_core::source_analysis::is_valid_selector(sel) {
+        return Err(format!("invalid selector: '{sel}'"));
     }
-
-    if sel
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == ':')
-    {
-        return Ok(());
-    }
-
-    Err(format!("invalid selector: '{sel}'"))
+    Ok(())
 }
 
 fn workspace_roots(params: &InitializeParams) -> Vec<PathBuf> {

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -177,46 +177,22 @@ fn validate_erlang_module_name(name: &str) -> Result<(), rmcp::ErrorData> {
 /// Validate that a string is a valid Beamtalk selector.
 ///
 /// Accepts keyword/unary selectors (`increment`, `at:put:`) and binary operator
-/// selectors (`+`, `>=`, `**`) matching the lexer's `is_binary_selector_char`.
+/// selectors (`+`, `>=`, `**`). The canonical shape check is
+/// `beamtalk_core::source_analysis::is_valid_selector`.
 fn validate_selector(sel: &str) -> Result<(), rmcp::ErrorData> {
-    fn is_binary_selector_char(c: char) -> bool {
-        matches!(
-            c,
-            '+' | '-' | '*' | '/' | '<' | '>' | '=' | '~' | '%' | '&' | '?' | ',' | '\\'
-        )
-    }
-
     if sel.is_empty() {
         return Err(rmcp::ErrorData::invalid_params(
             "Selector must not be empty.",
             None,
         ));
     }
-
-    // Binary operator selectors: all chars are operator chars
-    let first = sel.chars().next().unwrap();
-    if is_binary_selector_char(first) {
-        if sel.chars().all(is_binary_selector_char) {
-            return Ok(());
-        }
+    if !beamtalk_core::source_analysis::is_valid_selector(sel) {
         return Err(rmcp::ErrorData::invalid_params(
-            format!("Invalid binary selector: '{sel}'."),
+            format!("Invalid selector: '{sel}'."),
             None,
         ));
     }
-
-    // Keyword/unary selectors: alphanumeric, underscores, and colons
-    if sel
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == ':')
-    {
-        return Ok(());
-    }
-
-    Err(rmcp::ErrorData::invalid_params(
-        format!("Invalid selector: '{sel}'."),
-        None,
-    ))
+    Ok(())
 }
 
 /// Pretty-print a JSON value, falling back to `Display` on serialization error.


### PR DESCRIPTION
## Summary

- Add `pub fn is_valid_selector(sel: &str) -> bool` to `beamtalk-core::source_analysis` alongside the existing `is_valid_class_name`
- Update `beamtalk-mcp` and `beamtalk-lsp` `validate_selector` helpers to delegate their boolean check to the new core function
- Remove the LSP comment that said "there is no shared crate for this; both surfaces need the same shape check"

## Motivation

`validate_selector` and its inner `is_binary_selector_char` function were duplicated verbatim between `crates/beamtalk-mcp/src/server.rs` and `crates/beamtalk-lsp/src/server.rs`. The LSP's own docstring acknowledged this explicitly. The existing `is_valid_class_name` function established the pattern: canonical boolean check in core, surface-specific error formatting in each caller.

## Files Changed

- `crates/beamtalk-core/src/source_analysis/mod.rs` — new `is_valid_selector` with unit tests (unary, keyword, binary, empty, mixed-shape cases)
- `crates/beamtalk-mcp/src/server.rs` — `validate_selector` now delegates to core
- `crates/beamtalk-lsp/src/server.rs` — `validate_selector` now delegates to core; stale duplication comment removed

## Testing

- All existing unit tests pass (`cargo test -p beamtalk-core`)
- New unit tests added for `is_valid_selector`
- Full `just ci` green (Rust tests, Erlang runtime, REPL protocol E2E, clippy, fmt, dialyzer)

---
_Generated by [Claude Code](https://claude.ai/code/session_0172FQAKCrGJ1wUv6dbDKMiy)_