### PR TITLE
docs(stdlib): stop promising unconditional value semantics on Value (BT-3029)

### DIFF
--- a/stdlib/src/Value.bt
+++ b/stdlib/src/Value.bt
@@ -11,7 +11,18 @@
 ///
 /// - **Immutable:** slot assignments (e.g., `self.x := 5`) are compile errors.
 ///   Use methods that return new instances (e.g., `self withX: 5`).
-/// - **Value Semantics:** Compared by value, not identity.
+/// - **Compared by term, not identity:** `=:=`/`==` are never dispatched —
+///   they compile to Erlang's `=:=`/`==` on the receiver's term at every call
+///   site (ADR 0002), so `Value` cannot override them. This *reads* as value
+///   semantics exactly when a subclass's representation is a pure function of
+///   its contents, so that structurally-equal instances are also
+///   term-identical (as core `Array` guarantees via its canonical
+///   representation, ADR 0090). A subclass whose representation is
+///   history-dependent (e.g. amortized structures that keep internal state
+///   not determined solely by their logical contents) cannot rely on `=:=`
+///   for value comparison and should document its own comparison contract —
+///   typically an explicit message like `equals:` — rather than promise
+///   `=:=` correctness.
 /// - **Lightweight:** No actor processes; methods are pure functions.
 ///
 /// ## Subclassing


### PR DESCRIPTION
## Problem

`Value`'s class doc unconditionally stated "Value Semantics: Compared by value, not identity." This is false as a universal promise: Beamtalk has no dispatchable equality — `=:=`/`==` compile to inline Erlang BIFs at every call site (ADR 0002), so a user-defined `=:=` method on a `Value` subclass compiles but is never invoked. "Compared by value" really means "compared as an Erlang term," which only coincides with true value semantics when a subclass's representation is a pure function of its contents.

Core `Array` achieves this via canonical representation (ADR 0090). But subclasses with history-dependent representations (e.g. amortized structures like `Deque`, `PriorityQueue`, `SortedMap`, `SortedSet` in the separate beamtalk-collections package) can't honor this promise and instead expose an explicit `equals:` message (per BT-3023, already resolved elsewhere).

## Fix

Rewrote the "Value Semantics" bullet in `Value`'s class doc (`stdlib/src/Value.bt`) to:
- State concretely what "compared by value" means: `=:=`/`==` compare the receiver's Erlang term, not a dispatched equality method (cross-references ADR 0002).
- Note this coincides with true value semantics when representation is a pure function of contents, as core `Array` guarantees (cross-references ADR 0090).
- Add guidance for subclass authors with history-dependent representation: they cannot rely on `=:=` and should document their own comparison contract (e.g. an explicit `equals:` message).

Kept it to a class-doc-comment-sized fix — no new ADR, matching the style already used in `ProtoObject.bt`'s `=:=` documentation (which also cites ADR 0002 for why it's never dispatched).

## Verification

Doc-only change confined to `///` comment lines preceding the class declaration; no code paths touched. Not able to run `just build-stdlib` from this session due to a local tooling/session issue — please confirm via CI on this PR.

## Acceptance criteria
- [x] `Value`'s class doc no longer makes an unconditional value-semantics promise.
- [x] Doc states concretely what "compared by value" means.
- [x] Guidance added for subclass authors with history-dependent representation.
- [x] Cross-references ADR 0090 and ADR 0002.

Resolves BT-3029.


---
_Generated by [Claude Code](https://claude.ai/code/session_012vops3aox9QAcSknGKtCWP)_