### PR TITLE
Route shared String/Binary selectors straight to bt@stdlib@binary (BT-3049)

### DIFF
--- a/crates/beamtalk-cli/src/commands/build_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/build_stdlib.rs
@@ -2936,7 +2936,7 @@ mod tests {
     ///
     /// BT-3049: this only sees overrides made by editing `Binary.bt`/`String.bt`
     /// directly — it has no visibility into selectors added via the `extend`
-    /// mechanism (ADR 0005), which lives in separate extension sources, not the
+    /// mechanism (ADR 0066), which lives in separate extension sources, not the
     /// class bodies this test parses. That's a known, currently-low-risk gap
     /// (an `extend` can't override a class-body-defined method per ADR 0066, and
     /// `beamtalk_primitive:module_for_value/2` separately checks the extension

--- a/crates/beamtalk-cli/src/commands/build_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/build_stdlib.rs
@@ -2933,6 +2933,15 @@ mod tests {
     /// drifts from the hardcoded Erlang list, so a future edit to either file
     /// that changes the override relationship is caught here instead of
     /// silently reintroducing BT-2999-style misdispatch.
+    ///
+    /// BT-3049: this only sees overrides made by editing `Binary.bt`/`String.bt`
+    /// directly — it has no visibility into selectors added via the `extend`
+    /// mechanism (ADR 0005), which lives in separate extension sources, not the
+    /// class bodies this test parses. That's a known, currently-low-risk gap
+    /// (an `extend` can't override a class-body-defined method per ADR 0066, and
+    /// `beamtalk_primitive:module_for_value/2` separately checks the extension
+    /// registry at runtime for `String`-side overrides), not a guarantee this
+    /// test makes today.
     #[test]
     fn test_binary_string_shared_selectors_stay_in_sync() {
         let root = project_root();

--- a/docs/development/benchmarks.md
+++ b/docs/development/benchmarks.md
@@ -683,5 +683,5 @@ a large fraction of a small number, not a large fraction of the whole path.
 now returns `'bt@stdlib@binary'` directly (see `beamtalk_primitive.erl`'s
 doc comment on `module_for_value/2` for the ADR 0066 argument this relies
 on). `test_binary_string_shared_selectors_stay_in_sync` gained a note that
-it can't see `extend`-registered overrides (ADR 0005), documenting the
+it can't see `extend`-registered overrides (ADR 0066), documenting the
 guarantee boundary the issue asked for.

--- a/docs/development/benchmarks.md
+++ b/docs/development/benchmarks.md
@@ -649,3 +649,39 @@ fragility the issue flagged for approach 1 is caught by CI, not left to
 manual vigilance. `class_of/1` and every selector not in the shared set are
 untouched and still pay the full `is_utf8/1` scan, so dispatch stays exactly
 as consistent with `class` as BT-2999 made it.
+
+### Follow-up: route straight to `bt@stdlib@binary` (BT-3049)
+
+BT-3033's initial fast path routed to `'bt@stdlib@string'` for the 9 shared
+selectors. Since none of them are locally defined in `String.bt`, that
+module's compiled `dispatch/3` re-checks `beamtalk_extensions:lookup/2` for
+a `String` extension and then delegates to `'bt@stdlib@binary'` anyway — a
+redundant hop the fast path pays on every shared-selector send. Since all 9
+selectors are locally defined on `Binary`, and ADR 0066 forbids an `extend`
+from overriding a class-body-defined method, `Binary` itself can never have
+a competing extension for one of them — so once the `String`-extension
+check (already required for correctness, see above) passes, routing
+straight to `'bt@stdlib@binary'` is safe and skips that hop entirely.
+
+**Isolated measurement** (`bench_hop/0` in the same escript, 1 MB binary,
+200,000 direct `dispatch/3` calls, no `send/3` wrapper — isolates the hop
+cost from `module_for_value/2`'s own ~40-200 ns of overhead):
+
+| path | us/op |
+|---|---|
+| via `'bt@stdlib@string'` (old: extra hop + extension re-check) | 0.214 |
+| via `'bt@stdlib@binary'` (new: direct) | 0.036 |
+
+**~6x reduction on the isolated hop** — consistent across repeated runs
+(0.21-0.22 vs 0.035-0.04 us/op). In the full `send/3` pipeline (the `after`
+rows in the table above), this shows up as a smaller, noisier effect since
+`module_for_value/2`'s own checks (selector match, `extensions:has`) and
+`send/3`'s dispatch wrapper dominate the ~0.2 us total — the removed hop was
+a large fraction of a small number, not a large fraction of the whole path.
+
+**Decision:** implemented — `module_for_value/2`'s shared-selector branch
+now returns `'bt@stdlib@binary'` directly (see `beamtalk_primitive.erl`'s
+doc comment on `module_for_value/2` for the ADR 0066 argument this relies
+on). `test_binary_string_shared_selectors_stay_in_sync` gained a note that
+it can't see `extend`-registered overrides (ADR 0005), documenting the
+guarantee boundary the issue asked for.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_primitive.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_primitive.erl
@@ -544,10 +544,18 @@ entirely — String and Binary agree on that selector's behaviour regardless
 of which one the value "really" is, so either module answers identically.
 Falls back to `module_for_value/1` (and its UTF-8 scan) for every other
 selector, and for a shared selector that a `String` extension has
-overridden — `'bt@stdlib@string':dispatch/3` checks the extension registry
-*before* delegating to `'bt@stdlib@binary'`, so an unconditional fast path
-would let a String-only extension fire on a genuinely non-UTF-8 receiver
-that `class_of/1` still reports as `Binary` (caught in review).
+overridden — an unconditional fast path would let a String-only extension
+fire on a genuinely non-UTF-8 receiver that `class_of/1` still reports as
+`Binary` (caught in review).
+
+Routes straight to `'bt@stdlib@binary'` rather than `'bt@stdlib@string'`
+(BT-3049): all 9 shared selectors are locally defined on `Binary`, and ADR
+0066 extensions cannot override a class-body-defined method, so `Binary`
+itself can never have a competing extension for one of them — only
+`String`'s extension registry needs checking (done above), and going
+straight to `'bt@stdlib@binary'` skips the redundant hop through
+`'bt@stdlib@string':dispatch/3`, which would otherwise re-check the
+extension registry itself before delegating to `'bt@stdlib@binary'` anyway.
 """.
 -spec module_for_value(term(), atom()) -> atom() | undefined.
 module_for_value(X, Selector) when is_binary(X) ->
@@ -555,7 +563,7 @@ module_for_value(X, Selector) when is_binary(X) ->
         is_string_binary_shared_selector(Selector) andalso
             not beamtalk_extensions:has('String', Selector)
     of
-        true -> 'bt@stdlib@string';
+        true -> 'bt@stdlib@binary';
         false -> module_for_value(X)
     end;
 module_for_value(X, _Selector) ->
@@ -582,23 +590,24 @@ Soundness depends on a codegen invariant, not just name-matching: a selector
 `String.bt` doesn't locally define is never duplicated into
 `'bt@stdlib@string'`'s compiled `dispatch/3`/`has_method/1` — it's compiled
 as a runtime delegation to `'bt@stdlib@binary'`'s implementation instead. So
-routing one of these selectors through `'bt@stdlib@string'` calls the exact
-same code as routing it through `'bt@stdlib@binary'` would, for any binary,
-valid UTF-8 or not — the sync test only needs to track selector *names*
-because the two modules already share the method *body*. If that delegation
-model ever changes (e.g. inherited primitives get inlined/duplicated per
-subclass for a future perf win), this list's safety would need re-deriving
-from semantics again, not just names.
+routing one of these selectors through `'bt@stdlib@string'` would call the
+exact same code as routing it through `'bt@stdlib@binary'` directly — which
+is what `module_for_value/2` does (BT-3049), skipping that redundant
+delegation hop — for any binary, valid UTF-8 or not. The sync test only
+needs to track selector *names* because the two modules already share the
+method *body*. If that delegation model ever changes (e.g. inherited
+primitives get inlined/duplicated per subclass for a future perf win), this
+list's safety would need re-deriving from semantics again, not just names.
 
 This function alone is *not* sufficient to pick the fast path, only a
-necessary precondition: `'bt@stdlib@string':dispatch/3`'s generated fallback
-checks `beamtalk_extensions:lookup/2` for a `String` extension (ADR 0066)
-*before* delegating to `'bt@stdlib@binary'`. A selector in this set with a
-registered `String` extension is no longer "identical either way" — it
-would run String-only logic against a receiver `class_of/1` still reports
-as `Binary`. Callers must additionally check `beamtalk_extensions:has/2`
-(see `module_for_value/2`, the only caller — call this function directly
-elsewhere only if you replicate that check too).
+necessary precondition: since these selectors are locally defined on
+`Binary`, ADR 0066 forbids a competing `Binary` extension for any of them,
+but a `String` extension is legal (they're absent from `String.bt`) and
+would make the selector no longer "identical either way" — it would run
+String-only logic against a receiver `class_of/1` still reports as
+`Binary`. Callers must additionally check `beamtalk_extensions:has/2` for a
+`String` override (see `module_for_value/2`, the only caller — call this
+function directly elsewhere only if you replicate that check too).
 """.
 -spec is_string_binary_shared_selector(atom()) -> boolean().
 is_string_binary_shared_selector('byteAt:') -> true;

--- a/runtime/perf/bench_string_binary_dispatch.escript
+++ b/runtime/perf/bench_string_binary_dispatch.escript
@@ -12,6 +12,13 @@
 %% byte-level selector `byteAt:` sent dynamically, in a loop, to the *same*
 %% >=1 MB untyped binary receiver (the acceptance-criteria scenario: an
 %% N-iteration loop over one large binary is O(N x size) before the fix).
+%%
+%% BT-3049 follow-up: the fast path now routes straight to
+%% 'bt@stdlib@binary' instead of 'bt@stdlib@string', skipping the redundant
+%% hop where bt@stdlib@string's dispatch/3 re-checks the extension registry
+%% before delegating to bt@stdlib@binary anyway. bench_hop/0 isolates that
+%% one hop's cost directly (outside the noise of the full send/3 pipeline,
+%% where it's a small fraction of total overhead).
 -mode(compile).
 
 main(_) ->
@@ -22,8 +29,10 @@ main(_) ->
     lists:foreach(fun(B) -> code:ensure_loaded(list_to_atom(filename:basename(B, ".beam"))) end,
                   filelib:wildcard("apps/beamtalk_stdlib/ebin/bt@stdlib@*.beam")),
     timer:sleep(800),
+    beamtalk_extensions:init(),
     Sizes = [1024, 65536, 1048576],
     lists:foreach(fun bench/1, Sizes),
+    bench_hop(),
     ok.
 
 bench(Size) ->
@@ -74,3 +83,25 @@ run(Label, F, Idx, K) ->
     F(hd(Idx)),
     {Us, _} = timer:tc(fun() -> lists:foreach(F, Idx) end),
     io:format("  ~s ~10.3f us/op~n", [Label, Us / K]).
+
+%% BT-3049: isolates the cost of the redundant module hop the fast path used
+%% to pay before routing directly to bt@stdlib@binary — calls each compiled
+%% module's dispatch/3 directly (no beamtalk_primitive:send/3 wrapper), so
+%% the ~40-200 ns of module_for_value/2's own overhead (selector match,
+%% extensions:has check) doesn't dilute the signal.
+bench_hop() ->
+    K = 200000,
+    Bin = binary:copy(<<"A">>, 1048576),
+    ViaString = fun() -> 'bt@stdlib@string':dispatch('byteAt:', [0], Bin) end,
+    ViaBinary = fun() -> 'bt@stdlib@binary':dispatch('byteAt:', [0], Bin) end,
+    Expected = binary:at(Bin, 0),
+    Expected = ViaString(),
+    Expected = ViaBinary(),
+    io:format("~n=== BT-3049: isolated hop cost (byteAt: on 1 MB binary, ~p calls) ===~n", [K]),
+    run0("via bt@stdlib@string (old: extra hop + re-check)", ViaString, K),
+    run0("via bt@stdlib@binary (new: direct)              ", ViaBinary, K).
+
+run0(Label, F, K) ->
+    F(),
+    {Us, _} = timer:tc(fun() -> lists:foreach(fun(_) -> F() end, lists:seq(1, K)) end),
+    io:format("  ~s ~10.4f us/op~n", [Label, Us / K]).

--- a/runtime/perf/bench_string_binary_dispatch.escript
+++ b/runtime/perf/bench_string_binary_dispatch.escript
@@ -29,6 +29,10 @@ main(_) ->
     lists:foreach(fun(B) -> code:ensure_loaded(list_to_atom(filename:basename(B, ".beam"))) end,
                   filelib:wildcard("apps/beamtalk_stdlib/ebin/bt@stdlib@*.beam")),
     timer:sleep(800),
+    %% Defensive/idempotent: beamtalk_runtime_app's start/2 already calls this,
+    %% but bench_hop/0 calls dispatch/3 directly rather than through send/3,
+    %% so this makes the escript's dependency on the extensions table explicit
+    %% rather than relying on app-startup ordering.
     beamtalk_extensions:init(),
     Sizes = [1024, 65536, 1048576],
     lists:foreach(fun bench/1, Sizes),


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-3049

## Summary

Follow-up from BT-3033's adversarial review (#3227). `beamtalk_primitive:module_for_value/2`'s fast path routed the 9 shared String/Binary selectors (`byteAt:`, `byteSize`, `part:size:`, `concat:`, `toBytes`, `asStringUnchecked`, `asBase64`, `asBase64Url`, `asHex`) to `'bt@stdlib@string'`. Since none of them are locally defined in `String.bt`, that module's compiled `dispatch/3` re-checks the extension registry for a `String` override and then delegates to `'bt@stdlib@binary'` anyway — a redundant hop paid on every shared-selector send.

Since all 9 selectors are locally defined on `Binary`, and ADR 0066 forbids an `extend` from overriding a class-body-defined method, `Binary` itself can never have a competing extension for one of them. So once the (already-required) `String`-extension check passes, routing straight to `'bt@stdlib@binary'` is safe and skips that hop.

## Key changes

- `module_for_value/2` (`runtime/apps/beamtalk_runtime/src/beamtalk_primitive.erl`) now returns `'bt@stdlib@binary'` instead of `'bt@stdlib@string'` for the shared-selector fast path, with doc comments recording the ADR 0066 argument this relies on.
- `test_binary_string_shared_selectors_stay_in_sync` (`crates/beamtalk-cli/src/commands/build_stdlib.rs`) gained a note documenting that it only inspects `Binary.bt`/`String.bt` class bodies, not `extend`-registered overrides (ADR 0005) — the guarantee-boundary documentation the issue asked for.
- `runtime/perf/bench_string_binary_dispatch.escript` gained an isolated hop-cost measurement (`bench_hop/0`), recorded in `docs/development/benchmarks.md`: ~0.214 µs/op via `'bt@stdlib@string'` vs ~0.036 µs/op via `'bt@stdlib@binary'` directly — ~6x on the isolated hop, smaller/noisier in the full `send/3` pipeline where `module_for_value/2`'s own overhead dominates the ~0.2 µs total.

## Test plan

- [x] `just test` — all green except one pre-existing flaky test (`ReactiveSubprocessTest testExitCodePushedToNotify`, a subprocess-notification timing test unrelated to this change; passes cleanly in isolation, confirmed before pushing)
- [x] `cargo test test_binary_string_shared_selectors_stay_in_sync` — passes
- [x] `rebar3 eunit --module=beamtalk_primitive_tests` — 214/214, including the BT-3033 shared-selector and extension-interaction regression tests, unaffected by the routing change
- [x] Benchmark re-run, isolated hop-cost measurement added and recorded in `docs/development/benchmarks.md`
- [x] `just clippy && just fmt-check` — clean

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYHzEMM2sPVK8LtffFrWeg)_