### PR TITLE
test: tighten placeholder assertions in inline_class_hot_reload.btscript

### DIFF
--- a/tests/repl-protocol/cases/inline_class_hot_reload.btscript
+++ b/tests/repl-protocol/cases/inline_class_hot_reload.btscript
@@ -25,7 +25,7 @@
 Actor subclass: InlineRedefActor
   state: count = 0
   bump => self.count := self.count + 1
-// => _
+// => InlineRedefActor
 
 ir := InlineRedefActor spawn
 // => Actor(InlineRedefActor, _)
@@ -44,7 +44,7 @@ ir bump
 Actor subclass: InlineRedefActor
   state: count = 0
   bump => self.count := self.count + 10
-// => _
+// => InlineRedefActor
 
 // Existing actor picks up new bump (adds 10). Count preserved at 2.
 ir bump
@@ -73,10 +73,10 @@ ir2 bump
 Actor subclass: MethodDropActor
   state: x = 0
   setX => self.x := self.x + 1
-// => _
+// => MethodDropActor
 
 MethodDropActor >> secret => "visible"
-// => _
+// => MethodDropActor>>secret
 
 md := MethodDropActor spawn
 // => Actor(MethodDropActor, _)
@@ -91,7 +91,7 @@ md secret
 Actor subclass: MethodDropActor
   state: x = 0
   setX => self.x := self.x + 1
-// => _
+// => MethodDropActor
 
 // setX still works on existing actor after hot reload
 md setX


### PR DESCRIPTION
## Summary

Replace 5 `// => _` placeholder assertions in `tests/repl-protocol/cases/inline_class_hot_reload.btscript` with concrete expected values.

**Smell:** Inline class definitions and `>>` method extensions returned wildcard assertions where the REPL output is fully deterministic — a regression in how REPL displays class-definition or method-extension results would not be caught.

**Changes:**

| Expression | Before | After |
|---|---|---|
| `Actor subclass: InlineRedefActor` (initial) | `// => _` | `// => InlineRedefActor` |
| `Actor subclass: InlineRedefActor` (redefinition) | `// => _` | `// => InlineRedefActor` |
| `Actor subclass: MethodDropActor` (initial) | `// => _` | `// => MethodDropActor` |
| `MethodDropActor >> secret => "visible"` | `// => _` | `// => MethodDropActor>>secret` |
| `Actor subclass: MethodDropActor` (redefinition) | `// => _` | `// => MethodDropActor` |

**Evidence the values are correct:**
- `inline_class.btscript`: `Actor subclass: InlineCounter ...` → `// => InlineCounter`
- `adr_0105_killer_demo.btscript`: class redefinition of `KillerDemoCounter` also returns `KillerDemoCounter`
- `extension_type_annotations.btscript`: `Greeter >> shout ...` → `// => Greeter>>shout`

**Safety:** No change in test intent. The hot-reload semantics are still verified by the downstream `ir bump` / `md setX` / `md secret` assertions. This only adds coverage of the REPL display format for class and method definitions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVdgzi2SavFy4qmH6ujrxd)_