### PR TITLE
test: tighten 3 placeholder assertions in hot_reload.btscript

### DIFF
--- a/tests/repl-protocol/cases/hot_reload.btscript
+++ b/tests/repl-protocol/cases/hot_reload.btscript
@@ -65,10 +65,10 @@ hc getStep
 Actor subclass: LiveActor
   state: count = 0
   bump => self.count := self.count + 1
-// => _
+// => LiveActor
 
 LiveActor >> getCount => self.count
-// => _
+// => LiveActor>>getCount
 
 la := LiveActor spawn
 // => Actor(LiveActor, _)
@@ -84,7 +84,7 @@ la getCount
 
 // Redefine bump to add 100 instead of 1
 LiveActor >> bump => self.count := self.count + 100
-// => _
+// => LiveActor>>bump
 
 // Existing actor uses new method
 la bump


### PR DESCRIPTION
## Summary

Replace three `// => _` wildcard assertions in `tests/repl-protocol/cases/hot_reload.btscript` with their deterministic expected values. An inline `Actor subclass:` definition returns the class name; an inline `>>` method definition returns `ClassName>>selector`. Both patterns are confirmed by five other REPL-protocol test files.

## Changes

| Expression | Before | After |
|---|---|---|
| `Actor subclass: LiveActor …` | `// => _` | `// => LiveActor` |
| `LiveActor >> getCount => …` | `// => _` | `// => LiveActor>>getCount` |
| `LiveActor >> bump => …` (redefinition) | `// => _` | `// => LiveActor>>bump` |

## Why the values are correct

The pattern `ClassName>>selector` for `>>` method definitions and `ClassName` for `subclass:` definitions appears in:
- `tests/repl-protocol/cases/extension_type_annotations.btscript` — `Greeter >> shout … // => Greeter>>shout`
- `tests/repl-protocol/cases/adr_0105_killer_demo.btscript` — `KillerDemoCounter >> getCount … // => KillerDemoCounter>>getCount`
- `tests/repl-protocol/cases/repl_inline_class_superclass_index.btscript` — `Shape subclass: Triangle … // => Triangle`
- `tests/repl-protocol/cases/inline_class.btscript` — inline class definition `// => InlineCounter`
- `tests/repl-protocol/cases/announcements.btscript` — multiple `Announcement subclass: X … // => X` patterns

## Why it is safe

No test logic changes — only the wildcard is replaced with the actual expected value. If the runtime ever stopped returning `LiveActor` from a class definition, or `LiveActor>>getCount` from a method definition, the test will now correctly catch the regression instead of silently accepting any value. Diff is exactly 3 lines changed; no files added or removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDsh6zE48U1X1XVsUkFLjy)_