### PR TITLE
Fix Windows CI flake: hermetic registry cache tests + stable git clone cwd (BT-3040)

### DIFF
--- a/crates/beamtalk-cli/src/commands/deps/registry.rs
+++ b/crates/beamtalk-cli/src/commands/deps/registry.rs
@@ -585,25 +585,52 @@ fn clone_index(url: &str, target: &Utf8Path) -> Result<()> {
             .wrap_err_with(|| format!("Failed to remove stale registry clone '{target}'"))?;
     }
 
-    if let Some(parent) = target.parent() {
+    // `target` is passed to `git clone` unchanged below while `current_dir`
+    // is set to its parent (BT-3040) — that combination is only correct if
+    // `target` is absolute; a relative `target` would have its destination
+    // argument re-resolved against its own parent by git, landing one level
+    // too deep. Every caller derives `target` from `registry_cache_root`,
+    // which is always absolute (home-dir-based, or joined against
+    // `project_root`, itself always `std::env::current_dir()` — see
+    // `find_project_root`), so this should never trip; it exists to catch a
+    // future caller that breaks that chain rather than silently misplacing
+    // a clone.
+    debug_assert!(
+        target.is_absolute(),
+        "clone_index target must be absolute, got '{target}'"
+    );
+
+    let parent = target.parent();
+    if let Some(parent) = parent {
         std::fs::create_dir_all(parent)
             .into_diagnostic()
             .wrap_err_with(|| format!("Failed to create registry directory '{parent}'"))?;
     }
 
     info!(url, %target, "Cloning registry index");
-    let output = Command::new("git")
-        .args([
-            "-c",
-            "protocol.ext.allow=never",
-            "clone",
-            "--quiet",
-            "--depth",
-            "1",
-            "--",
-            url,
-            target.as_str(),
-        ])
+    let mut cmd = Command::new("git");
+    cmd.args([
+        "-c",
+        "protocol.ext.allow=never",
+        "clone",
+        "--quiet",
+        "--depth",
+        "1",
+        "--",
+        url,
+        target.as_str(),
+    ]);
+    // Run from `parent` rather than inheriting the process's current
+    // directory (BT-3040): the process cwd is global, so a `git clone`
+    // spawned without an explicit `current_dir` can be handed a directory
+    // another thread is concurrently changing (or has since deleted) —
+    // Windows surfaces that as a spurious "Unable to read current working
+    // directory" clone failure. `parent` was just created above, so it is
+    // stable for the lifetime of this call.
+    if let Some(parent) = parent {
+        cmd.current_dir(parent);
+    }
+    let output = cmd
         .output()
         .into_diagnostic()
         .wrap_err("Failed to execute 'git clone' for the registry index")?;
@@ -1227,6 +1254,15 @@ git = "g"
     }
 
     #[test]
+    // BT-3040: `registry_cache_root` reads `REGISTRY_CACHE_DIR_ENV_VAR` at
+    // call time, and this test relies on it being unset (so the index lands
+    // under the real, shared `~/.beamtalk/registry/`). Without joining the
+    // `env_var` serial group, a concurrently running test that *does* set
+    // the override (e.g. `test_registry_cache_root_env_var_override`) can
+    // flip it mid-test — `ensure_index` and the `registry_cache_root` call
+    // used to compute the expected path would then disagree, since each
+    // reads the env var independently.
+    #[serial_test::serial(env_var)]
     fn test_ensure_index_clones_git_registry() {
         let (_repo, url) = make_git_index(&[("yaml", YAML_ENTRY)]);
         let project = TempDir::new().unwrap();
@@ -1255,6 +1291,8 @@ git = "g"
     }
 
     #[test]
+    // BT-3040: see the serialization note on `test_ensure_index_clones_git_registry`.
+    #[serial_test::serial(env_var)]
     fn test_resolve_release_through_git_registry() {
         let (_repo, url) = make_git_index(&[("yaml", YAML_ENTRY)]);
         let project = TempDir::new().unwrap();
@@ -1271,6 +1309,11 @@ git = "g"
 
     /// A newly published version is picked up by the miss-then-refresh retry.
     #[test]
+    // BT-3040: see the serialization note on `test_ensure_index_clones_git_registry`.
+    // This test calls `ensure_index`/`resolve_release` twice (once to seed
+    // the cache, once to observe the refresh); an env var flip between the
+    // two calls would send them to different cache directories.
+    #[serial_test::serial(env_var)]
     fn test_resolve_release_refresh_picks_up_new_version() {
         let (repo, url) = make_git_index(&[("yaml", YAML_ENTRY)]);
         let project = TempDir::new().unwrap();
@@ -1298,6 +1341,8 @@ git = "g"
     /// A refresh that cannot reach the remote must leave the working index
     /// intact rather than deleting it and failing.
     #[test]
+    // BT-3040: see the serialization note on `test_ensure_index_clones_git_registry`.
+    #[serial_test::serial(env_var)]
     fn test_failed_refresh_keeps_existing_index() {
         let (repo, url) = make_git_index(&[("yaml", YAML_ENTRY)]);
         let project = TempDir::new().unwrap();
@@ -1325,6 +1370,10 @@ git = "g"
     }
 
     #[test]
+    // BT-3040: `ensure_git_index` computes `registry_cache_root` before
+    // validating the URL, so this still touches the env-var-dependent path;
+    // see the serialization note on `test_ensure_index_clones_git_registry`.
+    #[serial_test::serial(env_var)]
     fn test_ensure_index_rejects_dangerous_registry_url() {
         let project = TempDir::new().unwrap();
         let err = ensure_index(
@@ -1575,6 +1624,11 @@ git = "g"
     /// or MCP lookup) resolving against the same git registry at once must
     /// both succeed, and must never see a half-swapped index (BT-2996).
     #[test]
+    // BT-3040: see the serialization note on `test_ensure_index_clones_git_registry`.
+    // The concurrency this test cares about (multiple threads racing the
+    // same registry) is internal to the test itself; serializing against
+    // *other tests* just keeps the env var stable for the duration.
+    #[serial_test::serial(env_var)]
     fn test_concurrent_resolutions_against_same_registry_both_succeed() {
         let (_repo, url) = make_git_index(&[("yaml", YAML_ENTRY)]);
         let location = RegistryLocation::Git(url.clone());
@@ -1778,6 +1832,8 @@ git = "g"
     }
 
     #[test]
+    // BT-3040: see the serialization note on `test_ensure_index_clones_git_registry`.
+    #[serial_test::serial(env_var)]
     fn test_resolve_latest_release_through_git_registry() {
         let (_repo, url) = make_git_index(&[("yaml", YAML_ENTRY)]);
         let project = TempDir::new().unwrap();

--- a/crates/beamtalk-cli/src/commands/deps/registry.rs
+++ b/crates/beamtalk-cli/src/commands/deps/registry.rs
@@ -573,6 +573,18 @@ fn fast_forward_index(index_dir: &Utf8Path) -> bool {
 }
 
 /// Clone the registry index into `target`, replacing anything already there.
+/// # Relative `file://` URLs
+///
+/// `git clone` below runs with `current_dir` set to `target`'s parent (the
+/// hash-keyed cache directory, BT-3040 — see the `debug_assert!` just below
+/// for why), not the process's actual working directory. A *relative*
+/// `file://` URL (`validate_git_url` only requires the scheme prefix, not
+/// that what follows is absolute) would therefore resolve against that
+/// cache-internal location instead of anywhere user-meaningful. Every
+/// caller/test in this module always builds absolute `file://` URLs, so
+/// this is not reachable in practice today — but a registry `file://` URL
+/// is expected to always be absolute; this isn't enforced beyond
+/// convention.
 fn clone_index(url: &str, target: &Utf8Path) -> Result<()> {
     // The registry URL can come from the environment or the manifest; screen it
     // with the same rules as a dependency URL so `ext::` and option-lookalikes


### PR DESCRIPTION
Fixes https://linear.app/beamtalk/issue/BT-3040

## Summary

Root-caused and fixed two related sources of Windows CI flakiness in `crates/beamtalk-cli/src/commands/deps/registry.rs`, both stemming from process-global state (`BEAMTALK_REGISTRY_CACHE_DIR` env var and process cwd) leaking across concurrently-running tests in the same test binary:

- Several tests (`test_ensure_index_clones_git_registry` and 6 others) read `REGISTRY_CACHE_DIR_ENV_VAR` indirectly via `registry_cache_root`/`ensure_index`/`resolve_release`, without joining the repo's existing `#[serial_test::serial(env_var)]` group. A concurrently running test that *does* set the override (e.g. `test_registry_cache_root_env_var_override`) could flip the env var mid-test, so `ensure_index`'s internal cache-root computation and the test's own recomputation of the expected path would disagree — exactly the `left`/`right` mismatch seen in the failing CI run. Fixed by joining all 7 affected tests to the `env_var` serial group.
- While stress-testing with full `just test`/`just ci-changed` runs, reproduced a second, related race: `clone_index`'s `git clone` subprocess never set an explicit `current_dir`, so it inherited the process-global cwd. A concurrent test that calls `std::env::set_current_dir` (`test_registry_cache_root_relative_env_var_override_ignores_process_cwd`) could hand it a stale/deleted directory, which Windows surfaces as `fatal: Unable to read current working directory`. Fixed by running the clone from `target`'s parent, with a `debug_assert!` protecting the absolute-path invariant that makes this safe (verified `target` is always absolute in both production and test code paths).

## Verification

- `cargo test --bin beamtalk registry::` — 62/62 passing, run repeatedly with no flakes
- `just build && just clippy && just fmt-check` — clean
- Full `just ci-changed` — passes except one pre-existing, unrelated failure (`cli_lint::expect_type_on_ffi_arg_mismatch_is_not_stale_across_lint_and_build_bt_2851`), confirmed to reproduce identically against unpatched `origin/main` (stashed this diff, rebuilt, reran) — tracked separately as BT-3064, not caused by this change

## Follow-up issues filed

- BT-3064 — the pre-existing `cli_lint` FFI arg-type check failure noted above
- BT-3067 — `beamtalk_stdlib.app.src`'s generated `source_file` paths use native (backslash) separators when regenerated on Windows, an unrelated portability bug in `build_alias_metadata`/`build.rs` found while running `just build` repeatedly during this investigation