### PR TITLE
Desktop .deb bundle: declare beam.smp's runtime library dependencies (BT-3017)

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -63,6 +63,25 @@ validation` for independently-signed NIFs) to both that pre-pass and the
 top-level app (`bundle.macOS.entitlements`). See the workflow file's header
 comment for the full signing/notarization flow and the required secrets.
 
+On Linux, `bundle.linux.deb.depends` in `tauri.conf.json` declares
+`libssl3t64` — Tauri's generated `.deb` metadata only covers the
+webkit2gtk/gtk3 stack it needs directly, and has no idea the bundled
+`dist-liveview` release also ships a full BEAM release whose `:crypto`
+NIF (`crypto.so`) dynamically links `libcrypto.so.3`. That package name
+and the rest of this list (BT-3017) came from running `ldd` against a real
+`just dist-liveview` build's `erts-*/bin/beam.smp`, `erts-*/bin/epmd`, and
+every NIF `.so` under `lib/*/priv/lib/` on Ubuntu 24.04 (`noble`) — the OS
+`desktop-release.yml`'s `ubuntu-latest` runner used at the time. Every
+other shared-library dependency those binaries have (`libc.so.6`,
+`libm.so.6`, `libgcc_s.so.1`, `libstdc++.so.6`, `libtinfo.so.6`,
+`libz.so.1`) is already pulled in transitively by the webkit2gtk/gtk3/
+appindicator packages Tauri's bundler declares on its own, so they're
+deliberately left off this list rather than declared redundantly. **This
+list needs re-deriving (same `ldd` procedure) if the CI runner's Ubuntu
+version ever changes** — package names and transitive-dependency
+guarantees are specific to `noble`'s package set and aren't guaranteed to
+hold on a future Ubuntu release.
+
 **This packaging lane is unverified for the same reason the app itself is**
 (see below) — no macOS/Tauri toolchain has been available to actually run
 `cargo tauri build` end-to-end here, so it is wired as `workflow_dispatch`/

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -36,6 +36,11 @@
     "resources": {
       "../../dist-liveview": "dist-liveview"
     },
+    "linux": {
+      "deb": {
+        "depends": ["libssl3t64"]
+      }
+    },
     "macOS": {
       "entitlements": "entitlements.plist",
       "hardenedRuntime": true,


### PR DESCRIPTION
## Summary

- Adds `bundle.linux.deb.depends: ["libssl3t64"]` to `desktop/src-tauri/tauri.conf.json` so the desktop `.deb`'s `Depends:` control field declares the bundled `bt_attach` ERTS release's runtime library needs, not just Tauri's own webkit2gtk/gtk3 stack.
- Documents the dependency list's provenance and a re-check note in `desktop/README.md`.

## Why

Tauri's `.deb` bundler only knows about the webview/GTK stack it needs directly — it has no idea `desktop/src-tauri`'s bundled `dist-liveview` resource also ships a full BEAM release (`beam.smp`, `epmd`, NIFs) with its own shared-library requirements. Without an explicit `Depends:` entry, `apt install`/`dpkg -i` succeeds on a system missing those libraries, and the failure only surfaces later when a user tries to attach to a workspace and the bundled `beam.smp`/NIFs can't `dlopen` a required `.so`.

## How this was verified

This session's sandbox happened to match `desktop-release.yml`'s `ubuntu-latest` runner (Ubuntu 24.04 "noble") and had `sudo`, so rather than guessing package names, I did the real investigation:

1. Installed Tauri's documented Linux build prerequisites (same list as the CI workflow).
2. Built the actual `bt_attach` release via `just dist-liveview`.
3. Ran `ldd` against `erts-*/bin/beam.smp`, `erts-*/bin/epmd`, and every NIF `.so` under `lib/*/priv/lib/`.
4. Found only the `:crypto` NIF (`crypto.so`, `otp_test_engine.so`) links anything beyond the base glibc/libstdc++/zlib/libtinfo set: `libcrypto.so.3`, owned by `libssl3t64` on Ubuntu 24.04.
5. Confirmed (`apt-cache depends --recurse`) the base glibc/gcc/stdc++/zlib/tinfo libs are already transitively guaranteed by Tauri's own webkit2gtk/gtk3/appindicator `Depends:` entries, so they're deliberately left off this list.
6. Installed `cargo-tauri` and ran a real `cargo tauri build --bundles deb`, then inspected the output:
   - `dpkg-deb -I` → `Depends: libssl3t64, libwebkit2gtk-4.1-0, libgtk-3-0` (config merged correctly with Tauri's auto-detected deps).
   - `dpkg-deb -c` → confirmed `beam.smp`, `epmd`, and `crypto.so` are genuinely present in the bundle at the expected resource path.

Linear issue: https://linear.app/beamtalk/issue/BT-3017

---
_Generated by [Claude Code](https://claude.ai/code/session_01KouizSnSKciKJCqASd8hKt)_