### PR TITLE
refactor(cli): extract validate_module_name and write_core_erlang_bytes helpers

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -100,6 +100,22 @@ pub(crate) fn is_valid_module_name(name: &str) -> bool {
             .all(|c| c == '_' || c == '@' || c.is_ascii_alphanumeric())
 }
 
+fn validate_module_name(name: &str) -> Result<()> {
+    if !is_valid_module_name(name) {
+        miette::bail!(
+            "Invalid module name '{}': must be non-empty and contain only alphanumeric characters, underscores, and @",
+            name
+        );
+    }
+    Ok(())
+}
+
+fn write_core_erlang_bytes(bytes: impl AsRef<[u8]>, output_path: &Utf8Path) -> Result<()> {
+    std::fs::write(output_path, bytes)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Failed to write Core Erlang to '{output_path}'"))
+}
+
 /// BEAM bytecode compiler.
 ///
 /// Handles compilation of Core Erlang to BEAM bytecode using the embedded
@@ -596,15 +612,8 @@ pub fn write_core_erlang_with_source(
     output_path: &Utf8Path,
     source_text: Option<&str>,
 ) -> Result<()> {
-    // Validate module name to prevent path traversal and injection
-    if !is_valid_module_name(module_name) {
-        miette::bail!(
-            "Invalid module name '{}': must be non-empty and contain only alphanumeric characters, underscores, and @",
-            module_name
-        );
-    }
+    validate_module_name(module_name)?;
 
-    // Generate Core Erlang
     let core_erlang = beamtalk_core::erlang::generate_module(
         module,
         beamtalk_core::erlang::CodegenOptions::new(module_name)
@@ -618,12 +627,7 @@ pub fn write_core_erlang_with_source(
     .into_diagnostic()
     .wrap_err("Failed to generate Core Erlang")?;
 
-    // Write to file
-    std::fs::write(output_path, core_erlang)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("Failed to write Core Erlang to '{output_path}'"))?;
-
-    Ok(())
+    write_core_erlang_bytes(&core_erlang, output_path)
 }
 
 /// Cross-file class hierarchy data needed during compilation.
@@ -719,12 +723,7 @@ pub fn write_core_erlang_with_bindings(
     source: Option<(&str, Option<&str>)>,
     native_type_registry: Option<std::sync::Arc<NativeTypeRegistry>>,
 ) -> Result<()> {
-    if !is_valid_module_name(module_name) {
-        miette::bail!(
-            "Invalid module name '{}': must be non-empty and contain only alphanumeric characters, underscores, and @",
-            module_name
-        );
-    }
+    validate_module_name(module_name)?;
 
     let (source_text, source_path) = match source {
         Some((text, path)) => (Some(text), path),
@@ -758,11 +757,7 @@ pub fn write_core_erlang_with_bindings(
     .into_diagnostic()
     .wrap_err("Failed to generate Core Erlang")?;
 
-    std::fs::write(output_path, core_erlang)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("Failed to write Core Erlang to '{output_path}'"))?;
-
-    Ok(())
+    write_core_erlang_bytes(&core_erlang, output_path)
 }
 
 /// Compiles a Beamtalk source file (.bt) to Core Erlang (.core).


### PR DESCRIPTION
## Summary

- Extract `validate_module_name` private helper to consolidate the module-name validation bail shared by `write_core_erlang_with_source` and `write_core_erlang_with_bindings`
- Extract `write_core_erlang_bytes` private helper to consolidate the `fs::write` + diagnostic-mapping tail shared by the same two functions
- No behaviour change; both callers now delegate to a single enforcement point

## Motivation

Both functions contained identical copy-pasted blocks:

**Validation bail** (previously at lines 600–605 and 722–727):
```rust
if !is_valid_module_name(module_name) {
    miette::bail!("Invalid module name '{}': ...", module_name);
}
```

**File-write tail** (previously at lines 622–624 and 761–763):
```rust
std::fs::write(output_path, core_erlang)
    .into_diagnostic()
    .wrap_err_with(|| format!("Failed to write Core Erlang to '{output_path}'"))?;
Ok(())
```

With the helpers in place, the validation constraint ("no dots, no special chars") and the error message format live in exactly one place. A future change to either (e.g. adding a new allowed character, or switching the write to an atomic rename) touches one line instead of two.

## Files changed

- `crates/beamtalk-cli/src/beam_compiler.rs` — two new private helpers; two callers updated

## Test plan

- [x] `cargo clippy --package beamtalk-cli` — clean (no new warnings)
- [x] `cargo test --package beamtalk-cli -- beam_compiler` — 31 passed, 0 failed (covers `test_write_core_erlang_invalid_module_name` and `test_write_core_erlang`)
- [x] Pre-push hooks (clippy, fmt, Dialyzer, stdlib build, spec validation, Elixir checks) — all passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFSVqQJG2xPyt5BeUM8HTK)_