### PR TITLE
test(stdlib): cover beamtalk_system halt error paths and platform_name clauses

### DIFF
--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_system.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_system.erl
@@ -40,6 +40,10 @@ detecting the operating system and architecture, and querying process info.
 -export([getEnv/1, getEnv/2]).
 -export([setEnv/2, unsetEnv/1]).
 
+-ifdef(TEST).
+-export([platform_name/1]).
+-endif.
+
 -include_lib("kernel/include/logger.hrl").
 
 %%% ============================================================================

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_system_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_system_tests.erl
@@ -241,3 +241,62 @@ unique_id_monotonic_test() ->
     C = beamtalk_system:uniqueId(),
     ?assert(B > A),
     ?assert(C > B).
+
+%%% ============================================================================
+%%% halt/0, halt:/1, halt/1 — error paths (non-node-owning context)
+%%%
+%%% In the test environment node_owning defaults to false, so all halt calls
+%%% safely raise #beamtalk_error{kind=unsupported} instead of halting the VM.
+%%% ============================================================================
+
+halt_zero_raises_unsupported_test() ->
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = unsupported}},
+        beamtalk_system:halt()
+    ).
+
+halt_colon_valid_code_raises_unsupported_test() ->
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = unsupported}},
+        beamtalk_system:'halt:'(0)
+    ).
+
+halt_colon_out_of_range_negative_raises_invalid_argument_test() ->
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = invalid_argument}},
+        beamtalk_system:'halt:'(-1)
+    ).
+
+halt_colon_out_of_range_too_large_raises_invalid_argument_test() ->
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = invalid_argument}},
+        beamtalk_system:'halt:'(256)
+    ).
+
+halt_colon_non_integer_raises_type_error_test() ->
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = type_error}},
+        beamtalk_system:'halt:'(not_an_integer)
+    ).
+
+halt_shim_delegates_to_halt_colon_test() ->
+    ?assertError(
+        #{'$beamtalk_class' := _, error := #beamtalk_error{kind = unsupported}},
+        beamtalk_system:halt(0)
+    ).
+
+%%% ============================================================================
+%%% platform_name/1 (exported under TEST)
+%%% ============================================================================
+
+platform_name_darwin_test() ->
+    ?assertEqual(<<"darwin">>, beamtalk_system:platform_name(darwin)).
+
+platform_name_linux_test() ->
+    ?assertEqual(<<"linux">>, beamtalk_system:platform_name(linux)).
+
+platform_name_nt_test() ->
+    ?assertEqual(<<"win32">>, beamtalk_system:platform_name(nt)).
+
+platform_name_other_atom_test() ->
+    ?assertEqual(<<"freebsd">>, beamtalk_system:platform_name(freebsd)).


### PR DESCRIPTION
## Summary

Adds 10 EUnit tests to `beamtalk_system_tests.erl`, raising `beamtalk_system` line coverage from 79.6% (43/54) toward 100%.

Two real gaps were entirely untested:

**halt/0, halt:/1, halt/1 error paths** — In CI (non-node-owning context) all halt calls safely raise `#beamtalk_error{}` without halting the VM. None of the seven lines in these paths were covered:
- `halt/0` and valid-code `halt:/1` → `#beamtalk_error{kind=unsupported}` (node_owning defaults to false)
- `halt:(-1)` / `halt:(256)` → `#beamtalk_error{kind=invalid_argument}` (out-of-range POSIX code)
- `halt:(not_integer)` → `#beamtalk_error{kind=type_error}`
- `halt/1` shim → delegates correctly to `halt:/1`

**platform_name/1 clauses** — Only the `linux` clause was ever reached on CI. The `darwin`, `nt`, and `Other` fallback clauses were dead. Exports the private function under `-ifdef(TEST)` so the clauses can be tested directly.

## Changes

- `runtime/apps/beamtalk_stdlib/src/beamtalk_system.erl`: add `-ifdef(TEST)` export for `platform_name/1`
- `runtime/apps/beamtalk_stdlib/test/beamtalk_system_tests.erl`: 10 new test functions in two sections (halt error paths, platform_name clauses)

## Test plan

- [x] `just test-stdlib` — 231 tests, 0 failures (up from 221)
- [x] `just clippy` — no warnings
- [x] `rebar3 dialyzer` — clean
- [x] erlfmt — no violations

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fekk5KfGwgRUNHDtRu4vSf)_