### PR TITLE
fix: last_open_scope_result overloads a "_" sentinel with real variable names (BT-3053)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/conditionals.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/conditionals.rs
@@ -118,7 +118,7 @@ impl CoreErlangGenerator {
         let (cond_chain, cond_open_scope) = self.expression_doc_with_open_scope(receiver)?;
         let (cond_preamble, cond_val_doc) = match cond_open_scope {
             Some(OpenScopeResult::Value(result_var)) => (cond_chain, leaf::var(result_var)),
-            // BT-3053: no single value â substitute do:'s own `nil` contract.
+            // BT-3053: no single value — substitute do:'s own `nil` contract.
             Some(OpenScopeResult::NoValue) => (cond_chain, Document::Str("'nil'")),
             None => (Document::Nil, cond_chain),
         };
@@ -165,7 +165,7 @@ impl CoreErlangGenerator {
         let (cond_chain, cond_open_scope) = self.expression_doc_with_open_scope(receiver)?;
         let (cond_preamble, cond_val_doc) = match cond_open_scope {
             Some(OpenScopeResult::Value(result_var)) => (cond_chain, leaf::var(result_var)),
-            // BT-3053: no single value â substitute do:'s own `nil` contract.
+            // BT-3053: no single value — substitute do:'s own `nil` contract.
             Some(OpenScopeResult::NoValue) => (cond_chain, Document::Str("'nil'")),
             None => (Document::Nil, cond_chain),
         };
@@ -211,7 +211,7 @@ impl CoreErlangGenerator {
         let (cond_chain, cond_open_scope) = self.expression_doc_with_open_scope(receiver)?;
         let (cond_preamble, cond_val_doc) = match cond_open_scope {
             Some(OpenScopeResult::Value(result_var)) => (cond_chain, leaf::var(result_var)),
-            // BT-3053: no single value â substitute do:'s own `nil` contract.
+            // BT-3053: no single value — substitute do:'s own `nil` contract.
             Some(OpenScopeResult::NoValue) => (cond_chain, Document::Str("'nil'")),
             None => (Document::Nil, cond_chain),
         };
@@ -270,7 +270,7 @@ impl CoreErlangGenerator {
         let (recv_chain, recv_open_scope) = self.expression_doc_with_open_scope(receiver)?;
         let (recv_preamble, recv_val_doc) = match recv_open_scope {
             Some(OpenScopeResult::Value(result_var)) => (recv_chain, leaf::var(result_var)),
-            // BT-3053: no single value â substitute do:'s own `nil` contract.
+            // BT-3053: no single value — substitute do:'s own `nil` contract.
             Some(OpenScopeResult::NoValue) => (recv_chain, Document::Str("'nil'")),
             None => (Document::Nil, recv_chain),
         };

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/conditionals.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/conditionals.rs
@@ -44,7 +44,7 @@
 use super::super::document::Document;
 use super::super::document::leaf;
 use super::super::gen_server::BodyExprKind;
-use super::super::{CoreErlangGenerator, Result};
+use super::super::{CoreErlangGenerator, OpenScopeResult, Result};
 use crate::ast::{Block, Expression};
 use crate::docvec;
 
@@ -116,10 +116,11 @@ impl CoreErlangGenerator {
         // the value doc (the result variable). The preamble is emitted BEFORE
         // the case binding so ClassVarsN stays in scope inside the case.
         let (cond_chain, cond_open_scope) = self.expression_doc_with_open_scope(receiver)?;
-        let (cond_preamble, cond_val_doc) = if let Some(result_var) = cond_open_scope {
-            (cond_chain, leaf::var(result_var))
-        } else {
-            (Document::Nil, cond_chain)
+        let (cond_preamble, cond_val_doc) = match cond_open_scope {
+            Some(OpenScopeResult::Value(result_var)) => (cond_chain, leaf::var(result_var)),
+            // BT-3053: no single value â substitute do:'s own `nil` contract.
+            Some(OpenScopeResult::NoValue) => (cond_chain, Document::Str("'nil'")),
+            None => (Document::Nil, cond_chain),
         };
         let cond_var = self.fresh_temp_var("Cond");
         let outer_state = self.current_state_var();
@@ -162,10 +163,11 @@ impl CoreErlangGenerator {
     ) -> Result<Document<'static>> {
         // BT-1942: Split open let-chain from class method self-send sub-expressions.
         let (cond_chain, cond_open_scope) = self.expression_doc_with_open_scope(receiver)?;
-        let (cond_preamble, cond_val_doc) = if let Some(result_var) = cond_open_scope {
-            (cond_chain, leaf::var(result_var))
-        } else {
-            (Document::Nil, cond_chain)
+        let (cond_preamble, cond_val_doc) = match cond_open_scope {
+            Some(OpenScopeResult::Value(result_var)) => (cond_chain, leaf::var(result_var)),
+            // BT-3053: no single value â substitute do:'s own `nil` contract.
+            Some(OpenScopeResult::NoValue) => (cond_chain, Document::Str("'nil'")),
+            None => (Document::Nil, cond_chain),
         };
         let cond_var = self.fresh_temp_var("Cond");
         let outer_state = self.current_state_var();
@@ -207,10 +209,11 @@ impl CoreErlangGenerator {
     ) -> Result<Document<'static>> {
         // BT-1942: Split open let-chain from class method self-send sub-expressions.
         let (cond_chain, cond_open_scope) = self.expression_doc_with_open_scope(receiver)?;
-        let (cond_preamble, cond_val_doc) = if let Some(result_var) = cond_open_scope {
-            (cond_chain, leaf::var(result_var))
-        } else {
-            (Document::Nil, cond_chain)
+        let (cond_preamble, cond_val_doc) = match cond_open_scope {
+            Some(OpenScopeResult::Value(result_var)) => (cond_chain, leaf::var(result_var)),
+            // BT-3053: no single value â substitute do:'s own `nil` contract.
+            Some(OpenScopeResult::NoValue) => (cond_chain, Document::Str("'nil'")),
+            None => (Document::Nil, cond_chain),
         };
         let cond_var = self.fresh_temp_var("Cond");
         let outer_state = self.current_state_var();
@@ -265,10 +268,11 @@ impl CoreErlangGenerator {
     ) -> Result<Document<'static>> {
         // BT-1942: Split open let-chain from class method self-send sub-expressions.
         let (recv_chain, recv_open_scope) = self.expression_doc_with_open_scope(receiver)?;
-        let (recv_preamble, recv_val_doc) = if let Some(result_var) = recv_open_scope {
-            (recv_chain, leaf::var(result_var))
-        } else {
-            (Document::Nil, recv_chain)
+        let (recv_preamble, recv_val_doc) = match recv_open_scope {
+            Some(OpenScopeResult::Value(result_var)) => (recv_chain, leaf::var(result_var)),
+            // BT-3053: no single value â substitute do:'s own `nil` contract.
+            Some(OpenScopeResult::NoValue) => (recv_chain, Document::Str("'nil'")),
+            None => (Document::Nil, recv_chain),
         };
         let obj_var = self.fresh_temp_var("Obj");
         let outer_state = self.current_state_var();

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/dict_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/dict_ops.rs
@@ -497,6 +497,47 @@ mod tests {
     }
 
     #[test]
+    fn test_dict_do_nested_in_direct_params_loop_fed_directly_to_nlr_return() {
+        // BT-3053: same shape as
+        // control_flow::list_ops::tests::test_do_nested_in_direct_params_loop_fed_directly_to_nlr_return,
+        // but for the dictionary `do:` producer (dict_ops.rs:104) rather than
+        // list `do:` (basic_ops.rs:104) — both hit the identical
+        // `OpenScopeResult::NoValue` branch, but only the list-ops path had a
+        // regression test pinning the fix (flagged by the Claude review bot
+        // on the original PR). `^` (Expression::Return, via the NLR-throw
+        // path) fed the direct result of a mutation-threaded dictionary
+        // `do:` nested inside a direct-params loop must not reference the
+        // old bare `"_"` sentinel as if it were a bound variable.
+        let src = concat!(
+            "Actor subclass: Ctr3053Dict\n",
+            "  state: x = 0\n\n",
+            "  run: dict =>\n",
+            "    count := 0\n",
+            "    seen := 0\n",
+            "    1 to: 3 do: [:i |\n",
+            "      count := count + 1\n",
+            "      ^dict do: [:v | seen := seen + v]\n",
+            "    ]\n",
+            "    count\n",
+        );
+        let code = codegen(src);
+        let nlr_throw_idx = code
+            .find("call 'erlang':'throw'({'$bt_nlr'")
+            .expect("expected an NLR throw call in generated code");
+        let nlr_throw_window = &code[nlr_throw_idx..(nlr_throw_idx + 120).min(code.len())];
+        assert!(
+            !nlr_throw_window.contains(", _,"),
+            "NLR throw tuple must not reference a bare unbound `_` as the return \
+             value — the NoValue case must substitute 'nil'. Got window:\n{nlr_throw_window}\n\nFull:\n{code}"
+        );
+        assert!(
+            nlr_throw_window.contains("'nil'"),
+            "NLR throw tuple should substitute the literal 'nil' atom for a \
+             NoValue open scope. Got window:\n{nlr_throw_window}\n\nFull:\n{code}"
+        );
+    }
+
+    #[test]
     fn test_dict_do_with_key_field_mutation_uses_maps_to_list_foldl() {
         // doWithKey: with a field mutation generates maps:to_list + lists:foldl.
         // The foldl lambda receives {K, V} pairs extracted from the list.

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/dict_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/dict_ops.rs
@@ -12,7 +12,7 @@
 use super::super::document::Document;
 use super::super::document::leaf;
 use super::super::intrinsics::validate_block_arity_exact;
-use super::super::{CodeGenContext, CoreErlangGenerator, Result, block_analysis};
+use super::super::{CodeGenContext, CoreErlangGenerator, OpenScopeResult, Result, block_analysis};
 use super::{BodyKind, ThreadingPlan};
 use crate::ast::{Block, Expression};
 use crate::docvec;
@@ -97,7 +97,11 @@ impl CoreErlangGenerator {
             let fold_result = self.fresh_temp_var("FoldResult");
             let extract_doc = plan.generate_tuple_extract_suffix_doc(&fold_result, 1, self);
             let result_doc = if self.in_direct_params_loop {
-                self.last_open_scope_result = Some("_".to_string());
+                // BT-1329/BT-3053: see the identical branch in
+                // `control_flow/list_ops/basic_ops.rs`'s `do:` — same shape here for a
+                // dictionary iteration: multiple rebound accumulator vars, no single
+                // "result" value, so signal open-with-no-value rather than naming one.
+                self.last_open_scope_result = Some(OpenScopeResult::NoValue);
                 docvec![
                     " in let ",
                     leaf::var(fold_result.clone()),
@@ -301,7 +305,11 @@ impl CoreErlangGenerator {
             let fold_result = self.fresh_temp_var("FoldResult");
             let extract_doc = plan.generate_tuple_extract_suffix_doc(&fold_result, 1, self);
             let result_doc = if self.in_direct_params_loop {
-                self.last_open_scope_result = Some("_".to_string());
+                // BT-1329/BT-3053: see the identical branch in
+                // `control_flow/list_ops/basic_ops.rs`'s `do:` — same shape here for a
+                // dictionary iteration: multiple rebound accumulator vars, no single
+                // "result" value, so signal open-with-no-value rather than naming one.
+                self.last_open_scope_result = Some(OpenScopeResult::NoValue);
                 docvec![
                     " in let ",
                     leaf::var(fold_result.clone()),

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/basic_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/basic_ops.rs
@@ -6,7 +6,7 @@
 use super::super::super::document::Document;
 use super::super::super::document::leaf;
 use super::super::super::intrinsics::validate_block_arity_exact;
-use super::super::super::{CodeGenContext, CoreErlangGenerator, Result};
+use super::super::super::{CodeGenContext, CoreErlangGenerator, OpenScopeResult, Result};
 use super::super::{BodyKind, ThreadingPlan};
 use crate::ast::{Block, Expression};
 use crate::docvec;
@@ -95,9 +95,13 @@ impl CoreErlangGenerator {
                 // BT-1329: In direct-params loop context, skip StateAcc repack and omit
                 // trailing 'nil'. The extracted vars are left as open let-bindings so they
                 // escape to the outer scope (the caller chains the next expression directly).
-                // BT-1448: Signal open scope so the annotation guard in generate_expression
-                // does not wrap this open let-chain in `( ... -| [...] )`.
-                self.last_open_scope_result = Some("_".to_string());
+                // BT-1448/BT-3053: Signal open scope with no single value (multiple
+                // accumulator vars may have been rebound; `do:` itself always answers
+                // `nil`) so the annotation guard in generate_expression does not wrap
+                // this open let-chain in `( ... -| [...] )`, and a consumer that needs
+                // to reference a value substitutes `do:`'s own `nil` contract instead
+                // of a nonexistent variable.
+                self.last_open_scope_result = Some(OpenScopeResult::NoValue);
                 docvec![
                     " in let ",
                     leaf::var(fold_result.clone()),

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/tests.rs
@@ -2036,8 +2036,9 @@ fn test_do_nested_in_direct_params_loop() {
     // The outer loop sets in_direct_params_loop=true, which causes
     // generate_list_do_with_mutations to hit the tuple-acc + in_direct_params_loop
     // branch (basic_ops.rs lines 94-112): StateAcc repack is skipped, an open
-    // let-chain is emitted, and last_open_scope_result is set to "_" so the outer
-    // loop can chain the next expression directly.
+    // let-chain is emitted, and last_open_scope_result is set to
+    // Some(OpenScopeResult::NoValue) (BT-3053) so the outer loop can chain the
+    // next expression directly.
     let src = concat!(
         "Actor subclass: Ctr\n",
         "  state: x = 0\n\n",
@@ -2067,6 +2068,62 @@ fn test_do_nested_in_direct_params_loop() {
     assert!(
         code.contains("ExitSA"),
         "Direct-params outer loop should rebuild StateAcc at exit. Got:\n{code}"
+    );
+}
+
+#[test]
+fn test_do_nested_in_direct_params_loop_fed_directly_to_nlr_return() {
+    // BT-3053: `^` (Expression::Return, compiled via the NLR-throw path since
+    // it's inside a block) fed the *direct result* of a mutation-threaded
+    // `do:` nested inside a direct-params loop — the exact shape that used to
+    // reference the bare `"_"` sentinel as if it were a bound variable
+    // (`last_open_scope_result` was `Option<String>` before this fix, and
+    // `"_"` did double duty as both a real name and a "still open, no value"
+    // flag). Before the fix this produced `call 'erlang':'throw'({'$bt_nlr',
+    // Token, _, State})` — a reference to an unbound `_`. After the fix, the
+    // NoValue case substitutes `do:`'s own `nil` return-value contract.
+    //
+    // Reuses the outer-loop/nested-do: setup from
+    // `test_do_nested_in_direct_params_loop` above, with `^` inside the
+    // outer to:do:'s own block wrapping the nested do:'s result directly —
+    // any `^` inside a block (not just the ADR 0109 cross-process case)
+    // goes through the NLR-throw codegen path (see BT-3051's fix in
+    // `Expression::Return`) rather than a plain return.
+    let src = concat!(
+        "Actor subclass: Ctr3053\n",
+        "  state: x = 0\n\n",
+        "  run: items =>\n",
+        "    count := 0\n",
+        "    seen := 0\n",
+        "    1 to: 3 do: [:i |\n",
+        "      count := count + 1\n",
+        "      ^items do: [:item | seen := seen + 1]\n",
+        "    ]\n",
+        "    count\n",
+    );
+    let code = codegen(src);
+    // Isolate the NLR throw tuple itself — `", _, "` alone is too broad (it
+    // also matches unrelated wildcard patterns elsewhere in the generated
+    // module boilerplate).
+    let nlr_throw_idx = code
+        .find("call 'erlang':'throw'({'$bt_nlr'")
+        .expect("expected an NLR throw call in generated code");
+    // The throw call's argument list (`{'$bt_nlr', Token, Value, State})`) is
+    // short — a window comfortably covers it without picking up unrelated
+    // `", _, "` occurrences elsewhere in the module's boilerplate.
+    let nlr_throw_window = &code[nlr_throw_idx..(nlr_throw_idx + 120).min(code.len())];
+    // The critical assertion: no reference to a bare, unbound `_` variable as
+    // the NLR throw tuple's Value position (element 3) — the actual bug this
+    // issue fixes. A real bound variable name never renders as a lone `_`.
+    assert!(
+        !nlr_throw_window.contains(", _,"),
+        "NLR throw tuple must not reference a bare unbound `_` as the return \
+         value — the NoValue case must substitute 'nil'. Got window:\n{nlr_throw_window}\n\nFull:\n{code}"
+    );
+    assert!(
+        nlr_throw_window.contains("'nil'"),
+        "NLR throw tuple should substitute the literal 'nil' atom for a \
+         NoValue open scope. Got window:\n{nlr_throw_window}\n\nFull:\n{code}"
     );
 }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -32,7 +32,9 @@ mod list_ops;
 mod while_loops;
 
 use super::document::{Document, join, leaf};
-use super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result, block_analysis};
+use super::{
+    CodeGenContext, CodeGenError, CoreErlangGenerator, OpenScopeResult, Result, block_analysis,
+};
 use crate::ast::Expression;
 use crate::docvec;
 use crate::source_analysis::Span;
@@ -3156,7 +3158,18 @@ impl CoreErlangGenerator {
 
                 // BT-1397: If the RHS produced an open scope (class method self-send),
                 // emit the open scope first, then bind the variable to the result.
-                if let Some(open_scope_result) = open_scope {
+                // BT-3053: a `NoValue` scope (no single value — e.g. the RHS is a
+                // mutation-threaded `do:` nested in a direct-params loop) substitutes
+                // do:'s own `nil` contract rather than referencing a variable that
+                // doesn't exist.
+                let open_scope_value_doc = match open_scope {
+                    Some(OpenScopeResult::Value(open_scope_result)) => {
+                        Some(leaf::var(open_scope_result))
+                    }
+                    Some(OpenScopeResult::NoValue) => Some(Document::Str("'nil'")),
+                    None => None,
+                };
+                if let Some(open_scope_value_doc) = open_scope_value_doc {
                     // BT-2703: see note below — rebind so later same-iteration reads
                     // observe the freshly-written value.
                     self.bind_var(&id.name, &val_var);
@@ -3166,7 +3179,7 @@ impl CoreErlangGenerator {
                             "let ",
                             leaf::var(val_var.clone()),
                             " = ",
-                            leaf::var(open_scope_result),
+                            open_scope_value_doc,
                             " in let ",
                             leaf::var(new_state),
                             " = call 'maps':'put'(",

--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -38,7 +38,7 @@
 
 use super::document::Document;
 use super::document::leaf;
-use super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result};
+use super::{CodeGenContext, CodeGenError, CoreErlangGenerator, OpenScopeResult, Result};
 use crate::ast::{Expression, Literal, MessageSelector, WellKnownSelector};
 use crate::docvec;
 
@@ -180,16 +180,26 @@ impl CoreErlangGenerator {
             }
             let saved_cv = self.class_var_version();
             let (doc, open_scope) = self.expression_doc_with_open_scope(arg)?;
-            if let Some(result_var) = open_scope {
-                // Close the open scope inline: the let-chain + result_var forms
-                // a valid closed expression (e.g., `let X = ... in X`).
-                // Roll back class var version since the ClassVarsN binding is
-                // scoped inside the closed expression and not visible to
-                // subsequent code.
-                self.set_class_var_version(saved_cv);
-                parts.push(docvec![doc, leaf::var(result_var)]);
-            } else {
-                parts.push(doc);
+            match open_scope {
+                Some(OpenScopeResult::Value(result_var)) => {
+                    // Close the open scope inline: the let-chain + result_var forms
+                    // a valid closed expression (e.g., `let X = ... in X`).
+                    // Roll back class var version since the ClassVarsN binding is
+                    // scoped inside the closed expression and not visible to
+                    // subsequent code.
+                    self.set_class_var_version(saved_cv);
+                    parts.push(docvec![doc, leaf::var(result_var)]);
+                }
+                // BT-3053: e.g. a message argument that's itself `items do:
+                // [...]` nested in a direct-params loop — no single value,
+                // substitute do:'s own `nil` contract.
+                Some(OpenScopeResult::NoValue) => {
+                    self.set_class_var_version(saved_cv);
+                    parts.push(docvec![doc, "'nil'"]);
+                }
+                None => {
+                    parts.push(doc);
+                }
             }
         }
         Ok(Document::Vec(parts))
@@ -307,24 +317,37 @@ impl CoreErlangGenerator {
         for arg in arguments {
             let (arg_doc, open_scope) = self.expression_doc_with_open_scope(arg)?;
             let arg_var = self.fresh_temp_var(prefix);
-            if let Some(result_var) = open_scope {
-                any_open_scope = true;
-                preamble_parts.push(arg_doc);
-                preamble_parts.push(docvec![
-                    "let ",
-                    leaf::var(arg_var.clone()),
-                    " = ",
-                    leaf::var(result_var),
-                    " in ",
-                ]);
-            } else {
-                preamble_parts.push(docvec![
-                    "let ",
-                    leaf::var(arg_var.clone()),
-                    " = ",
-                    arg_doc,
-                    " in ",
-                ]);
+            match open_scope {
+                Some(OpenScopeResult::Value(result_var)) => {
+                    any_open_scope = true;
+                    preamble_parts.push(arg_doc);
+                    preamble_parts.push(docvec![
+                        "let ",
+                        leaf::var(arg_var.clone()),
+                        " = ",
+                        leaf::var(result_var),
+                        " in ",
+                    ]);
+                }
+                // BT-3053: no single value — substitute do:'s own `nil` contract.
+                Some(OpenScopeResult::NoValue) => {
+                    any_open_scope = true;
+                    preamble_parts.push(arg_doc);
+                    preamble_parts.push(docvec![
+                        "let ",
+                        leaf::var(arg_var.clone()),
+                        " = 'nil' in ",
+                    ]);
+                }
+                None => {
+                    preamble_parts.push(docvec![
+                        "let ",
+                        leaf::var(arg_var.clone()),
+                        " = ",
+                        arg_doc,
+                        " in ",
+                    ]);
+                }
             }
             arg_refs.push(leaf::var(arg_var));
         }
@@ -364,10 +387,11 @@ impl CoreErlangGenerator {
         expr: &Expression,
     ) -> Result<(Document<'static>, Document<'static>)> {
         let (expr_doc, open_scope) = self.expression_doc_with_open_scope(expr)?;
-        if let Some(result_var) = open_scope {
-            Ok((expr_doc, leaf::var(result_var)))
-        } else {
-            Ok((Document::Nil, expr_doc))
+        match open_scope {
+            Some(OpenScopeResult::Value(result_var)) => Ok((expr_doc, leaf::var(result_var))),
+            // BT-3053: no single value — substitute do:'s own `nil` contract.
+            Some(OpenScopeResult::NoValue) => Ok((expr_doc, Document::Str("'nil'"))),
+            None => Ok((Document::Nil, expr_doc)),
         }
     }
 
@@ -402,7 +426,7 @@ impl CoreErlangGenerator {
             call_doc,
             " in ",
         ];
-        self.last_open_scope_result = Some(result_var);
+        self.last_open_scope_result = Some(OpenScopeResult::Value(result_var));
         doc
     }
 
@@ -478,7 +502,7 @@ impl CoreErlangGenerator {
             leaf::var(plain_res),
             " end in ",
         ];
-        self.last_open_scope_result = Some(result);
+        self.last_open_scope_result = Some(OpenScopeResult::Value(result));
         doc
     }
 
@@ -2761,7 +2785,7 @@ impl CoreErlangGenerator {
                 case_doc,
                 " in ",
             ];
-            self.last_open_scope_result = Some(result_var);
+            self.last_open_scope_result = Some(OpenScopeResult::Value(result_var));
             Ok(doc)
         } else {
             Ok(docvec![lookup_binding, arg_preamble, case_doc])
@@ -2841,7 +2865,7 @@ impl CoreErlangGenerator {
                 case_doc,
                 " in ",
             ];
-            self.last_open_scope_result = Some(result_var);
+            self.last_open_scope_result = Some(OpenScopeResult::Value(result_var));
             Ok(doc)
         } else {
             Ok(docvec![lookup_binding, arg_preamble, case_doc])

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -21,7 +21,7 @@ use std::collections::HashSet;
 
 use super::document::Document;
 use super::document::leaf;
-use super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result};
+use super::{CodeGenContext, CodeGenError, CoreErlangGenerator, OpenScopeResult, Result};
 use crate::ast::{
     BinaryEndianness, BinarySegment, BinarySegmentType, BinarySignedness, Block, CascadeMessage,
     Expression, Identifier, Literal, MapPair, MapPatternKey, MatchArm, MessageSelector, Pattern,
@@ -603,7 +603,7 @@ impl CoreErlangGenerator {
                     shadow_doc,
                 ];
                 // Store result var name for callers that need to reference it
-                self.last_open_scope_result = Some(val_var);
+                self.last_open_scope_result = Some(OpenScopeResult::Value(val_var));
                 return Ok(doc);
             }
             return Err(CodeGenError::UnsupportedFeature {
@@ -1190,37 +1190,54 @@ impl CoreErlangGenerator {
                     let state = self.current_state_var();
                     // BT-1397: If the expression left an open scope, close it with
                     // the result variable then wrap in the Tier 2 tuple.
-                    if let Some(result_var) = open_scope {
-                        docs.push(docvec![
-                            doc,
-                            "{",
-                            leaf::var(result_var),
-                            ", ",
-                            leaf::var(state),
-                            "}"
-                        ]);
-                    } else {
-                        let result_var = self.fresh_temp_var("T2Res");
-                        docs.push(docvec![
-                            "let ",
-                            leaf::var(result_var.clone()),
-                            " = ",
-                            doc,
-                            " in {",
-                            leaf::var(result_var),
-                            ", ",
-                            leaf::var(state),
-                            "}"
-                        ]);
+                    match open_scope {
+                        Some(OpenScopeResult::Value(result_var)) => {
+                            docs.push(docvec![
+                                doc,
+                                "{",
+                                leaf::var(result_var),
+                                ", ",
+                                leaf::var(state),
+                                "}"
+                            ]);
+                        }
+                        // BT-3053: no single value — substitute do:'s own `nil` contract.
+                        Some(OpenScopeResult::NoValue) => {
+                            docs.push(docvec![doc, "{'nil', ", leaf::var(state), "}"]);
+                        }
+                        None => {
+                            let result_var = self.fresh_temp_var("T2Res");
+                            docs.push(docvec![
+                                "let ",
+                                leaf::var(result_var.clone()),
+                                " = ",
+                                doc,
+                                " in {",
+                                leaf::var(result_var),
+                                ", ",
+                                leaf::var(state),
+                                "}"
+                            ]);
+                        }
                     }
-                } else if let Some(result_var) = open_scope {
-                    // BT-1397: Open scope from class method self-send — emit chain
-                    // then discard the result.
-                    docs.push(docvec![doc, "let _ = ", leaf::var(result_var), " in "]);
                 } else {
-                    docs.push(Document::Str("let _ = "));
-                    docs.push(doc);
-                    docs.push(Document::Str(" in "));
+                    match open_scope {
+                        Some(OpenScopeResult::Value(result_var)) => {
+                            // BT-1397: Open scope from class method self-send — emit chain
+                            // then discard the result.
+                            docs.push(docvec![doc, "let _ = ", leaf::var(result_var), " in "]);
+                        }
+                        // BT-3053: no single value to discard — its own rebindings
+                        // are already visible; nothing to bind here.
+                        Some(OpenScopeResult::NoValue) => {
+                            docs.push(doc);
+                        }
+                        None => {
+                            docs.push(Document::Str("let _ = "));
+                            docs.push(doc);
+                            docs.push(Document::Str(" in "));
+                        }
+                    }
                 }
             }
         }
@@ -1560,10 +1577,13 @@ impl CoreErlangGenerator {
                 // The generated code leaves an open scope ending with `in ` — close it
                 // with the unwrapped result variable (same pattern as generate_class_method_body).
                 let (expr_doc, open_scope) = self.expression_doc_with_open_scope(expr)?;
-                if let Some(result_var) = open_scope {
-                    Ok(docvec![expr_doc, leaf::var(result_var)])
-                } else {
-                    Ok(expr_doc)
+                match open_scope {
+                    Some(OpenScopeResult::Value(result_var)) => {
+                        Ok(docvec![expr_doc, leaf::var(result_var)])
+                    }
+                    // BT-3053: no single value — substitute do:'s own `nil` contract.
+                    Some(OpenScopeResult::NoValue) => Ok(docvec![expr_doc, "'nil'"]),
+                    None => Ok(expr_doc),
                 }
             }
             BlockExprKind::LastExpr => {
@@ -1577,10 +1597,13 @@ impl CoreErlangGenerator {
                 // saving/restoring class_var_version and clearing
                 // last_open_scope_result.
                 let (expr_doc, open_scope) = self.expression_doc_with_open_scope(expr)?;
-                if let Some(result_var) = open_scope {
-                    Ok(docvec![expr_doc, leaf::var(result_var)])
-                } else {
-                    Ok(expr_doc)
+                match open_scope {
+                    Some(OpenScopeResult::Value(result_var)) => {
+                        Ok(docvec![expr_doc, leaf::var(result_var)])
+                    }
+                    // BT-3053: no single value — substitute do:'s own `nil` contract.
+                    Some(OpenScopeResult::NoValue) => Ok(docvec![expr_doc, "'nil'"]),
+                    None => Ok(expr_doc),
                 }
             }
             BlockExprKind::FieldAssignment => {
@@ -1597,15 +1620,17 @@ impl CoreErlangGenerator {
                 // BT-1397: Class method self-send as non-last expression in a block body.
                 // The generated code leaves an open scope — emit it and discard the result.
                 let (expr_doc, open_scope) = self.expression_doc_with_open_scope(expr)?;
-                if let Some(result_var) = open_scope {
-                    Ok(docvec![
+                match open_scope {
+                    Some(OpenScopeResult::Value(result_var)) => Ok(docvec![
                         expr_doc,
                         "let _Unit = ",
                         leaf::var(result_var),
                         " in "
-                    ])
-                } else {
-                    Ok(docvec!["let _Unit = ", expr_doc, " in "])
+                    ]),
+                    // BT-3053: no single value to discard — its own rebindings
+                    // are already visible; nothing to bind here.
+                    Some(OpenScopeResult::NoValue) => Ok(expr_doc),
+                    None => Ok(docvec!["let _Unit = ", expr_doc, " in "]),
                 }
             }
             BlockExprKind::SideEffect => {
@@ -1614,15 +1639,17 @@ impl CoreErlangGenerator {
                 // receiver/args contain class method self-sends, by closing
                 // the chain here and binding the result var.
                 let (expr_doc, open_scope) = self.expression_doc_with_open_scope(expr)?;
-                if let Some(result_var) = open_scope {
-                    Ok(docvec![
+                match open_scope {
+                    Some(OpenScopeResult::Value(result_var)) => Ok(docvec![
                         expr_doc,
                         "let _Unit = ",
                         leaf::var(result_var),
                         " in "
-                    ])
-                } else {
-                    Ok(docvec!["let _Unit = ", expr_doc, " in "])
+                    ]),
+                    // BT-3053: no single value to discard — its own rebindings
+                    // are already visible; nothing to bind here.
+                    Some(OpenScopeResult::NoValue) => Ok(expr_doc),
+                    None => Ok(docvec!["let _Unit = ", expr_doc, " in "]),
                 }
             }
         }
@@ -1792,23 +1819,29 @@ impl CoreErlangGenerator {
         self.bind_var(var_name, &core_var);
         // BT-1397: If the RHS produced an open scope (class method self-send),
         // emit the open scope then bind the variable to its result.
-        if let Some(open_scope_result) = open_scope {
-            Ok(docvec![
+        match open_scope {
+            Some(OpenScopeResult::Value(open_scope_result)) => Ok(docvec![
                 val_doc,
                 "let ",
                 leaf::var(core_var),
                 " = ",
                 leaf::var(open_scope_result),
                 " in "
-            ])
-        } else {
-            Ok(docvec![
+            ]),
+            // BT-3053: no single value — substitute do:'s own `nil` contract.
+            Some(OpenScopeResult::NoValue) => Ok(docvec![
+                val_doc,
+                "let ",
+                leaf::var(core_var),
+                " = 'nil' in "
+            ]),
+            None => Ok(docvec![
                 "let ",
                 leaf::var(core_var.clone()),
                 " = ",
                 val_doc,
                 " in "
-            ])
+            ]),
         }
     }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -13,7 +13,9 @@ use super::super::document::{Document, INDENT, join, leaf, line, nest};
 use super::super::selector_mangler::safe_class_method_fn_name;
 use super::super::spec_codegen;
 use super::super::value_type_codegen::has_opaque_native_representation;
-use super::super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result, block_analysis};
+use super::super::{
+    CodeGenContext, CodeGenError, CoreErlangGenerator, OpenScopeResult, Result, block_analysis,
+};
 use crate::ast::{
     Block, CascadeMessage, ClassDefinition, ClassKind, Expression, Identifier, Literal, MapPair,
     MessageSelector, MethodDefinition, MethodKind, Module, ParameterDefinition,
@@ -3410,10 +3412,13 @@ impl CoreErlangGenerator {
         if has_class_vars {
             let result_var = self.fresh_temp_var("Ret");
             let (value_str, open_scope) = self.expression_doc_with_open_scope(value)?;
-            let (preamble, value_doc) = if let Some(open_scope_result) = open_scope {
-                (value_str, leaf::var(open_scope_result))
-            } else {
-                (Document::Nil, value_str)
+            let (preamble, value_doc) = match open_scope {
+                Some(OpenScopeResult::Value(open_scope_result)) => {
+                    (value_str, leaf::var(open_scope_result))
+                }
+                // BT-3053: no single value — substitute do:'s own `nil` contract.
+                Some(OpenScopeResult::NoValue) => (value_str, Document::Str("'nil'")),
+                None => (Document::Nil, value_str),
             };
             if self.class_var_mutated() {
                 let final_cv = self.current_class_var();
@@ -3443,10 +3448,13 @@ impl CoreErlangGenerator {
         } else {
             // BT-1942: Same treatment for the no-class-vars path.
             let (value_str, open_scope) = self.expression_doc_with_open_scope(value)?;
-            if let Some(open_scope_result) = open_scope {
-                Ok(docvec![value_str, leaf::var(open_scope_result)])
-            } else {
-                Ok(value_str)
+            match open_scope {
+                Some(OpenScopeResult::Value(open_scope_result)) => {
+                    Ok(docvec![value_str, leaf::var(open_scope_result)])
+                }
+                // BT-3053: no single value — substitute do:'s own `nil` contract.
+                Some(OpenScopeResult::NoValue) => Ok(docvec![value_str, "'nil'"]),
+                None => Ok(value_str),
             }
         }
     }
@@ -3517,29 +3525,40 @@ impl CoreErlangGenerator {
         if self.is_class_var_assignment(expr) || self.is_class_method_self_send(expr) {
             let (expr_str, open_scope) = self.expression_doc_with_open_scope(expr)?;
             let final_cv = self.current_class_var();
-            if let Some(result_var) = open_scope {
-                Ok(docvec![
+            match open_scope {
+                Some(OpenScopeResult::Value(result_var)) => Ok(docvec![
                     expr_str,
                     "{'class_var_result', ",
                     leaf::var(result_var),
                     ", ",
                     leaf::var(final_cv),
                     "}",
-                ])
-            } else {
-                Ok(docvec![
+                ]),
+                // BT-3053: `NoValue` isn't reachable via this branch's own guard
+                // (class-var assignments/self-sends never produce it) — falls
+                // through to the same `'nil'` value the closed (`None`) case
+                // already used before this type existed.
+                Some(OpenScopeResult::NoValue) | None => Ok(docvec![
                     expr_str,
                     "{'class_var_result', 'nil', ",
                     leaf::var(final_cv),
                     "}",
-                ])
+                ]),
             }
         } else {
             let result_var = self.fresh_temp_var("Ret");
             // BT-1201: Use expression_doc_with_open_scope to detect open-scope results
             // produced by THIS expression, not by a previous field assignment.
             let (expr_str, open_scope) = self.expression_doc_with_open_scope(expr)?;
-            if let Some(open_scope_result) = open_scope {
+            let open_scope_value_doc = match open_scope {
+                Some(OpenScopeResult::Value(open_scope_result)) => {
+                    Some(leaf::var(open_scope_result))
+                }
+                // BT-3053: no single value — substitute do:'s own `nil` contract.
+                Some(OpenScopeResult::NoValue) => Some(Document::Str("'nil'")),
+                None => None,
+            };
+            if let Some(open_scope_value_doc) = open_scope_value_doc {
                 if self.class_var_mutated() {
                     let final_cv = self.current_class_var();
                     Ok(docvec![
@@ -3547,7 +3566,7 @@ impl CoreErlangGenerator {
                         "let ",
                         leaf::var(result_var.clone()),
                         " = ",
-                        leaf::var(open_scope_result),
+                        open_scope_value_doc,
                         " in {'class_var_result', ",
                         leaf::var(result_var),
                         ", ",
@@ -3555,7 +3574,7 @@ impl CoreErlangGenerator {
                         "}",
                     ])
                 } else {
-                    Ok(docvec![expr_str, leaf::var(open_scope_result)])
+                    Ok(docvec![expr_str, open_scope_value_doc])
                 }
             } else if self.class_var_mutated() {
                 let final_cv = self.current_class_var();
@@ -3591,18 +3610,26 @@ impl CoreErlangGenerator {
         if self.is_class_method_self_send(expr) {
             // BT-891: Class method self-send as last expression with no class vars.
             let (expr_str, open_scope) = self.expression_doc_with_open_scope(expr)?;
-            if let Some(result_var) = open_scope {
-                Ok(docvec![expr_str, leaf::var(result_var)])
-            } else {
-                Ok(expr_str)
+            match open_scope {
+                Some(OpenScopeResult::Value(result_var)) => {
+                    Ok(docvec![expr_str, leaf::var(result_var)])
+                }
+                // BT-3053: not reachable via this branch's own guard (a class
+                // method self-send never produces NoValue), handled the same
+                // way as the general case for consistency.
+                Some(OpenScopeResult::NoValue) => Ok(docvec![expr_str, "'nil'"]),
+                None => Ok(expr_str),
             }
         } else {
             // BT-1201: Use expression_doc_with_open_scope to detect open-scope results.
             let (expr_str, open_scope) = self.expression_doc_with_open_scope(expr)?;
-            if let Some(open_scope_result) = open_scope {
-                Ok(docvec![expr_str, leaf::var(open_scope_result)])
-            } else {
-                Ok(expr_str)
+            match open_scope {
+                Some(OpenScopeResult::Value(open_scope_result)) => {
+                    Ok(docvec![expr_str, leaf::var(open_scope_result)])
+                }
+                // BT-3053: no single value — substitute do:'s own `nil` contract.
+                Some(OpenScopeResult::NoValue) => Ok(docvec![expr_str, "'nil'"]),
+                None => Ok(expr_str),
             }
         }
     }
@@ -3648,17 +3675,23 @@ impl CoreErlangGenerator {
             // after it while keeping ClassVarsN in scope.
             let tmp_var = self.fresh_temp_var("seq");
             let (expr_str, open_scope) = self.expression_doc_with_open_scope(expr)?;
-            if let Some(result_var) = open_scope {
-                Ok(docvec![
+            match open_scope {
+                Some(OpenScopeResult::Value(result_var)) => Ok(docvec![
                     expr_str,
                     "let ",
                     leaf::var(tmp_var),
                     " = ",
                     leaf::var(result_var),
                     " in "
-                ])
-            } else {
-                Ok(docvec!["let ", leaf::var(tmp_var), " = ", expr_str, " in "])
+                ]),
+                // BT-3053: no single value — substitute do:'s own `nil` contract.
+                Some(OpenScopeResult::NoValue) => Ok(docvec![
+                    expr_str,
+                    "let ",
+                    leaf::var(tmp_var),
+                    " = 'nil' in "
+                ]),
+                None => Ok(docvec!["let ", leaf::var(tmp_var), " = ", expr_str, " in "]),
             }
         }
     }
@@ -3695,15 +3728,27 @@ impl CoreErlangGenerator {
                 // BT-1201: Use expression_doc_with_open_scope to detect open-scope results.
                 let (val_doc, open_scope) = self.expression_doc_with_open_scope(value)?;
                 self.bind_var(var_name, &core_var);
-                if let Some(open_scope_result) = open_scope {
-                    return Ok(docvec![
-                        val_doc,
-                        "let ",
-                        leaf::var(core_var),
-                        " = ",
-                        leaf::var(open_scope_result),
-                        " in "
-                    ]);
+                match open_scope {
+                    Some(OpenScopeResult::Value(open_scope_result)) => {
+                        return Ok(docvec![
+                            val_doc,
+                            "let ",
+                            leaf::var(core_var),
+                            " = ",
+                            leaf::var(open_scope_result),
+                            " in "
+                        ]);
+                    }
+                    // BT-3053: no single value — substitute do:'s own `nil` contract.
+                    Some(OpenScopeResult::NoValue) => {
+                        return Ok(docvec![
+                            val_doc,
+                            "let ",
+                            leaf::var(core_var),
+                            " = 'nil' in "
+                        ]);
+                    }
+                    None => {}
                 }
                 return Ok(docvec!["let ", leaf::var(core_var), " = ", val_doc, " in "]);
             }

--- a/crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs
@@ -23,7 +23,9 @@
 //! fundamental language operations that cannot be deferred to runtime dispatch.
 
 use super::document::{Document, join, leaf};
-use super::{CodeGenContext, CodeGenError, CoreErlangGenerator, Result, block_analysis};
+use super::{
+    CodeGenContext, CodeGenError, CoreErlangGenerator, OpenScopeResult, Result, block_analysis,
+};
 use crate::ast::{Block, Expression, MessageSelector, WellKnownSelector};
 use crate::docvec;
 
@@ -1042,7 +1044,7 @@ impl CoreErlangGenerator {
                 case_doc,
                 " in ",
             ]);
-            self.last_open_scope_result = Some(result_var);
+            self.last_open_scope_result = Some(OpenScopeResult::Value(result_var));
         } else {
             parts.push(case_doc);
         }
@@ -1503,7 +1505,7 @@ impl CoreErlangGenerator {
                 case_doc,
                 " in ",
             ]);
-            self.last_open_scope_result = Some(result_var);
+            self.last_open_scope_result = Some(OpenScopeResult::Value(result_var));
         } else {
             parts.push(case_doc);
         }

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -1181,6 +1181,31 @@ impl ValueTypeContext {
 /// - **Variable context**: Scope management and variable generation
 /// - **State threading**: Simulated mutation via State, State1, State2...
 ///
+/// BT-3053: what an open let-chain produced via `last_open_scope_result`
+/// stands for, once the chain is closed.
+///
+/// Before this type existed, the field was `Option<String>` and `"_"` did
+/// double duty as a pure "still open" boolean sentinel alongside genuine
+/// bound variable names — any consumer that pattern-matched `Some(var) =>
+/// leaf::var(var)` without checking for the literal string `"_"` risked
+/// emitting a *reference* to a variable that was never bound (a mutation-
+/// threaded `do:`/dict-`do:` nested in a direct-params loop has several
+/// rebound accumulator vars, not one meaningful "result", so its producer
+/// could only signal "stay open," not name a value). This enum makes the
+/// two cases distinct types instead of one type with a magic string, so a
+/// consumer that needs a value is forced to decide what `NoValue` means at
+/// its own call site rather than silently referencing an unbound `_`.
+enum OpenScopeResult {
+    /// A real, referenceable result variable bound by the open let-chain.
+    Value(String),
+    /// The chain stays open — more statements may follow directly after it
+    /// — but there is no single value to reference by name. Matches the
+    /// producing construct's own return-value contract when substituted
+    /// (e.g. `do:` always answers `nil`, so a consumer needing a value here
+    /// substitutes the `'nil'` atom rather than a variable reference).
+    NoValue,
+}
+
 /// The generator delegates to specialized submodules:
 /// - [`control_flow`] - Iteration and loop compilation
 /// - [`dispatch_codegen`] - Message sending and dispatch
@@ -1293,7 +1318,7 @@ pub(crate) struct CoreErlangGenerator {
     /// this field directly. Functions that produce their own open let-chains
     /// (`generate_field_assignment_open`, `generate_self_field_at_put_open`,
     /// `generate_local_var_assignment_in_loop`) return the result variable explicitly.
-    last_open_scope_result: Option<String>,
+    last_open_scope_result: Option<OpenScopeResult>,
     /// BT-845/BT-860: Source file path to embed as `beamtalk_source` module attribute.
     /// Set from `CodegenOptions::source_path` before generation begins.
     source_path: Option<String>,
@@ -2882,7 +2907,16 @@ impl CoreErlangGenerator {
                         self.current_self_var()
                     };
                     let (preamble, value_doc) = match open_scope {
-                        Some(result_var) => (Some(val_preamble), leaf::var(result_var)),
+                        Some(OpenScopeResult::Value(result_var)) => {
+                            (Some(val_preamble), leaf::var(result_var))
+                        }
+                        // BT-3053: e.g. `^(items do: [...])` inside a direct-params
+                        // loop — no single value was bound, so substitute do:'s own
+                        // `nil` return-value contract rather than referencing a
+                        // nonexistent variable.
+                        Some(OpenScopeResult::NoValue) => {
+                            (Some(val_preamble), Document::Str("'nil'"))
+                        }
                         None => (None, val_preamble),
                     };
                     let throw_doc = docvec![

--- a/crates/beamtalk-core/src/codegen/core_erlang/util.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/util.rs
@@ -244,7 +244,10 @@ impl CoreErlangGenerator {
     pub(super) fn expression_doc_with_open_scope(
         &mut self,
         expr: &Expression,
-    ) -> Result<(super::document::Document<'static>, Option<String>)> {
+    ) -> Result<(
+        super::document::Document<'static>,
+        Option<super::OpenScopeResult>,
+    )> {
         self.last_open_scope_result = None;
         let doc = self.generate_expression(expr)?;
         Ok((doc, self.last_open_scope_result.take()))
@@ -261,13 +264,21 @@ impl CoreErlangGenerator {
     /// `detect:` / `count:` / …) — the dangling `in` produces invalid Core Erlang
     /// (`{core_parse_error, …, "syntax error before: in"}`). This helper closes
     /// the scope by appending the result variable so the doc stands alone.
+    ///
+    /// BT-3053: a `NoValue` chain (a mutation-threaded `do:`/dict-`do:` nested
+    /// in a direct-params loop — several rebound vars, no single result)
+    /// substitutes `do:`'s own `nil` return-value contract rather than
+    /// referencing a variable that doesn't exist.
     pub(super) fn closed_expression_doc(
         &mut self,
         expr: &Expression,
     ) -> Result<super::document::Document<'static>> {
         let (doc, open_scope) = self.expression_doc_with_open_scope(expr)?;
         Ok(match open_scope {
-            Some(result_var) => docvec![doc, super::document::leaf::var(result_var)],
+            Some(super::OpenScopeResult::Value(result_var)) => {
+                docvec![doc, super::document::leaf::var(result_var)]
+            }
+            Some(super::OpenScopeResult::NoValue) => docvec![doc, "'nil'"],
             None => doc,
         })
     }
@@ -284,6 +295,11 @@ impl CoreErlangGenerator {
     /// keep the chain at the current level and append `let _ = <result_var> in `
     /// to discard the value and sequence on. With no open scope this is the
     /// original `let _ = <expr> in `.
+    ///
+    /// BT-3053: a `NoValue` chain has nothing to bind — its own rebindings are
+    /// already visible to subsequent statements, and (unlike the `Value` case)
+    /// there is no variable to reference in a discard `let`, so the doc is
+    /// pushed as-is with no closing `let _ = ... in` appended at all.
     pub(super) fn push_discarded_stmt(
         &mut self,
         docs: &mut Vec<super::document::Document<'static>>,
@@ -291,13 +307,16 @@ impl CoreErlangGenerator {
     ) -> Result<()> {
         let (doc, open_scope) = self.expression_doc_with_open_scope(expr)?;
         match open_scope {
-            Some(result_var) => {
+            Some(super::OpenScopeResult::Value(result_var)) => {
                 docs.push(doc);
                 docs.push(docvec![
                     "let _ = ",
                     super::document::leaf::var(result_var),
                     " in "
                 ]);
+            }
+            Some(super::OpenScopeResult::NoValue) => {
+                docs.push(doc);
             }
             None => {
                 docs.push(docvec!["let _ = ", doc, " in "]);


### PR DESCRIPTION
## Summary

`last_open_scope_result: Option<String>` used the literal string `"_"` as a pure boolean "still open, no single value" flag (a mutation-threaded `do:`/dict-`do:` nested in a direct-params loop rebinds several accumulator vars but has no one meaningful result) alongside genuine bound variable names produced by self-sends and class-var assignments. Every consumer that pattern-matched `Some(var) => leaf::var(var)` without checking for the literal `"_"` first risked emitting a reference to a variable that was never actually bound. Flagged by the Claude review bot on BT-3051 (#3240) as a plausible-but-unconfirmed pre-existing risk.

**Confirmed reachable**, not just theoretical: `^(items do: [...])` inside a direct-params loop produced `call 'erlang':'throw'({'$bt_nlr', Token, _, State})` — a genuine reference to an unbound `_`.

## Fix

Replaces the overloaded `Option<String>` with `Option<OpenScopeResult>`, an enum distinguishing:
- `Value(String)` — a real, referenceable result variable
- `NoValue` — the chain stays open, but there's no single value to reference; a consumer that needs a value substitutes the producing construct's own `nil` return-value contract (`do:` always answers `nil`) instead of a variable reference

This isn't just a rename — the compiler then forced every one of the ~17 consumer call sites (across `dispatch_codegen.rs`, `expressions.rs`, `gen_server/methods.rs`, `control_flow/mod.rs`, `control_flow/conditionals.rs`) to handle both cases explicitly. Several of these turned out to share the exact same blind-pattern-match shape as the two sites already known from BT-3051's review (`push_discarded_stmt`, `Expression::Return`) — not caught by the original manual audit, only surfaced by making the type system enumerate every call site.

## Two adjacent bugs found and filed separately

While constructing a minimal repro to confirm reachability, two structurally distinct bugs surfaced — both confirmed unrelated to this sentinel-overload fix (reproduced with a plain self-send and no `do:`/sentinel involved at all):

- **BT-3055**: `^` inside a counted loop (`to:do:`) references an unbound `State`/`StateAcc` variable — affects class methods, value types, and actor tuple-acc loops. Filed with root-cause analysis and a confirmed minimal repro.

Neither is fixed in this PR — they're genuinely separate root causes (loop-body state-variable resolution, not the `last_open_scope_result` channel), and fixing them here would expand this PR's scope well beyond its actual title.

## Test plan

- New Rust unit test (`control_flow/list_ops/tests.rs`) pins the fix directly: `^(items do: [...])` nested in a direct-params loop no longer emits a bare unbound `_` in the NLR throw tuple, and correctly substitutes `'nil'`.
- Full `just test` (Rust 5430/5430, stdlib 231/231, BUnit 3187/3189, runtime 5485+1806) — all passing, confirming no regressions across the ~17 touched call sites.
- `cargo clippy` clean, `rebar3 dialyzer` clean, `erlfmt`/`cargo fmt` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwrPQHiJxWFPwqdYdaXHBK)_