### PR TITLE
Windows spawn path: predict_node_name fix, current_dir fix, shared contract (BT-3045)

### DIFF
--- a/crates/beamtalk-desktop-broker/src/error.rs
+++ b/crates/beamtalk-desktop-broker/src/error.rs
@@ -5,6 +5,24 @@
 //!
 //! **DDD Context:** Desktop Shell
 
+use std::fmt;
+
+/// Display wrapper for [`BrokerError::PortsExhausted`]'s `last_exit_status`.
+///
+/// Renders `" — last launcher exit: <status>"` when a diagnostic is present,
+/// or an empty string when `None` (the pre-BT-3045 message shape, unchanged
+/// when there's nothing more to say).
+struct DisplayLastExitStatus<'a>(&'a Option<String>);
+
+impl fmt::Display for DisplayLastExitStatus<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(status) => write!(f, " — last launcher exit: {status}"),
+            None => Ok(()),
+        }
+    }
+}
+
 /// Errors the broker core can produce.
 ///
 /// Kept as a concrete enum (rather than `miette::Report`, which the CLI/
@@ -37,8 +55,28 @@ pub enum BrokerError {
     MissingCookie(String),
 
     /// Ran out of port-allocation attempts (see [`crate::port::allocate_port_with_retry`]).
-    #[error("failed to allocate a free port after {0} attempt(s)")]
-    PortsExhausted(u32),
+    ///
+    /// `last_exit_status`, when available, is the most recent spawn attempt's
+    /// launcher process exit status (`std::process::ExitStatus`'s own
+    /// `Display` — e.g. `"exit status: 1"` on Unix or `"exit code:
+    /// 0xc0000135"` on Windows), threaded through from
+    /// [`crate::port::SpawnAttempt::PortTaken`]. Carrying it matters because
+    /// [`crate::spawn::spawn_front_with_port_retry`]'s retry signal is a
+    /// heuristic (any early process exit looks like a port conflict — see its
+    /// doc comment), not a proof: a genuine launcher failure unrelated to
+    /// port conflicts (a crash, a missing DLL, `bin\bt_attach.bat` rejecting
+    /// its `start` invocation for some Windows-specific reason) would
+    /// previously report only a bare attempt count here, reading as "every
+    /// candidate port really was taken" even when that was never true (BT-3045
+    /// adversarial-review follow-up).
+    #[error(
+        "failed to allocate a free port after {attempts} attempt(s){}",
+        DisplayLastExitStatus(.last_exit_status)
+    )]
+    PortsExhausted {
+        attempts: u32,
+        last_exit_status: Option<String>,
+    },
 
     /// The installed `beamtalk` CLI could not be located (checked `PATH` and
     /// the configured fallback locations). GUI apps launched from a dock/

--- a/crates/beamtalk-desktop-broker/src/port.rs
+++ b/crates/beamtalk-desktop-broker/src/port.rs
@@ -42,14 +42,26 @@ pub fn find_free_port() -> Result<u16> {
 
 /// Outcome of a single spawn attempt at a candidate port, as reported by the
 /// caller-supplied `try_spawn` closure in [`allocate_port_with_retry`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SpawnAttempt {
     /// The port was free and the front was spawned (or spawn was attempted
     /// with no evidence of a port conflict) — stop retrying.
     Bound,
     /// The port was already taken by the time the real spawn tried to bind
     /// it (the race the module docs describe) — try another candidate.
-    PortTaken,
+    ///
+    /// Carries a diagnostic string describing why the caller believes this
+    /// attempt failed (typically the launcher process's own
+    /// `std::process::ExitStatus` `Display` output), when available — a
+    /// caller that cannot cheaply produce one (or genuinely has none, e.g. a
+    /// synchronous bind failure with no process involved) may pass `None`.
+    /// [`allocate_port_with_retry`] carries the most recent one through to
+    /// [`BrokerError::PortsExhausted`] so a caller that exhausts every
+    /// attempt sees *something* about the real cause, not just a bare count
+    /// (BT-3045 adversarial-review follow-up — see that error variant's doc
+    /// comment for why a bare count alone can be actively misleading on the
+    /// Windows spawn path).
+    PortTaken(Option<String>),
 }
 
 /// Find a free port and hand it to `try_spawn`, retrying with a fresh
@@ -61,20 +73,26 @@ pub enum SpawnAttempt {
 ///
 /// # Errors
 ///
-/// Returns [`BrokerError::PortsExhausted`] after `max_attempts` conflicts,
-/// or propagates the first non-conflict error from `try_spawn` or
-/// [`find_free_port`].
+/// Returns [`BrokerError::PortsExhausted`] after `max_attempts` conflicts
+/// (carrying the last attempt's `PortTaken` diagnostic, if any — see that
+/// variant's doc comment), or propagates the first non-conflict error from
+/// `try_spawn` or [`find_free_port`].
 pub fn allocate_port_with_retry(
     max_attempts: u32,
     mut try_spawn: impl FnMut(u16) -> Result<SpawnAttempt>,
 ) -> Result<u16> {
+    let mut last_exit_status = None;
     for _ in 0..max_attempts.max(1) {
         let candidate = find_free_port()?;
-        if let SpawnAttempt::Bound = try_spawn(candidate)? {
-            return Ok(candidate);
+        match try_spawn(candidate)? {
+            SpawnAttempt::Bound => return Ok(candidate),
+            SpawnAttempt::PortTaken(reason) => last_exit_status = reason,
         }
     }
-    Err(BrokerError::PortsExhausted(max_attempts))
+    Err(BrokerError::PortsExhausted {
+        attempts: max_attempts,
+        last_exit_status,
+    })
 }
 
 #[cfg(test)]
@@ -128,7 +146,7 @@ mod tests {
             calls += 1;
             seen_candidates.insert(candidate);
             if calls < 3 {
-                Ok(SpawnAttempt::PortTaken)
+                Ok(SpawnAttempt::PortTaken(None))
             } else {
                 Ok(SpawnAttempt::Bound)
             }
@@ -148,10 +166,41 @@ mod tests {
         let mut calls = 0;
         let result = allocate_port_with_retry(4, |_candidate| {
             calls += 1;
-            Ok(SpawnAttempt::PortTaken)
+            Ok(SpawnAttempt::PortTaken(None))
         });
-        assert!(matches!(result, Err(BrokerError::PortsExhausted(4))));
+        assert!(matches!(
+            result,
+            Err(BrokerError::PortsExhausted {
+                attempts: 4,
+                last_exit_status: None
+            })
+        ));
         assert_eq!(calls, 4, "should stop after exactly max_attempts tries");
+    }
+
+    /// BT-3045: the diagnostic carried by the *last* `PortTaken` attempt
+    /// should surface in the terminal `PortsExhausted` error, not get
+    /// silently dropped — this is the whole point of threading it through
+    /// `allocate_port_with_retry` instead of just counting attempts.
+    #[test]
+    fn allocate_port_with_retry_surfaces_the_last_exit_status_when_exhausted() {
+        let mut calls = 0;
+        let result = allocate_port_with_retry(3, |_candidate| {
+            calls += 1;
+            Ok(SpawnAttempt::PortTaken(Some(format!(
+                "exit status: {calls}"
+            ))))
+        });
+        assert!(
+            matches!(
+                result,
+                Err(BrokerError::PortsExhausted {
+                    attempts: 3,
+                    last_exit_status: Some(ref s)
+                }) if s == "exit status: 3"
+            ),
+            "expected the third (last) attempt's diagnostic, got {result:?}"
+        );
     }
 
     #[test]
@@ -173,7 +222,7 @@ mod tests {
         let mut calls = 0;
         let result = allocate_port_with_retry(0, |_candidate| {
             calls += 1;
-            Ok(SpawnAttempt::PortTaken)
+            Ok(SpawnAttempt::PortTaken(None))
         });
         assert!(result.is_err());
         assert_eq!(calls, 1, "0 attempts should be clamped to at least 1");

--- a/crates/beamtalk-desktop-broker/src/reap.rs
+++ b/crates/beamtalk-desktop-broker/src/reap.rs
@@ -100,6 +100,62 @@ pub fn save_record(dir: &Path, record: &FrontRecord) -> Result<()> {
     Ok(())
 }
 
+/// Correct a front record's `node_name` after the fact (BT-3045) — used on
+/// the Windows attach path, where [`save_record`]'s initial write (via
+/// `desktop/src-tauri/src/commands.rs`'s `persist_front_record`) cannot yet
+/// know the front's real epmd registration name (`sname::predict_node_name`'s
+/// pid guess is wrong there — see that module's doc comment — and
+/// `sname::resolve_registered_node_name`'s epmd query only has an answer once
+/// the front has actually distributed, which happens lazily on the first
+/// `/readiness` call, after the initial record write). Once readiness
+/// confirms `Ready` and a real epmd-resolved name is available, this
+/// overwrites the placeholder in place. The caller
+/// (`desktop/src-tauri/src/commands.rs`'s `attach_and_open_window`) runs this
+/// on a detached background thread rather than inline (`node_name` has no
+/// reader today, so nothing should block on it) — which widens, not just
+/// tolerates, the window for the race `expected_pid` exists to close below.
+///
+/// Compare-and-swap on `expected_pid`, not a blind overwrite: without it, a
+/// record removed by a concurrent `detach`/`quit`/failed-attach cleanup
+/// (`kill_and_untrack`) between this function's read and write would be
+/// silently *recreated* by the write — describing a process this broker
+/// already killed as if it were still the live front. Checking the pid also
+/// guards the (currently unlikely, since ports are freshly OS-allocated per
+/// spawn — see `crate::port`'s module docs — but not impossible) case where
+/// the same `(workspace_id, port)` key got reused by an entirely different,
+/// newer front in between: this must never stamp a stale epmd-resolved name
+/// onto a record that isn't the one this call was resolving it for.
+///
+/// No-op (not an error) if the record no longer exists, or if it exists but
+/// its `pid` no longer matches `expected_pid` — either way there's nothing
+/// left for *this* call to correct, not a failure of this function's own job.
+///
+/// # Errors
+///
+/// Returns an error if the record exists but can't be read/parsed/rewritten.
+pub fn update_record_node_name(
+    dir: &Path,
+    workspace_id: &str,
+    port: u16,
+    expected_pid: u32,
+    node_name: &str,
+) -> Result<()> {
+    let path = record_path(dir, workspace_id, port);
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e.into()),
+    };
+    let mut record: FrontRecord = serde_json::from_str(&content)?;
+    if record.pid != expected_pid {
+        return Ok(());
+    }
+    node_name.clone_into(&mut record.node_name);
+    let json = serde_json::to_string_pretty(&record)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
 /// Remove a front record — called on clean detach, so a graceful stop
 /// doesn't leave a stale record for the next sweep to trip over. Also
 /// removes that front's per-front `RELEASE_TMP` directory on Windows
@@ -625,6 +681,83 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         // Removing a record that was never saved must not error.
         remove_record(tmp.path(), "nonexistent", 1).unwrap();
+    }
+
+    // ── update_record_node_name (BT-3045) ───────────────────────────────
+
+    #[test]
+    fn update_record_node_name_corrects_the_persisted_value() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rec = record(4242, Some(555));
+        save_record(tmp.path(), &rec).unwrap();
+
+        update_record_node_name(
+            tmp.path(),
+            &rec.workspace_id,
+            rec.port,
+            rec.pid,
+            "bt_attach_abc123_9999@localhost",
+        )
+        .unwrap();
+
+        let loaded = load_all_records(tmp.path()).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].node_name, "bt_attach_abc123_9999@localhost");
+        // Every other field must survive untouched — this only corrects
+        // node_name, not a full re-save of caller-supplied data.
+        assert_eq!(loaded[0].pid, rec.pid);
+        assert_eq!(loaded[0].port, rec.port);
+        assert_eq!(loaded[0].workspace_id, rec.workspace_id);
+        assert_eq!(loaded[0].start_time, rec.start_time);
+    }
+
+    #[test]
+    fn update_record_node_name_is_a_noop_when_the_record_is_already_gone() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // A concurrent detach/quit could have already cleared the record —
+        // must not error, there's simply nothing left to correct.
+        update_record_node_name(
+            tmp.path(),
+            "nonexistent",
+            1,
+            4242,
+            "bt_attach_x_1@localhost",
+        )
+        .unwrap();
+    }
+
+    /// Regression test (adversarial-review follow-up): without the
+    /// `expected_pid` compare-and-swap check, this call would have
+    /// unconditionally overwritten `node_name`, which — combined with the
+    /// caller now running this on a background thread (see
+    /// `update_record_node_name`'s doc comment) — could resurrect/mutate a
+    /// record for a process that's no longer the one this correction was
+    /// actually resolving a name for (e.g. a concurrent detach recreated the
+    /// same `(workspace_id, port)` key for a genuinely different, newer
+    /// front in between this call being scheduled and running).
+    #[test]
+    fn update_record_node_name_is_a_noop_when_the_recorded_pid_no_longer_matches() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rec = record(4242, Some(555));
+        save_record(tmp.path(), &rec).unwrap();
+
+        // A stale correction for the *old* pid arrives after a new front
+        // record (same workspace_id/port, different pid) has replaced it.
+        update_record_node_name(
+            tmp.path(),
+            &rec.workspace_id,
+            rec.port,
+            9999, // not rec.pid
+            "bt_attach_abc123_9999@localhost",
+        )
+        .unwrap();
+
+        let loaded = load_all_records(tmp.path()).unwrap();
+        assert_eq!(
+            loaded,
+            vec![rec],
+            "record must be left completely untouched when expected_pid doesn't match"
+        );
     }
 
     #[cfg(windows)]

--- a/crates/beamtalk-desktop-broker/src/sname.rs
+++ b/crates/beamtalk-desktop-broker/src/sname.rs
@@ -42,10 +42,31 @@
 //! `std::process::Child::id()` actually reports — not `erl.exe`'s pid, and
 //! not `bin/server`'s single extra hop either. `predict_node_name` is
 //! therefore expected to predict the *wrong* name on Windows, not just an
-//! unverified one; nothing in this crate currently corrects for that (it
-//! would need an epmd query instead of pid prediction there). See
-//! `crate::spawn`'s and `crate::winjob`'s module docs for how orphan-killing
-//! is handled despite this (a job object, not `Child::kill`/pid tracking).
+//! unverified one. See `crate::spawn`'s and `crate::winjob`'s module docs for
+//! how orphan-*killing* is handled despite this (a job object, not
+//! `Child::kill`/pid tracking) — `predict_node_name`'s pid guess plays no
+//! part in that mechanism.
+//!
+//! **Fixed (BT-3045) by not trusting the pid guess on Windows at all**:
+//! [`resolve_registered_node_name`] queries epmd directly — the same
+//! `NAMES_REQ` protocol [`crate::discovery`]'s liveness check already uses —
+//! for a registration matching the known `bt_attach_<suffix>_` prefix,
+//! rather than predicting a pid it cannot correctly guess. This only returns
+//! an answer once the front has actually distributed (`ensure_distributed/0`
+//! runs lazily, on the first `/readiness` call — see
+//! `crate::spawn`/`desktop/src-tauri/src/commands.rs`'s `attach_and_open_window`,
+//! which calls it once readiness reaches `Ready`, not at spawn time), so it
+//! cannot replace `predict_node_name` for the *earlier* orphan-reaping
+//! bookkeeping write (`persist_front_record` in `commands.rs`, which must
+//! record something as soon as the process exists, before readiness is
+//! known) — Windows records an explicit "not yet known" placeholder there
+//! instead of a wrong-looking real name, and corrects it once
+//! `resolve_registered_node_name` has a real answer. `FrontRecord.node_name`
+//! itself remains bookkeeping/display only: `crate::reap`'s sweep keys
+//! entirely off `FrontRecord.pid` (and, on Windows, the
+//! [`crate::winjob::JobHandle`] tree-kill — neither touches `node_name`), so
+//! a stale or placeholder value there was never a kill/reap-correctness bug,
+//! only a misleading one for anyone reading the on-disk record.
 //!
 //! **DDD Context:** Desktop Shell
 
@@ -79,6 +100,82 @@ pub fn predict_node_name(suffix: &str, os_pid: u32) -> String {
 #[must_use]
 pub fn predict_short_name(suffix: &str, os_pid: u32) -> String {
     format!("bt_attach_{suffix}_{os_pid}")
+}
+
+/// A placeholder `FrontRecord.node_name` value for a front just spawned on a
+/// platform where [`predict_node_name`] cannot be trusted (Windows —
+/// `desktop/src-tauri/src/commands.rs`'s `persist_front_record` calls this
+/// instead of guessing a pid-based name it knows is wrong; see this module's
+/// doc comment). Deliberately shaped so it can never collide
+/// with a real `bt_attach_<suffix>_<pid>@localhost` registration (no `@`, and
+/// the `pending:` tag makes it obviously not a dist node name to a human
+/// reading the on-disk record) — callers should replace it via
+/// [`resolve_registered_node_name`] once the front's readiness is confirmed,
+/// but a record that never gets that follow-up call (e.g. attach fails
+/// before reaching `Ready`) is at least honestly labeled rather than
+/// silently wrong.
+#[must_use]
+pub fn pending_node_name(suffix: &str) -> String {
+    format!("<pending:{suffix}>")
+}
+
+/// Resolve a front's *actual* epmd registration name by querying epmd
+/// directly, rather than guessing from an OS pid — the Windows-correct
+/// alternative to [`predict_node_name`] this module's doc comment describes
+/// (BT-3045). Looks for exactly one currently-registered short name with the
+/// `bt_attach_<suffix>_` prefix `BtAttach.Workspace.attach_sname/2` always
+/// produces.
+///
+/// Returns `Ok(None)` — not a guess — when epmd reports zero matches (the
+/// front hasn't distributed yet; `ensure_distributed/0` only runs lazily on
+/// the first `/readiness` call, so this only has a real answer to give once
+/// readiness has resolved at least once) or more than one (two fronts
+/// attached to the same workspace concurrently — a real, ADR-anticipated
+/// scenario, see [`attach_node_suffix`]'s doc comment — make the prefix alone
+/// ambiguous; a caller needing to disambiguate that case has a better signal
+/// available, e.g. the specific pid it just spawned combined with
+/// `metadata.json`'s freshly-written `node_name` once the front persists it).
+///
+/// # Errors
+///
+/// Returns an error only if the epmd query itself fails (a transport-level
+/// I/O error after a connection was established — "epmd not running" is not
+/// an error there and surfaces here as `Ok(None)`, zero names to match
+/// against). See [`beamtalk_workspace::epmd::query_epmd_names`].
+pub fn resolve_registered_node_name(suffix: &str) -> crate::error::Result<Option<String>> {
+    let names = beamtalk_workspace::epmd::query_epmd_names()?;
+    Ok(find_unique_match(names.iter().map(String::as_str), suffix))
+}
+
+/// Pure matching logic behind [`resolve_registered_node_name`] — given a set
+/// of currently-registered epmd short names, find the unique one (if any)
+/// whose `bt_attach_<suffix>_<pid>` shape has exactly `suffix` for its
+/// suffix segment. Split out so this decision is testable without a real
+/// epmd running, matching the pure-decision/impure-I/O split
+/// [`crate::reap::classify_record`] already uses for the same reason.
+///
+/// Deliberately **not** a plain `starts_with("bt_attach_{suffix}_")` check:
+/// workspace ids (and thus suffixes — [`attach_node_suffix`] passes them
+/// through unchanged) may themselves contain `_` (e.g. `"my_feature_1"`, see
+/// [`attach_node_suffix`]'s own tests), so a bare prefix match on suffix
+/// `"my"` would also match a *different* workspace's registration
+/// `bt_attach_my_feature_1_42` — the shared `bt_attach_my_` prefix is a
+/// false positive there, not a real match. Splitting off the pid at the
+/// *last* `_` instead (the pid — `System.pid()` — is always a plain decimal
+/// integer with no embedded `_` of its own) and comparing the remaining
+/// suffix segment for exact equality closes that gap.
+fn find_unique_match<'a>(names: impl IntoIterator<Item = &'a str>, suffix: &str) -> Option<String> {
+    let mut matches = names.into_iter().filter(|n| {
+        n.strip_prefix("bt_attach_")
+            .and_then(|rest| rest.rsplit_once('_'))
+            .is_some_and(|(name_suffix, pid)| {
+                name_suffix == suffix && !pid.is_empty() && pid.bytes().all(|b| b.is_ascii_digit())
+            })
+    });
+    match (matches.next(), matches.next()) {
+        (Some(only), None) => Some(format!("{only}@localhost")),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -149,5 +246,89 @@ mod tests {
         for id in ["abc123def456", "my-feature", "my_feature_1"] {
             assert_eq!(attach_node_suffix(id), id);
         }
+    }
+
+    // ── pending_node_name / find_unique_match (BT-3045) ─────────────────
+
+    #[test]
+    fn pending_node_name_is_not_shaped_like_a_real_dist_node_name() {
+        let placeholder = pending_node_name("abc123");
+        assert!(
+            !placeholder.contains('@'),
+            "must not look like a real node@host dist name that could be \
+             mistaken for a genuine (if stale) registration: {placeholder:?}"
+        );
+        assert!(placeholder.contains("abc123"));
+    }
+
+    #[test]
+    fn find_unique_match_returns_none_when_epmd_has_no_matching_name() {
+        let names = ["some_other_node", "bt_attach_other-workspace_123"];
+        assert_eq!(find_unique_match(names, "spike-a"), None);
+    }
+
+    #[test]
+    fn find_unique_match_returns_none_when_epmd_is_empty() {
+        assert_eq!(find_unique_match([], "spike-a"), None);
+    }
+
+    #[test]
+    fn find_unique_match_finds_the_single_matching_registration() {
+        let names = ["unrelated_node", "bt_attach_spike-a_4242"];
+        assert_eq!(
+            find_unique_match(names, "spike-a"),
+            Some("bt_attach_spike-a_4242@localhost".to_string())
+        );
+    }
+
+    #[test]
+    fn find_unique_match_returns_none_when_two_fronts_on_the_same_workspace_are_ambiguous() {
+        // ADR 0097-anticipated scenario (see attach_node_suffix's doc
+        // comment): a second window, or a crash→respawn racing the dying
+        // front's epmd deregistration. The prefix alone can't disambiguate
+        // which one a caller means — refuse to guess rather than picking one
+        // arbitrarily.
+        let names = ["bt_attach_spike-a_1001", "bt_attach_spike-a_1002"];
+        assert_eq!(find_unique_match(names, "spike-a"), None);
+    }
+
+    #[test]
+    fn find_unique_match_does_not_treat_a_longer_suffix_as_a_prefix_match() {
+        // suffix "a" must not match a registration for workspace "ab".
+        let names = ["bt_attach_ab_123"];
+        assert_eq!(find_unique_match(names, "a"), None);
+    }
+
+    /// Regression test for a real ambiguity a naive `starts_with` prefix
+    /// check would have: workspace ids (and thus suffixes) may themselves
+    /// contain `_` (see `attach_node_suffix_preserves_arbitrary_workspace_ids`
+    /// above, e.g. `"my_feature_1"`) — a *different*, unrelated workspace
+    /// named `"my_feature_1"` running at the same time as one named `"my"`
+    /// must never have its registration mistaken for `"my"`'s just because
+    /// `"bt_attach_my_"` happens to be a string prefix of
+    /// `"bt_attach_my_feature_1_42"`.
+    #[test]
+    fn find_unique_match_does_not_confuse_an_underscore_containing_suffix_with_a_shorter_one() {
+        let names = ["bt_attach_my_feature_1_42"];
+        assert_eq!(
+            find_unique_match(names, "my"),
+            None,
+            "workspace suffix 'my' must not match a registration belonging to \
+             workspace 'my_feature_1'"
+        );
+        assert_eq!(
+            find_unique_match(names, "my_feature_1"),
+            Some("bt_attach_my_feature_1_42@localhost".to_string()),
+            "the actual owning workspace's suffix should still match correctly"
+        );
+    }
+
+    #[test]
+    fn find_unique_match_rejects_a_non_numeric_trailing_segment() {
+        // A malformed/foreign registration that happens to share the
+        // bt_attach_ prefix and suffix but has a non-pid trailing segment
+        // must not be treated as a match.
+        let names = ["bt_attach_spike-a_notapid"];
+        assert_eq!(find_unique_match(names, "spike-a"), None);
     }
 }

--- a/crates/beamtalk-desktop-broker/src/spawn.rs
+++ b/crates/beamtalk-desktop-broker/src/spawn.rs
@@ -43,6 +43,31 @@
 //! - sets `PHX_SERVER=true` (what `bin/server` sets right before its own
 //!   `exec bin/bt_attach start`)
 //!
+//! **Why this is a Rust reimplementation and not a `bin\server.bat` mirroring
+//! `bin/server`'s shape (BT-3045 adversarial-review follow-up):** `bin/server`
+//! resolves `BT_WORKSPACE_NODE` with a `sed` regex against `metadata.json`,
+//! which works but is exactly the kind of fragile hand-rolled JSON access a
+//! `.bat` equivalent (batch has no JSON parser at all — a working port would
+//! mean an even more fragile `findstr`/`for /f` regex reimplementation) would
+//! have to imitate to get *worse* correctness, not parity. Windows already
+//! gets a strictly better implementation of the same resolution
+//! ([`crate::discovery::read_node_name`], the real `serde_json` parser
+//! [`crate::discovery::discover_workspaces`] itself uses) by staying in Rust
+//! — introducing a second, `.bat`-based entry point purely for symmetry with
+//! Unix would add a second-worse implementation of the one thing `bin/server`
+//! does that actually needs mirroring, not remove the drift risk. What *was*
+//! missing, and what BT-3045 actually closes, is a **test** tying the two
+//! together: `spawn::tests::windows_launch_env_matches_bin_server_contract`
+//! (Windows-only, since it exercises `build_launch_command`'s Windows arm)
+//! reads `bin/server`'s source and asserts each of today's known contract env
+//! vars still appears there as a real assignment, and is also set here — so
+//! *removing or renaming* one of them in `bin/server` fails this crate's test
+//! suite instead of silently drifting. It is a removal/rename guard, not
+//! full behavioral-equivalence proof — see that test's own doc comment for
+//! what it deliberately does not (and structurally cannot, without
+//! duplicating `bin/server`'s logic) catch, e.g. a *new* var `bin/server`
+//! starts setting that this test's hardcoded list hasn't been told about yet.
+//!
 //! `RELEASE_DISTRIBUTION=none` is a hard requirement on every platform, not
 //! an optimization — the spike (`docs/research/desktop-shell-spike.md`,
 //! criterion (a)) found that `mix release`'s generated launcher boots the VM
@@ -353,10 +378,10 @@ fn check_launcher_platform(launcher: &std::path::Path) -> Result<()> {
 /// see this module's doc comment for the full rationale. `bin/server` does
 /// not exist on Windows, so this function does what it would have: resolve
 /// `BT_WORKSPACE_NODE`/`BT_WORKSPACE_COOKIE` from the on-disk workspace
-/// directory, generate an ephemeral `SECRET_KEY_BASE`, and set `PHX_SERVER`
-/// — then invoke the release's own `bin\bt_attach.bat start` directly rather
-/// than passing `workspace_id` as an argv the Windows launcher has no shell
-/// script to interpret.
+/// directory, generate an ephemeral `SECRET_KEY_BASE`, set `PHX_SERVER`, and
+/// `cd` to the release root — then invoke the release's own
+/// `bin\bt_attach.bat start` directly rather than passing `workspace_id` as
+/// an argv the Windows launcher has no shell script to interpret.
 ///
 /// # Errors
 ///
@@ -383,6 +408,23 @@ fn build_launch_command(config: &SpawnConfig) -> Result<Command> {
     cmd.env("SECRET_KEY_BASE", generate_secret_key_base());
     cmd.env("PHX_SERVER", "true");
 
+    // BT-3045 adversarial-review follow-up: `bin/server`'s Unix arm always
+    // `cd -P -- "$(dirname -- "$0")/.."`s to the release root before its
+    // final `exec bin/bt_attach start` (see the sibling `#[cfg(unix)]`
+    // `build_launch_command` above, which relies on that `exec` inheriting
+    // the launcher's own cwd rather than setting one itself) — this arm
+    // never had an equivalent, so the BEAM inherited whatever cwd the
+    // spawning Tauri app process happened to have (unrelated to the release)
+    // instead of the release root, affecting crash dumps and any
+    // relative-path writes the release makes assuming it's running from
+    // there. `release_root` mirrors that `dirname/..` computation; a
+    // best-effort skip (not an error) when it can't be determined keeps this
+    // function's error surface unchanged for callers/tests that pass a bare
+    // relative launcher path with no real parent directory.
+    if let Some(root) = release_root(&config.launcher) {
+        cmd.current_dir(root);
+    }
+
     // BT-3046 adversarial-review follow-up: a bundled MSI/NSIS install lands
     // under `C:\Program Files\Beamtalk\...`, which a standard (non-admin)
     // Windows user cannot write to. Mix releases resolve `RELEASE_TMP`
@@ -396,6 +438,45 @@ fn build_launch_command(config: &SpawnConfig) -> Result<Command> {
     cmd.env("RELEASE_TMP", release_tmp);
 
     Ok(cmd)
+}
+
+/// The release root a Windows launcher path implies — `bin\bt_attach.bat`'s
+/// grandparent directory, mirroring `bin/server`'s own `dirname -- "$0")/..`
+/// (this module's doc comment, BT-3045).
+///
+/// **Requires an absolute `launcher`, deliberately** (adversarial-review
+/// follow-up) — `desktop/src-tauri/src/launcher.rs`'s `resolve_launcher_path`
+/// resolves an *absolute* path in the normal bundled-app case, but its
+/// documented fallbacks are not: `resource_dir()` failing, or a developer
+/// setting `BEAMTALK_ATTACH_LAUNCHER` to a bare relative path (its own doc
+/// comment's example, "against a `just dist-liveview` output"), both leave
+/// `launcher` relative (e.g. `dist-liveview\bin\bt_attach.bat`). Computing a
+/// *relative* release root from that and handing it to `Command::current_dir`
+/// would be actively harmful, not just unhelpful: the `.bat` still routes
+/// through `cmd.exe` (this module's doc comment, `BatBadBut`), and `cmd.exe`
+/// resolves the still-relative launcher path it was told to run *against the
+/// new current directory* — turning `dist-liveview\bin\bt_attach.bat` into
+/// an attempted `dist-liveview\dist-liveview\bin\bt_attach.bat`, which
+/// doesn't exist, so `cmd.exe` exits almost immediately. That early exit is
+/// exactly what [`spawn_front_with_port_retry`]'s heuristic treats as a
+/// suspected port conflict — silently turning a real (if unusual)
+/// dev-workflow launcher path into a confusing `PortsExhausted`, the precise
+/// failure mode this same issue's `PortsExhausted` diagnostic improvement
+/// exists to prevent. Requiring `is_absolute()` keeps this a no-op (today's
+/// behavior: no `current_dir` set, BEAM inherits the Tauri app's cwd) for
+/// that dev/fallback shape instead.
+#[cfg(windows)]
+fn release_root(launcher: &std::path::Path) -> Option<PathBuf> {
+    if !launcher.is_absolute() {
+        return None;
+    }
+    let bin_dir = launcher.parent()?;
+    let root = bin_dir.parent()?;
+    if root.as_os_str().is_empty() {
+        None
+    } else {
+        Some(root.to_path_buf())
+    }
 }
 
 /// Guard against [`SpawnConfig::launcher`] pointing at the wrong platform's
@@ -566,7 +647,12 @@ pub const DEFAULT_BIND_FAILURE_GRACE: Duration = Duration::from_secs(5);
 /// # Errors
 ///
 /// Returns [`BrokerError::PortsExhausted`] if every port attempt looks like
-/// a conflict, or propagates the first non-conflict error (OIDC refusal,
+/// a conflict — carrying the *last* attempt's real launcher exit status as a
+/// diagnostic (BT-3045; see that variant's doc comment for why: this
+/// function's retry signal is a heuristic, so a genuine non-conflict launcher
+/// failure that happens to exit early on every attempt would otherwise be
+/// reported as an opaque attempt count with no clue it wasn't really a port
+/// conflict) — or propagates the first non-conflict error (OIDC refusal,
 /// unknown workspace, spawn I/O failure, or a `try_wait` I/O error).
 ///
 /// # Panics
@@ -587,8 +673,15 @@ pub fn spawn_front_with_port_retry(config: &SpawnAttemptConfig) -> Result<(Spawn
         };
         let mut child = spawn_front(&spawn_config)?;
         std::thread::sleep(config.bind_failure_grace);
-        if let Some(_exit_status) = child.try_wait()? {
-            Ok(SpawnAttempt::PortTaken)
+        if let Some(exit_status) = child.try_wait()? {
+            // BT-3045: carry the launcher's actual exit status through, so a
+            // caller that exhausts every attempt sees more than a bare count
+            // (see BrokerError::PortsExhausted's doc comment) — this is a
+            // diagnostic only, not a reclassification: an early exit is still
+            // just *treated* as a suspected port conflict per this
+            // function's own heuristic doc comment above, whatever the real
+            // cause turns out to be.
+            Ok(SpawnAttempt::PortTaken(Some(exit_status.to_string())))
         } else {
             *spawned.borrow_mut() = Some(child);
             Ok(SpawnAttempt::Bound)
@@ -805,6 +898,182 @@ mod tests {
              — this also doubles as a real writability check: create_dir_all only succeeds if \
              the current user can actually write there"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn build_launch_command_sets_current_dir_to_the_release_root() {
+        // BT-3045: unlike the other Windows tests here, this one needs a
+        // launcher path with a real parent chain (bin\bt_attach.bat under a
+        // real release root) — `release_root` deliberately no-ops on the
+        // bare relative `r"bin\bt_attach.bat"` the other tests use (see its
+        // doc comment), so this uses an absolute tempdir path instead, the
+        // same shape `desktop/src-tauri/src/launcher.rs::resolve_launcher_path`
+        // always produces in production.
+        let ws = WindowsTestWorkspaceDir::new("win_launch_cwd", None, Some("c"));
+        let release_root = tempfile::TempDir::new().unwrap();
+        let launcher = release_root.path().join("bin").join("bt_attach.bat");
+        let config = SpawnConfig::new(launcher, ws.id.clone(), 4567);
+
+        let cmd = build_launch_command(&config).expect("should build a command");
+
+        assert_eq!(
+            cmd.get_current_dir(),
+            Some(release_root.path()),
+            "current_dir should be the launcher's grandparent directory \
+             (bin\\bt_attach.bat -> bin -> release root), matching bin/server's \
+             own `cd -P -- \"$(dirname \"$0\")/..\"` on Unix"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn release_root_is_none_for_a_launcher_with_no_real_parent_chain() {
+        // The bare relative paths the other Windows tests in this file use
+        // (e.g. r"bin\bt_attach.bat") have no real release root to cd into —
+        // release_root must no-op (return None) rather than resolve to an
+        // empty/current-directory PathBuf that `Command::current_dir` would
+        // then be handed nonsensically.
+        assert_eq!(
+            release_root(std::path::Path::new(r"bin\bt_attach.bat")),
+            None
+        );
+        assert_eq!(release_root(std::path::Path::new("bt_attach.bat")), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn release_root_resolves_an_absolute_launcher_paths_grandparent() {
+        assert_eq!(
+            release_root(std::path::Path::new(
+                r"C:\Program Files\Beamtalk\dist-liveview\bin\bt_attach.bat"
+            )),
+            Some(PathBuf::from(r"C:\Program Files\Beamtalk\dist-liveview"))
+        );
+    }
+
+    /// Regression test (adversarial-review follow-up): a *relative* launcher
+    /// path with a real multi-level parent chain — exactly the shape
+    /// `desktop/src-tauri/src/launcher.rs::resolve_launcher_path` falls back
+    /// to when `resource_dir()` fails, or a developer sets
+    /// `BEAMTALK_ATTACH_LAUNCHER=dist-liveview/bin/bt_attach.bat` (that
+    /// module's own doc-comment example) — must still resolve to `None`, not
+    /// `Some("dist-liveview")`. Before this guard, `release_root` treated
+    /// this as a valid release root and handed it to `Command::current_dir`;
+    /// since the launcher path itself stays relative too, `cmd.exe` (which
+    /// `.bat` launches always route through) would then resolve it against
+    /// the *new* cwd, effectively looking for
+    /// `dist-liveview\dist-liveview\bin\bt_attach.bat` — silently breaking
+    /// this exact dev workflow with a confusing early `cmd.exe` exit
+    /// misclassified as a port conflict. See `release_root`'s doc comment
+    /// for the full failure chain.
+    #[cfg(windows)]
+    #[test]
+    fn release_root_is_none_for_a_relative_launcher_even_with_a_real_parent_chain() {
+        assert_eq!(
+            release_root(std::path::Path::new(r"dist-liveview\bin\bt_attach.bat")),
+            None,
+            "a relative launcher path must never produce a current_dir — see this \
+             function's doc comment for why that's actively harmful, not just unhelpful"
+        );
+    }
+
+    /// BT-3045 adversarial-review follow-up: `bin/server`'s Unix arm and
+    /// `build_launch_command`'s Windows arm are two independent
+    /// implementations of "resolve `BT_WORKSPACE_NODE`/`BT_WORKSPACE_COOKIE`,
+    /// generate `SECRET_KEY_BASE` if needed, set `PHX_SERVER`" — nothing
+    /// previously compared them. This closes the specific gap that mattered
+    /// most in practice: it reads `bin/server`'s actual source (not a
+    /// duplicated copy of its logic) and asserts each of the four vars below
+    /// still appears there as a real shell **assignment** (`"{var}="`), not
+    /// merely mentioned in a comment — so deleting/renaming the functional
+    /// block while leaving the header comment's prose untouched (which
+    /// mentions these same names) still fails this test, unlike a bare
+    /// substring search would.
+    ///
+    /// **What this does *not* catch**, so a reviewer doesn't over-trust it:
+    /// `contract_vars` below is a hardcoded list of *today's* var names —
+    /// this test cannot discover a wholly new env var `bin/server` starts
+    /// setting in the future (a human still has to notice and add it here
+    /// too), and it only checks *presence*, not exact semantics (e.g.
+    /// `bin/server` only generates `SECRET_KEY_BASE` when unset, while the
+    /// Windows arm always regenerates one — both end up ephemeral-per-boot
+    /// for this broker's own call shape, since neither platform's broker
+    /// code pre-sets that var itself, but this test would not notice if that
+    /// stopped being true). It is a removal/rename guard, not a full
+    /// behavioral-equivalence proof.
+    ///
+    /// Windows-only (like the rest of this section): it exercises
+    /// `build_launch_command`'s `#[cfg(windows)]` arm, the half of the
+    /// contract this crate can actually drift on — `bin/server` itself needs
+    /// no equivalent check of its own code.
+    #[cfg(windows)]
+    #[test]
+    fn windows_launch_env_matches_bin_server_contract() {
+        // crates/beamtalk-desktop-broker -> crates -> repo root.
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        let bin_server_path = repo_root
+            .join("editors")
+            .join("liveview")
+            .join("rel")
+            .join("overlays")
+            .join("bin")
+            .join("server");
+        let bin_server = std::fs::read_to_string(&bin_server_path).unwrap_or_else(|e| {
+            panic!(
+                "could not read {}: {e} — has bin/server moved? update this test's path \
+                 alongside it",
+                bin_server_path.display()
+            )
+        });
+
+        // Every env var bin/server's workspace-id branch sets/exports for
+        // `bin/bt_attach start` to inherit, beyond the four broker-set vars
+        // build_env's own test already covers cross-platform
+        // (PORT/BT_ATTACH_BIND_IP/BT_ATTACH_NODE_SUFFIX/RELEASE_DISTRIBUTION
+        // — bin/server never touches those itself, so they're out of scope
+        // here).
+        let contract_vars = [
+            "BT_WORKSPACE_NODE",
+            "BT_WORKSPACE_COOKIE",
+            "SECRET_KEY_BASE",
+            "PHX_SERVER",
+        ];
+        for var in contract_vars {
+            // A real shell assignment ("VAR=..."), not just the var name
+            // appearing somewhere (e.g. bin/server's own header-comment
+            // prose mentions BT_WORKSPACE_NODE/BT_WORKSPACE_COOKIE narratively
+            // without an "=" — a bare `.contains(var)` would still pass even
+            // if the actual assignment lines below the comment were deleted).
+            let assignment = format!("{var}=");
+            assert!(
+                bin_server.contains(&assignment),
+                "bin/server no longer assigns {var} (looked for {assignment:?}) — either it \
+                 was removed there (update this test's `contract_vars` list) or renamed \
+                 (update both this test AND build_launch_command's Windows arm to match)"
+            );
+        }
+
+        let ws = WindowsTestWorkspaceDir::new("win_launch_contract", None, Some("c"));
+        let config = SpawnConfig::new(PathBuf::from(r"bin\bt_attach.bat"), ws.id.clone(), 4567);
+        let cmd = build_launch_command(&config).expect("should build a command");
+        let env_names: std::collections::HashSet<String> = cmd
+            .get_envs()
+            .filter_map(|(k, v)| v.map(|_| k.to_string_lossy().into_owned()))
+            .collect();
+
+        for var in contract_vars {
+            assert!(
+                env_names.contains(var),
+                "build_launch_command's Windows arm doesn't set {var}, which bin/server sets \
+                 on Unix — the two have drifted out of sync"
+            );
+        }
     }
 
     #[cfg(windows)]
@@ -1035,8 +1304,16 @@ mod tests {
 
         let result = spawn_front_with_port_retry(&config);
         assert!(
-            matches!(result, Err(BrokerError::PortsExhausted(3))),
-            "expected PortsExhausted(3), got {result:?}"
+            matches!(
+                result,
+                Err(BrokerError::PortsExhausted {
+                    attempts: 3,
+                    last_exit_status: Some(_)
+                })
+            ),
+            "expected PortsExhausted with attempts=3 and a diagnostic exit status \
+             (BT-3045 — the launcher's real exit status should be surfaced, not just \
+             a bare count), got {result:?}"
         );
     }
 
@@ -1174,8 +1451,16 @@ mod tests {
 
         let result = spawn_front_with_port_retry(&config);
         assert!(
-            matches!(result, Err(BrokerError::PortsExhausted(3))),
-            "expected PortsExhausted(3), got {result:?}"
+            matches!(
+                result,
+                Err(BrokerError::PortsExhausted {
+                    attempts: 3,
+                    last_exit_status: Some(_)
+                })
+            ),
+            "expected PortsExhausted with attempts=3 and a diagnostic exit status \
+             (BT-3045 — the launcher's real exit status should be surfaced, not just \
+             a bare count), got {result:?}"
         );
     }
 

--- a/crates/beamtalk-desktop-broker/src/winjob.rs
+++ b/crates/beamtalk-desktop-broker/src/winjob.rs
@@ -10,9 +10,11 @@
 //! `cmd.exe /c` instead of failing. That means the process
 //! [`std::process::Child`] actually tracks is **`cmd.exe`**, not the BEAM VM
 //! `bin\bt_attach.bat` eventually execs into — so `Child::id()` is the wrong
-//! PID for [`crate::sname::predict_node_name`], and plain `Child::kill()`
-//! only terminates `cmd.exe`, orphaning `erl.exe` underneath it (with a live
-//! workspace cookie and a bound port) every time a front is detached.
+//! PID for [`crate::sname::predict_node_name`] (fixed on Windows, BT-3045, by
+//! not using that prediction there at all — see `sname`'s module doc for the
+//! epmd-query replacement), and plain `Child::kill()` only terminates
+//! `cmd.exe`, orphaning `erl.exe` underneath it (with a live workspace cookie
+//! and a bound port) every time a front is detached.
 //!
 //! A Windows Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` fixes the
 //! orphan half of that (not the PID-prediction half — nothing here changes

--- a/crates/beamtalk-desktop-broker/tests/live_front.rs
+++ b/crates/beamtalk-desktop-broker/tests/live_front.rs
@@ -159,6 +159,16 @@ fn drive_to_terminal(port: u16, timeouts: ProbeTimeouts) -> ReadinessState {
 /// workspace and confirm `sname::predict_node_name` (via
 /// `predict_short_name`, epmd's own vocabulary) matches what epmd actually
 /// reports once the front distributes.
+///
+/// Unix-only (BT-3045): `predict_node_name`'s pid prediction is *only*
+/// verified correct on Unix (see `sname`'s module doc comment — Windows'
+/// `Child::id()` reports `cmd.exe`'s pid, never `erl.exe`'s, since
+/// `bin\bt_attach.bat` can only run via that console-subsystem wrapper). This
+/// exact assertion is therefore *expected* to fail on Windows, by
+/// construction — not a gap this test should paper over. See
+/// `resolve_registered_node_name_matches_a_live_epmd_registration` below for
+/// the cross-platform (and Windows-correct) replacement.
+#[cfg(not(windows))]
 #[test]
 #[ignore = "needs a live dist-liveview release + running workspace — see module doc comment"]
 fn predict_node_name_matches_a_live_epmd_registration() {
@@ -184,6 +194,43 @@ fn predict_node_name_matches_a_live_epmd_registration() {
     assert!(
         names.contains(&expected),
         "predicted short name {expected:?} not found in epmd's registered names {names:?}"
+    );
+}
+
+/// BT-3045: the Windows-correct replacement for the pid-based prediction
+/// above — spawn a real front, drive it to `Ready` (forcing
+/// `ensure_distributed/0` to actually run), then confirm
+/// `sname::resolve_registered_node_name` finds it via a real epmd query.
+/// Cross-platform (unlike the pid-based test above): this is exactly the
+/// mechanism `desktop/src-tauri/src/commands.rs`'s
+/// `update_windows_node_name_after_readiness` uses to correct a Windows
+/// front record's placeholder `node_name` once readiness confirms `Ready`.
+#[test]
+#[ignore = "needs a live dist-liveview release + running workspace — see module doc comment"]
+fn resolve_registered_node_name_matches_a_live_epmd_registration() {
+    let ws = workspace_id();
+    let mut config = SpawnAttemptConfig::new(launcher(), ws.clone());
+    config.bind_failure_grace = Duration::from_millis(300); // fast path, not under test here
+
+    let (child, port) =
+        spawn_front_with_port_retry(&config).expect("live front should spawn and bind");
+    let _guard = KillOnDrop(child);
+
+    // Force distribution to actually start (lazy, first-/readiness-call).
+    let state = drive_to_terminal(port, ProbeTimeouts::default_local());
+    assert!(
+        matches!(state, ReadinessState::Ready(_)),
+        "expected the live front to reach Ready against a real workspace, got {state:?}"
+    );
+
+    let suffix = beamtalk_desktop_broker::sname::attach_node_suffix(&ws);
+    let resolved = beamtalk_desktop_broker::sname::resolve_registered_node_name(&suffix)
+        .expect("epmd query should succeed with a real front now registered")
+        .expect("exactly one front should be registered under this workspace's suffix");
+    assert!(
+        resolved.starts_with(&format!("bt_attach_{suffix}_")) && resolved.ends_with("@localhost"),
+        "resolved node name {resolved:?} doesn't look like a real bt_attach registration \
+         for suffix {suffix:?}"
     );
 }
 

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -222,10 +222,21 @@ fn attach_and_open_window(
             // nothing consumes yet. Matches the same
             // spawn-a-detached-`std::thread`-for-best-effort-background-work
             // shape `spawn_monitor` below already uses in this file.
-            let workspace_id_for_correction = workspace_id.to_string();
-            std::thread::spawn(move || {
-                update_windows_node_name_after_readiness(&workspace_id_for_correction, port, pid);
-            });
+            // `update_windows_node_name_after_readiness` is a no-op stub off
+            // Windows (see its `#[cfg(not(windows))]` arm) — gate the spawn
+            // itself so this doesn't burn an OS thread just to immediately
+            // return on every attach.
+            #[cfg(windows)]
+            {
+                let workspace_id_for_correction = workspace_id.to_string();
+                std::thread::spawn(move || {
+                    update_windows_node_name_after_readiness(
+                        &workspace_id_for_correction,
+                        port,
+                        pid,
+                    );
+                });
+            }
         }
         ReadinessState::Failed(reason) => {
             kill_and_untrack(state, workspace_id, port);

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -203,7 +203,30 @@ fn attach_and_open_window(
     );
 
     match final_state {
-        ReadinessState::Ready(_version) => {}
+        ReadinessState::Ready(_version) => {
+            // BT-3045: the front has now actually distributed
+            // (`ensure_distributed/0` runs lazily on the first `/readiness`
+            // call, which just resolved above), so a real epmd-resolved
+            // node_name is available on Windows for the first time — correct
+            // persist_front_record's placeholder now that it's known. See
+            // `update_windows_node_name_after_readiness`'s doc comment.
+            //
+            // Fire-and-forget on a background thread (adversarial-review
+            // follow-up) rather than awaited inline here: `node_name` is
+            // bookkeeping/display only — nothing in this repo reads
+            // `FrontRecord.node_name` back today (`crate::reap`'s sweep keys
+            // entirely off `pid`) — so there is no correctness reason for
+            // window-opening below to wait on an epmd round-trip (typically
+            // fast, but not zero-cost, and occasionally as slow as epmd's own
+            // ~1.5s connect+read timeout budget) purely to correct a value
+            // nothing consumes yet. Matches the same
+            // spawn-a-detached-`std::thread`-for-best-effort-background-work
+            // shape `spawn_monitor` below already uses in this file.
+            let workspace_id_for_correction = workspace_id.to_string();
+            std::thread::spawn(move || {
+                update_windows_node_name_after_readiness(&workspace_id_for_correction, port, pid);
+            });
+        }
         ReadinessState::Failed(reason) => {
             kill_and_untrack(state, workspace_id, port);
             return Err(format!(
@@ -440,21 +463,72 @@ fn emit_progress(app: &AppHandle, workspace_id: &str, stage: &str) {
     );
 }
 
+/// Best-effort initial `node_name` guess for a just-spawned front, recorded
+/// before its readiness (and thus its real epmd registration) is known.
+///
+/// Unix: `predict_node_name`'s pid-based prediction is verified correct
+/// there (`beamtalk_desktop_broker::sname`'s module doc — `Child::id()` is
+/// the same pid `System.pid()` reports, an unbroken `exec` chain), so it's
+/// used directly.
+///
+/// Windows: the same prediction is *provably wrong* there (`Child::id()` is
+/// `cmd.exe`'s pid, `bin\bt_attach.bat` can only run via a console-subsystem
+/// wrapper — see `sname`'s module doc) — recording it anyway would look like
+/// real data while being silently incorrect. `sname::pending_node_name`
+/// records an explicit placeholder instead, corrected once
+/// `attach_and_open_window` confirms readiness and can resolve the real
+/// name via epmd (`update_windows_node_name_after_readiness` below).
+fn initial_node_name(workspace_id: &str, pid: u32) -> String {
+    let suffix = beamtalk_desktop_broker::sname::attach_node_suffix(workspace_id);
+    #[cfg(windows)]
+    {
+        let _ = pid; // only meaningful to the (wrong, on Windows) pid-based prediction
+        beamtalk_desktop_broker::sname::pending_node_name(&suffix)
+    }
+    #[cfg(not(windows))]
+    {
+        beamtalk_desktop_broker::sname::predict_node_name(&suffix, pid)
+    }
+}
+
 fn persist_front_record(workspace_id: &str, port: u16, pid: u32) {
     let Ok(dir) = reap::state_dir() else {
         return;
     };
-    let suffix = beamtalk_desktop_broker::sname::attach_node_suffix(workspace_id);
-    let node_name = beamtalk_desktop_broker::sname::predict_node_name(&suffix, pid);
     let record = reap::FrontRecord {
         workspace_id: workspace_id.to_string(),
         port,
         pid,
-        node_name,
+        node_name: initial_node_name(workspace_id, pid),
         start_time: reap::read_start_time(pid),
     };
     let _ = reap::save_record(&dir, &record);
 }
+
+/// Correct a Windows front record's placeholder `node_name` once readiness
+/// confirms the front is actually up (BT-3045) — see [`initial_node_name`]'s
+/// doc comment for why the initial write can't have a real answer yet.
+/// Best-effort and silent on failure everywhere (no epmd match yet, the
+/// record already gone via a racing detach/quit, an I/O error): `node_name`
+/// remains bookkeeping/display only (`beamtalk_desktop_broker::reap`'s sweep
+/// keys entirely off `pid`), so there is nothing correctness-critical riding
+/// on this succeeding, and `attach_and_open_window` should not fail (or even
+/// log noisily) an otherwise-successful attach over it. A no-op on Unix,
+/// where [`initial_node_name`] already recorded the verified-correct value.
+#[cfg(windows)]
+fn update_windows_node_name_after_readiness(workspace_id: &str, port: u16, pid: u32) {
+    let suffix = beamtalk_desktop_broker::sname::attach_node_suffix(workspace_id);
+    let Ok(Some(node_name)) = beamtalk_desktop_broker::sname::resolve_registered_node_name(&suffix)
+    else {
+        return;
+    };
+    if let Ok(dir) = reap::state_dir() {
+        let _ = reap::update_record_node_name(&dir, workspace_id, port, pid, &node_name);
+    }
+}
+
+#[cfg(not(windows))]
+fn update_windows_node_name_after_readiness(_workspace_id: &str, _port: u16, _pid: u32) {}
 
 /// Undo [`persist_front_record`] on an attach failure that already killed
 /// the child, so a clean in-session failure doesn't leave a record for a

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -222,10 +222,11 @@ fn attach_and_open_window(
             // nothing consumes yet. Matches the same
             // spawn-a-detached-`std::thread`-for-best-effort-background-work
             // shape `spawn_monitor` below already uses in this file.
-            // `update_windows_node_name_after_readiness` is a no-op stub off
-            // Windows (see its `#[cfg(not(windows))]` arm) — gate the spawn
-            // itself so this doesn't burn an OS thread just to immediately
-            // return on every attach.
+            // `update_windows_node_name_after_readiness` only exists (and is
+            // only needed) on Windows — see its doc comment — so this gates
+            // the spawn itself rather than calling into a no-op there,
+            // avoiding an OS thread that would immediately return on every
+            // attach off Windows.
             #[cfg(windows)]
             {
                 let workspace_id_for_correction = workspace_id.to_string();
@@ -524,8 +525,11 @@ fn persist_front_record(workspace_id: &str, port: u16, pid: u32) {
 /// remains bookkeeping/display only (`beamtalk_desktop_broker::reap`'s sweep
 /// keys entirely off `pid`), so there is nothing correctness-critical riding
 /// on this succeeding, and `attach_and_open_window` should not fail (or even
-/// log noisily) an otherwise-successful attach over it. A no-op on Unix,
-/// where [`initial_node_name`] already recorded the verified-correct value.
+/// log noisily) an otherwise-successful attach over it. Windows-only: the
+/// call site gates the background thread that invokes this behind
+/// `#[cfg(windows)]` too, since [`initial_node_name`] already recorded the
+/// verified-correct value on Unix — there is nothing for this to correct
+/// there.
 #[cfg(windows)]
 fn update_windows_node_name_after_readiness(workspace_id: &str, port: u16, pid: u32) {
     let suffix = beamtalk_desktop_broker::sname::attach_node_suffix(workspace_id);
@@ -537,9 +541,6 @@ fn update_windows_node_name_after_readiness(workspace_id: &str, port: u16, pid: 
         let _ = reap::update_record_node_name(&dir, workspace_id, port, pid, &node_name);
     }
 }
-
-#[cfg(not(windows))]
-fn update_windows_node_name_after_readiness(_workspace_id: &str, _port: u16, _pid: u32) {}
 
 /// Undo [`persist_front_record`] on an attach failure that already killed
 /// the child, so a clean in-session failure doesn't leave a record for a


### PR DESCRIPTION
## Summary

Fixes the Windows-specific bugs an adversarial code-review pass on PR #3213 (BT-2988) flagged in `crates/beamtalk-desktop-broker`'s spawn path:

- **`predict_node_name` is wrong on Windows** — `Child::id()` reports `cmd.exe`'s pid, never `erl.exe`'s (`.bat` launches can only run via that console-subsystem wrapper). Added `sname::resolve_registered_node_name`, which queries epmd directly for the front's real registration instead of guessing from a pid. Since epmd registration is lazy (only happens on the first `/readiness` call, after the initial orphan-reaping record is written), the initial write now records an honest `sname::pending_node_name` placeholder on Windows and corrects it — on a background thread, since `FrontRecord.node_name` has no reader anywhere in the repo today — once readiness confirms the front actually distributed. `reap::update_record_node_name` is a pid-checked compare-and-swap, not a blind overwrite, to avoid resurrecting a record a concurrent detach/quit already removed.
- **No `current_dir` on the Windows launch command** — set to the release root now, matching `bin/server`'s `cd -P -- "$(dirname "$0")/.."` on Unix. Gated on an absolute launcher path so the documented `BEAMTALK_ATTACH_LAUNCHER` dev-override fallback (a relative path) can't turn into a corrupted double-relative path that `cmd.exe` then fails to resolve.
- **No shared, repo-owned contract between `bin/server` and `spawn.rs`'s Windows reimplementation** — documented why a `bin\server.bat` port was rejected (batch has no real JSON parser; Windows already gets a strictly better implementation by staying in Rust) in favor of a test (`windows_launch_env_matches_bin_server_contract`) that reads `bin/server`'s actual source and asserts its env-var assignments are mirrored in the Windows Rust arm — a removal/rename drift guard.
- **`spawn_front_with_port_retry` masked the real error on launcher rejection** — `BrokerError::PortsExhausted` now carries the last spawn attempt's real launcher exit status as a diagnostic, so a genuine non-conflict failure isn't reported as an opaque attempt count that reads as "every port was taken."

## Verification

No Windows sandbox was available for this crate's earlier work (BT-2988/BT-3046), but this session ran on a real Windows machine — built and tested both `beamtalk-desktop-broker` and the Tauri `beamtalk-desktop` crate directly against real Win32 APIs (job objects, `GetProcessTimes`, process-tree kill via `ping.exe`, real filesystem `current_dir` checks). 131 tests passing in `beamtalk-desktop-broker`, clippy clean with `-D warnings`, `cargo fmt --check` clean on both crates.

Full live E2E verification (`just dist-liveview` + a real attach) was attempted but blocked by an unrelated, pre-existing Erlang-on-Windows limitation (`erlang:open_port(spawn_executable, ...)` can't directly exec `npm.cmd` — ironically the same "can't `CreateProcessW` a `.bat`" class of issue this PR's own `current_dir`/launcher-path fixes are about). A new live test (`resolve_registered_node_name_matches_a_live_epmd_registration`, `#[ignore]`d like its siblings) is ready to run once that's unblocked or on real Windows CI.

Went through a 3-pass review (diff / system / adversarial with a second model) before pushing — see the two follow-up issues below for what was found but out of scope to fix here.

## Follow-ups filed

- BT-3060 — pre-existing divergence: Windows silently defaults `node_name` when `metadata.json` lacks one; `bin/server` hard-fails
- BT-3061 — `desktop/src-tauri` has zero CI test coverage (excluded from workspace, no `cargo test` step in any GitHub Actions workflow)

Linear: https://linear.app/beamtalk/issue/BT-3045

🤖 Generated with [Claude Code](https://claude.com/claude-code)