### PR TITLE
fix: class_of_object_by_name deadlocks when called from a foreign-process block (BT-3052)

### DIFF
--- a/crates/beamtalk-examples/corpus.json
+++ b/crates/beamtalk-examples/corpus.json
@@ -17901,6 +17901,32 @@
       "explanation": "BT-3051: `^self <inheritedSelector>` with no block involved at all — the plain-return codegen path (no active NLR token), not the throw/catch path `bt3051_parent.bt` exercises. Already worked before the fix (the method-body generator closes the open scope for a body's final statement independently of `Expression::Return`'s own codegen); pinned here as a regression guard against the throw-path fix accidentally affecting this path too."
     },
     {
+      "id": "stdlib-test-fixtures-bt3052-parent",
+      "title": "BT3052Parent",
+      "category": "stdlib-fixtures",
+      "tags": [
+        "BT3047Ancestor",
+        "BT3052Parent",
+        "assign",
+        "assignment",
+        "bt3052_parent",
+        "constructor",
+        "create",
+        "extends",
+        "inherit",
+        "inheritance",
+        "instantiate",
+        "makeSelfClassThrough:over:",
+        "mutate",
+        "mutation",
+        "object",
+        "set",
+        "subclassing"
+      ],
+      "source": "// BT-3052: exercises `self new class` as a single expression inside a block\n// that executes in a foreign class's process (ADR 0109), as opposed to\n// `bt3047_parent.bt`'s `makeSelfThrough:` which keeps `.class` outside the\n// block. This combination used to deadlock — see\n// stdlib/test/self_new_class_in_foreign_block_test.bt for the full story.\n\nBT3047Ancestor subclass: BT3052Parent\n\n  class makeSelfClassThrough: aDriverClass over: aList :: List =>\n    aDriverClass\n      run: [:x |\n        result := self new class\n        ^result\n      ]\n      over: aList\n    #wrong",
+      "explanation": "BT-3052: exercises `self new class` as a single expression inside a block that executes in a foreign class's process (ADR 0109), as opposed to `bt3047_parent.bt`'s `makeSelfThrough:` which keeps `.class` outside the block. This combination used to deadlock — see stdlib/test/self_new_class_in_foreign_block_test.bt for the full story."
+    },
+    {
       "id": "stdlib-test-fixtures-calculator",
       "title": "Calculator",
       "category": "stdlib-fixtures",
@@ -27341,6 +27367,27 @@
       ],
       "source": "// BT-2005: Regression tests for `self class spawnWith:as:` /\n// `self class spawnAs:` inside a class factory method. Before the fix, the\n// metaclass dispatch path routed through `gen_server:call` on the class\n// process, which is the *same* process executing the class method — the call\n// deadlocked with `{calling_self, gen_server:call([...])}`.\n//\n// Fixture: stdlib/test/fixtures/self_class_named_factory_actor.bt\n\nTestCase subclass: SelfClassSpawnTest\n\n  testSelfClassSpawnAsRegistersName =>\n    name := #bt2005_self_class_spawnas_success\n    result := SelfClassNamedFactoryActor startViaClassAs: name\n    self assert: result isOk\n    actor := result unwrap\n    self assert: actor registeredName equals: name\n    self assert: actor isRegistered\n    actor stop\n\n  testSelfClassSpawnWithAsRegistersName =>\n    name := #bt2005_self_class_spawnwithas_success\n    result := SelfClassNamedFactoryActor startViaClassWith: #{\n      #value => 42\n    } as: name\n    self assert: result isOk\n    actor := result unwrap\n    self assert: actor getValue equals: 42\n    self assert: actor registeredName equals: name\n    actor stop\n\n  testSelfClassSpawnWithAsDuplicateReturnsError =>\n    name := #bt2005_self_class_spawnwithas_dup\n    first := (SelfClassNamedFactoryActor startViaClassWith: #{\n      #value => 1\n    } as: name) unwrap\n    second := SelfClassNamedFactoryActor startViaClassWith: #{\n      #value => 2\n    } as: name\n    self assert: second isError\n    self assert: second error kind equals: #name_registered\n    first stop\n\n  testSelfClassSpawnAsReservedNameReturnsError =>\n    result := SelfClassNamedFactoryActor startViaClassAs: #logger\n    self assert: result isError\n    self assert: result error kind equals: #reserved_name\n\n  testSelfClassSpawnPlain =>\n    actor := SelfClassNamedFactoryActor startViaClassPlain\n    self assert: actor getValue equals: 0\n    actor stop\n\n  testSelfClassSpawnWithMap =>\n    actor := SelfClassNamedFactoryActor startViaClassWithMap: #{#value => 7}\n    self assert: actor getValue equals: 7\n    actor stop",
       "explanation": "BT-2005: Regression tests for `self class spawnWith:as:` / `self class spawnAs:` inside a class factory method. Before the fix, the metaclass dispatch path routed through `gen_server:call` on the class process, which is the *same* process executing the class method — the call deadlocked with `{calling_self, gen_server:call([...])}`.  Fixture: stdlib/test/fixtures/self_class_named_factory_actor.bt"
+    },
+    {
+      "id": "stdlib-test-self-new-class-in-foreign-block-test",
+      "title": "SelfNewClassInForeignBlockTest",
+      "category": "stdlib-tests",
+      "tags": [
+        "SelfNewClassInForeignBlockTest",
+        "TestCase",
+        "constructor",
+        "create",
+        "extends",
+        "inherit",
+        "inheritance",
+        "instantiate",
+        "object",
+        "self_new_class_in_foreign_block_test",
+        "subclassing",
+        "testSelfNewClassInsideForeignBlockDoesNotDeadlock"
+      ],
+      "source": "// BT-3052: `self new class` inside a block that executes in a foreign\n// class's process (ADR 0109) used to deadlock. `self new` (closure-captured\n// via `ClassSelf`, per BT-3047) constructs an instance of the block's\n// lexical home class — but sending `.class` to it resolved the class's\n// module via a `gen_server:call` to that class's own pid\n// (`beamtalk_object_class:module_name/1`). Since the block executes inside\n// the *driver's* process, and the driver was itself synchronously invoked\n// by this class's own process (which is now blocked waiting on the\n// driver), that call cycles straight back to the blocked caller — a\n// gen_server:call deadlock distinct from BT-893's guarded direct-self-call\n// case (the two pids genuinely differ here). Fixed in\n// `beamtalk_primitive:class_of_object_by_name/1` by resolving the module\n// via the `beamtalk_class_metadata` ETS table instead (no message send).\n//\n// Fixtures: fixtures/bt3047_ancestor.bt, fixtures/bt3047_driver_plain.bt,\n// fixtures/bt3052_parent.bt.\n\nTestCase subclass: SelfNewClassInForeignBlockTest\n\n  testSelfNewClassInsideForeignBlockDoesNotDeadlock =>\n    self assert: (BT3052Parent makeSelfClassThrough: BT3047DriverPlain over: #(1)) equals: BT3052Parent",
+      "explanation": "BT-3052: `self new class` inside a block that executes in a foreign class's process (ADR 0109) used to deadlock. `self new` (closure-captured via `ClassSelf`, per BT-3047) constructs an instance of the block's lexical home class — but sending `.class` to it resolved the class's module via a `gen_server:call` to that class's own pid (`beamtalk_object_class:module_name/1`). Since the block executes inside the *driver's* process, and the driver was itself synchronously invoked by this class's own process (which is now blocked waiting on the driver), that call cycles straight back to the blocked caller — a gen_server:call deadlock distinct from BT-893's guarded direct-self-call case (the two pids genuinely differ here). Fixed in `beamtalk_primitive:class_of_object_by_name/1` by resolving the module via the `beamtalk_class_metadata` ETS table instead (no message send).  Fixtures: fixtures/bt3047_ancestor.bt, fixtures/bt3047_driver_plain.bt, fixtures/bt3052_parent.bt."
     },
     {
       "id": "stdlib-test-self-reference-test",

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_primitive.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_primitive.erl
@@ -154,14 +154,40 @@ class_of_object(X) ->
 class_of_object_inner(ClassName) ->
     class_of_object_by_name(ClassName).
 
--doc "Return a class object given a class name atom (BT-412).".
+-doc """
+Return a class object given a class name atom (BT-412).
+
+BT-3052: resolves the module via the `beamtalk_class_metadata` ETS table
+(populated unconditionally alongside the class's own identity at
+init/reload, same precedent as BT-3047's `resolve_module_or_raise/2`)
+rather than `beamtalk_object_class:module_name/1`'s `gen_server:call(Pid,
+module_name)`. `class_of_object`/`class` is reachable from *any* value —
+including one constructed via `self new` inside a block that ADR 0109
+runs in a different class's process. If that different class was itself
+synchronously invoked by `ClassName`'s own process (e.g. `ClassName`
+called `otherClass someBlockTakingMethod: [...]` and the block does `self
+new class`), a `gen_server:call` back to `ClassName`'s pid here deadlocks:
+`ClassName`'s process is blocked waiting on the very process now trying to
+call it back. This is a different shape from BT-893's guarded case
+(`ClassPid =:= self()`, a *direct* self-call) — here the two pids differ,
+so no existing check catches it. The metadata-table read sidesteps the
+problem entirely: no message send, so no cycle to deadlock on. Falls back
+to the gen_server call only for the practically-unreachable case where a
+class object exists in the registry but hasn't (yet) written its metadata
+row — accepting the old deadlock exposure there rather than raising, since
+that miss should not happen for a class that can already be instantiated.
+""".
 -spec class_of_object_by_name(atom()) -> tuple() | atom().
 class_of_object_by_name(ClassName) ->
     case beamtalk_class_registry:whereis_class(ClassName) of
         undefined ->
             ClassName;
         Pid when is_pid(Pid) ->
-            ModuleName = beamtalk_object_class:module_name(Pid),
+            ModuleName =
+                case beamtalk_class_metadata:lookup_module(ClassName) of
+                    {ok, Module} -> Module;
+                    not_found -> beamtalk_object_class:module_name(Pid)
+                end,
             ClassTag = beamtalk_class_registry:class_object_tag(ClassName),
             {beamtalk_object, ClassTag, ModuleName, Pid}
     end.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_primitive_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_primitive_tests.erl
@@ -931,7 +931,22 @@ class_of_object_by_name_test_() ->
             {"unknown class returns atom", fun() ->
                 Result = beamtalk_primitive:class_of_object_by_name('NonExistentClass'),
                 ?assertEqual('NonExistentClass', Result)
-            end}
+            end},
+            {"resolves module via beamtalk_class_metadata, matching the metadata row (BT-3052)",
+                fun() ->
+                    %% BT-3052: class_of_object_by_name/1 used to resolve the module via
+                    %% beamtalk_object_class:module_name/1 (a gen_server:call to the class's
+                    %% own pid), which deadlocks when called from a process that class's pid
+                    %% is itself synchronously blocked waiting on (e.g. `self new class`
+                    %% inside a block ADR 0109 runs in a different class's process). The fix
+                    %% reads beamtalk_class_metadata's ETS-backed row instead — no message
+                    %% send, so no such cycle. Pin that the resolved module actually matches
+                    %% the metadata table's row, not just that a result comes back.
+                    {ok, ExpectedModule} = beamtalk_class_metadata:lookup_module('Integer'),
+                    {beamtalk_object, _, ActualModule, _} =
+                        beamtalk_primitive:class_of_object_by_name('Integer'),
+                    ?assertEqual(ExpectedModule, ActualModule)
+                end}
         ]}.
 
 %%% ============================================================================

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_primitive_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_primitive_tests.erl
@@ -946,7 +946,32 @@ class_of_object_by_name_test_() ->
                     {beamtalk_object, _, ActualModule, _} =
                         beamtalk_primitive:class_of_object_by_name('Integer'),
                     ?assertEqual(ExpectedModule, ActualModule)
-                end}
+                end},
+            {"falls back to gen_server:call when the metadata row is missing (BT-3052)", fun() ->
+                %% Flagged by the Claude review bot: the not_found fallback branch (still
+                %% the old beamtalk_object_class:module_name/1 gen_server:call) had no
+                %% direct coverage — it was only indirectly "covered" by being currently
+                %% unreachable. Delete 'Integer's live metadata row to force the fallback,
+                %% and confirm it still resolves correctly via the gen_server call, so a
+                %% future change that breaks the fallback doesn't go unnoticed. Save and
+                %% restore the row (in an after-clause, so it survives an assertion
+                %% failure) since 'Integer' is a shared bootstrap class other tests in
+                %% this suite depend on.
+                {ok, SavedModule} = beamtalk_class_metadata:lookup_module('Integer'),
+                {ok, SavedSuperclass} = beamtalk_class_metadata:lookup_superclass('Integer'),
+                {ok, _, SavedSelectors} = beamtalk_class_metadata:lookup_methods('Integer'),
+                {ok, SavedIsAbstract} = beamtalk_class_metadata:lookup_is_abstract('Integer'),
+                beamtalk_class_metadata:delete('Integer'),
+                try
+                    ?assertEqual(not_found, beamtalk_class_metadata:lookup_module('Integer')),
+                    Result = beamtalk_primitive:class_of_object_by_name('Integer'),
+                    ?assertMatch({beamtalk_object, _, SavedModule, _}, Result)
+                after
+                    beamtalk_class_metadata:insert(
+                        'Integer', SavedModule, SavedSelectors, SavedSuperclass, SavedIsAbstract
+                    )
+                end
+            end}
         ]}.
 
 %%% ============================================================================

--- a/stdlib/test/fixtures/bt3052_parent.bt
+++ b/stdlib/test/fixtures/bt3052_parent.bt
@@ -1,0 +1,19 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-3052: exercises `self new class` as a single expression inside a block
+// that executes in a foreign class's process (ADR 0109), as opposed to
+// `bt3047_parent.bt`'s `makeSelfThrough:` which keeps `.class` outside the
+// block. This combination used to deadlock — see
+// stdlib/test/self_new_class_in_foreign_block_test.bt for the full story.
+
+BT3047Ancestor subclass: BT3052Parent
+
+  class makeSelfClassThrough: aDriverClass over: aList :: List =>
+    aDriverClass
+      run: [:x |
+        result := self new class
+        ^result
+      ]
+      over: aList
+    #wrong

--- a/stdlib/test/self_new_class_in_foreign_block_test.bt
+++ b/stdlib/test/self_new_class_in_foreign_block_test.bt
@@ -1,0 +1,24 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-3052: `self new class` inside a block that executes in a foreign
+// class's process (ADR 0109) used to deadlock. `self new` (closure-captured
+// via `ClassSelf`, per BT-3047) constructs an instance of the block's
+// lexical home class — but sending `.class` to it resolved the class's
+// module via a `gen_server:call` to that class's own pid
+// (`beamtalk_object_class:module_name/1`). Since the block executes inside
+// the *driver's* process, and the driver was itself synchronously invoked
+// by this class's own process (which is now blocked waiting on the
+// driver), that call cycles straight back to the blocked caller — a
+// gen_server:call deadlock distinct from BT-893's guarded direct-self-call
+// case (the two pids genuinely differ here). Fixed in
+// `beamtalk_primitive:class_of_object_by_name/1` by resolving the module
+// via the `beamtalk_class_metadata` ETS table instead (no message send).
+//
+// Fixtures: fixtures/bt3047_ancestor.bt, fixtures/bt3047_driver_plain.bt,
+// fixtures/bt3052_parent.bt.
+
+TestCase subclass: SelfNewClassInForeignBlockTest
+
+  testSelfNewClassInsideForeignBlockDoesNotDeadlock =>
+    self assert: (BT3052Parent makeSelfClassThrough: BT3047DriverPlain over: #(1)) equals: BT3052Parent


### PR DESCRIPTION
## Summary

`self new class` inside a block that executes in a foreign class's process (ADR 0109) hung/timed out. Found while writing regression tests for BT-3047, filed separately since root-causing it needed its own investigation (the original hypothesis was unconfirmed — see BT-3052's acceptance criteria).

**Root cause**, confirmed via a minimal Erlang harness before touching any production code: `self new` constructs an instance of the block's lexical home class (correct, per BT-3047's `ClassSelf` fix). Sending `.class` to that instance resolves the class's module via `beamtalk_object_class:module_name/1`, which does `gen_server:call(ClassPid, module_name)` whenever the caller isn't already running inside `ClassPid` (`ClassPid =:= self()`, BT-893's guard for the *direct* self-call case).

But here the block executes inside the *driver's* process — a different pid — and that driver was itself synchronously invoked (`gen_server:call`) by `ClassPid`'s own process, which is now blocked waiting on the driver's reply. So the `.class` call cycles straight back to a process that's blocked waiting on the very process now trying to call it: a genuine cross-process circular wait that BT-893's `ClassPid =:= self()` check can't catch, since the two pids genuinely differ.

**Fix**: `beamtalk_primitive:class_of_object_by_name/1` now resolves the module via `beamtalk_class_metadata:lookup_module/1` (the same ETS-backed table BT-3047's `resolve_module_or_raise/2` uses — populated unconditionally alongside the class's own identity at init/reload) instead of the gen_server call. No message send, so no cycle to deadlock on. Falls back to the old `gen_server:call` only if the metadata row is somehow missing (practically unreachable for a class that can already be instantiated).

## Verification

- Reproduced the exact hang via a standalone Erlang diagnostic harness first, to confirm it's a real `gen_server:call` deadlock (not a slow path) and pin the exact call site — before making any code changes.
- Reproduced again through the real compiled pipeline: `stdlib/test/self_new_class_in_foreign_block_test.bt` failed with `"the operation timed out"` before the fix, and other tests in the same file continued running afterward (confirming this is a bounded circular-wait timeout, not a full-VM deadlock).
- Passes cleanly after the fix.
- `beamtalk_object_class:module_name/1` has 30+ other call sites across the runtime — only the one reachable from this repro (`class_of_object_by_name/1`) was changed. `just test` (Rust + stdlib 231/231 + BUnit 3187/3189 + runtime 5484+1806, 0 failures) confirms no regressions from the change.

## Test plan

- New regression test: `stdlib/test/self_new_class_in_foreign_block_test.bt` (+ fixture `bt3052_parent.bt`, reusing BT-3047's `bt3047_ancestor.bt`/`bt3047_driver_plain.bt`).
- New EUnit case in `beamtalk_primitive_tests.erl` pinning that `class_of_object_by_name/1`'s resolved module matches `beamtalk_class_metadata:lookup_module/1`'s row.
- `just build-corpus` regenerated for the new fixture.
- `just test` and pre-push lint gate (clippy, dialyzer, erlfmt, beamtalk fmt) all green locally; see CI for authoritative result.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwrPQHiJxWFPwqdYdaXHBK)_