### PR TITLE
Runtime: add {nlr_relay, ...} class-method outcome variant with shadow read/erase (BT-3036)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
@@ -258,6 +258,12 @@ unwrap_self_dispatch_outcome(ClassName, Selector, Outcome) ->
             erlang:error(undef);
         {error, {raised, ErrClass, Error, ST}} ->
             erlang:raise(ErrClass, Error, ST);
+        {nlr_relay, Nlr, ST} ->
+            %% ADR 0110 / BT-3032: self-dispatch runs in the caller's own
+            %% process, so resume the non-local return unwind directly —
+            %% identical behavior to when these throws were tagged
+            %% {error, {raised, throw, ...}}.
+            erlang:raise(throw, Nlr, ST);
         test_spawn ->
             %% `TestCase>>runAll` / `run:` self-sent from inside another
             %% class method would run the test suite inline in the class
@@ -612,28 +618,60 @@ invoke_class_method(Selector, Args, ClassName, _Module, DefiningClass, DefiningM
     %% so both dispatch paths see identical error classification, class-var
     %% threading, and the BT-440 test_spawn escape hatch. This function
     %% adapts the shared outcome to the gen_server `{reply, _, State}` shape.
-    case
-        apply_class_method_in_context(
-            Selector, Args, ClassName, DefiningClass, DefiningModule, ClassVars
-        )
-    of
-        test_spawn ->
-            test_spawn;
-        {ok, {class_var_result, Result, NewClassVars}} ->
-            {reply, {ok, Result}, NewClassVars};
-        {ok, Result} ->
-            {reply, {ok, Result}, ClassVars};
-        {error, #beamtalk_error{} = Error} ->
-            {reply, {error, Error}, ClassVars};
-        {error, undef_in_body} ->
-            {reply, {error, undef}, ClassVars};
-        {error, {raised, _ErrClass, Error, _ST}} ->
-            {reply, {error, Error}, ClassVars}
+    %%
+    %% ADR 0110 / BT-3032: the whole body runs inside try ... after so the
+    %% '$bt_class_vars_shadow' process-dictionary key (written by codegen at
+    %% top-level class-var mutations) never outlives a dispatch, whatever the
+    %% outcome.
+    try
+        case
+            apply_class_method_in_context(
+                Selector, Args, ClassName, DefiningClass, DefiningModule, ClassVars
+            )
+        of
+            test_spawn ->
+                test_spawn;
+            {ok, {class_var_result, Result, NewClassVars}} ->
+                {reply, {ok, Result}, NewClassVars};
+            {ok, Result} ->
+                {reply, {ok, Result}, ClassVars};
+            {nlr_relay, Nlr, _ST} ->
+                %% ADR 0110 / BT-3032: a foreign `^` relaying out of the class
+                %% method is control flow, not a failure — class-var writes made
+                %% before the unwind must survive. The codegen write-through
+                %% (BT-3037) records them under '$bt_class_vars_shadow'; until
+                %% that lands the shadow is never set and this falls back to the
+                %% pre-call ClassVars, exactly today's behavior. The reply shape
+                %% is byte-identical to the historical {error, Nlr}, so the
+                %% ?IS_NLR re-throw clauses in class_send_dispatch/3 and
+                %% metaclass_send_dispatch/4 need no change.
+                ShadowClassVars =
+                    case erlang:get('$bt_class_vars_shadow') of
+                        undefined -> ClassVars;
+                        Shadow -> Shadow
+                    end,
+                {reply, {error, Nlr}, ShadowClassVars};
+            {error, #beamtalk_error{} = Error} ->
+                {reply, {error, Error}, ClassVars};
+            {error, undef_in_body} ->
+                {reply, {error, undef}, ClassVars};
+            {error, {raised, _ErrClass, Error, _ST}} ->
+                {reply, {error, Error}, ClassVars}
+        end
+    after
+        erlang:erase('$bt_class_vars_shadow')
     end.
 
+%% ADR 0110 / BT-3032: `{nlr_relay, Nlr, ST}` is a foreign `^` (non-local
+%% return) relaying out of the class method — the relayed NLR tuple plus its
+%% stacktrace. It is kept distinct from `{error, {raised, ...}}` so
+%% `invoke_class_method/7` can preserve class-var writes recorded under the
+%% `'$bt_class_vars_shadow'` process-dictionary key instead of reverting them
+%% the way it does for genuine errors.
 -type class_method_outcome() ::
     test_spawn
     | {ok, term()}
+    | {nlr_relay, term(), list()}
     | {error, #beamtalk_error{}}
     | {error, undef_in_body}
     | {error, {raised, atom(), term(), list()}}.
@@ -712,8 +750,11 @@ apply_class_method_fun(Fun, ClassSelf, ClassVars, Args, ClassName, Selector) ->
         %% BT-3022: a `^` non-local return that unwound through this class method
         %% belongs to a method frame in the *calling* process. Pass it through
         %% unlogged so class_send_dispatch/3 can re-throw it there.
+        %% ADR 0110 / BT-3032: tagged as its own outcome variant (not
+        %% {error, {raised, ...}}) so invoke_class_method/7 can keep class-var
+        %% writes made before the unwind instead of reverting them.
         throw:Nlr:NlrST when ?IS_NLR(Nlr) ->
-            {error, {raised, throw, Nlr, NlrST}};
+            {nlr_relay, Nlr, NlrST};
         error:undef:ST ->
             ?LOG_ERROR(
                 "Runtime class method ~p:~p raised undef internally",
@@ -762,8 +803,10 @@ apply_compiled_class_method(
             {error, {raised, throw, ScriptExit, ScriptST}};
         %% BT-3022: see apply_class_method_fun/6 — a non-local return unwinding out
         %% of a class method is control flow for a frame in the calling process.
+        %% ADR 0110 / BT-3032: tagged {nlr_relay, ...} so class-var writes made
+        %% before the unwind can be recovered rather than reverted.
         throw:Nlr:NlrST when ?IS_NLR(Nlr) ->
-            {error, {raised, throw, Nlr, NlrST}};
+            {nlr_relay, Nlr, NlrST};
         error:undef:ST ->
             classify_undef(ClassName, DefiningClass, DefiningModule, Selector, FunName, ST);
         ErrClass:Error:ErrST ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_dispatch_test_helper.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_dispatch_test_helper.erl
@@ -24,6 +24,7 @@ Function naming convention follows Beamtalk's `class_` prefix scheme:
     class_testInternalUndef/2,
     class_testRaise/2,
     class_testScriptExit/2,
+    class_testNlrThrow/2,
     'class_testTwoArgs:and:'/4,
     class_testSupervisorNew/2,
     class_testAlreadyStarted/2,
@@ -93,6 +94,17 @@ class_send_dispatch/3.
 -spec class_testScriptExit(term(), map()) -> no_return().
 class_testScriptExit(_ClassSelf, _ClassVars) ->
     throw({beamtalk_script_exit, 7}).
+
+-doc """
+Zero-argument class method that throws a `^` non-local return signal
+(ADR 0110 / BT-3036) — the state-carrying `{'$bt_nlr', Token, Value, State}`
+4-tuple codegen throws for a foreign `^` unwinding out of a class method.
+Exercises the `{nlr_relay, Nlr, ST}` catch + the shadow read/erase in
+`invoke_class_method/7`.
+""".
+-spec class_testNlrThrow(term(), map()) -> no_return().
+class_testNlrThrow(_ClassSelf, _ClassVars) ->
+    throw({'$bt_nlr', bt3036_token, nlr_value, nlr_state}).
 
 -doc """
 Two-argument keyword class method for arity testing.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_dispatch_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_dispatch_tests.erl
@@ -1070,7 +1070,13 @@ invoke_class_method_errors_test_() ->
             {"method that raises error returns {error, Reason}", fun test_invoke_raises_error/0},
             {"connected Program exit: passes through the apply catch",
                 fun test_invoke_script_exit_passthrough/0},
-            {"multi-arg keyword selector dispatches correctly", fun test_invoke_two_arg_keyword/0}
+            {"multi-arg keyword selector dispatches correctly", fun test_invoke_two_arg_keyword/0},
+            {"NLR relay without shadow falls back to pre-call class vars",
+                fun test_invoke_nlr_relay_no_shadow/0},
+            {"NLR relay with shadow set replies with shadow class vars and erases it",
+                fun test_invoke_nlr_relay_reads_shadow/0},
+            {"genuine error ignores the shadow, reverts to pre-call class vars",
+                fun test_invoke_error_ignores_shadow/0}
         ]
     end}.
 
@@ -1128,6 +1134,72 @@ test_invoke_two_arg_keyword() ->
         #{}
     ),
     ?assertMatch({reply, {ok, {two_args, alpha, beta}}, _}, Result).
+
+%% ADR 0110 / BT-3036: a foreign `^` (NLR throw) relaying out of a class method
+%% replies {error, Nlr} with the *pre-call* ClassVars when nothing has written
+%% the '$bt_class_vars_shadow' key — exactly today's revert behavior.
+test_invoke_nlr_relay_no_shadow() ->
+    LocalMethods = #{testNlrThrow => <<>>},
+    ClassVars = #{count => 1},
+    Result = beamtalk_class_dispatch:handle_class_method_call(
+        testNlrThrow,
+        [],
+        'BT3036NlrNoShadowClass',
+        beamtalk_class_dispatch_test_helper,
+        LocalMethods,
+        ClassVars
+    ),
+    ?assertMatch(
+        {reply, {error, {'$bt_nlr', bt3036_token, nlr_value, nlr_state}}, #{count := 1}}, Result
+    ),
+    %% The shadow key never outlives a dispatch.
+    ?assertEqual(undefined, erlang:get('$bt_class_vars_shadow')).
+
+%% ADR 0110 / BT-3036: when the shadow key IS set (as the BT-3037 codegen
+%% write-through will do at top-level class-var mutations), the NLR relay path
+%% replies with the shadow class vars — preserving writes made before the
+%% unwind — and the after clause erases the key.
+test_invoke_nlr_relay_reads_shadow() ->
+    LocalMethods = #{testNlrThrow => <<>>},
+    erlang:put('$bt_class_vars_shadow', #{count => 99}),
+    try
+        Result = beamtalk_class_dispatch:handle_class_method_call(
+            testNlrThrow,
+            [],
+            'BT3036NlrShadowClass',
+            beamtalk_class_dispatch_test_helper,
+            LocalMethods,
+            #{count => 1}
+        ),
+        ?assertMatch(
+            {reply, {error, {'$bt_nlr', bt3036_token, nlr_value, nlr_state}}, #{count := 99}},
+            Result
+        ),
+        ?assertEqual(undefined, erlang:get('$bt_class_vars_shadow'))
+    after
+        erlang:erase('$bt_class_vars_shadow')
+    end.
+
+%% ADR 0110 / BT-3036: a genuine error still reverts to the pre-call ClassVars
+%% even when the shadow key is set — only the NLR relay path reads it. The
+%% after clause still erases the key.
+test_invoke_error_ignores_shadow() ->
+    LocalMethods = #{testRaise => <<>>},
+    erlang:put('$bt_class_vars_shadow', #{count => 99}),
+    try
+        Result = beamtalk_class_dispatch:handle_class_method_call(
+            testRaise,
+            [],
+            'BT3036ErrorShadowClass',
+            beamtalk_class_dispatch_test_helper,
+            LocalMethods,
+            #{count => 1}
+        ),
+        ?assertMatch({reply, {error, test_deliberate_error}, #{count := 1}}, Result),
+        ?assertEqual(undefined, erlang:get('$bt_class_vars_shadow'))
+    after
+        erlang:erase('$bt_class_vars_shadow')
+    end.
 
 %%% ============================================================================
 %%% 12. class_send instantiation variants (BT-1963)


### PR DESCRIPTION
## Summary

Part of ADR 0110 (fixes BT-3032), Phase 1 of 3.

Linear issue: https://linear.app/beamtalk/issue/BT-3036

A foreign `^` (non-local return) relaying out of a class method was folded into the same `{error, {raised, ...}}` outcome shape as a genuine error, so `invoke_class_method/7` reverted `ClassVars` for both. This PR makes the relay case a first-class outcome variant and teaches `invoke_class_method/7` to recover mutated class vars from the `'$bt_class_vars_shadow'` process-dictionary key on that path only.

**Zero behavior change:** nothing writes the shadow yet (BT-3037 adds the codegen write-through), so the shadow read is always `undefined` and every path behaves exactly as today. Landing runtime-first means the codegen writer never ships without its eraser.

## Key changes

All in `runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl`:

- `class_method_outcome()` gains `{nlr_relay, term(), list()}` (relayed NLR tuple + stacktrace), doc-commented with the ADR 0110 / BT-3032 rationale
- The two `throw:Nlr:NlrST when ?IS_NLR(Nlr)` catch clauses (`apply_class_method_fun/6`, `apply_compiled_class_method/7`) now produce `{nlr_relay, Nlr, NlrST}` instead of `{error, {raised, throw, Nlr, NlrST}}`
- `invoke_class_method/7` body wrapped in `try ... after erlang:erase('$bt_class_vars_shadow') end`; new `{nlr_relay, Nlr, _ST}` clause replies `{reply, {error, Nlr}, ShadowClassVars}` where the shadow value is used if set, else the pre-call `ClassVars`. Reply shape is byte-identical to today's, so the `?IS_NLR` re-throw clauses in `class_send_dispatch/3` / `metaclass_send_dispatch/4` need no change
- `unwrap_self_dispatch_outcome/3` gains `{nlr_relay, Nlr, ST} -> erlang:raise(throw, Nlr, ST)` (identical behavior to the path those throws took before)
- Genuine errors still reply with the pre-call `ClassVars` — revert semantics unchanged

Tests: 3 new EUnit tests directly covering the new contract (relay fallback without shadow, shadow pickup + erase, genuine-error revert with shadow set), plus a `class_testNlrThrow/2` test-helper method.

## Verification

- `just test` green: 5471 runtime EUnit tests, 3141 BUnit tests (BT-3022's NLR relay canaries included), 231 stdlib tests
- `just dialyzer` clean
- `just ci-changed` green (build, clippy, fmt-check, corpus, surface-drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZYjrGaKMfbrB9aviMSh8e

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZYjrGaKMfbrB9aviMSh8e)_