### PR TITLE
test: tighten placeholder assertions for >> returns in repl_inline_class_superclass_index

### DIFF
--- a/tests/repl-protocol/cases/repl_inline_class_superclass_index.btscript
+++ b/tests/repl-protocol/cases/repl_inline_class_superclass_index.btscript
@@ -28,10 +28,10 @@ Shape subclass: Triangle
 // => Triangle
 
 Triangle >> base => self.base
-// => _
+// => Triangle>>base
 
 Triangle >> area => self.base * self.base / 2.0
-// => _
+// => Triangle>>area
 
 // ===========================================================================
 // VERIFY VALUE-OBJECT BEHAVIOUR


### PR DESCRIPTION
## Summary

- Replaces two `// => _` wildcard assertions with their deterministic expected values in `tests/repl-protocol/cases/repl_inline_class_superclass_index.btscript`.
- The `>>` method-addition operator always returns `ClassName>>selector` — proven by 7 existing examples across `adr_0105_killer_demo.btscript` and `class_builder_capstone.btscript`.
- Lines changed: 31 (`Triangle >> base =>`) and 34 (`Triangle >> area =>`).

## Changes

```
- // => _
+ // => Triangle>>base

- // => _
+ // => Triangle>>area
```

## Why this is safe

The test's intent is unchanged — it verifies that inline subclass method additions compile and run correctly. Tightening the assertions from wildcard to the real return value makes the test stricter without modifying what it exercises. No other files are touched.

## Evidence for the expected values

| File | Expression | Assertion |
|------|-----------|-----------|
| `adr_0105_killer_demo.btscript` | `KillerDemoCounter >> getCount -> Integer => ...` | `// => KillerDemoCounter>>getCount` |
| `adr_0105_killer_demo.btscript` | `KillerDemoCounter >> cleanup => ...` | `// => KillerDemoCounter>>cleanup` |
| `class_builder_capstone.btscript` | `CapstoneLive class >> greeting => ...` | `// => CapstoneLive>>greeting` |
| `class_builder_capstone.btscript` | `CapstoneLive class >> answer => 42` | `// => CapstoneLive>>answer` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3SEJPfhbSC4fNUXcfTaF4)_