### PR TITLE
beamtalk lint: spurious HTTPHandlerLike alias-collision diagnostic sprayed across unrelated files (BT-3043)

### DIFF
--- a/crates/beamtalk-cli/src/commands/doc/extractor.rs
+++ b/crates/beamtalk-cli/src/commands/doc/extractor.rs
@@ -48,14 +48,13 @@ pub struct MethodInfo {
 /// that `beamtalk build` compiles — including classes in `src/` subdirectories
 /// (user packages) or `stdlib/src/` subdirectories.
 ///
-/// Build/VCS directories are excluded. `build::find_source_files` avoids them
-/// by preferring the package's `src/` subdirectory, but `doc` walks whatever
-/// path it is handed — so pointing it at a package root would otherwise pull
-/// in every dependency's classes from `_build/deps/`.
+/// Build/VCS directories are excluded (`FileWalker::source_files()`, BT-3043)
+/// — `build::find_source_files` avoids them by preferring the package's
+/// `src/` subdirectory, but `doc` walks whatever path it is handed, so
+/// pointing it at a package root would otherwise pull in every dependency's
+/// classes from `_build/deps/`.
 pub(super) fn find_source_files(path: &Utf8Path) -> Result<Vec<Utf8PathBuf>> {
-    beamtalk_core::file_walker::FileWalker::source_files()
-        .exclude_dirs(&[".git", "target", "node_modules", "_build"])
-        .walk(path)
+    beamtalk_core::file_walker::FileWalker::source_files().walk(path)
 }
 
 /// Parse a `.bt` source file and extract class documentation info.

--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -1268,6 +1268,66 @@ mod tests {
         );
     }
 
+    /// BT-3043: `collect_lint_files`'s directory walk must never treat a
+    /// dependency's own vendored checkout under `_build/deps/` as first-party
+    /// project source. Unlike a path dependency (whose source lives wherever
+    /// the path points, outside `_build`), a git/registry dependency is
+    /// cloned straight into `_build/deps/<name>/` — the actual reproduction
+    /// shape of the original bug report (an `http` dependency, not a path
+    /// dep): without this exclusion, `beamtalk lint .` would (a) lint the
+    /// vendored dependency's own source as if it were the user's code, and
+    /// (b) extract its declarations a second time stamped with the
+    /// *consuming* project's package name, producing a genuine mismatch
+    /// against the same declaration merged in correctly (stamped with the
+    /// dependency's own package name) via `merge_dependency_infos` — a
+    /// collision `AliasRegistry::add_pre_loaded`'s identity check cannot
+    /// recognise as a duplicate, since the two entries' `package` differs.
+    #[test]
+    fn collect_lint_files_excludes_vendored_dependency_checkout_under_build_dir() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+        std::fs::write(
+            root.join("beamtalk.toml"),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(
+            root.join("src").join("Main.bt"),
+            "Object subclass: Main\n  foo => 1\n",
+        )
+        .unwrap();
+
+        // Simulate a git/registry dependency's checkout (`clone_repo` clones
+        // straight into `_build/deps/<name>/` — see `BuildLayout::dep_checkout_dir`).
+        std::fs::create_dir_all(
+            root.join("_build")
+                .join("deps")
+                .join("producer")
+                .join("src"),
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("_build")
+                .join("deps")
+                .join("producer")
+                .join("src")
+                .join("types.bt"),
+            "type Handler = Block | Integer\n",
+        )
+        .unwrap();
+
+        let source_path = camino::Utf8PathBuf::from_path_buf(root.to_path_buf()).unwrap();
+        let (source_files, _erl_files) =
+            collect_lint_files(&source_path, source_path.as_str()).unwrap();
+
+        assert!(
+            source_files.iter().all(|f| !f.as_str().contains("_build")),
+            "vendored dependency source under _build/ must never be treated as project \
+             source: {source_files:?}"
+        );
+    }
+
     /// BT-3043 (acceptance criterion): a project depending on a package that
     /// declares a type alias exactly once must lint clean across every file
     /// in the project — no false "Pre-loaded type alias ... collides with
@@ -1384,6 +1444,126 @@ mod tests {
                 "a once-declared dependency alias must never be flagged as colliding: {diags:?}"
             );
         }
+    }
+
+    /// BT-3043 (acceptance criterion): a *genuine* cross-package alias
+    /// collision — two different dependencies each exporting a same-named
+    /// alias with a different RHS — must be reported exactly once across a
+    /// multi-file consumer project, not once per file. Exercises the real
+    /// pipeline end to end (`parse_and_extract_class_infos` +
+    /// `merge_dependency_infos` + the same Pass-2 loop shape `run_lint` uses,
+    /// dedup included) rather than synthetic diagnostics, so it would have
+    /// caught a regression in either the `AliasRegistry::add_pre_loaded`
+    /// identity check or `run_lint`'s cross-file dedup.
+    #[test]
+    fn lint_across_many_files_reports_a_genuine_cross_package_alias_collision_exactly_once() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+
+        for (pkg, rhs) in [("producer_a", "String"), ("producer_b", "Integer")] {
+            let dir = root.join(pkg);
+            std::fs::create_dir_all(dir.join("src")).unwrap();
+            std::fs::write(
+                dir.join("beamtalk.toml"),
+                format!("[package]\nname = \"{pkg}\"\nversion = \"0.1.0\"\n"),
+            )
+            .unwrap();
+            std::fs::write(
+                dir.join("src").join("types.bt"),
+                format!("type Shared = {rhs}\n"),
+            )
+            .unwrap();
+        }
+
+        let consumer_dir = root.join("consumer");
+        std::fs::create_dir_all(consumer_dir.join("src")).unwrap();
+        std::fs::write(
+            consumer_dir.join("beamtalk.toml"),
+            "[package]\nname = \"consumer\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nproducer_a = { path = \"../producer_a\" }\n\
+             producer_b = { path = \"../producer_b\" }\n",
+        )
+        .unwrap();
+        let mut source_files = Vec::new();
+        for i in 0..8 {
+            let file = consumer_dir.join("src").join(format!("File{i}.bt"));
+            std::fs::write(&file, format!("Object subclass: File{i}\n  foo => 1\n")).unwrap();
+            source_files.push(camino::Utf8PathBuf::from_path_buf(file).unwrap());
+        }
+
+        let consumer_root = camino::Utf8PathBuf::from_path_buf(consumer_dir.clone()).unwrap();
+
+        // Fake both producers' compiled state so dependency resolution takes
+        // the fresh/no-recompile fast path (mirrors the sibling tests above).
+        let layout = crate::commands::build_layout::BuildLayout::new(&consumer_root);
+        for pkg in ["producer_a", "producer_b"] {
+            let ebin_dir = layout.dep_ebin_dir(pkg);
+            std::fs::create_dir_all(&ebin_dir).unwrap();
+            std::fs::write(ebin_dir.join(format!("bt@{pkg}@types.beam")), b"BEAM").unwrap();
+            crate::commands::build_stamp::write_stamp(
+                &layout.dep_stamp_path(pkg),
+                crate::commands::build_stamp::current_otp_version(),
+            );
+        }
+
+        let (
+            mut all_class_infos,
+            extension_index,
+            mut all_protocol_infos,
+            mut all_alias_infos,
+            parsed_files,
+        ) = parse_and_extract_class_infos(&source_files, Some(&consumer_root), Some("consumer"))
+            .unwrap();
+        merge_dependency_infos(
+            &consumer_root,
+            &mut all_class_infos,
+            &mut all_protocol_infos,
+            &mut all_alias_infos,
+        );
+        assert_eq!(
+            all_alias_infos
+                .iter()
+                .filter(|a| a.name == "Shared")
+                .count(),
+            2,
+            "the fixture declares Shared twice, with different RHS: {all_alias_infos:?}"
+        );
+
+        let mut seen_pre_loaded_alias_collisions = std::collections::HashSet::new();
+        let mut collision_count = 0usize;
+        for (_file, _source, module, parse_diags) in parsed_files {
+            let cross_file_classes =
+                beamtalk_core::semantic_analysis::ClassHierarchy::cross_file_class_infos(
+                    &all_class_infos,
+                    &module,
+                );
+            let diags = collect_diagnostics(
+                &module,
+                parse_diags,
+                cross_file_classes,
+                all_protocol_infos.clone(),
+                all_alias_infos.clone(),
+                None,
+                beamtalk_core::semantic_analysis::KnowledgeScope::ProjectComplete,
+                &extension_index,
+                true,
+                Some("consumer"),
+            )
+            .into_iter()
+            .filter(|d| dedup_pre_loaded_alias_collision(d, &mut seen_pre_loaded_alias_collisions))
+            .collect::<Vec<_>>();
+
+            collision_count += diags
+                .iter()
+                .filter(|d| d.message.contains("collides with another type alias"))
+                .count();
+        }
+
+        assert_eq!(
+            collision_count, 1,
+            "a genuine cross-package collision must be reported exactly once for the whole \
+             lint run, not once per file"
+        );
     }
 
     /// BT-3043 (acceptance criterion): when two pre-loaded aliases *do*

--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -109,6 +109,38 @@ fn collect_diagnostics(
     lint_diags
 }
 
+/// Decides whether a diagnostic from one file's [`collect_diagnostics`] call
+/// should be kept, deduplicating repeat sightings of a pre-loaded alias
+/// collision across the whole `run_lint` invocation (BT-3043).
+///
+/// `run_lint`'s Pass 2 loop calls `collect_diagnostics` once per project
+/// file, each time seeding a *fresh* `AliasRegistry` from the same
+/// project-wide `all_alias_infos` list. A genuine collision between two of
+/// that list's entries is therefore rediscovered — with byte-identical
+/// message and span, since neither depends on the file currently being
+/// analysed — on every single call, once per file in the project instead of
+/// once per lint run. `seen` tracks which (message, span) pairs have already
+/// been kept so only the first sighting survives; every other diagnostic
+/// (file-specific by construction) always passes through unfiltered.
+///
+/// The `"Pre-loaded type alias "` prefix is the stable, distinctive lead-in
+/// shared by all three of `AliasRegistry::add_pre_loaded`'s diagnostic
+/// messages (alias-vs-class, alias-vs-protocol, alias-vs-alias) and no other
+/// diagnostic in the compiler — matching on it (rather than deduping every
+/// diagnostic indiscriminately by (message, span)) avoids ever dropping a
+/// genuinely distinct per-file diagnostic that happens to coincide with
+/// another file's on both message text and byte offset.
+fn dedup_pre_loaded_alias_collision(
+    diag: &beamtalk_core::source_analysis::Diagnostic,
+    seen: &mut std::collections::HashSet<(String, beamtalk_core::source_analysis::Span)>,
+) -> bool {
+    if diag.message.starts_with("Pre-loaded type alias ") {
+        seen.insert((diag.message.to_string(), diag.span))
+    } else {
+        true
+    }
+}
+
 /// Run lint passes on the given path (file or directory).
 ///
 /// Prints each lint diagnostic and returns an error if any are found.
@@ -205,6 +237,21 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
     let mut total_lint_count = 0usize;
     let mut all_diags: Vec<beamtalk_core::source_analysis::Diagnostic> = Vec::new();
 
+    // BT-3043: `all_alias_infos` (the pre-loaded/cross-package alias seed
+    // list) is identical on every iteration of the Pass 2 loop below, so a
+    // genuine collision between two of its entries — reported fresh by
+    // `AliasRegistry::add_pre_loaded` inside `collect_diagnostics` (a new
+    // `AliasRegistry` per file, seeded from the same list every time) — would
+    // otherwise be re-diagnosed once per file in the project instead of once
+    // per lint run. Dedup by (message, span): every `add_pre_loaded`
+    // collision diagnostic for a given colliding pair has byte-identical
+    // text and span regardless of which file triggered the seeding, since
+    // neither depends on the file currently being analysed.
+    let mut seen_pre_loaded_alias_collisions: std::collections::HashSet<(
+        String,
+        beamtalk_core::source_analysis::Span,
+    )> = std::collections::HashSet::new();
+
     // BT-2796: With a package root, Pass 1 walked the full package source set
     // (BT-2027), so the injected knowledge is project-complete. Without one
     // (a bare file outside any package), only the targeted files were parsed
@@ -234,6 +281,14 @@ pub fn run_lint(path: &str, format: OutputFormat) -> Result<()> {
             has_package_dependencies,
             current_package.as_deref(),
         );
+
+        // BT-3043: Drop repeat sightings of a pre-loaded alias collision —
+        // see `seen_pre_loaded_alias_collisions`'s doc above. Every other
+        // diagnostic is file-specific and passes through unfiltered.
+        let lint_diags: Vec<_> = lint_diags
+            .into_iter()
+            .filter(|d| dedup_pre_loaded_alias_collision(d, &mut seen_pre_loaded_alias_collisions))
+            .collect();
 
         for diag in &lint_diags {
             match format {
@@ -1211,6 +1266,170 @@ mod tests {
             !unresolved_names.iter().any(|m| m.contains("Greetable")),
             "dependency-exported Greetable protocol should resolve, unresolved: {unresolved_names:?}"
         );
+    }
+
+    /// BT-3043 (acceptance criterion): a project depending on a package that
+    /// declares a type alias exactly once must lint clean across every file
+    /// in the project — no false "Pre-loaded type alias ... collides with
+    /// another type alias of the same name" diagnostic, no matter how many
+    /// project files are analysed against the same merged
+    /// `all_alias_infos` seed list.
+    ///
+    /// Mirrors `lint_resolves_dependency_protocol_and_public_alias_but_not_internal_alias`'s
+    /// fixture shape (a real producer/consumer path-dependency pair with a
+    /// faked-fresh dependency stamp), but drives `collect_diagnostics` across
+    /// *several* consumer files the way `run_lint`'s Pass 2 loop does, since
+    /// the bug this guards against only manifests when the same pre-loaded
+    /// alias list is re-seeded into a fresh `AliasRegistry` once per file.
+    #[test]
+    fn lint_across_many_files_does_not_flag_a_singly_declared_dependency_alias_as_colliding() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+
+        let producer_dir = root.join("producer");
+        std::fs::create_dir_all(producer_dir.join("src")).unwrap();
+        std::fs::write(
+            producer_dir.join("beamtalk.toml"),
+            "[package]\nname = \"producer\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            producer_dir.join("src").join("types.bt"),
+            "type Handler = Block | Integer\n",
+        )
+        .unwrap();
+
+        let consumer_dir = root.join("consumer");
+        std::fs::create_dir_all(consumer_dir.join("src")).unwrap();
+        std::fs::write(
+            consumer_dir.join("beamtalk.toml"),
+            "[package]\nname = \"consumer\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\nproducer = { path = \"../producer\" }\n",
+        )
+        .unwrap();
+        let mut source_files = Vec::new();
+        for i in 0..8 {
+            let file = consumer_dir.join("src").join(format!("File{i}.bt"));
+            std::fs::write(
+                &file,
+                format!("Object subclass: File{i}\n  useIt: h :: Handler => h\n"),
+            )
+            .unwrap();
+            source_files.push(camino::Utf8PathBuf::from_path_buf(file).unwrap());
+        }
+
+        let consumer_root = camino::Utf8PathBuf::from_path_buf(consumer_dir.clone()).unwrap();
+
+        // Fake the producer's compiled state so dependency resolution takes
+        // the fresh/no-recompile fast path (mirrors the sibling test above).
+        let layout = crate::commands::build_layout::BuildLayout::new(&consumer_root);
+        let ebin_dir = layout.dep_ebin_dir("producer");
+        std::fs::create_dir_all(&ebin_dir).unwrap();
+        std::fs::write(ebin_dir.join("bt@producer@types.beam"), b"BEAM").unwrap();
+        crate::commands::build_stamp::write_stamp(
+            &layout.dep_stamp_path("producer"),
+            crate::commands::build_stamp::current_otp_version(),
+        );
+
+        let (
+            mut all_class_infos,
+            extension_index,
+            mut all_protocol_infos,
+            mut all_alias_infos,
+            parsed_files,
+        ) = parse_and_extract_class_infos(&source_files, Some(&consumer_root), Some("consumer"))
+            .unwrap();
+        merge_dependency_infos(
+            &consumer_root,
+            &mut all_class_infos,
+            &mut all_protocol_infos,
+            &mut all_alias_infos,
+        );
+        assert_eq!(
+            all_alias_infos
+                .iter()
+                .filter(|a| a.name == "Handler")
+                .count(),
+            1,
+            "the fixture declares Handler exactly once: {all_alias_infos:?}"
+        );
+
+        let mut seen_pre_loaded_alias_collisions = std::collections::HashSet::new();
+        for (_file, _source, module, parse_diags) in parsed_files {
+            let cross_file_classes =
+                beamtalk_core::semantic_analysis::ClassHierarchy::cross_file_class_infos(
+                    &all_class_infos,
+                    &module,
+                );
+            let diags = collect_diagnostics(
+                &module,
+                parse_diags,
+                cross_file_classes,
+                all_protocol_infos.clone(),
+                all_alias_infos.clone(),
+                None,
+                beamtalk_core::semantic_analysis::KnowledgeScope::ProjectComplete,
+                &extension_index,
+                true,
+                Some("consumer"),
+            )
+            .into_iter()
+            .filter(|d| dedup_pre_loaded_alias_collision(d, &mut seen_pre_loaded_alias_collisions))
+            .collect::<Vec<_>>();
+
+            assert!(
+                diags
+                    .iter()
+                    .all(|d| !d.message.contains("collides with another type alias")),
+                "a once-declared dependency alias must never be flagged as colliding: {diags:?}"
+            );
+        }
+    }
+
+    /// BT-3043 (acceptance criterion): when two pre-loaded aliases *do*
+    /// genuinely collide, `run_lint`'s per-file loop must report that
+    /// collision once for the whole run, not once per file — `add_pre_loaded`
+    /// rediscovers the same collision on every file (a fresh `AliasRegistry`
+    /// seeded from the same list each time), so without `run_lint`'s own
+    /// cross-file dedup the user would see the same diagnostic N times for
+    /// an N-file project.
+    #[test]
+    fn dedup_pre_loaded_alias_collision_keeps_only_the_first_sighting_across_simulated_files() {
+        use beamtalk_core::source_analysis::{Diagnostic, DiagnosticCategory, Span};
+
+        let collision = |span: Span| {
+            Diagnostic::error(
+                "Pre-loaded type alias `Id` collides with another type alias of the same name",
+                span,
+            )
+            .with_category(DiagnosticCategory::Type)
+        };
+
+        let mut seen = std::collections::HashSet::new();
+        // Same collision, rediscovered on 5 simulated files (byte-identical
+        // message + span, exactly as `add_pre_loaded` would re-emit it).
+        let kept: Vec<bool> = (0..5)
+            .map(|_| dedup_pre_loaded_alias_collision(&collision(Span::new(10, 12)), &mut seen))
+            .collect();
+
+        assert_eq!(
+            kept,
+            vec![true, false, false, false, false],
+            "only the first sighting of a given collision should survive"
+        );
+    }
+
+    #[test]
+    fn dedup_pre_loaded_alias_collision_never_drops_unrelated_diagnostics() {
+        use beamtalk_core::source_analysis::{Diagnostic, Span};
+
+        let mut seen = std::collections::HashSet::new();
+        // Two ordinary (non-"Pre-loaded type alias") diagnostics that happen
+        // to share message text and span across two simulated files — these
+        // are file-specific by construction and must never be deduped away.
+        let unrelated = Diagnostic::error("Unresolved class `Foo`", Span::new(5, 8));
+        assert!(dedup_pre_loaded_alias_collision(&unrelated, &mut seen));
+        assert!(dedup_pre_loaded_alias_collision(&unrelated, &mut seen));
     }
 
     /// BT-2027: `collect_package_class_files` must dedup across the absolute

--- a/crates/beamtalk-cli/src/diagnostic.rs
+++ b/crates/beamtalk-cli/src/diagnostic.rs
@@ -74,15 +74,26 @@ impl CompileDiagnostic {
             msg
         };
 
+        // BT-3043: A diagnostic's span is not always guaranteed to describe
+        // an offset within *this* file's buffer — e.g. a cross-package alias
+        // collision diagnostic carries the span of the pre-loaded alias's
+        // declaration site, which belongs to whichever file originally
+        // declared it, not the file currently being rendered. Rendering such
+        // a span unclamped crashes miette's snippet extraction with an
+        // `OutOfBounds` read (or worse, silently renders a garbled snippet
+        // from unrelated bytes that happen to fall in range). Clamp to the
+        // buffer length, mirroring the `.min(source.len())` guard already
+        // used for note spans above.
+        let start = (diagnostic.span.start() as usize).min(source.len());
+        let end = (diagnostic.span.end() as usize)
+            .min(source.len())
+            .max(start);
+
         Self {
             severity: diagnostic.severity,
             message,
             src: miette::NamedSource::new(source_path, source.to_string()),
-            span: (
-                diagnostic.span.start() as usize,
-                diagnostic.span.len() as usize,
-            )
-                .into(),
+            span: (start, end - start).into(),
             label: label.to_string(),
             help: diagnostic.hint.as_ref().map(ToString::to_string),
         }
@@ -138,6 +149,37 @@ mod tests {
 
         assert_eq!(diag.span.offset(), 10);
         assert_eq!(diag.span.len(), 0);
+    }
+
+    #[test]
+    fn test_from_core_diagnostic_clamps_span_beyond_source_length() {
+        // BT-3043: a diagnostic whose span was computed against a *different*
+        // file's (longer) source buffer — e.g. a cross-package alias
+        // collision, whose span points into the declaring dependency's file
+        // — must not crash miette's snippet extraction with an `OutOfBounds`
+        // read when rendered against the much shorter buffer of whichever
+        // file is currently being reported on.
+        let core_diag =
+            CoreDiagnostic::error("Pre-loaded type alias collision", Span::new(1556, 1638));
+        let source = "short";
+        let diag = CompileDiagnostic::from_core_diagnostic(&core_diag, "test.bt", source);
+
+        assert!(diag.span.offset() <= source.len());
+        assert!(diag.span.offset() + diag.span.len() <= source.len());
+    }
+
+    #[test]
+    fn test_from_core_diagnostic_clamps_span_partially_beyond_source_length() {
+        // A span that starts in-bounds but ends beyond the buffer (e.g. the
+        // current file happens to be long enough to contain the start
+        // offset but not the whole foreign span) must also clamp cleanly
+        // rather than reporting a length that runs past the buffer.
+        let core_diag = CoreDiagnostic::error("Some diagnostic", Span::new(2, 100));
+        let source = "short";
+        let diag = CompileDiagnostic::from_core_diagnostic(&core_diag, "test.bt", source);
+
+        assert_eq!(diag.span.offset(), 2);
+        assert_eq!(diag.span.len(), source.len() - 2);
     }
 
     #[test]

--- a/crates/beamtalk-core/src/file_walker.rs
+++ b/crates/beamtalk-core/src/file_walker.rs
@@ -121,16 +121,41 @@ impl FileWalker {
 
     /// Preset for collecting `.bt` source files.
     ///
-    /// Recursive, symlink-skipping, sorted, strict errors.
+    /// Recursive, symlink-skipping, sorted, strict errors. Excludes
+    /// `.git`/`target`/`node_modules`/`_build` (BT-3043) — `_build/deps/`
+    /// holds full source checkouts for git/registry dependencies (a path
+    /// dependency's source stays wherever the path points, outside
+    /// `_build`, but a git/registry dependency is cloned straight into
+    /// `_build/deps/<name>/`, `.bt` sources included), so any caller that
+    /// walks a project root or bare directory — `beamtalk lint`,
+    /// `beamtalk build` on a manifest-less directory, dependency-source
+    /// collection when a dependency has no `src/` — would otherwise treat a
+    /// dependency's own vendored sources as first-party project files: lint
+    /// diagnostics against code the user doesn't own, and (for a name that
+    /// also appears in the project's own dependency-exported alias/protocol
+    /// info, seeded independently via the proper dependency-resolution
+    /// path) a spurious duplicate declaration under a different `package`
+    /// stamp, which `AliasRegistry::add_pre_loaded`'s identity check cannot
+    /// recognise as the same physical declaration.
     pub fn source_files() -> Self {
-        Self::new().extensions(&["bt"])
+        Self::new()
+            .extensions(&["bt"])
+            .exclude_dirs(&[".git", "target", "node_modules", "_build"])
     }
 
     /// Preset for collecting `.bt` test files.
     ///
-    /// Same as `source_files()` but excludes `fixtures/`.
+    /// Same as `source_files()` but also excludes `fixtures/`. `exclude_dirs`
+    /// replaces rather than extends the excluded-dir set, so this repeats
+    /// `source_files()`'s list explicitly rather than building on top of it.
     pub fn test_files() -> Self {
-        Self::new().extensions(&["bt"]).exclude_dirs(&["fixtures"])
+        Self::new().extensions(&["bt"]).exclude_dirs(&[
+            ".git",
+            "target",
+            "node_modules",
+            "_build",
+            "fixtures",
+        ])
     }
 
     /// Preset for collecting formattable files (`.bt` and `.btscript`).
@@ -165,9 +190,10 @@ impl FileWalker {
 
     /// Preset for linting `.bt` files.
     ///
-    /// Same as `source_files()` — recursive, sorted, strict errors.
+    /// Same as `source_files()` — recursive, sorted, strict errors,
+    /// excluding `.git`/`target`/`node_modules`/`_build`.
     pub fn lint_files() -> Self {
-        Self::new().extensions(&["bt"])
+        Self::source_files()
     }
 
     // ── Walking ─────────────────────────────────────────────────────────
@@ -336,8 +362,36 @@ mod tests {
         assert!(walker.strict_errors);
         assert!(walker.sort);
         assert!(walker.recursive);
-        assert!(walker.excluded_dirs.is_empty());
+        assert!(walker.excluded_dirs.contains(".git"));
+        assert!(walker.excluded_dirs.contains("target"));
+        assert!(walker.excluded_dirs.contains("node_modules"));
+        assert!(walker.excluded_dirs.contains("_build"));
         assert!(walker.max_files.is_none());
+    }
+
+    /// BT-3043: a directory walk over a project root must never treat a
+    /// git/registry dependency's vendored checkout under `_build/deps/` as
+    /// first-party source — see `source_files()`'s doc for the false
+    /// alias-collision/spurious-lint-diagnostic consequences when it does.
+    #[test]
+    fn test_source_files_excludes_build_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = Utf8Path::from_path(dir.path()).unwrap();
+        fs::create_dir_all(dir_path.join("_build").join("deps").join("somedep")).unwrap();
+        fs::write(dir_path.join("a.bt"), "").unwrap();
+        fs::write(
+            dir_path
+                .join("_build")
+                .join("deps")
+                .join("somedep")
+                .join("vendored.bt"),
+            "",
+        )
+        .unwrap();
+
+        let files = FileWalker::source_files().walk(dir_path).unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].as_str().ends_with("a.bt"));
     }
 
     #[test]

--- a/crates/beamtalk-core/src/semantic_analysis/alias_registry.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/alias_registry.rs
@@ -596,6 +596,15 @@ impl AliasRegistry {
                 // whole `AliasInfo` (not just `name`) is deliberate: two
                 // genuinely different aliases that happen to share a name
                 // are extremely unlikely to also share every other field.
+                // (`span` is a byte offset local to whichever file produced
+                // it, not a globally unique id, so in principle two distinct
+                // same-package files could coincidentally declare `Foo` with
+                // identical RHS text at the same offset and be silently
+                // coalesced here instead of flagged — `AliasInfo` has no
+                // file-path field to rule this out precisely. Accepted as a
+                // vanishingly unlikely trade-off against the alternative:
+                // every project with a singly-declared dependency alias
+                // failing lint/build outright.)
                 if existing == &info {
                     continue;
                 }

--- a/crates/beamtalk-core/src/semantic_analysis/alias_registry.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/alias_registry.rs
@@ -581,7 +581,25 @@ impl AliasRegistry {
                 continue;
             }
 
-            if self.aliases.contains_key(&info.name) {
+            if let Some(existing) = self.aliases.get(&info.name) {
+                // BT-3043: A pre-loaded batch can legitimately contain the
+                // *same* declaration more than once — e.g. a dependency
+                // reachable via more than one path through the project's
+                // merged class/protocol/alias info lists (callers like
+                // `beamtalk lint`/`beamtalk build` simply concatenate
+                // same-package and dependency-exported sources with no
+                // dedup — see `collect_all_alias_infos`'s doc). Re-seeding
+                // the identical declaration (same name, RHS, internal flag,
+                // package, and source span) is idempotent, not a namespace
+                // collision — only a *different* declaration of the same
+                // name is a real collision worth diagnosing. Comparing the
+                // whole `AliasInfo` (not just `name`) is deliberate: two
+                // genuinely different aliases that happen to share a name
+                // are extremely unlikely to also share every other field.
+                if existing == &info {
+                    continue;
+                }
+
                 diagnostics.push(
                     Diagnostic::error(
                         format!(
@@ -2355,6 +2373,42 @@ mod tests {
             registry.get("Id").unwrap().annotation,
             TypeAnnotation::Simple(ident("String"))
         );
+    }
+
+    #[test]
+    fn add_pre_loaded_does_not_flag_a_duplicate_seed_of_the_same_declaration_as_a_collision() {
+        // BT-3043: `beamtalk lint`/`beamtalk build` merge same-package and
+        // dependency-exported alias infos via plain concatenation (see
+        // `collect_all_alias_infos`'s doc in `build.rs`) with no dedup —
+        // callers rely on `add_pre_loaded` itself to tell a namespace
+        // collision (two *different* declarations of the same name) apart
+        // from the *same* declaration reaching the seed list more than once
+        // (e.g. a dependency reachable through more than one path). Only the
+        // former is a real collision; re-seeding an identical `AliasInfo`
+        // (same name, RHS, internal flag, package, and span) must be a
+        // silent no-op.
+        let hierarchy = ClassHierarchy::with_builtins();
+        let protocol_registry = ProtocolRegistry::new();
+        let mut registry = AliasRegistry::new();
+
+        let declared_once = alias_info_with_package(
+            "HTTPHandlerLike",
+            TypeAnnotation::Simple(ident("Block")),
+            false,
+            Some("http"),
+        );
+        let diags = registry.add_pre_loaded(
+            vec![declared_once.clone(), declared_once],
+            &hierarchy,
+            &protocol_registry,
+            Some("consumer"),
+        );
+
+        assert!(
+            diags.is_empty(),
+            "re-seeding the identical declaration must not be reported as a collision: {diags:?}"
+        );
+        assert!(registry.has_alias("HTTPHandlerLike"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://linear.app/beamtalk/issue/BT-3043

## Summary

`beamtalk lint` was reporting a false "Pre-loaded type alias collides with another type alias of the same name" diagnostic once per file in a project (~110 diagnostics for a 110-file project), for an alias declared exactly once in the whole dependency tree — most with garbled/`OutOfBounds` source-snippet rendering.

**Root cause:** `beamtalk lint`'s directory walk (`FileWalker::source_files()`) didn't exclude `_build/`. A git/registry dependency is cloned straight into `_build/deps/<name>/` (sources included, unlike a path dependency whose source stays outside `_build`), so lint was treating a dependency's own vendored `.bt` files as first-party project source — linting them directly, and re-extracting their type-alias declarations a second time stamped with the *consuming* project's package name. That duplicate then collided with the same declaration merged in correctly (stamped with the dependency's own package) via the normal dependency-resolution path.

## Changes

- `crates/beamtalk-core/src/file_walker.rs` — exclude `.git`/`target`/`node_modules`/`_build` from `source_files()`/`lint_files()`/`test_files()`, mirroring the existing `preload_files()` precedent (this is the actual fix for the reported bug).
- `crates/beamtalk-core/src/semantic_analysis/alias_registry.rs` — `AliasRegistry::add_pre_loaded` now treats re-seeding a *structurally identical* alias declaration as a no-op instead of a namespace collision (defense in depth against any other source of list-level duplication).
- `crates/beamtalk-cli/src/commands/lint.rs` — dedupe repeat sightings of a *genuine* cross-package alias collision across the whole lint run instead of once per file.
- `crates/beamtalk-cli/src/diagnostic.rs` — clamp diagnostic spans to the current file's buffer length before rendering, so a diagnostic whose span belongs to a different file can no longer crash miette's snippet extraction with `OutOfBounds`.
- `crates/beamtalk-cli/src/commands/doc/extractor.rs` — simplified now that the underlying `_build` exclusion lives in `FileWalker::source_files()` itself.

## Test plan

- [x] `just ci-changed` passes (build, clippy, fmt, Rust/stdlib/BUnit/runtime tests, corpus check, surface-parity check)
- [x] New regression tests: `FileWalker` excludes `_build`; `AliasRegistry::add_pre_loaded` doesn't flag a duplicate re-seed as a collision; `beamtalk lint` end-to-end tests for both a singly-declared dependency alias (no false positive) and a genuine cross-package collision (reported exactly once, not once per file); `collect_lint_files` excludes a vendored dependency checkout under `_build/deps/`; diagnostic span clamping.
- [x] Manually reproduced the original bug shape (a project with a dependency whose checkout sits under `_build/deps/`) against the pre-fix and post-fix binaries to confirm the fix closes it.

Filed BT-3044 as a follow-up: `beamtalk build` has the identical "genuine collision reported once per compiled file" issue that this PR fixes for `beamtalk lint`, unaddressed here (lower-impact due to incremental compilation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)