### PR TITLE
desktop/src-tauri Tauri app crate has zero CI test coverage (BT-3061)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,76 @@ jobs:
         # docs/development/surface-parity.md. Fails fast on inventory drift.
         run: just check-surface-drift
 
+  # ─── Desktop app (Tauri) crate tests (BT-3061) ─────────────────────────
+  # desktop/src-tauri is excluded from the root Cargo workspace (root
+  # Cargo.toml's `exclude`, see desktop/README.md) because it needs the
+  # Tauri toolchain — webkit2gtk-4.1/glib/gtk3 dev packages on Linux;
+  # WebView2 (preinstalled) on Windows and WKWebView (part of the OS) on
+  # macOS need no extra packages — that the rest of the workspace doesn't
+  # require, so `just build`/`just test`'s `cargo build --workspace` never
+  # touches it. That left this crate's `#[cfg(test)]` unit tests (e.g.
+  # `commands::tests::locked_recovers_from_a_poisoned_mutex`) running only
+  # via a manual local `cargo test -p beamtalk-desktop` (easy to forget) or
+  # indirectly via desktop/e2e/'s whole-stack Playwright scripts — this job
+  # closes that gap on every platform desktop-release.yml ships for
+  # (BT-3061). Runs `just test-desktop`, which mirrors this same
+  # webkit2gtk-4.1 install list from desktop-release.yml's build job (minus
+  # `patchelf`, needed only for that lane's AppImage bundling, not for
+  # compiling/testing this crate).
+  test-desktop:
+    strategy:
+      fail-fast: false
+      matrix:
+        # Same OS set as the 'check' job above (including the win25 pin —
+        # see its comment), not desktop-release.yml's full release matrix:
+        # that workflow also builds macos-15-intel as a second *shipping*
+        # architecture, but this crate's Rust source has no architecture-
+        # specific logic, so one macOS unit-test run is sufficient
+        # coverage.
+        os: [ubuntu-latest, macos-latest, windows-2022]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - name: Install Just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      - name: Cache Rust dependencies (desktop/src-tauri)
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: desktop/src-tauri -> target
+
+      # Tauri v2's documented Debian/Ubuntu prerequisites
+      # (https://v2.tauri.app/start/prerequisites/) — same list
+      # desktop-release.yml installs before its own `cargo tauri build`,
+      # minus `patchelf` (only needed for that lane's AppImage bundling
+      # step, not for compiling/testing this crate).
+      - name: Install Linux Tauri prerequisites
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Test beamtalk-desktop (Tauri app crate)
+        run: just test-desktop
+
   # ─── Corpus drift check (BT-2737) ──────────────────────────────────────
   # crates/beamtalk-examples/corpus.json is generated from the .bt example/
   # test sources; this fails the PR if it wasn't regenerated after a source

--- a/Justfile
+++ b/Justfile
@@ -453,6 +453,42 @@ dist-desktop:
 dist-desktop:
     just dist-desktop-platform msi,nsis
 
+# Run beamtalk-desktop's (desktop/src-tauri, the Tauri app crate) own
+# `#[cfg(test)]` unit tests (BT-3061). NOT part of `just test`/`just ci` —
+# this crate is deliberately excluded from the root Cargo workspace (see
+# root Cargo.toml's `exclude` and desktop/README.md) because it needs the
+# Tauri toolchain (webkit2gtk-4.1/glib/gtk3 dev packages on Linux; WebView2
+# on Windows and WKWebView on macOS need no extra packages) that the rest
+# of the workspace doesn't require. A dedicated CI job in ci.yml installs
+# that toolchain per-platform and calls this recipe directly; run it by
+# hand once you have the same Tauri prerequisites `cargo tauri dev` needs
+# (desktop/README.md).
+#
+# tauri-build's config validation (invoked from this crate's build.rs)
+# checks that tauri.conf.json's `bundle.resources` source path
+# (`../../dist-liveview`) exists on disk, but `cargo test` never invokes
+# the actual bundler — an empty placeholder directory satisfies the check
+# without a full `just dist-liveview` release build (Erlang/Elixir/Node),
+# which would make this recipe as slow as `just dist-desktop-platform` for
+# no test-coverage benefit. Verified locally: an empty dist-liveview/ is
+# sufficient for `cargo test` to build and run this crate's unit tests.
+[unix]
+test-desktop:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p dist-liveview
+    cd desktop/src-tauri
+    cargo test --locked
+
+[windows]
+test-desktop:
+    #!powershell.exe
+    $ErrorActionPreference = "Stop"
+    New-Item -ItemType Directory -Force -Path dist-liveview | Out-Null
+    Set-Location desktop/src-tauri
+    cargo test --locked
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
 # Ensure the loopback hex-bridge proxy is up before any rebar3/mix dep fetch.
 # Cloud containers only (gated on CLAUDE_CODE_REMOTE): a session can outlive the
 # SessionStart launch, and a dead bridge makes `rebar3 compile` fail to fetch

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -173,6 +173,22 @@ everyone, not just this crate. Wiring an actual CI build lane that installs
 the Linux/macOS toolchain is BT-2987's job (packaging); this issue (BT-2986)
 only writes the picker's source.
 
+### Unit test CI coverage (BT-3061)
+
+Being excluded from the root workspace does NOT mean this crate's own
+`#[cfg(test)]` unit tests go untested in CI — `.github/workflows/ci.yml`'s
+`test-desktop` job installs the same Linux Tauri toolchain (Linux only;
+Windows/macOS runners already ship what's needed) and runs `just
+test-desktop` on every push/PR, across Linux, macOS, and Windows, same as
+every other test job in that workflow. That's a separate concern from the
+packaging lane above: `test-desktop` only compiles and runs this crate's own
+unit tests (fast, no `dist-liveview` release build required — an empty
+placeholder directory satisfies `tauri.conf.json`'s `bundle.resources`
+existence check that this crate's `build.rs` enforces via `tauri_build::
+build()`), where `desktop-release.yml` builds and bundles the full shippable
+app. Run it locally with `just test-desktop` once you have the same
+prerequisites `cargo tauri dev` needs (below).
+
 ## Shell decision status (read before extending this app)
 
 The BT-2984 spike (`docs/research/desktop-shell-spike.md`) leans Tauri but


### PR DESCRIPTION
https://linear.app/beamtalk/issue/BT-3061/desktopsrc-tauri-tauri-app-crate-has-zero-ci-test-coverage

## Summary

`desktop/src-tauri` is excluded from the root Cargo workspace (needs the
Tauri toolchain), so its `#[cfg(test)]` unit tests never ran anywhere but a
manual local `cargo test -p beamtalk-desktop` or indirectly via `desktop/e2e/`'s
whole-stack Playwright scripts. This adds a dedicated CI job that runs them
on every push/PR, on Linux, macOS, and Windows.

- Added `just test-desktop`: creates an empty placeholder `dist-liveview/`
  directory (verified locally — this alone satisfies `tauri.conf.json`'s
  `bundle.resources` existence check that this crate's `build.rs` enforces
  via `tauri_build::build()`, without needing a full `just dist-liveview`
  release build), then runs `cargo test --locked` from `desktop/src-tauri`.
- Added a `test-desktop` job to `.github/workflows/ci.yml`, matrixed across
  `ubuntu-latest` / `macos-latest` / `windows-2022` (same OS set as the
  `check` job), installing the same Linux Tauri prerequisites
  `desktop-release.yml`'s build job already documents (minus `patchelf`,
  only needed for that lane's AppImage bundling).
- Documented the new coverage in `desktop/README.md`.

## Verification

- Verified locally on Windows: `just test-desktop` compiles the full crate
  (previously never compiled by `rustc` in this repo per `desktop/README.md`'s
  "What was and wasn't verified" section) and runs its one existing test,
  `commands::tests::locked_recovers_from_a_poisoned_mutex` — passes.
- The Linux/macOS legs are unverified locally (no toolchain available in this
  sandbox) — this PR's own CI run is the first real verification of those,
  per the issue's guidance.
- Ran the rest of the local test suite (`build`, `clippy`, `fmt-check`,
  `test-stdlib`, `test-bunit`, `test-runtime`, `check-surface-drift`) — all
  green. One pre-existing, unrelated Windows-environment test failure was
  observed in `test-rust` (`cli_lint::expect_type_on_ffi_arg_mismatch_...`,
  BT-2851) but confirmed passing in the actual GitHub Actions run on the
  exact `main` commit this branch is based on (4244a693) — not caused by
  this diff, which touches no Rust/Erlang source.

## Gate decision (per the issue's acceptance criteria)

Branch protection today only formally requires `Claude BeamTalk Review` and
`check-corpus` — none of `ci.yml`'s other test jobs (`check`, `test-beam`,
`test-runtime`, `test-integration`, `test-parity`) are individually required
either. `test-desktop` is wired in the same way as those: it runs on every
push/PR and shows up in the PR checks list, but isn't added as an
individually-required branch-protection check, matching existing convention
rather than introducing a stricter bar for this one job.

## Follow-up filed

While validating locally on Windows, discovered that `just build-stdlib`
regenerates `beamtalk_stdlib.app.src` with backslash path separators in
`source_file` fields (a pre-existing, unrelated bug in
`build_alias_metadata()`, `crates/beamtalk-cli/src/commands/build.rs`).
Reverted that incidental change before committing and filed
[BT-3068](https://linear.app/beamtalk/issue/BT-3068) to track the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)