### PR TITLE
test(codegen): pin foreign extension registration codegen

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -6278,3 +6278,100 @@ fn test_bt_2998_opaque_native_class_registers_as_non_constructible() {
         "opaque native class must register isConstructible => false. Got:\n{code}"
     );
 }
+
+// ── Foreign cross-class extension codegen (gen_server/extensions.rs) ──────
+
+/// BT-2250: A unary foreign extension on a stdlib value class generates a
+/// `beamtalk_extensions:register/5` call with a 2-arity fun.
+///
+/// The target class (`String`) is not declared in this module, so the
+/// standalone method is foreign and must be registered at load time.
+#[test]
+fn test_foreign_extension_unary_emits_register_with_2arity_fun() {
+    let src = "String >> shout => self uppercase ++ \"!\"\n";
+    let code = super::codegen(src);
+    assert!(
+        code.contains("call 'beamtalk_extensions':'register'"),
+        "foreign extension should emit beamtalk_extensions:register. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'String'"),
+        "foreign extension should register under the bare class name 'String'. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'shout'"),
+        "foreign extension should register the selector atom. Got:\n{code}"
+    );
+    // Value-type targets use a 2-arity fun (ExtArgs + Self).
+    assert!(
+        code.contains("fun (_ExtArgs, Self)"),
+        "value-type foreign extension fun must be 2-arity. Got:\n{code}"
+    );
+    assert!(
+        !code.contains("fun (_ExtArgs, Self, State)"),
+        "value-type foreign extension must NOT use the 3-arity actor fun shape. Got:\n{code}"
+    );
+}
+
+/// BT-2250: A keyword foreign extension generates `_ExtArgs` list unpacking
+/// for each declared parameter.
+#[test]
+fn test_foreign_extension_keyword_unpacks_ext_args() {
+    let src = "String >> wrapWith: edge => edge ++ self ++ edge\n";
+    let code = super::codegen(src);
+    assert!(
+        code.contains("call 'beamtalk_extensions':'register'"),
+        "keyword foreign extension should emit register. Got:\n{code}"
+    );
+    assert!(
+        code.contains("_ExtArgs"),
+        "keyword foreign extension should reference _ExtArgs for parameter unpacking. Got:\n{code}"
+    );
+    // The first (and only) parameter is bound via erlang:hd(_ExtArgs).
+    assert!(
+        code.contains("'erlang':'hd'"),
+        "first keyword parameter must be bound via erlang:hd(_ExtArgs). Got:\n{code}"
+    );
+}
+
+/// BT-2250: A class-side foreign extension (`Target class >> sel`) registers
+/// under the metaclass tag `'Target class'` (with a space), not the bare class
+/// name. This is the established tag convention for metaclass registration.
+#[test]
+fn test_foreign_extension_class_side_uses_metaclass_tag() {
+    let src = "String class >> banner => \"=== banner ===\"\n";
+    let code = super::codegen(src);
+    assert!(
+        code.contains("call 'beamtalk_extensions':'register'"),
+        "class-side foreign extension should emit register. Got:\n{code}"
+    );
+    // Metaclass tag uses a space: 'String class' (not 'Stringclass' or 'String').
+    assert!(
+        code.contains("'String class'"),
+        "class-side extension must use the metaclass tag 'String class'. Got:\n{code}"
+    );
+    assert!(
+        code.contains("'banner'"),
+        "class-side extension should register the selector atom. Got:\n{code}"
+    );
+}
+
+/// BT-2250: A self-extension (target class declared in the same module) is
+/// folded into the host class module and must NOT emit a
+/// `beamtalk_extensions:register` call.
+#[test]
+fn test_self_extension_not_registered_via_beamtalk_extensions() {
+    let src = concat!(
+        "Actor subclass: Counter\n",
+        "  state: value = 0\n",
+        "  get => value\n",
+        "\n",
+        "Counter >> getDouble => value * 2\n",
+    );
+    let code = super::codegen(src);
+    assert!(
+        !code.contains("call 'beamtalk_extensions':'register'"),
+        "self-extension (Counter >> in the same module as Counter) must NOT emit \
+         beamtalk_extensions:register. Got:\n{code}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add 4 Rust unit tests in `crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs` that exercise `gen_server/extensions.rs`, which had **zero prior test coverage**
- The gen_server module aggregate sits at 71%; this PR closes the gap for the foreign extension registration code path that generates `beamtalk_extensions:register/5` calls

## What is being tested

`gen_server/extensions.rs` generates load-time registration calls for foreign class extension methods — `TargetClass >> selector => body` where the target class is declared in stdlib or another file. Before this PR, regressions in the generated fun arity, the metaclass tag for class-side extensions, or the self-extension exclusion logic would only surface at runtime.

Tests added:

| Test | Code path |
|---|---|
| `test_foreign_extension_unary_emits_register_with_2arity_fun` | `generate_value_extension_fun` — 2-arity `fun (_ExtArgs, Self)` for value-type targets |
| `test_foreign_extension_keyword_unpacks_ext_args` | `bind_extension_params` — `erlang:hd(_ExtArgs)` unpacking for keyword methods |
| `test_foreign_extension_class_side_uses_metaclass_tag` | `extension_class_tag` — `'Target class'` metaclass tag (with space) for `Target class >> sel` |
| `test_self_extension_not_registered_via_beamtalk_extensions` | `foreign_extension_methods` filter — self-extensions excluded, no `register` call emitted |

## Test plan

- [x] `cargo test -p beamtalk-core foreign_extension` — all 3 new tests pass
- [x] `cargo test -p beamtalk-core self_extension` — new test passes
- [x] `cargo test -p beamtalk-core` — all 5429 tests pass, 0 failures
- [x] `cargo clippy -p beamtalk-core --tests` — clean
- [x] Pre-push hooks (clippy, dialyzer, build) — all passed
- No runtime code changed — test-only PR

## Coverage impact

Exercises previously uncovered functions in `gen_server/extensions.rs`:
`foreign_extension_methods`, `has_foreign_extensions`, `generate_foreign_extension_registrations`, `generate_extension_registration`, `generate_value_extension_fun`, `bind_extension_params`, `extension_class_tag`, `extension_owner`, `extension_source_doc`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Acw6chzz2U9paxCR2nCfaQ)_