### PR TITLE
refactor: add Severity::as_str() to eliminate duplicated match

### DIFF
--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -2092,12 +2092,7 @@ fn handle_diagnostics(request: &Map) -> Term {
 fn diag_info(d: &beamtalk_core::source_analysis::Diagnostic) -> DiagInfo {
     DiagInfo {
         message: d.message.to_string(),
-        severity: match d.severity {
-            beamtalk_core::source_analysis::Severity::Error => "error".to_string(),
-            beamtalk_core::source_analysis::Severity::Warning => "warning".to_string(),
-            beamtalk_core::source_analysis::Severity::Lint => "lint".to_string(),
-            beamtalk_core::source_analysis::Severity::Hint => "hint".to_string(),
-        },
+        severity: d.severity.as_str().to_string(),
         category: diag_category(d),
         start: d.span.start(),
         end: d.span.end(),

--- a/crates/beamtalk-core/src/source_analysis/parser/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/mod.rs
@@ -707,6 +707,19 @@ pub enum Severity {
     Hint,
 }
 
+impl Severity {
+    /// Canonical lowercase string for this severity level.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+            Severity::Lint => "lint",
+            Severity::Hint => "hint",
+        }
+    }
+}
+
 /// Maximum nesting depth for expressions before the parser bails out.
 ///
 /// Prevents stack overflow on deeply nested input (e.g., `(((((...)))))`).


### PR DESCRIPTION
## Summary

- Add `Severity::as_str() -> &'static str` to `beamtalk-core`, following the established `MethodSide::as_str()` and `DiagCategory::as_str()` pattern
- Simplify `diag_info()` in `beamtalk-compiler-port` from a 4-arm match to `d.severity.as_str().to_string()`

## Context

`Severity` was the only core diagnostic enum without a canonical string conversion, so callers had to independently write the same 4-arm match. `beamtalk-compiler-port/src/main.rs:2095–2099` duplicated the full mapping verbatim. Two other sites (`main.rs:946` and `beamtalk-mcp/src/server.rs:2816`) have intentionally *different* mappings (collapsing `Warning|Lint` → `"warning"`) and are left untouched — `as_str()` adds the canonical truth without forcing those callers to change.

Adding `as_str()` means a future new `Severity` variant will produce a compile error at every consumer, preventing silent drift.

## Changes

| File | Change |
|---|---|
| `crates/beamtalk-core/src/source_analysis/parser/mod.rs` | Add `impl Severity { pub const fn as_str(self) -> &'static str }` |
| `crates/beamtalk-compiler-port/src/main.rs` | Replace 5-line match in `diag_info()` with `d.severity.as_str().to_string()` |

**Diff:** 14 additions, 6 deletions. Zero behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmBSLEP85x8HXnLYN6ptcT)_