### PR TITLE
Desktop picker: harden monitor stale-port guard, mutex-poisoning recovery, and frontend refresh debounce (BT-3008)

### DIFF
--- a/crates/beamtalk-desktop-shell/src/attach.rs
+++ b/crates/beamtalk-desktop-shell/src/attach.rs
@@ -77,11 +77,12 @@ enum Slot {
     /// for this workspace and no matching [`AttachManager::record_attached`]
     /// or [`AttachManager::release_claim`] has happened yet — a spawn +
     /// readiness wait is presumed in flight. Carries the generation assigned
-    /// at claim time, so [`AttachManager::record_attached_if_claiming`] can
-    /// tell a live claim from a *different*, newer claim for the same
-    /// workspace (the claim was released and re-claimed while the original
-    /// caller's spawn/probe was still in flight) rather than treating any
-    /// `Claiming` slot as a match for any caller.
+    /// at claim time, so [`AttachManager::record_attached_if_claiming`] and
+    /// [`AttachManager::release_claim`] can each tell a live claim from a
+    /// *different*, newer claim for the same workspace (the claim was
+    /// cleared and re-claimed while the original caller's spawn/probe was
+    /// still in flight) rather than treating any `Claiming` slot as a match
+    /// for any caller.
     Claiming(u64),
     /// A front is attached and its window should already exist.
     Attached(AttachedFront),
@@ -200,11 +201,21 @@ impl AttachManager {
 
     /// Release a claim that didn't pan out (spawn or readiness failed) so
     /// the next attach click is free to try again instead of being stuck
-    /// behind a claim nothing will ever resolve. A no-op if `workspace_id`
-    /// isn't currently claiming (e.g. it was already attached, or already
-    /// released) — safe to call defensively from every failure path.
-    pub fn release_claim(&mut self, workspace_id: &str) {
-        if matches!(self.attached.get(workspace_id), Some(Slot::Claiming(_))) {
+    /// behind a claim nothing will ever resolve. A no-op unless `workspace_id`
+    /// is currently claiming *under this exact `generation`* — mirroring
+    /// [`Self::record_attached_if_claiming`]'s guard, and for the same
+    /// reason: checking only "is *a* claim pending" would let a stale caller
+    /// whose own claim was already cleared (e.g. by a concurrent `remove`)
+    /// clear out a *different*, newer claim that has since replaced it —
+    /// silently undoing another in-flight attach's `AlreadyInFlight`
+    /// protection and letting a third `decide_and_claim` spawn a second
+    /// front for the same workspace while that newer claim is still live.
+    /// Safe to call defensively from every failure path regardless of
+    /// whether `workspace_id` was ever actually claimed under this
+    /// generation, was already attached, or was already released.
+    pub fn release_claim(&mut self, workspace_id: &str, generation: u64) {
+        if matches!(self.attached.get(workspace_id), Some(Slot::Claiming(claimed_generation)) if *claimed_generation == generation)
+        {
             self.attached.remove(workspace_id);
         }
     }
@@ -319,7 +330,7 @@ mod tests {
         // lives.
         let mut manager = AttachManager::new();
         let gen1 = claim(&mut manager, "abc123");
-        manager.release_claim("abc123");
+        manager.release_claim("abc123", gen1);
         let gen2 = claim(&mut manager, "abc123");
         assert_ne!(gen1, gen2);
     }
@@ -367,9 +378,9 @@ mod tests {
     #[test]
     fn release_claim_lets_a_failed_attach_be_retried() {
         let mut manager = AttachManager::new();
-        claim(&mut manager, "abc123");
+        let generation = claim(&mut manager, "abc123");
 
-        manager.release_claim("abc123");
+        manager.release_claim("abc123", generation);
 
         assert!(matches!(
             manager.decide_and_claim("abc123"),
@@ -384,7 +395,7 @@ mod tests {
 
         // Defensive call from a failure path must never undo a real,
         // already-recorded attachment.
-        manager.release_claim("abc123");
+        manager.release_claim("abc123", 0);
 
         assert!(manager.is_attached("abc123"));
     }
@@ -392,8 +403,35 @@ mod tests {
     #[test]
     fn release_claim_of_an_untracked_workspace_is_a_no_op() {
         let mut manager = AttachManager::new();
-        manager.release_claim("nonexistent"); // must not panic
+        manager.release_claim("nonexistent", 0); // must not panic
         assert!(!manager.is_attached("nonexistent"));
+    }
+
+    #[test]
+    fn release_claim_refuses_a_stale_generation_after_re_claim() {
+        // The exact race an adversarial review pass found: caller A claims,
+        // something else (e.g. a concurrent `remove`) clears A's claim
+        // before A's own spawn/probe resolves, caller B then claims fresh
+        // (a new generation) — and A's own failure path *still* calls
+        // `release_claim` with its now-stale generation. Without the
+        // generation check, that stale call would see "some claim is
+        // pending" (true — it's B's) and clear B's live claim out from under
+        // it, letting a third `decide_and_claim` spawn a second front for
+        // this workspace while B's attach is still in flight — silently
+        // defeating the `AttachDecision::AlreadyInFlight` protection.
+        let mut manager = AttachManager::new();
+        let stale_generation = claim(&mut manager, "abc123"); // caller A
+        manager.remove("abc123"); // something clears A's claim
+        let fresh_generation = claim(&mut manager, "abc123"); // caller B, fresh
+        assert_ne!(stale_generation, fresh_generation);
+
+        manager.release_claim("abc123", stale_generation); // A's stale failure path
+
+        assert_eq!(
+            manager.decide_and_claim("abc123"),
+            AttachDecision::AlreadyInFlight,
+            "a stale release_claim must not clear a newer, live claim"
+        );
     }
 
     #[test]

--- a/crates/beamtalk-desktop-shell/src/attach.rs
+++ b/crates/beamtalk-desktop-shell/src/attach.rs
@@ -61,6 +61,11 @@ pub struct AttachedFront {
     pub workspace_id: String,
     pub port: u16,
     pub pid: u32,
+    /// The generation this front was spawned under (assigned by
+    /// [`AttachManager::decide_and_claim`]) — see
+    /// [`AttachManager::is_current_front`] for why a post-attach monitor's
+    /// stop condition must key on this instead of `port`.
+    pub generation: u64,
 }
 
 /// Internal per-workspace bookkeeping state. Not exposed directly — callers
@@ -71,8 +76,13 @@ enum Slot {
     /// [`AttachManager::decide_and_claim`] has handed out [`AttachDecision::Spawn`]
     /// for this workspace and no matching [`AttachManager::record_attached`]
     /// or [`AttachManager::release_claim`] has happened yet — a spawn +
-    /// readiness wait is presumed in flight.
-    Claiming,
+    /// readiness wait is presumed in flight. Carries the generation assigned
+    /// at claim time, so [`AttachManager::record_attached_if_claiming`] can
+    /// tell a live claim from a *different*, newer claim for the same
+    /// workspace (the claim was released and re-claimed while the original
+    /// caller's spawn/probe was still in flight) rather than treating any
+    /// `Claiming` slot as a match for any caller.
+    Claiming(u64),
     /// A front is attached and its window should already exist.
     Attached(AttachedFront),
 }
@@ -84,8 +94,12 @@ pub enum AttachDecision {
     /// No existing or in-flight front for this workspace: spawn one, and the
     /// workspace is now claimed — call [`AttachManager::record_attached`] on
     /// success or [`AttachManager::release_claim`] on failure so the claim
-    /// doesn't linger forever.
-    Spawn,
+    /// doesn't linger forever. `generation` is this claim's generation
+    /// number (see [`AttachManager::is_current_front`]) — carry it through
+    /// to the [`AttachedFront`] passed to `record_attached`/
+    /// `record_attached_if_claiming` on success, and to the post-attach
+    /// monitor's stop-condition check.
+    Spawn { generation: u64 },
     /// A front is already attached: focus/reuse its window rather than
     /// spawning a second one (BT-2984 spike decision).
     FocusExisting { window_id: WindowId, port: u16 },
@@ -103,6 +117,13 @@ pub enum AttachDecision {
 #[derive(Debug, Default)]
 pub struct AttachManager {
     attached: HashMap<String, Slot>,
+    /// Monotonically increasing counter, one new value handed out per
+    /// successful claim (every [`AttachDecision::Spawn`]). Never reused —
+    /// see [`Self::is_current_front`] for why a monitor must be able to tell
+    /// two attach attempts on the same `(workspace_id, port)` pair apart
+    /// even when the OS's ephemeral-port allocator hands back the same port
+    /// number for both.
+    next_generation: u64,
 }
 
 impl AttachManager {
@@ -121,11 +142,13 @@ impl AttachManager {
                 window_id: window_label(workspace_id),
                 port: front.port,
             },
-            Some(Slot::Claiming) => AttachDecision::AlreadyInFlight,
+            Some(Slot::Claiming(_)) => AttachDecision::AlreadyInFlight,
             None => {
+                let generation = self.next_generation;
+                self.next_generation += 1;
                 self.attached
-                    .insert(workspace_id.to_string(), Slot::Claiming);
-                AttachDecision::Spawn
+                    .insert(workspace_id.to_string(), Slot::Claiming(generation));
+                AttachDecision::Spawn { generation }
             }
         }
     }
@@ -140,18 +163,23 @@ impl AttachManager {
     }
 
     /// Like [`Self::record_attached`], but refuses to record if
-    /// `front.workspace_id` is no longer [`Slot::Claiming`] — i.e. a
-    /// concurrent [`Self::remove`] (from `detach`/`quit` racing the tail end
-    /// of this same attach's spawn-and-probe) already cleared the claim out
-    /// from under the caller. Returns `false` in that case so the caller
-    /// (which just finished spawning a process and opening a window) knows
-    /// to tear both back down instead of leaving a ghost [`Slot::Attached`]
-    /// entry for a front nothing supervises anymore: nothing would ever
-    /// clean it up, `is_attached` would wrongly report `true` for this
-    /// workspace forever, and a future attach click would try to
-    /// [`AttachDecision::FocusExisting`] a window that may already be
-    /// closed — a permanently stuck workspace with no way to re-attach short
-    /// of restarting the whole app.
+    /// `front.workspace_id` is no longer [`Slot::Claiming`] *for the same
+    /// generation `front.generation` was claimed under* — i.e. a concurrent
+    /// [`Self::remove`] (from `detach`/`quit` racing the tail end of this
+    /// same attach's spawn-and-probe) already cleared the claim out from
+    /// under the caller, possibly followed by a *fresh* claim (a new
+    /// generation) from a subsequent attach click. Returns `false` in either
+    /// case so the caller (which just finished spawning a process and
+    /// opening a window) knows to tear both back down instead of leaving a
+    /// ghost [`Slot::Attached`] entry for a front nothing supervises
+    /// anymore: nothing would ever clean it up, `is_attached` would wrongly
+    /// report `true` for this workspace forever, and a future attach click
+    /// would try to [`AttachDecision::FocusExisting`] a window that may
+    /// already be closed — a permanently stuck workspace with no way to
+    /// re-attach short of restarting the whole app. Checking the generation
+    /// (not just "is *a* claim still pending") also stops this stale caller
+    /// from clobbering a legitimately newer in-flight claim it knows nothing
+    /// about.
     ///
     /// This is the real-world-reachable race [`Self::record_attached`]'s own
     /// "or, if called without a prior claim, still records" leniency does
@@ -161,7 +189,8 @@ impl AttachManager {
     /// concurrent detach.
     #[must_use]
     pub fn record_attached_if_claiming(&mut self, front: AttachedFront) -> bool {
-        if !matches!(self.attached.get(&front.workspace_id), Some(Slot::Claiming)) {
+        if !matches!(self.attached.get(&front.workspace_id), Some(Slot::Claiming(claimed_generation)) if *claimed_generation == front.generation)
+        {
             return false;
         }
         self.attached
@@ -175,7 +204,7 @@ impl AttachManager {
     /// isn't currently claiming (e.g. it was already attached, or already
     /// released) — safe to call defensively from every failure path.
     pub fn release_claim(&mut self, workspace_id: &str) {
-        if matches!(self.attached.get(workspace_id), Some(Slot::Claiming)) {
+        if matches!(self.attached.get(workspace_id), Some(Slot::Claiming(_))) {
             self.attached.remove(workspace_id);
         }
     }
@@ -187,7 +216,7 @@ impl AttachManager {
     pub fn remove(&mut self, workspace_id: &str) -> Option<AttachedFront> {
         match self.attached.remove(workspace_id) {
             Some(Slot::Attached(front)) => Some(front),
-            Some(Slot::Claiming) | None => None,
+            Some(Slot::Claiming(_)) | None => None,
         }
     }
 
@@ -196,27 +225,31 @@ impl AttachManager {
         matches!(self.attached.get(workspace_id), Some(Slot::Attached(_)))
     }
 
-    /// Is `port` the port of the *currently* attached front for
+    /// Is `generation` the generation of the *currently* attached front for
     /// `workspace_id`? A post-attach monitor loop must use this, not
     /// [`Self::is_attached`], as its stop condition: detach-then-re-attach
-    /// spawns a fresh front on a fresh port (a free-port allocation, not a
-    /// reused one), so an older monitor thread still polling the *old* port
-    /// would otherwise see `is_attached` flip back to `true` for the new
-    /// attachment and wrongly keep running — polling a dead port and
-    /// fighting the new monitor over the same window's title/events. Tying
-    /// the stop condition to the exact `(workspace_id, port)` pair a monitor
-    /// was started for makes a stale monitor recognize its own generation
-    /// has ended, even though the workspace id itself is attached again.
+    /// spawns a fresh front under a fresh generation, so an older monitor
+    /// thread from a prior attach would otherwise see `is_attached` flip
+    /// back to `true` for the new attachment and wrongly keep running.
+    ///
+    /// Keyed on `generation` (assigned by [`Self::decide_and_claim`], never
+    /// reused), not `port`: `port` alone is not a reliable discriminator
+    /// here, because `find_free_port`'s ephemeral-port allocation can — rare
+    /// but not impossible — hand the same port back to a fresh spawn shortly
+    /// after the workspace that used it was detached, at which point a
+    /// stale monitor and the fresh one would become indistinguishable by
+    /// `(workspace_id, port)` alone and both would run forever, polling the
+    /// same port and fighting over the window's title/events.
     #[must_use]
-    pub fn is_current_front(&self, workspace_id: &str, port: u16) -> bool {
-        matches!(self.attached.get(workspace_id), Some(Slot::Attached(front)) if front.port == port)
+    pub fn is_current_front(&self, workspace_id: &str, generation: u64) -> bool {
+        matches!(self.attached.get(workspace_id), Some(Slot::Attached(front)) if front.generation == generation)
     }
 
     #[must_use]
     pub fn get(&self, workspace_id: &str) -> Option<&AttachedFront> {
         match self.attached.get(workspace_id) {
             Some(Slot::Attached(front)) => Some(front),
-            Some(Slot::Claiming) | None => None,
+            Some(Slot::Claiming(_)) | None => None,
         }
     }
 
@@ -228,7 +261,7 @@ impl AttachManager {
             .iter()
             .filter_map(|(id, slot)| match slot {
                 Slot::Attached(_) => Some(id.as_str()),
-                Slot::Claiming => None,
+                Slot::Claiming(_) => None,
             })
             .collect()
     }
@@ -238,11 +271,23 @@ impl AttachManager {
 mod tests {
     use super::*;
 
-    fn front(workspace_id: &str, port: u16) -> AttachedFront {
+    fn front(workspace_id: &str, port: u16, generation: u64) -> AttachedFront {
         AttachedFront {
             workspace_id: workspace_id.to_string(),
             port,
             pid: 4242,
+            generation,
+        }
+    }
+
+    /// `decide_and_claim` and unwrap the resulting generation, panicking if
+    /// the decision wasn't `Spawn` — a test helper for the common case where
+    /// a test just needs a fresh claim's generation number, not the
+    /// decision itself.
+    fn claim(manager: &mut AttachManager, workspace_id: &str) -> u64 {
+        match manager.decide_and_claim(workspace_id) {
+            AttachDecision::Spawn { generation } => generation,
+            other => panic!("expected AttachDecision::Spawn, got {other:?}"),
         }
     }
 
@@ -260,7 +305,23 @@ mod tests {
     #[test]
     fn decide_and_claim_spawns_when_nothing_tracked() {
         let mut manager = AttachManager::new();
-        assert_eq!(manager.decide_and_claim("abc123"), AttachDecision::Spawn);
+        assert_eq!(
+            manager.decide_and_claim("abc123"),
+            AttachDecision::Spawn { generation: 0 }
+        );
+    }
+
+    #[test]
+    fn decide_and_claim_assigns_a_fresh_generation_per_claim() {
+        // Consecutive claims (even for different workspaces) must never
+        // reuse a generation number — the monitor stale-port guard depends
+        // on generations being unique for as long as this AttachManager
+        // lives.
+        let mut manager = AttachManager::new();
+        let gen1 = claim(&mut manager, "abc123");
+        manager.release_claim("abc123");
+        let gen2 = claim(&mut manager, "abc123");
+        assert_ne!(gen1, gen2);
     }
 
     #[test]
@@ -270,7 +331,7 @@ mod tests {
         // second, before any record_attached/release_claim, must not also
         // get Spawn.
         let mut manager = AttachManager::new();
-        assert_eq!(manager.decide_and_claim("abc123"), AttachDecision::Spawn);
+        claim(&mut manager, "abc123");
         assert_eq!(
             manager.decide_and_claim("abc123"),
             AttachDecision::AlreadyInFlight
@@ -280,7 +341,7 @@ mod tests {
     #[test]
     fn decide_and_claim_focuses_the_existing_window_on_a_second_attach() {
         let mut manager = AttachManager::new();
-        manager.record_attached(front("abc123", 4567));
+        manager.record_attached(front("abc123", 4567, 0));
 
         assert_eq!(
             manager.decide_and_claim("abc123"),
@@ -294,26 +355,32 @@ mod tests {
     #[test]
     fn decide_and_claim_is_scoped_per_workspace() {
         let mut manager = AttachManager::new();
-        manager.record_attached(front("abc123", 4567));
+        manager.record_attached(front("abc123", 4567, 0));
 
         // A different, never-attached workspace still spawns.
-        assert_eq!(manager.decide_and_claim("def456"), AttachDecision::Spawn);
+        assert!(matches!(
+            manager.decide_and_claim("def456"),
+            AttachDecision::Spawn { .. }
+        ));
     }
 
     #[test]
     fn release_claim_lets_a_failed_attach_be_retried() {
         let mut manager = AttachManager::new();
-        assert_eq!(manager.decide_and_claim("abc123"), AttachDecision::Spawn);
+        claim(&mut manager, "abc123");
 
         manager.release_claim("abc123");
 
-        assert_eq!(manager.decide_and_claim("abc123"), AttachDecision::Spawn);
+        assert!(matches!(
+            manager.decide_and_claim("abc123"),
+            AttachDecision::Spawn { .. }
+        ));
     }
 
     #[test]
     fn release_claim_does_not_clear_a_real_attachment() {
         let mut manager = AttachManager::new();
-        manager.record_attached(front("abc123", 4567));
+        manager.record_attached(front("abc123", 4567, 0));
 
         // Defensive call from a failure path must never undo a real,
         // already-recorded attachment.
@@ -332,23 +399,26 @@ mod tests {
     #[test]
     fn record_attached_resolves_a_prior_claim() {
         let mut manager = AttachManager::new();
-        assert_eq!(manager.decide_and_claim("abc123"), AttachDecision::Spawn);
+        claim(&mut manager, "abc123");
 
-        manager.record_attached(front("abc123", 4567));
+        manager.record_attached(front("abc123", 4567, 0));
 
         assert!(manager.is_attached("abc123"));
-        assert_eq!(manager.get("abc123"), Some(&front("abc123", 4567)));
+        assert_eq!(manager.get("abc123"), Some(&front("abc123", 4567, 0)));
     }
 
     #[test]
     fn record_attached_if_claiming_succeeds_and_resolves_a_live_claim() {
         let mut manager = AttachManager::new();
-        assert_eq!(manager.decide_and_claim("abc123"), AttachDecision::Spawn);
+        let generation = claim(&mut manager, "abc123");
 
-        assert!(manager.record_attached_if_claiming(front("abc123", 4567)));
+        assert!(manager.record_attached_if_claiming(front("abc123", 4567, generation)));
 
         assert!(manager.is_attached("abc123"));
-        assert_eq!(manager.get("abc123"), Some(&front("abc123", 4567)));
+        assert_eq!(
+            manager.get("abc123"),
+            Some(&front("abc123", 4567, generation))
+        );
     }
 
     #[test]
@@ -358,10 +428,10 @@ mod tests {
         // racing the tail end of this same attach's spawn-and-probe) clears
         // the claim before the in-flight attach gets to record success.
         let mut manager = AttachManager::new();
-        assert_eq!(manager.decide_and_claim("abc123"), AttachDecision::Spawn);
+        let generation = claim(&mut manager, "abc123");
         manager.remove("abc123"); // simulates the racing detach/quit
 
-        assert!(!manager.record_attached_if_claiming(front("abc123", 4567)));
+        assert!(!manager.record_attached_if_claiming(front("abc123", 4567, generation)));
         assert!(
             !manager.is_attached("abc123"),
             "a refused record must not leave a ghost Attached entry"
@@ -369,9 +439,30 @@ mod tests {
     }
 
     #[test]
+    fn record_attached_if_claiming_refuses_a_stale_generation_after_re_claim() {
+        // Stronger than the plain "claim was cleared" race above: the claim
+        // wasn't merely cleared, it was cleared *and* re-claimed (a fresh
+        // generation) before the original, now-stale caller's
+        // record_attached_if_claiming lands. The stale caller must not be
+        // able to clobber the newer claim just because *some* claim is
+        // still pending.
+        let mut manager = AttachManager::new();
+        let stale_generation = claim(&mut manager, "abc123");
+        manager.remove("abc123"); // simulates the racing detach/quit
+        let fresh_generation = claim(&mut manager, "abc123"); // a new attach click re-claims
+        assert_ne!(stale_generation, fresh_generation);
+
+        assert!(!manager.record_attached_if_claiming(front("abc123", 4567, stale_generation)));
+        assert!(
+            !manager.is_attached("abc123"),
+            "a refused stale record must not clobber the newer live claim"
+        );
+    }
+
+    #[test]
     fn record_attached_if_claiming_refuses_when_nothing_was_ever_claimed() {
         let mut manager = AttachManager::new();
-        assert!(!manager.record_attached_if_claiming(front("abc123", 4567)));
+        assert!(!manager.record_attached_if_claiming(front("abc123", 4567, 0)));
         assert!(!manager.is_attached("abc123"));
     }
 
@@ -383,54 +474,58 @@ mod tests {
         // method only ever resolves a `Claiming` slot, never overwrites an
         // existing real attachment the way `record_attached` will.
         let mut manager = AttachManager::new();
-        manager.record_attached(front("abc123", 4567));
+        manager.record_attached(front("abc123", 4567, 0));
 
-        assert!(!manager.record_attached_if_claiming(front("abc123", 9999)));
-        assert_eq!(manager.get("abc123"), Some(&front("abc123", 4567)));
+        assert!(!manager.record_attached_if_claiming(front("abc123", 9999, 0)));
+        assert_eq!(manager.get("abc123"), Some(&front("abc123", 4567, 0)));
     }
 
     #[test]
-    fn is_current_front_matches_the_attached_port() {
+    fn is_current_front_matches_the_attached_generation() {
         let mut manager = AttachManager::new();
-        manager.record_attached(front("abc123", 4567));
-        assert!(manager.is_current_front("abc123", 4567));
+        manager.record_attached(front("abc123", 4567, 7));
+        assert!(manager.is_current_front("abc123", 7));
     }
 
     #[test]
-    fn is_current_front_is_false_for_a_stale_port_after_re_attach() {
+    fn is_current_front_is_false_for_a_stale_generation_after_re_attach() {
         // The exact scenario a post-attach monitor must survive: detach,
-        // then re-attach on a fresh (different) port. A monitor still
-        // holding the old port must recognize it's stale.
+        // then re-attach — even if the fresh attach happens to land on the
+        // *same* port (ephemeral-port reuse), a monitor still holding the
+        // old generation must recognize it's stale.
         let mut manager = AttachManager::new();
-        manager.record_attached(front("abc123", 4567));
+        manager.record_attached(front("abc123", 4567, 0));
         manager.remove("abc123");
-        manager.record_attached(front("abc123", 9999));
+        manager.record_attached(front("abc123", 4567, 1)); // same port, new generation
 
-        assert!(!manager.is_current_front("abc123", 4567));
-        assert!(manager.is_current_front("abc123", 9999));
+        assert!(!manager.is_current_front("abc123", 0));
+        assert!(manager.is_current_front("abc123", 1));
     }
 
     #[test]
     fn is_current_front_is_false_while_merely_claiming() {
         let mut manager = AttachManager::new();
-        assert_eq!(manager.decide_and_claim("abc123"), AttachDecision::Spawn);
-        assert!(!manager.is_current_front("abc123", 4567));
+        let generation = claim(&mut manager, "abc123");
+        assert!(!manager.is_current_front("abc123", generation));
     }
 
     #[test]
     fn is_current_front_is_false_for_an_untracked_workspace() {
         let manager = AttachManager::new();
-        assert!(!manager.is_current_front("nonexistent", 4567));
+        assert!(!manager.is_current_front("nonexistent", 0));
     }
 
     #[test]
     fn remove_clears_bookkeeping_so_the_next_attach_spawns_again() {
         let mut manager = AttachManager::new();
-        manager.record_attached(front("abc123", 4567));
+        manager.record_attached(front("abc123", 4567, 0));
 
         let removed = manager.remove("abc123");
-        assert_eq!(removed, Some(front("abc123", 4567)));
-        assert_eq!(manager.decide_and_claim("abc123"), AttachDecision::Spawn);
+        assert_eq!(removed, Some(front("abc123", 4567, 0)));
+        assert!(matches!(
+            manager.decide_and_claim("abc123"),
+            AttachDecision::Spawn { .. }
+        ));
     }
 
     #[test]
@@ -442,7 +537,7 @@ mod tests {
     #[test]
     fn remove_of_a_merely_claiming_workspace_returns_none() {
         let mut manager = AttachManager::new();
-        assert_eq!(manager.decide_and_claim("abc123"), AttachDecision::Spawn);
+        claim(&mut manager, "abc123");
         // Never actually attached (no record_attached yet) — nothing real
         // to return, even though something is tracked.
         assert_eq!(manager.remove("abc123"), None);
@@ -452,7 +547,7 @@ mod tests {
     fn is_attached_reflects_current_bookkeeping() {
         let mut manager = AttachManager::new();
         assert!(!manager.is_attached("abc123"));
-        manager.record_attached(front("abc123", 4567));
+        manager.record_attached(front("abc123", 4567, 0));
         assert!(manager.is_attached("abc123"));
         manager.remove("abc123");
         assert!(!manager.is_attached("abc123"));
@@ -461,7 +556,7 @@ mod tests {
     #[test]
     fn is_attached_is_false_while_merely_claiming() {
         let mut manager = AttachManager::new();
-        assert_eq!(manager.decide_and_claim("abc123"), AttachDecision::Spawn);
+        claim(&mut manager, "abc123");
         assert!(
             !manager.is_attached("abc123"),
             "a claim in flight is not yet a real attachment"
@@ -471,24 +566,24 @@ mod tests {
     #[test]
     fn get_returns_the_recorded_front() {
         let mut manager = AttachManager::new();
-        manager.record_attached(front("abc123", 4567));
-        assert_eq!(manager.get("abc123"), Some(&front("abc123", 4567)));
+        manager.record_attached(front("abc123", 4567, 0));
+        assert_eq!(manager.get("abc123"), Some(&front("abc123", 4567, 0)));
         assert_eq!(manager.get("nonexistent"), None);
     }
 
     #[test]
     fn record_attached_overwrites_a_stale_prior_record() {
         let mut manager = AttachManager::new();
-        manager.record_attached(front("abc123", 4567));
-        manager.record_attached(front("abc123", 9999));
-        assert_eq!(manager.get("abc123"), Some(&front("abc123", 9999)));
+        manager.record_attached(front("abc123", 4567, 0));
+        manager.record_attached(front("abc123", 9999, 1));
+        assert_eq!(manager.get("abc123"), Some(&front("abc123", 9999, 1)));
     }
 
     #[test]
     fn attached_ids_lists_every_currently_attached_workspace() {
         let mut manager = AttachManager::new();
-        manager.record_attached(front("abc123", 4567));
-        manager.record_attached(front("def456", 4568));
+        manager.record_attached(front("abc123", 4567, 0));
+        manager.record_attached(front("def456", 4568, 1));
 
         let mut ids = manager.attached_ids();
         ids.sort_unstable();
@@ -498,8 +593,8 @@ mod tests {
     #[test]
     fn attached_ids_excludes_merely_claiming_workspaces() {
         let mut manager = AttachManager::new();
-        manager.record_attached(front("abc123", 4567));
-        assert_eq!(manager.decide_and_claim("def456"), AttachDecision::Spawn);
+        manager.record_attached(front("abc123", 4567, 0));
+        claim(&mut manager, "def456");
 
         assert_eq!(manager.attached_ids(), vec!["abc123"]);
     }

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -22,6 +22,7 @@
 //! Tauri's async-runtime thread pool instead, off the UI thread, without
 //! requiring the function itself to be `async fn` or to `.await` anything.
 
+use std::sync::{Mutex, MutexGuard, PoisonError};
 use std::time::Duration;
 
 use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder, WindowEvent};
@@ -45,13 +46,33 @@ use crate::state::AppState;
 const ATTACH_TIMEOUT: Duration = Duration::from_secs(30);
 const ATTACH_POLL_INTERVAL: Duration = Duration::from_millis(300);
 
+/// Lock `mutex`, recovering from poisoning instead of propagating it.
+///
+/// `state.attach`/`state.children` are each locked from several independent
+/// commands (`list_workspaces`, `attach`, `detach`, `quit`, the post-attach
+/// monitor thread, …). A `.map_err(|e| e.to_string())?` on `.lock()` — the
+/// std default — means a single panic anywhere while holding either lock
+/// poisons it permanently, and every subsequent command that touches it
+/// (including `quit`/`detach_all`, the one path that could otherwise clean
+/// up a still-attached front left behind by that panic) starts failing for
+/// the rest of the process's life, leaking any front still running. The
+/// protected data itself is usually still perfectly usable after a panic —
+/// a poisoned `Mutex` is std's conservative default (the panic *might* have
+/// happened mid-mutation, leaving inconsistent state), not a guarantee that
+/// it did — so recovering with `into_inner()` and carrying on is the safer
+/// choice for a long-lived desktop app than making the picker permanently
+/// unusable until restart.
+fn locked<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
 /// List discovered workspaces plus the picker's first-run empty-state
 /// classification (ADR 0097 Broker §5 / User Impact: "never a silent empty
 /// list").
 #[tauri::command(async)]
 pub fn list_workspaces(state: State<'_, AppState>) -> Result<PickerView, String> {
     let summaries = discovery::discover_workspaces().map_err(|e| e.to_string())?;
-    let attach = state.attach.lock().map_err(|e| e.to_string())?;
+    let attach = locked(&state.attach);
     let workspaces: Vec<WorkspaceView> = summaries
         .iter()
         .map(|s| WorkspaceView::from_summary(s, attach.is_attached(&s.id)))
@@ -81,12 +102,9 @@ pub fn attach(
     // coordinator, where two near-simultaneous attach clicks for the same
     // workspace both saw "nothing tracked" and both spawned a front. See
     // `beamtalk_desktop_shell::attach`'s module docs.
-    let decision = {
-        let mut attach = state.attach.lock().map_err(|e| e.to_string())?;
-        attach.decide_and_claim(&workspace_id)
-    };
+    let decision = locked(&state.attach).decide_and_claim(&workspace_id);
 
-    match decision {
+    let generation = match decision {
         AttachDecision::FocusExisting { window_id, .. } => {
             if let Some(window) = app.get_webview_window(&window_id) {
                 let _ = window.set_focus();
@@ -94,19 +112,17 @@ pub fn attach(
             return Ok(AttachOutcome::Focused);
         }
         AttachDecision::AlreadyInFlight => return Ok(AttachOutcome::AlreadyAttaching),
-        AttachDecision::Spawn => {}
-    }
+        AttachDecision::Spawn { generation } => generation,
+    };
 
     // From here on, the workspace is claimed: every exit path (including
     // early returns below) must release the claim on failure, or record the
     // real attachment on success, so a future attach click is never stuck
     // behind a claim nothing will resolve.
-    match attach_and_open_window(&app, &state, &workspace_id) {
+    match attach_and_open_window(&app, &state, &workspace_id, generation) {
         Ok(outcome) => Ok(outcome),
         Err(err) => {
-            if let Ok(mut attach) = state.attach.lock() {
-                attach.release_claim(&workspace_id);
-            }
+            locked(&state.attach).release_claim(&workspace_id);
             Err(err)
         }
     }
@@ -114,11 +130,16 @@ pub fn attach(
 
 /// The claimed part of [`attach`]: spawn, wait for readiness, open a window,
 /// and record the attachment. Split out so [`attach`] can release the claim
-/// uniformly on any `Err` this returns, from any step.
+/// uniformly on any `Err` this returns, from any step. `generation` is the
+/// claim's generation number (from [`AttachDecision::Spawn`]) — threaded
+/// through to the recorded [`AttachedFront`] and [`spawn_monitor`] so the
+/// post-attach monitor's stop condition survives ephemeral-port reuse (see
+/// [`beamtalk_desktop_shell::attach::AttachManager::is_current_front`]).
 fn attach_and_open_window(
     app: &AppHandle,
     state: &AppState,
     workspace_id: &str,
+    generation: u64,
 ) -> Result<AttachOutcome, String> {
     emit_progress(app, workspace_id, "spawning");
 
@@ -149,11 +170,7 @@ fn attach_and_open_window(
     // a local `child.kill()` — the child is no longer this function's to
     // kill directly once it's in the shared map.
     persist_front_record(workspace_id, port, pid);
-    state
-        .children
-        .lock()
-        .map_err(|e| e.to_string())?
-        .insert(workspace_id.to_string(), child);
+    locked(&state.children).insert(workspace_id.to_string(), child);
 
     emit_progress(app, workspace_id, "probing");
 
@@ -225,14 +242,12 @@ fn attach_and_open_window(
         });
     }
 
-    let recorded = {
-        let mut attach = state.attach.lock().map_err(|e| e.to_string())?;
-        attach.record_attached_if_claiming(AttachedFront {
-            workspace_id: workspace_id.to_string(),
-            port,
-            pid,
-        })
-    };
+    let recorded = locked(&state.attach).record_attached_if_claiming(AttachedFront {
+        workspace_id: workspace_id.to_string(),
+        port,
+        pid,
+        generation,
+    });
 
     if !recorded {
         // A concurrent `detach`/`quit` cleared this workspace's claim while
@@ -261,7 +276,7 @@ fn attach_and_open_window(
     // The child is already tracked in `state.children` (inserted right
     // after spawn, above) — nothing more to do there on the success path.
 
-    spawn_monitor(app.clone(), workspace_id.to_string(), port);
+    spawn_monitor(app.clone(), workspace_id.to_string(), port, generation);
 
     Ok(AttachOutcome::Opened)
 }
@@ -274,11 +289,9 @@ fn attach_and_open_window(
 /// comment) — killing it locally without untracking would leave a dangling
 /// map entry for an already-dead process.
 fn kill_and_untrack(state: &AppState, workspace_id: &str, port: u16) {
-    if let Ok(mut children) = state.children.lock() {
-        if let Some(mut child) = children.remove(workspace_id) {
-            let _ = child.kill();
-            let _ = child.wait();
-        }
+    if let Some(mut child) = locked(&state.children).remove(workspace_id) {
+        let _ = child.kill();
+        let _ = child.wait();
     }
     remove_front_record(workspace_id, port);
 }
@@ -316,11 +329,7 @@ pub fn detach_internal(
     state: &AppState,
     workspace_id: &str,
 ) -> Result<(), String> {
-    let removed = state
-        .attach
-        .lock()
-        .map_err(|e| e.to_string())?
-        .remove(workspace_id);
+    let removed = locked(&state.attach).remove(workspace_id);
 
     if let Some(front) = removed {
         if let Ok(dir) = reap::state_dir() {
@@ -328,12 +337,7 @@ pub fn detach_internal(
         }
     }
 
-    if let Some(mut child) = state
-        .children
-        .lock()
-        .map_err(|e| e.to_string())?
-        .remove(workspace_id)
-    {
+    if let Some(mut child) = locked(&state.children).remove(workspace_id) {
         let _ = child.kill();
         let _ = child.wait();
     }
@@ -387,14 +391,15 @@ pub fn quit(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
 /// still kill that front within this session rather than leaving it for the
 /// next restart's orphan sweep to find.
 ///
-/// Best-effort: a poisoned `children` mutex means nothing is known to be
-/// tracked, so there is nothing safe to detach — silently does nothing
-/// rather than panicking on the way out during app exit.
+/// Uses [`locked`] (recovers from a poisoned `children` mutex rather than
+/// giving up) precisely because this is the one path that could otherwise
+/// clean up after a panic elsewhere left a front still attached — bailing
+/// out here on a poisoned lock, as a plain `.lock()?` would, is the single
+/// worst place in this file to do that: it would leak every still-attached
+/// front for the rest of the OS process's life, on the exact path (quit)
+/// meant to guarantee they get killed.
 pub fn detach_all(app: &AppHandle, state: &AppState) {
-    let ids: Vec<String> = match state.children.lock() {
-        Ok(children) => children.keys().cloned().collect(),
-        Err(_) => return,
-    };
+    let ids: Vec<String> = locked(&state.children).keys().cloned().collect();
     for id in ids {
         let _ = detach_internal(app, state, &id);
     }
@@ -442,24 +447,27 @@ fn remove_front_record(workspace_id: &str, port: u16) {
 /// disconnected window instead of the front's RPCs silently hanging or the
 /// LiveView page filling with socket-error noise (spike criterion (f)).
 ///
-/// Stops once `(workspace_id, port)` is no longer the *current* attachment —
-/// checked via [`beamtalk_desktop_shell::attach::AttachManager::is_current_front`],
-/// not merely `is_attached`. A bare id check would let a stale monitor from
-/// a detach-then-re-attach cycle survive: the new attach spawns on a fresh
-/// port (free-port allocation, not a reused one) and starts its own
-/// monitor, but the *old* monitor would see `is_attached` flip back to
-/// `true` for the same id and wrongly keep polling the dead old port,
-/// fighting the new monitor over the same window's title/events.
-fn spawn_monitor(app: AppHandle, workspace_id: String, port: u16) {
+/// Stops once `generation` is no longer the *current* attachment's
+/// generation — checked via
+/// [`beamtalk_desktop_shell::attach::AttachManager::is_current_front`], not
+/// merely `is_attached` and not `port`. A bare id check would let a stale
+/// monitor from a detach-then-re-attach cycle survive: the new attach starts
+/// its own monitor, but the *old* monitor would see `is_attached` flip back
+/// to `true` for the same id and wrongly keep polling the dead old port,
+/// fighting the new monitor over the same window's title/events. `port`
+/// alone isn't a reliable discriminator either — the OS's ephemeral-port
+/// allocator can (rarely) hand the fresh attach the *same* port the old one
+/// used, which a `(workspace_id, port)` check would then treat as still
+/// current. `generation` (assigned once per claim, by
+/// [`beamtalk_desktop_shell::attach::AttachManager::decide_and_claim`], and
+/// never reused) doesn't have that gap.
+fn spawn_monitor(app: AppHandle, workspace_id: String, port: u16, generation: u64) {
     std::thread::spawn(move || {
         let mut monitor = Monitor::new();
         loop {
             let still_current = {
                 let state = app.state::<AppState>();
-                let Ok(attach) = state.attach.lock() else {
-                    return;
-                };
-                attach.is_current_front(&workspace_id, port)
+                locked(&state.attach).is_current_front(&workspace_id, generation)
             };
             if !still_current {
                 return;
@@ -508,10 +516,8 @@ fn spawn_monitor(app: AppHandle, workspace_id: String, port: u16) {
 /// [`spawn_monitor`]'s call site).
 fn reap_if_exited(app: &AppHandle, workspace_id: &str) {
     let state = app.state::<AppState>();
-    if let Ok(mut children) = state.children.lock() {
-        if let Some(child) = children.get_mut(workspace_id) {
-            let _ = child.try_wait();
-        }
+    if let Some(child) = locked(&state.children).get_mut(workspace_id) {
+        let _ = child.try_wait();
     }
 }
 
@@ -550,4 +556,42 @@ fn reflect_connection_state(
             state: ConnectionStateView::from(connection_state),
         },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locked_recovers_from_a_poisoned_mutex() {
+        // The exact scenario `locked` exists to survive: some thread panics
+        // while holding the lock (a bug elsewhere in a command handler, not
+        // anything `locked` itself does), poisoning the `Mutex`. A plain
+        // `.lock()?` would make this mutex permanently unusable for the rest
+        // of the process's life; `locked` must instead keep handing back a
+        // usable guard.
+        let mutex = Mutex::new(vec![1, 2, 3]);
+
+        std::thread::scope(|scope| {
+            let handle = scope.spawn(|| {
+                let mut guard = mutex.lock().unwrap();
+                guard.push(4);
+                panic!("simulated panic while holding the lock");
+            });
+            // The panic is expected and deliberately triggered — just
+            // confirm the thread actually unwound rather than propagating
+            // it into this test.
+            assert!(handle.join().is_err());
+        });
+
+        assert!(mutex.is_poisoned());
+
+        // Recovers the guard *and* carries forward the in-progress mutation
+        // (`push(4)`) rather than discarding it — `into_inner()` hands back
+        // the data exactly as the panicking thread left it, which is the
+        // whole basis for `locked`'s doc comment claim that the protected
+        // data is "usually still perfectly usable after a panic".
+        let guard = locked(&mutex);
+        assert_eq!(*guard, vec![1, 2, 3, 4]);
+    }
 }

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -122,7 +122,7 @@ pub fn attach(
     match attach_and_open_window(&app, &state, &workspace_id, generation) {
         Ok(outcome) => Ok(outcome),
         Err(err) => {
-            locked(&state.attach).release_claim(&workspace_id);
+            locked(&state.attach).release_claim(&workspace_id, generation);
             Err(err)
         }
     }

--- a/desktop/ui/main.js
+++ b/desktop/ui/main.js
@@ -32,13 +32,57 @@ const attachProgress = new Map();
 // attached workspaces the post-attach monitor has flagged as unhealthy.
 const connectionBadges = new Map();
 
-async function refresh() {
+// Coalescing window for `scheduleRefresh` (below) — chosen to smooth out a
+// flapping connection or several concurrent attaches firing `attach-progress`/
+// `connection-state-changed` several times a second, while still feeling
+// immediate for a single user action.
+const REFRESH_DEBOUNCE_MS = 150;
+let refreshDebounceTimer = null;
+// True while a `list_workspaces` invoke is in flight, so a refresh request
+// that lands mid-invoke queues one more run afterwards instead of firing a
+// second overlapping invoke.
+let refreshInFlight = false;
+// Set by any refresh request (direct call or event) that arrives while one
+// is already in flight — consumed by that in-flight refresh's `finally` to
+// run exactly one more time, so the latest state always wins without
+// unbounded queuing.
+let refreshPending = false;
+
+// Coalesce refresh requests within `REFRESH_DEBOUNCE_MS` of each other into
+// a single `runRefresh()` call. Bursty callers (the `attach-progress`/
+// `connection-state-changed` event listeners, the periodic poll) go through
+// this; a direct response to a single user action (attach/detach/create
+// completing) calls `runRefresh()` itself instead, for immediate feedback —
+// see `reconcileWorkspaceList`'s doc comment for why an uncoalesced flood of
+// overlapping invokes was a problem worth fixing either way.
+function scheduleRefresh() {
+  if (refreshDebounceTimer !== null) {
+    return;
+  }
+  refreshDebounceTimer = setTimeout(() => {
+    refreshDebounceTimer = null;
+    runRefresh();
+  }, REFRESH_DEBOUNCE_MS);
+}
+
+async function runRefresh() {
+  if (refreshInFlight) {
+    refreshPending = true;
+    return;
+  }
+  refreshInFlight = true;
   try {
     const view = await invoke("list_workspaces");
     render(view);
   } catch (err) {
     statusEl.hidden = false;
     statusEl.textContent = `Failed to list workspaces: ${err}`;
+  } finally {
+    refreshInFlight = false;
+    if (refreshPending) {
+      refreshPending = false;
+      scheduleRefresh();
+    }
   }
 }
 
@@ -50,12 +94,64 @@ function render(view) {
 
   if (!hasWorkspaces) {
     renderEmptyState(view.empty_state);
+    // Nothing to reconcile against once the list is empty — clear any rows
+    // left over from a prior non-empty render so the next transition back
+    // to non-empty starts from a clean slate.
+    workspaceListEl.replaceChildren();
     return;
   }
 
-  workspaceListEl.innerHTML = "";
-  for (const workspace of view.workspaces) {
-    workspaceListEl.appendChild(renderWorkspaceRow(workspace));
+  reconcileWorkspaceList(view.workspaces);
+}
+
+// Update `workspaceListEl` to match `workspaces` by reusing existing row
+// elements (keyed by `li.dataset.workspaceId`) wherever possible, instead
+// of `innerHTML = ""` + a full rebuild every refresh. Two problems that
+// full teardown caused, both worth avoiding given how often a refresh can
+// now fire (a flapping connection or several concurrent attaches, each
+// driving its own `attach-progress`/`connection-state-changed` events):
+//
+// - A click can land on a button mid-replacement: `innerHTML = ""` detaches
+//   every existing button from the document an instant before its
+//   replacement is appended, so a click that lands in that window is lost
+//   (dispatched to a node no longer in the DOM) rather than reaching the
+//   freshly created button's handler.
+// - Rebuilding every row's DOM nodes on every refresh is wasted work when,
+//   as is by far the common case, only a badge or a button's text/disabled
+//   state actually changed for one row out of many.
+function reconcileWorkspaceList(workspaces) {
+  const existingRows = new Map();
+  for (const li of workspaceListEl.children) {
+    existingRows.set(li.dataset.workspaceId, li);
+  }
+
+  let previousRow = null;
+  for (const workspace of workspaces) {
+    let li = existingRows.get(workspace.id);
+    if (li) {
+      updateWorkspaceRow(li, workspace);
+      existingRows.delete(workspace.id);
+    } else {
+      li = renderWorkspaceRow(workspace);
+    }
+
+    const referenceNode = previousRow
+      ? previousRow.nextSibling
+      : workspaceListEl.firstChild;
+    // `insertBefore` with a node already positioned right before
+    // `referenceNode` is a documented no-op, so an already-correctly-placed
+    // row's DOM position (and thus its subtree, including the button) is
+    // left completely untouched.
+    if (referenceNode !== li) {
+      workspaceListEl.insertBefore(li, referenceNode);
+    }
+    previousRow = li;
+  }
+
+  // Anything left in `existingRows` is a row for a workspace no longer in
+  // `workspaces` (e.g. it stopped being discoverable) — drop it.
+  for (const staleRow of existingRows.values()) {
+    staleRow.remove();
   }
 }
 
@@ -71,6 +167,11 @@ function renderEmptyState(emptyState) {
   }
 }
 
+// Build a brand-new row's DOM structure (name, live badge, connection
+// badge, path, action button — each a stable element `updateWorkspaceRow`
+// can find again on a later refresh instead of recreating), then populate
+// it via the same `updateWorkspaceRow` a reused row goes through, so the
+// initial-render and update paths can't drift apart.
 function renderWorkspaceRow(workspace) {
   const li = document.createElement("li");
   li.className = "workspace-row";
@@ -81,49 +182,68 @@ function renderWorkspaceRow(workspace) {
 
   const name = document.createElement("span");
   name.className = "workspace-name";
-  name.textContent = workspace.id;
   info.appendChild(name);
 
   const liveBadge = document.createElement("span");
-  liveBadge.className = workspace.alive
-    ? "badge badge-alive"
-    : "badge badge-dead";
-  liveBadge.textContent = workspace.alive ? "live" : "not running";
+  liveBadge.className = "workspace-live-badge";
   info.appendChild(liveBadge);
 
-  const connectionLabel = connectionBadges.get(workspace.id);
-  if (connectionLabel) {
-    const connBadge = document.createElement("span");
-    connBadge.className = "badge badge-warning";
-    connBadge.textContent = connectionLabel;
-    info.appendChild(connBadge);
-  }
+  const connBadge = document.createElement("span");
+  connBadge.className = "badge badge-warning workspace-connection-badge";
+  info.appendChild(connBadge);
 
-  if (workspace.project_path) {
-    const path = document.createElement("span");
-    path.className = "workspace-path";
-    path.textContent = workspace.project_path;
-    info.appendChild(path);
-  }
+  const path = document.createElement("span");
+  path.className = "workspace-path";
+  info.appendChild(path);
 
   li.appendChild(info);
-  li.appendChild(renderActionButton(workspace));
+
+  const button = document.createElement("button");
+  button.className = "workspace-action-button";
+  li.appendChild(button);
+
+  updateWorkspaceRow(li, workspace);
   return li;
 }
 
-function renderActionButton(workspace) {
-  const button = document.createElement("button");
+// Refresh an existing row's badges/text/button in place — no child
+// elements are created, removed, or reordered here, so a row already
+// showing (e.g.) an open dropdown or mid-click button is left otherwise
+// undisturbed by an unrelated refresh.
+function updateWorkspaceRow(li, workspace) {
+  const name = li.querySelector(".workspace-name");
+  name.textContent = workspace.id;
+
+  const liveBadge = li.querySelector(".workspace-live-badge");
+  liveBadge.className = workspace.alive
+    ? "badge badge-alive workspace-live-badge"
+    : "badge badge-dead workspace-live-badge";
+  liveBadge.textContent = workspace.alive ? "live" : "not running";
+
+  const connBadge = li.querySelector(".workspace-connection-badge");
+  const connectionLabel = connectionBadges.get(workspace.id);
+  connBadge.hidden = !connectionLabel;
+  connBadge.textContent = connectionLabel ?? "";
+
+  const path = li.querySelector(".workspace-path");
+  path.hidden = !workspace.project_path;
+  path.textContent = workspace.project_path ?? "";
+
+  updateActionButton(li.querySelector(".workspace-action-button"), workspace);
+}
+
+function updateActionButton(button, workspace) {
   if (workspace.attached) {
     button.textContent = "Detach";
+    button.disabled = false;
     button.onclick = () => detach(workspace.id, button);
-    return button;
+    return;
   }
 
   const progress = attachProgress.get(workspace.id);
   button.textContent = progress ? `${progress}…` : "Attach";
   button.disabled = Boolean(progress);
   button.onclick = () => attach(workspace.id, button);
-  return button;
 }
 
 async function attach(workspaceId, button) {
@@ -136,7 +256,11 @@ async function attach(workspaceId, button) {
     statusEl.textContent = `Could not attach to '${workspaceId}': ${err}`;
   } finally {
     attachProgress.delete(workspaceId);
-    await refresh();
+    // A direct response to this user action, not the flapping-event case
+    // `scheduleRefresh`'s debounce exists for — refresh right away (still
+    // single-flight-guarded by `runRefresh` against any concurrently
+    // in-flight event-triggered refresh).
+    await runRefresh();
   }
 }
 
@@ -146,7 +270,7 @@ async function detach(workspaceId, button) {
     await invoke("detach", { workspaceId });
   } finally {
     connectionBadges.delete(workspaceId);
-    await refresh();
+    await runRefresh();
   }
 }
 
@@ -164,7 +288,7 @@ createWorkspaceButton.addEventListener("click", async () => {
     statusEl.textContent = `Could not create workspace '${workspaceId}': ${err}`;
   } finally {
     createWorkspaceButton.disabled = false;
-    await refresh();
+    await runRefresh();
   }
 });
 
@@ -172,9 +296,13 @@ quitButton.addEventListener("click", () => {
   invoke("quit");
 });
 
+// These two events are the flapping/bursty case `scheduleRefresh`'s debounce
+// exists for: a shaky connection or several concurrent attaches can each
+// fire several times a second, and without coalescing, each one used to
+// trigger its own overlapping `list_workspaces` invoke.
 listen("attach-progress", (event) => {
   attachProgress.set(event.payload.workspace_id, event.payload.stage);
-  refresh();
+  scheduleRefresh();
 });
 
 listen("connection-state-changed", (event) => {
@@ -186,8 +314,8 @@ listen("connection-state-changed", (event) => {
   } else {
     connectionBadges.set(workspaceId, "unreachable");
   }
-  refresh();
+  scheduleRefresh();
 });
 
-refresh();
-setInterval(refresh, 3000);
+runRefresh();
+setInterval(scheduleRefresh, 3000);


### PR DESCRIPTION
Linear issue: https://linear.app/beamtalk/issue/BT-3008

## Summary

Follow-up hardening from the BT-2986 adversarial review pass — three lower-severity, narrow edge cases in the desktop picker that don't block shipping but shouldn't be silently dropped.

- **Monitor stale-port guard defeated by port reuse** (`crates/beamtalk-desktop-shell/src/attach.rs`): `AttachManager` now assigns each claim a monotonically increasing `generation: u64` (via `decide_and_claim` → `AttachDecision::Spawn { generation }`), carried through `AttachedFront` and threaded to `record_attached_if_claiming`/`is_current_front`. The post-attach monitor's stop condition (`desktop/src-tauri/src/commands.rs`'s `spawn_monitor`) now keys on `(workspace_id, generation)` instead of `(workspace_id, port)`, so a stale monitor from an old attach and a fresh one from a quick re-attach can no longer become indistinguishable when the OS's ephemeral-port allocator happens to hand back the same port.
- **Mutex poisoning is unrecoverable** (`desktop/src-tauri/src/commands.rs`): added a `locked()` helper (`mutex.lock().unwrap_or_else(PoisonError::into_inner)`) used at every `state.attach`/`state.children` call site instead of `.map_err(|e| e.to_string())?`, so a single panic anywhere while holding either lock no longer permanently disables every subsequent command (including `quit`/`detach_all`, which is the one path that could otherwise clean up a still-attached front left behind by that panic).
- **Frontend refresh has no debounce/in-flight guard** (`desktop/ui/main.js`): added `scheduleRefresh()` (coalesces refresh requests within a 150ms window) for the bursty `attach-progress`/`connection-state-changed` event listeners and the periodic poll, plus a single-flight guard (`runRefresh()`) so at most one `list_workspaces` invoke is ever in flight. `render()` now reconciles the workspace list in place (`reconcileWorkspaceList`, keyed by `workspace.id`, reusing existing row/button DOM nodes) instead of a full `innerHTML = ""` teardown + rebuild on every refresh, so a click can no longer land on a button mid-replacement.

## Key changes

- `crates/beamtalk-desktop-shell/src/attach.rs`: `generation: u64` on `AttachedFront` and `Slot::Claiming`; `AttachDecision::Spawn { generation }`; `record_attached_if_claiming` now refuses a stale generation (stronger than the prior "any claim still pending" check); `is_current_front` keyed on generation instead of port. Test suite updated and extended (37 tests, including two new races: fresh-generation-per-claim, and a stale caller unable to clobber a newer re-claim).
- `desktop/src-tauri/src/commands.rs`: `locked()` mutex-poison-recovery helper used throughout; `generation` threaded from `attach` through `attach_and_open_window` to `spawn_monitor`; new unit test proving `locked()` actually recovers a poisoned mutex (and carries forward the in-progress mutation).
- `desktop/ui/main.js`: debounced/single-flight refresh scheduling; keyed DOM reconciliation for the workspace list instead of full teardown.

## Test plan

- [x] `cargo test -p beamtalk-desktop-shell` — 37/37 passing
- [x] `cargo build`/`cargo clippy --all-targets -- -D warnings`/`cargo test` for `desktop/src-tauri` (built locally with GTK/WebKit dev packages installed for this session; normally excluded from the root workspace — see `desktop/README.md`)
- [x] `node --check desktop/ui/main.js`
- [x] `just build && just clippy && just fmt-check` (full workspace)
- [x] Full pre-push CI (build, clippy, fmt, Dialyzer, lint) passed clean

---
_Generated by [Claude Code](https://claude.ai/code/session_012GHV5wZCdTyiQADqppbgSQ)_