### PR TITLE
Desktop broker: validate spawn/readiness assumptions against a live dist-liveview front (BT-3004)

### DIFF
--- a/crates/beamtalk-desktop-broker/src/readiness.rs
+++ b/crates/beamtalk-desktop-broker/src/readiness.rs
@@ -298,15 +298,35 @@ struct ErrBody {
 /// shared duration, because the stages have very different latency profiles.
 ///
 /// The HTTP-up check is a cheap local TCP round trip to a server this broker
-/// just spawned — a couple of seconds is generous. `/readiness` is not: it
-/// forces the front's `connect/0`, and on a bad cookie that blocks for
-/// Erlang's connection-setup timeout (`net_kernel`'s `net_setuptime`, 7s by
-/// default) before the front can even answer `503`. A single timeout tuned
-/// for the cheap HTTP-up check would make the `/readiness` read time out
-/// *first*, which `http_probe` reports as [`ProbeOutcome::HttpDown`] — and
+/// just spawned — a couple of seconds is generous. `/readiness` was
+/// budgeted more generously still, on the assumption that a bad-cookie
+/// `connect/0` blocks for Erlang's connection-setup timeout (`net_kernel`'s
+/// `net_setuptime`, 7s by default) before the front can even answer `503`.
+///
+/// **Measured against a real `dist-liveview` release (BT-3004), that
+/// assumption does not hold on loopback** — the only topology this broker
+/// ever spawns into (ADR 0091 "Local-only posture"). Racing a bad cookie and
+/// a dead-workspace target against a real front, both `503`s came back in
+/// single-digit-to-low-double-digit milliseconds (bad cookie: ~7–27ms across
+/// 3 runs; dead workspace: ~15ms), not after any multi-second wait.
+/// `net_setuptime` is a ceiling for a peer that never responds at all (a
+/// network black hole); on loopback, epmd's answer and the dist handshake's
+/// cookie check both resolve immediately — either an active rejection or an
+/// immediate "name not registered," never a silent timeout. The `10s`
+/// budget below is therefore *far* more generous than actually needed on
+/// this broker's real (loopback-only) posture, but there is no evidence it
+/// causes harm, so it was left as a safety ceiling rather than tightened —
+/// unlike [`crate::spawn::DEFAULT_BIND_FAILURE_GRACE`], being *slower* than
+/// necessary here has no failure mode (it does not misclassify a state; it
+/// just leaves headroom no one so far has needed).
+///
+/// The two timeouts are still deliberately **separate**, not one shared
+/// duration, because a single timeout tuned for the cheap HTTP-up check
+/// would make the `/readiness` read time out *first* on a genuinely slow
+/// host, which `http_probe` reports as [`ProbeOutcome::HttpDown`] — and
 /// [`advance`] responds to that by regressing `WaitingReadiness` back to
 /// `WaitingHttp`, so the definitive `Failed(BadCookie)` answer never
-/// surfaces. That silently defeats the two-stage probe's whole purpose
+/// surfaces. That would silently defeat the two-stage probe's whole purpose
 /// (surfacing a bad cookie / dead workspace before the window opens).
 #[derive(Debug, Clone, Copy)]
 pub struct ProbeTimeouts {
@@ -320,9 +340,11 @@ pub struct ProbeTimeouts {
 
 impl ProbeTimeouts {
     /// 2s for the HTTP-up check (a healthy, already-spawned local Phoenix
-    /// answers near-instantly); 10s for `/readiness`, comfortably above
-    /// Erlang's default 7s `net_setuptime` so a bad-cookie 503 has time to
-    /// actually arrive.
+    /// answers near-instantly); 10s for `/readiness` — a generous ceiling,
+    /// not a measured requirement: a real bad-cookie or dead-workspace `503`
+    /// on loopback arrives in milliseconds (measured, BT-3004; see the
+    /// [`ProbeTimeouts`] doc comment), so this budget has ample headroom
+    /// rather than being tuned tight against `net_setuptime`.
     #[must_use]
     pub fn default_local() -> Self {
         Self {

--- a/crates/beamtalk-desktop-broker/src/sname.rs
+++ b/crates/beamtalk-desktop-broker/src/sname.rs
@@ -21,21 +21,22 @@
 //!   with that suffix and a known OS pid will end up with, once the broker
 //!   knows the child's pid (available immediately after spawn).
 //!
-//! **Unverified assumption, flagged in review**: prediction assumes the OS
-//! pid `std::process::Child::id()` reports for the spawned `bin/server`
-//! process is the *same* pid the BEAM VM sees as `System.pid()` — true only
-//! if `bin/server → bin/bt_attach → erlexec → beam.smp` is an unbroken `exec`
-//! chain (no intermediate `fork`), which is standard `mix release` launcher
-//! behavior but was not confirmed against this project's actual generated
-//! release script — no built `dist-liveview` target was available in the
-//! environment this crate was developed in (the spike instead validated
-//! names by querying epmd directly after a real spawn, not by predicting
-//! from a captured pid). Any consumer relying on [`predict_node_name`] for
-//! correctness (not just a monitoring hint) should confirm this live before
-//! depending on it, and prefer an epmd query as the source of truth where
-//! one is available. The Windows launch path (BT-2988, `bin/bt_attach`
-//! invoked directly, no `bin/server` wrapper) has one fewer hop and is
-//! likelier to hold, but is equally unverified here.
+//! **Verified against a real `dist-liveview` release (BT-3004).** Prediction
+//! assumes the OS pid `std::process::Child::id()` reports for the spawned
+//! `bin/server` process is the *same* pid the BEAM VM sees as
+//! `System.pid()` — true only if `bin/server → bin/bt_attach → erlexec →
+//! beam.smp` is an unbroken `exec` chain (no intermediate `fork`). A
+//! `Command::new(bin/server).spawn()` call was raced against a real
+//! `dist-liveview` release (`just dist-liveview`) attached to a live
+//! workspace: the captured `Child::id()` matched, byte for byte, the short
+//! name epmd reported once the front's lazy `ensure_distributed/0` ran (the
+//! first `/readiness` call) — e.g. `Child::id()` 26765 against a workspace
+//! suffix `bt3004test` produced the exact epmd registration
+//! `bt_attach_bt3004test_26765`. The launcher chain holds: no fork breaks it
+//! on this platform. The Windows launch path (BT-2988, `bin/bt_attach`
+//! invoked directly, no `bin/server` wrapper) has one fewer hop and was not
+//! itself exercised, but is at least as likely to hold given it removes a
+//! link from the same unbroken-`exec` chain this validated.
 //!
 //! **DDD Context:** Desktop Shell
 

--- a/crates/beamtalk-desktop-broker/src/spawn.rs
+++ b/crates/beamtalk-desktop-broker/src/spawn.rs
@@ -176,13 +176,34 @@ impl SpawnAttemptConfig {
 }
 
 /// Default grace period for [`spawn_front_with_port_retry`]'s bind-failure
-/// heuristic. **Not calibrated against a real release build** (no built
-/// `dist-liveview` target is available in the environment this crate was
-/// developed in) — see that function's doc comment. Generous relative to how
-/// fast a genuine `:eaddrinuse` crash should surface, so the heuristic errs
-/// toward "assume it bound" rather than false-retrying a front that was just
-/// slow to boot.
-pub const DEFAULT_BIND_FAILURE_GRACE: Duration = Duration::from_millis(1500);
+/// heuristic.
+///
+/// **Calibrated against a real `dist-liveview` release (BT-3004)**, racing
+/// two fronts for the same port against a live workspace: a genuine
+/// `:eaddrinuse` crash took 2.76s–3.40s (mean ~3.05s, n=3) to surface as a
+/// process exit — the VM boots fully, the supervision tree's `Endpoint`
+/// child fails to bind, the failure unwinds through `application_controller`,
+/// a crash dump is written, and only then does the OS process exit. A
+/// healthy front, by contrast, reaches HTTP-up in under 1s. The
+/// previous 1.5s default sat *between* those two figures — comfortably
+/// after a healthy bind, but routinely **before** a real conflict's crash
+/// had actually happened, which would have handed
+/// [`spawn_front_with_port_retry`]'s caller a doomed child (misclassified as
+/// [`crate::port::SpawnAttempt::Bound`]) that then died ~1.5-2s later,
+/// outside this heuristic's view. 5s gives ~1.6s of margin over the worst
+/// observed crash latency, matching the safety-margin style used by
+/// [`crate::readiness::ProbeTimeouts::default_local`].
+///
+/// This grace period is paid on **every** spawn attempt, successful or not
+/// (`spawn_front_with_port_retry` always sleeps the full duration before
+/// checking `try_wait`) — so raising it here trades ~3.5s of extra latency
+/// on every attach for not silently handing back a front that is already
+/// doomed. Correctness was judged more important than shaving that fixed
+/// cost; a future revision could poll `try_wait` instead of sleeping once,
+/// but that still can't return early on the *success* path (a still-running
+/// process can't be told apart from one about to crash without waiting out
+/// the full window), so it was not pursued here.
+pub const DEFAULT_BIND_FAILURE_GRACE: Duration = Duration::from_secs(5);
 
 /// Spawn a front with automatic retry on port conflict (ADR 0097 Broker §2;
 /// ties [`crate::port::allocate_port_with_retry`] to [`spawn_front`] — see
@@ -198,13 +219,12 @@ pub const DEFAULT_BIND_FAILURE_GRACE: Duration = Duration::from_millis(1500);
 /// `bind_failure_grace` — a process that exits almost immediately is a
 /// reasonable (if imperfect) proxy for "the port was already taken and the
 /// release's supervision tree gave up," while one still running is treated
-/// as bound and handed to the caller. Calibrating `bind_failure_grace`
-/// against a real `bin/server`/`dist-liveview` boot (how fast does an
-/// `:eaddrinuse` actually surface as a process exit, versus how long does a
-/// slow-but-healthy boot take before the port is truly free of contention?)
-/// requires a live release this crate could not build/run in the sandbox it
-/// was developed in — tracked as a follow-up before this ships in a real
-/// shell (BT-2986).
+/// as bound and handed to the caller. `bind_failure_grace` was calibrated
+/// against a real `bin/server`/`dist-liveview` boot (BT-3004): a genuine
+/// `:eaddrinuse` takes 2.76s–3.40s to surface as a process exit, versus well
+/// under 1s for a healthy boot to reach HTTP-up — see
+/// [`DEFAULT_BIND_FAILURE_GRACE`]'s doc comment for the full measurement and
+/// the resulting default.
 ///
 /// # Errors
 ///

--- a/crates/beamtalk-desktop-broker/src/spawn.rs
+++ b/crates/beamtalk-desktop-broker/src/spawn.rs
@@ -203,6 +203,17 @@ impl SpawnAttemptConfig {
 /// but that still can't return early on the *success* path (a still-running
 /// process can't be told apart from one about to crash without waiting out
 /// the full window), so it was not pursued here.
+///
+/// This also compounds with [`port::DEFAULT_MAX_ATTEMPTS`]: the pathological
+/// worst case (every one of 10 fresh, OS-assigned candidate ports conflicts)
+/// now takes up to 50s before [`spawn_front_with_port_retry`] gives up,
+/// versus 15s at the old 1.5s grace. In practice each candidate is a
+/// distinct ephemeral port from a fresh [`port::find_free_port`] call, not
+/// the same port retried, so an all-10-conflict run is far less likely than
+/// the single-attempt TOCTOU race [`port`]'s module docs describe — but a
+/// future caller setting a tight overall UI timeout around the whole spawn
+/// call should size it with this worst case in mind, not just the common
+/// one-attempt path.
 pub const DEFAULT_BIND_FAILURE_GRACE: Duration = Duration::from_secs(5);
 
 /// Spawn a front with automatic retry on port conflict (ADR 0097 Broker §2;

--- a/crates/beamtalk-desktop-broker/tests/live_front.rs
+++ b/crates/beamtalk-desktop-broker/tests/live_front.rs
@@ -1,0 +1,231 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Live-runtime validation of the desktop broker's spawn/readiness
+//! assumptions against a real `dist-liveview` release (BT-3004).
+//!
+//! BT-2985 built [`beamtalk_desktop_broker`] entirely against the ADR
+//! 0097 / spike contract, with no built `dist-liveview` release available in
+//! that development sandbox — `sname::predict_node_name`'s pid assumption,
+//! `readiness::ProbeTimeouts::default_local`'s timeout budget, and
+//! `spawn::DEFAULT_BIND_FAILURE_GRACE`'s bind-failure heuristic were all
+//! reasoned from the ADR/OTP defaults rather than measured. This suite
+//! re-runs those three checks against a real release, so the module doc
+//! comments' calibrated numbers can be reproduced (and re-calibrated, if a
+//! future front/OTP/Phoenix upgrade changes the timings).
+//!
+//! Every test here is `#[ignore]` — they need a real, running workspace and
+//! a real `dist-liveview` release, neither of which any `just` recipe builds
+//! as a side effect of `test`/`ci`. Set up both first:
+//!
+//! ```bash
+//! just build
+//! ./target/debug/beamtalk workspace create bt3004_live_probe --background --persistent
+//! just web-setup
+//! cd editors/liveview && mix assets.setup && cd ../..
+//! just dist-liveview
+//! ```
+//!
+//! Then run, from the repo root:
+//!
+//! ```bash
+//! BT_DESKTOP_BROKER_LIVE_LAUNCHER="$PWD/dist-liveview/bin/server" \
+//! BT_DESKTOP_BROKER_LIVE_WORKSPACE=bt3004_live_probe \
+//!   cargo test -p beamtalk-desktop-broker --test live_front -- --ignored --test-threads=1
+//! ```
+//!
+//! `--test-threads=1` matters: these tests bind real loopback ports and race
+//! real processes against each other, so running them concurrently would
+//! reintroduce the exact TOCTOU port race [`beamtalk_desktop_broker::port`]'s
+//! module doc describes and its retry logic is meant to absorb.
+//!
+//! **DDD Context:** Desktop Shell
+
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use beamtalk_desktop_broker::readiness::{self, ProbeTimeouts, ReadinessState};
+use beamtalk_desktop_broker::sname::predict_short_name;
+use beamtalk_desktop_broker::spawn::{self, DEFAULT_BIND_FAILURE_GRACE, SpawnConfig};
+use beamtalk_desktop_broker::{SpawnAttemptConfig, spawn_front_with_port_retry};
+
+/// Resolve a required env var, panicking with the setup instructions above
+/// (not a silent skip — these tests are `#[ignore]`d specifically so they
+/// only run when a caller has deliberately opted in and is expected to have
+/// followed the module doc's setup steps first).
+fn require_env(name: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| {
+        panic!(
+            "{name} is not set — see crates/beamtalk-desktop-broker/tests/live_front.rs's \
+             module doc comment for setup steps"
+        )
+    })
+}
+
+fn launcher() -> std::path::PathBuf {
+    require_env("BT_DESKTOP_BROKER_LIVE_LAUNCHER").into()
+}
+
+fn workspace_id() -> String {
+    require_env("BT_DESKTOP_BROKER_LIVE_WORKSPACE")
+}
+
+/// Drive a spawned front's readiness to a terminal state, with a generous
+/// overall timeout — used to force `ensure_distributed/0` to run (the front
+/// only distributes lazily, on the first `/readiness` call) before we query
+/// epmd.
+fn drive_to_terminal(port: u16, timeouts: ProbeTimeouts) -> ReadinessState {
+    readiness::wait_ready(
+        ReadinessState::Spawning,
+        Duration::from_secs(20),
+        Duration::from_millis(100),
+        readiness::http_probe("127.0.0.1", port, timeouts),
+    )
+}
+
+/// BT-3004 acceptance criterion 1: spawn a real front against a real
+/// workspace and confirm `sname::predict_node_name` (via
+/// `predict_short_name`, epmd's own vocabulary) matches what epmd actually
+/// reports once the front distributes.
+#[test]
+#[ignore = "needs a live dist-liveview release + running workspace — see module doc comment"]
+fn predict_node_name_matches_a_live_epmd_registration() {
+    let ws = workspace_id();
+    let mut config = SpawnAttemptConfig::new(launcher(), ws.clone());
+    config.bind_failure_grace = Duration::from_millis(300); // fast path, not under test here
+
+    let (mut child, port) =
+        spawn_front_with_port_retry(&config).expect("live front should spawn and bind");
+    let pid = child.id();
+
+    // Force distribution to actually start (lazy, first-/readiness-call).
+    let state = drive_to_terminal(port, ProbeTimeouts::default_local());
+    assert!(
+        matches!(state, ReadinessState::Ready(_)),
+        "expected the live front to reach Ready against a real workspace, got {state:?}"
+    );
+
+    let names = beamtalk_workspace::epmd::query_epmd_names()
+        .expect("epmd query should succeed with a real front now registered");
+    let expected = predict_short_name(&ws, pid);
+    assert!(
+        names.contains(&expected),
+        "predicted short name {expected:?} not found in epmd's registered names {names:?}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// BT-3004 acceptance criterion 2: deliberately trigger a bad-cookie attach
+/// and confirm `/readiness`'s default timeout budget comfortably covers the
+/// real response latency (whatever it turns out to be — this asserts the
+/// *outcome*, not a specific millisecond figure, so it stays meaningful if a
+/// future OTP/front change alters the actual latency).
+///
+/// Bypasses `spawn::spawn_front` deliberately: that function always resolves
+/// the workspace's real on-disk cookie (see its doc comment), so producing a
+/// bad-cookie scenario means invoking the launcher directly with an
+/// overridden `BT_WORKSPACE_COOKIE`, the same shape the spike used for its
+/// own negative-path tests.
+#[test]
+#[ignore = "needs a live dist-liveview release + running workspace — see module doc comment"]
+fn bad_cookie_readiness_resolves_within_the_default_budget() {
+    let ws = workspace_id();
+    let node_name = format!("beamtalk_workspace_{ws}@localhost");
+    let port = beamtalk_desktop_broker::port::find_free_port().expect("free port");
+
+    let mut cmd = Command::new(launcher());
+    cmd.env("BT_WORKSPACE_NODE", &node_name);
+    cmd.env("BT_WORKSPACE_COOKIE", "bt3004-deliberately-wrong-cookie");
+    cmd.env("PORT", port.to_string());
+    cmd.env("BT_ATTACH_BIND_IP", "127.0.0.1");
+    cmd.env("BT_ATTACH_NODE_SUFFIX", "bt3004_bad_cookie_probe");
+    cmd.env("RELEASE_DISTRIBUTION", "none");
+    let mut child = cmd
+        .spawn()
+        .expect("front should spawn even with a bad cookie");
+
+    let timeouts = ProbeTimeouts::default_local();
+    let start = Instant::now();
+    let state = drive_to_terminal(port, timeouts);
+    let elapsed = start.elapsed();
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert_eq!(
+        state,
+        ReadinessState::Failed(readiness::FailureReason::BadCookie),
+        "expected a definitive BadCookie failure, got {state:?} after {elapsed:?}"
+    );
+    // Regression guard, not a tight bound: measured BT-3004 runs resolved in
+    // well under 100ms on loopback (see readiness.rs's ProbeTimeouts doc
+    // comment) — several seconds of margin is intentional headroom, not the
+    // expected figure.
+    assert!(
+        elapsed < timeouts.http_up + timeouts.readiness,
+        "bad-cookie readiness took {elapsed:?}, which exceeds the configured budget \
+         ({:?} + {:?}) — ProbeTimeouts::default_local's calibration may need revisiting",
+        timeouts.http_up,
+        timeouts.readiness
+    );
+}
+
+/// BT-3004 acceptance criterion 3: race two spawns on the same port and
+/// measure how long the losing front takes to actually exit, to calibrate
+/// `spawn::DEFAULT_BIND_FAILURE_GRACE`. A grace window shorter than this
+/// measured exit latency would misclassify a real port conflict as
+/// `SpawnAttempt::Bound` (see `DEFAULT_BIND_FAILURE_GRACE`'s doc comment).
+#[test]
+#[ignore = "needs a live dist-liveview release + running workspace — see module doc comment"]
+fn a_real_port_conflict_exits_within_the_calibrated_grace_period() {
+    let ws = workspace_id();
+    let port = beamtalk_desktop_broker::port::find_free_port().expect("free port");
+
+    // Front A: binds and holds the port.
+    let winner_config = SpawnConfig::new(launcher(), ws.clone(), port);
+    let mut winner = spawn::spawn_front(&winner_config).expect("winner should spawn");
+    // Give it a real chance to actually bind before racing the loser —
+    // measured healthy boots reach HTTP-up in under 1s (see
+    // DEFAULT_BIND_FAILURE_GRACE's doc comment).
+    std::thread::sleep(Duration::from_secs(2));
+    assert_eq!(
+        winner.try_wait().expect("try_wait should succeed"),
+        None,
+        "winner should still be running (holding the port) before the race"
+    );
+
+    // Front B: loses the eaddrinuse race for the same port.
+    let loser_config = SpawnConfig::new(launcher(), ws, port);
+    let mut loser =
+        spawn::spawn_front(&loser_config).expect("loser should spawn (exec succeeds, bind fails)");
+
+    let start = Instant::now();
+    let exit_status = loop {
+        if let Some(status) = loser.try_wait().expect("try_wait should succeed") {
+            break status;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(30),
+            "loser never exited within 30s — a real conflict should surface as a crash"
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    let elapsed = start.elapsed();
+
+    let _ = winner.kill();
+    let _ = winner.wait();
+
+    assert!(
+        !exit_status.success(),
+        "the losing front should exit non-zero (eaddrinuse crash), got {exit_status}"
+    );
+    assert!(
+        elapsed <= DEFAULT_BIND_FAILURE_GRACE,
+        "a real :eaddrinuse crash took {elapsed:?} to surface, which exceeds \
+         spawn::DEFAULT_BIND_FAILURE_GRACE ({DEFAULT_BIND_FAILURE_GRACE:?}) — the grace \
+         period would misclassify this conflict as SpawnAttempt::Bound and needs \
+         recalibrating (see that constant's doc comment for the BT-3004 methodology)"
+    );
+}

--- a/crates/beamtalk-desktop-broker/tests/live_front.rs
+++ b/crates/beamtalk-desktop-broker/tests/live_front.rs
@@ -41,13 +41,25 @@
 //!
 //! **DDD Context:** Desktop Shell
 
-use std::process::Command;
+use std::process::{Child, Command};
 use std::time::{Duration, Instant};
 
 use beamtalk_desktop_broker::readiness::{self, ProbeTimeouts, ReadinessState};
 use beamtalk_desktop_broker::sname::predict_short_name;
 use beamtalk_desktop_broker::spawn::{self, DEFAULT_BIND_FAILURE_GRACE, SpawnConfig};
 use beamtalk_desktop_broker::{SpawnAttemptConfig, spawn_front_with_port_retry};
+
+/// Kills the wrapped front on drop, including on a mid-test panic (an
+/// `assert!` failure otherwise skips any explicit `child.kill()` below it,
+/// leaking a live BEAM process — and its held port — past the failing test).
+struct KillOnDrop(Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
 
 /// Resolve a required env var, panicking with the setup instructions above
 /// (not a silent skip — these tests are `#[ignore]`d specifically so they
@@ -94,9 +106,10 @@ fn predict_node_name_matches_a_live_epmd_registration() {
     let mut config = SpawnAttemptConfig::new(launcher(), ws.clone());
     config.bind_failure_grace = Duration::from_millis(300); // fast path, not under test here
 
-    let (mut child, port) =
+    let (child, port) =
         spawn_front_with_port_retry(&config).expect("live front should spawn and bind");
     let pid = child.id();
+    let _guard = KillOnDrop(child);
 
     // Force distribution to actually start (lazy, first-/readiness-call).
     let state = drive_to_terminal(port, ProbeTimeouts::default_local());
@@ -112,9 +125,6 @@ fn predict_node_name_matches_a_live_epmd_registration() {
         names.contains(&expected),
         "predicted short name {expected:?} not found in epmd's registered names {names:?}"
     );
-
-    let _ = child.kill();
-    let _ = child.wait();
 }
 
 /// BT-3004 acceptance criterion 2: deliberately trigger a bad-cookie attach
@@ -142,17 +152,15 @@ fn bad_cookie_readiness_resolves_within_the_default_budget() {
     cmd.env("BT_ATTACH_BIND_IP", "127.0.0.1");
     cmd.env("BT_ATTACH_NODE_SUFFIX", "bt3004_bad_cookie_probe");
     cmd.env("RELEASE_DISTRIBUTION", "none");
-    let mut child = cmd
+    let child = cmd
         .spawn()
         .expect("front should spawn even with a bad cookie");
+    let _guard = KillOnDrop(child);
 
     let timeouts = ProbeTimeouts::default_local();
     let start = Instant::now();
     let state = drive_to_terminal(port, timeouts);
     let elapsed = start.elapsed();
-
-    let _ = child.kill();
-    let _ = child.wait();
 
     assert_eq!(
         state,
@@ -185,25 +193,28 @@ fn a_real_port_conflict_exits_within_the_calibrated_grace_period() {
 
     // Front A: binds and holds the port.
     let winner_config = SpawnConfig::new(launcher(), ws.clone(), port);
-    let mut winner = spawn::spawn_front(&winner_config).expect("winner should spawn");
+    let mut winner = KillOnDrop(spawn::spawn_front(&winner_config).expect("winner should spawn"));
     // Give it a real chance to actually bind before racing the loser —
     // measured healthy boots reach HTTP-up in under 1s (see
     // DEFAULT_BIND_FAILURE_GRACE's doc comment).
     std::thread::sleep(Duration::from_secs(2));
     assert_eq!(
-        winner.try_wait().expect("try_wait should succeed"),
+        winner.0.try_wait().expect("try_wait should succeed"),
         None,
         "winner should still be running (holding the port) before the race"
     );
 
-    // Front B: loses the eaddrinuse race for the same port.
+    // Front B: loses the eaddrinuse race for the same port. Guarded too: if
+    // the 30s assert below ever fires, the loser genuinely never crashed and
+    // would otherwise leak a process holding this port.
     let loser_config = SpawnConfig::new(launcher(), ws, port);
-    let mut loser =
-        spawn::spawn_front(&loser_config).expect("loser should spawn (exec succeeds, bind fails)");
+    let mut loser = KillOnDrop(
+        spawn::spawn_front(&loser_config).expect("loser should spawn (exec succeeds, bind fails)"),
+    );
 
     let start = Instant::now();
     let exit_status = loop {
-        if let Some(status) = loser.try_wait().expect("try_wait should succeed") {
+        if let Some(status) = loser.0.try_wait().expect("try_wait should succeed") {
             break status;
         }
         assert!(
@@ -213,9 +224,6 @@ fn a_real_port_conflict_exits_within_the_calibrated_grace_period() {
         std::thread::sleep(Duration::from_millis(20));
     };
     let elapsed = start.elapsed();
-
-    let _ = winner.kill();
-    let _ = winner.wait();
 
     assert!(
         !exit_status.success(),

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -38,10 +38,29 @@ use crate::dto::{
 };
 use crate::state::AppState;
 
-/// Overall attach timeout: generous enough for a slow-but-healthy front boot
-/// plus the worst-case bad-cookie `/readiness` wait (Erlang's ~7s
-/// `net_setuptime` — see `beamtalk_desktop_broker::readiness::ProbeTimeouts`'s
-/// doc comment).
+/// Overall timeout for the `wait_ready` readiness-polling phase only —
+/// generous headroom above a healthy boot, not a measured requirement. It
+/// does **not** bound `spawn_front_with_port_retry` above, which runs first
+/// and can itself block synchronously for up to
+/// `port::DEFAULT_MAX_ATTEMPTS * spawn::DEFAULT_BIND_FAILURE_GRACE`
+/// (currently up to 50s in the pathological worst case — every candidate
+/// port conflicting) before `wait_ready` is ever called; `attach`'s true
+/// worst-case latency is that plus this timeout, not just this timeout. In
+/// practice each candidate is a fresh, distinct OS-assigned ephemeral port
+/// (not the same port retried), so an all-conflict run is far less likely
+/// than the single-attempt TOCTOU race `beamtalk_desktop_broker::port`'s
+/// module docs describe — noted here rather than acted on, since bounding
+/// the combined worst case is a product-judgment call (drop
+/// `max_port_attempts` for this caller? wrap both phases in one timeout?)
+/// beyond what BT-3004's calibration pass itself changed.
+///
+/// Originally sized against an assumption that a bad-cookie `/readiness`
+/// blocks for Erlang's ~7s `net_setuptime` — measured wrong on loopback
+/// (BT-3004): a real bad-cookie/dead-workspace `503` arrives in
+/// milliseconds. `30s` is kept as safe headroom for a slow-but-healthy
+/// front boot, not because the bad-cookie path needs it — see
+/// `beamtalk_desktop_broker::readiness::ProbeTimeouts`'s doc comment for the
+/// measurement.
 const ATTACH_TIMEOUT: Duration = Duration::from_secs(30);
 const ATTACH_POLL_INTERVAL: Duration = Duration::from_millis(300);
 


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-3004

## Summary

BT-2985 built `beamtalk-desktop-broker` entirely against the ADR 0097/spike contract, with no built `dist-liveview` release available in that sandbox — three assumptions were flagged as unverified. This PR builds a real `dist-liveview` release (`just dist-liveview`) against a real workspace and validates all three:

1. **`sname::predict_node_name`'s OS-pid assumption — confirmed correct.** Raced a real `Command::new(bin/server).spawn()` against a live front: the captured `Child::id()` matched epmd's actual registration byte-for-byte (e.g. `Child::id()` 26765 + suffix `bt3004test` → epmd name `bt_attach_bt3004test_26765`). The `bin/server → bin/bt_attach → erlexec → beam.smp` exec chain holds; no fork breaks it.
2. **`readiness::ProbeTimeouts::default_local`'s ~7s `net_setuptime` reasoning — measured wrong on loopback.** A real bad-cookie attach and a dead-workspace target both returned `503` in single-digit-to-low-double-digit milliseconds (bad cookie: ~7–27ms across 3 runs; dead workspace: ~15ms), not after any multi-second wait. `net_setuptime` bounds an unresponsive peer, not a loopback active-rejection. The 10s budget is kept as safe headroom (no evidence it causes harm), with the doc comment corrected.
3. **`spawn::DEFAULT_BIND_FAILURE_GRACE` — recalibrated, was a real bug.** Racing two fronts for the same port, a genuine `:eaddrinuse` crash took 2.76s–3.40s (mean ~3.05s, n=3) to actually surface as a process exit — nearly double the old 1.5s default. That meant real port conflicts were routinely being misclassified as `SpawnAttempt::Bound`, handing the caller a doomed child. Recalibrated to 5s (~1.6s margin over the worst observed crash).

Also corrects a stale copy of the same `net_setuptime` reasoning in `desktop/src-tauri/src/commands.rs`'s `ATTACH_TIMEOUT` doc comment, and notes that constant only bounds the readiness-wait phase, not `spawn_front_with_port_retry`'s own (now larger) worst-case latency — flagged as a tradeoff, not fixed here (product-judgment call on whether to bound the combined worst case).

## Key changes

- `crates/beamtalk-desktop-broker/src/spawn.rs` — `DEFAULT_BIND_FAILURE_GRACE` 1.5s → 5s, doc comments rewritten with the measured methodology and numbers.
- `crates/beamtalk-desktop-broker/src/sname.rs` — doc comment updated from "unverified" to "verified against a real release," with the exact repro numbers.
- `crates/beamtalk-desktop-broker/src/readiness.rs` — `ProbeTimeouts` doc comments corrected; the 10s budget stays but the `net_setuptime` justification is replaced with the loopback measurement.
- `crates/beamtalk-desktop-broker/tests/live_front.rs` (new) — `#[ignore]`d live-runtime integration suite reproducing all three checks against a real release, so future recalibration doesn't require a fresh manual sandbox session. Spawned processes are wrapped in an RAII `KillOnDrop` guard so a mid-test panic can't leak a live BEAM process.
- `desktop/src-tauri/src/commands.rs` — `ATTACH_TIMEOUT` doc comment corrected to match the measured finding, and documents that it doesn't bound `spawn_front_with_port_retry`'s own worst case.

## Test plan

- [x] `cargo test -p beamtalk-desktop-broker` — 98 unit tests pass, 3 new live tests correctly `#[ignore]`d by default.
- [x] Live tests run manually against a real `dist-liveview` release + workspace — all 3 pass (verified before and after an RAII-guard refactor).
- [x] `just ci-changed` — full local CI green (build, clippy, fmt, dialyzer, spec validation, stdlib/BUnit/runtime tests, corpus, surface-drift).
- [x] Pre-push hook (full local CI) passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_012GHV5wZCdTyiQADqppbgSQ)_