### PR TITLE
Windows node-name background correction: TOCTOU + pid-vs-suffix disambiguation (BT-3062)

### DIFF
--- a/crates/beamtalk-desktop-broker/src/reap.rs
+++ b/crates/beamtalk-desktop-broker/src/reap.rs
@@ -44,11 +44,50 @@
 
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
+
+/// Serializes every read-modify-write or delete of a [`FrontRecord`] file
+/// ([`save_record`], [`update_record_node_name`], [`remove_record`]) so two
+/// of those operations racing the same `(workspace_id, port)` key can never
+/// interleave (BT-3062). Without this, `update_record_node_name`'s
+/// read-check-write had a window in which a concurrent `remove_record` (a
+/// racing `detach`/`quit`/failed-attach cleanup, per `kill_and_untrack`)
+/// could delete the file between the read and the write — the write would
+/// then silently *recreate* it, resurrecting a record for a front this
+/// broker already killed. See `update_record_node_name`'s doc comment for
+/// the full race description this closes.
+///
+/// One process-wide lock, not a per-key table: every operation it guards is
+/// a single fast file read/write, and record mutations across *different*
+/// keys are rare enough (one attach/detach at a time is the common case)
+/// that briefly serializing unrelated keys is a better trade than a per-key
+/// lock table's unbounded growth over a long-lived broker process's
+/// lifetime. Cross-process contention (e.g. this broker racing a *second*
+/// broker instance) is out of scope — ADR 0097 assumes one broker per user
+/// session — so a plain in-process [`Mutex`], not a cross-process file lock,
+/// is sufficient to close the specific same-process race this exists for.
+fn record_ops_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Lock [`record_ops_lock`], recovering from a poisoned mutex rather than
+/// propagating the panic to every future record operation for the rest of
+/// the process's life — matches `desktop/src-tauri/src/commands.rs`'s own
+/// `locked()` helper's reasoning for `state.attach`/`state.children`: a
+/// panic mid-mutation doesn't guarantee the record file itself was left
+/// inconsistent, and this is the one lock standing between a stuck broker
+/// and every future attach/detach silently failing to update its bookkeeping.
+fn locked_record_ops() -> MutexGuard<'static, ()> {
+    record_ops_lock()
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
 
 /// Bookkeeping for one spawned front, persisted so a future broker process
 /// (after a crash) can find and reap it.
@@ -96,6 +135,7 @@ pub fn save_record(dir: &Path, record: &FrontRecord) -> Result<()> {
     std::fs::create_dir_all(dir)?;
     let path = record_path(dir, &record.workspace_id, record.port);
     let json = serde_json::to_string_pretty(record)?;
+    let _guard = locked_record_ops();
     std::fs::write(path, json)?;
     Ok(())
 }
@@ -126,6 +166,19 @@ pub fn save_record(dir: &Path, record: &FrontRecord) -> Result<()> {
 /// newer front in between: this must never stamp a stale epmd-resolved name
 /// onto a record that isn't the one this call was resolving it for.
 ///
+/// **The resurrection window itself (BT-3062)** — the compare-and-swap above
+/// only ever protected against a *different* front's record being mutated;
+/// it did nothing about the file being deleted by a racing `remove_record`
+/// strictly between this function's read and its write, which would recreate
+/// the very file that call just deleted. [`locked_record_ops`] now wraps the
+/// whole read-check-write below in the same process-wide lock
+/// [`remove_record`] takes around its own delete, so the two can never
+/// interleave: either the delete completes first (this call then reads
+/// `NotFound` and no-ops, per the paragraph below) or this call's write
+/// completes first (and the delete, running after, removes the corrected
+/// file as intended) — never the read-delete-write ordering that used to
+/// resurrect it.
+///
 /// No-op (not an error) if the record no longer exists, or if it exists but
 /// its `pid` no longer matches `expected_pid` — either way there's nothing
 /// left for *this* call to correct, not a failure of this function's own job.
@@ -141,6 +194,7 @@ pub fn update_record_node_name(
     node_name: &str,
 ) -> Result<()> {
     let path = record_path(dir, workspace_id, port);
+    let _guard = locked_record_ops();
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
         Err(e) if e.kind() == ErrorKind::NotFound => return Ok(()),
@@ -167,6 +221,14 @@ pub fn update_record_node_name(
 /// sites in `desktop/src-tauri/src/commands.rs`) goes through here, so this
 /// one hook covers all of them.
 ///
+/// The actual record-file delete below takes [`locked_record_ops`] (BT-3062)
+/// — the `RELEASE_TMP` removal above deliberately does not, since it can
+/// legitimately retry for up to ~1s (see
+/// [`remove_release_tmp_dir_with_retry`]) and doesn't touch the record file
+/// itself, so there's no reason to hold up an unrelated
+/// [`update_record_node_name`] call for that long over a resource it never
+/// touches.
+///
 /// # Errors
 ///
 /// Returns an error if the record file exists but can't be removed
@@ -176,6 +238,7 @@ pub fn remove_record(dir: &Path, workspace_id: &str, port: u16) -> Result<()> {
     remove_release_tmp_dir_with_retry(workspace_id, port);
 
     let path = record_path(dir, workspace_id, port);
+    let _guard = locked_record_ops();
     match std::fs::remove_file(path) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == ErrorKind::NotFound => Ok(()),
@@ -757,6 +820,56 @@ mod tests {
             loaded,
             vec![rec],
             "record must be left completely untouched when expected_pid doesn't match"
+        );
+    }
+
+    /// Regression test (BT-3062): `update_record_node_name`'s read-check-write
+    /// and `remove_record`'s delete must never interleave, closing the
+    /// resurrection window described in `update_record_node_name`'s doc
+    /// comment (a racing `remove_record` landing strictly between the read
+    /// and the write would otherwise recreate the file it just deleted).
+    /// Rather than trying to force that exact interleaving from a test
+    /// (inherently racy to arrange), this proves the mechanism that prevents
+    /// it: both functions contend on the same [`record_ops_lock`], so a
+    /// `remove_record` that starts while that lock is held blocks until it's
+    /// released, rather than running concurrently.
+    #[test]
+    fn update_and_remove_are_mutually_exclusive_on_the_record_lock() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rec = record(4242, Some(555));
+        save_record(tmp.path(), &rec).unwrap();
+
+        // Stand in for `update_record_node_name`'s own critical section
+        // being "mid-flight" between its read and its write.
+        let guard = locked_record_ops();
+
+        let dir = tmp.path().to_path_buf();
+        let workspace_id = rec.workspace_id.clone();
+        let port = rec.port;
+        let handle = std::thread::spawn(move || {
+            remove_record(&dir, &workspace_id, port).unwrap();
+        });
+
+        // Give the spawned remove_record ample time to have run if it were
+        // (wrongly) unsynchronized, then confirm it's still blocked and the
+        // record file is still present.
+        std::thread::sleep(Duration::from_millis(200));
+        assert!(
+            !handle.is_finished(),
+            "remove_record should still be blocked on record_ops_lock"
+        );
+        assert_eq!(
+            load_all_records(tmp.path()).unwrap(),
+            vec![rec.clone()],
+            "record must still be on disk while the lock is held"
+        );
+
+        drop(guard);
+        handle.join().unwrap();
+
+        assert!(
+            load_all_records(tmp.path()).unwrap().is_empty(),
+            "remove_record should complete once the lock is released"
         );
     }
 

--- a/crates/beamtalk-desktop-broker/src/reap.rs
+++ b/crates/beamtalk-desktop-broker/src/reap.rs
@@ -833,6 +833,15 @@ mod tests {
     /// it: both functions contend on the same [`record_ops_lock`], so a
     /// `remove_record` that starts while that lock is held blocks until it's
     /// released, rather than running concurrently.
+    ///
+    /// Trade-off, noted rather than avoided (adversarial-review follow-up):
+    /// `record_ops_lock` is one process-wide `static`, not scoped per test,
+    /// so holding it for this test's 200ms window incidentally blocks any
+    /// other test in this binary that concurrently calls
+    /// `save_record`/`update_record_node_name`/`remove_record` on its own
+    /// unrelated tmp dir under default parallel `cargo test` execution. No
+    /// tight timeouts exist elsewhere in this suite, so this doesn't cause
+    /// failures — just up to 200ms of incidental cross-test latency.
     #[test]
     fn update_and_remove_are_mutually_exclusive_on_the_record_lock() {
         let tmp = tempfile::TempDir::new().unwrap();

--- a/crates/beamtalk-desktop-broker/src/sname.rs
+++ b/crates/beamtalk-desktop-broker/src/sname.rs
@@ -68,6 +68,49 @@
 //! a stale or placeholder value there was never a kill/reap-correctness bug,
 //! only a misleading one for anyone reading the on-disk record.
 //!
+//! **Suffix-only matching, deliberately not disambiguated by `pid` (BT-3062)**:
+//! a Claude review Suggestion on the BT-3045 PR proposed closing the
+//! crash→respawn race below by validating the resolved epmd name's own
+//! embedded pid segment against the caller's `expected_pid`
+//! (`Child::id()`/`FrontRecord.pid`) before [`crate::reap::update_record_node_name`]
+//! writes it. That doesn't actually work *here*: this function is only ever
+//! called from the Windows-only correction path
+//! (`desktop/src-tauri/src/commands.rs`'s `update_windows_node_name_after_readiness`,
+//! `#[cfg(windows)]`), and the pid segment epmd's real registration embeds is
+//! `System.pid()` — `erl.exe`'s own pid — which the "**Windows launch path**"
+//! paragraph above establishes is a *different* process from the one
+//! `Child::id()`/`FrontRecord.pid` identifies (`cmd.exe`, the `.bat` wrapper).
+//! Gating the match on `expected_pid == embedded pid` would therefore never
+//! match on Windows — not just in the racy case this was meant to close, but
+//! on *every* call, silently disabling the correction entirely rather than
+//! narrowing its race window. (On Unix the two pids genuinely are the same
+//! process per BT-3004's verification above, so the check would work there —
+//! but Unix never calls this function; `predict_node_name` is trusted
+//! directly there instead, see [`crate::spawn`]'s caller.)
+//!
+//! The crash→respawn race is real and stays open: front A (`FrontRecord`
+//! still on disk, pid X) dies and deregisters from epmd before its detach
+//! path runs, front B spawns for the *same* workspace under a different port
+//! and registers with epmd, and the background thread still resolving A's
+//! correction sees exactly one epmd match — B's — and (via
+//! `update_record_node_name`'s CAS, which only ever validates the *on-disk
+//! record's* pid, not the resolved name's) stamps B's real node name onto
+//! A's own record. Accepted rather than closed, because `FrontRecord.node_name`
+//! remains bookkeeping/display only everywhere it's read (`crate::reap`'s
+//! sweep keys entirely off `pid`, never `node_name` — see that module's doc
+//! comment) — the worst case is a transient, cosmetically-wrong value in a
+//! record a future sweep or the dying front's own delayed detach will clear
+//! anyway, not a kill/reap-correctness bug. A real fix would need a
+//! genuinely shared identity between the broker and the front's own
+//! `System.pid()` (e.g. baking per-spawn entropy — the HTTP port,
+//! already OS-allocated per spawn per `crate::port`'s docs — into
+//! [`attach_node_suffix`] itself, so two fronts for one workspace can never
+//! share a suffix in the first place) — a real but materially larger,
+//! cross-cutting change to a contract several other things depend on
+//! (`attach_node_suffix`'s own tests, the Elixir side's
+//! `BtAttach.Workspace.attach_sname/2` consumer), out of scope for this
+//! narrow follow-up.
+//!
 //! **DDD Context:** Desktop Shell
 
 /// Value to set `BT_ATTACH_NODE_SUFFIX` to for a spawn attaching to `workspace_id`.
@@ -125,6 +168,11 @@ pub fn pending_node_name(suffix: &str) -> String {
 /// (BT-3045). Looks for exactly one currently-registered short name with the
 /// `bt_attach_<suffix>_` prefix `BtAttach.Workspace.attach_sname/2` always
 /// produces.
+///
+/// Deliberately **not** disambiguated further by the caller's own pid
+/// (BT-3062) — see this module's doc comment's "**Suffix-only matching**"
+/// paragraph for why a pid-based check would silently break this function on
+/// the only platform it's actually called from, rather than narrow a race.
 ///
 /// Returns `Ok(None)` — not a guess — when epmd reports zero matches (the
 /// front hasn't distributed yet; `ensure_distributed/0` only runs lazily on
@@ -281,6 +329,15 @@ mod tests {
         );
     }
 
+    /// BT-3062 investigated closing this by requiring the resolved name's
+    /// embedded pid to match the caller's own known pid, but concluded (see
+    /// this module's doc comment, "**Suffix-only matching**" paragraph) that
+    /// a pid-based check would silently break every call on the only
+    /// platform this function runs on (Windows: the caller's known pid is
+    /// `cmd.exe`'s, not the `erl.exe` pid epmd's registration actually
+    /// embeds) — so this stays deliberately unresolved here, ambiguous
+    /// suffix matches still refuse to guess rather than picking one
+    /// arbitrarily.
     #[test]
     fn find_unique_match_returns_none_when_two_fronts_on_the_same_workspace_are_ambiguous() {
         // ADR 0097-anticipated scenario (see attach_node_suffix's doc

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -530,6 +530,15 @@ fn persist_front_record(workspace_id: &str, port: u16, pid: u32) {
 /// `#[cfg(windows)]` too, since [`initial_node_name`] already recorded the
 /// verified-correct value on Unix — there is nothing for this to correct
 /// there.
+///
+/// `resolve_registered_node_name` below is deliberately *not* also passed
+/// `pid` to disambiguate a same-suffix race (BT-3062 investigated this and
+/// rejected it): `pid` here is `Child::id()` — `cmd.exe`'s pid on Windows,
+/// per `sname`'s module doc comment — not the `System.pid()` epmd's real
+/// registration actually embeds, so a pid-based check would never match on
+/// this, the only platform this function runs on. See `sname`'s module doc
+/// comment ("**Suffix-only matching**") for the full reasoning and the
+/// residual race this leaves accepted rather than closed.
 #[cfg(windows)]
 fn update_windows_node_name_after_readiness(workspace_id: &str, port: u16, pid: u32) {
     let suffix = beamtalk_desktop_broker::sname::attach_node_suffix(workspace_id);


### PR DESCRIPTION
## Summary

Follow-up from two Claude review Suggestions on PR #3253 (BT-3045, Windows spawn path fixes). Closes BT-3062.

- **TOCTOU on record deletion** (`crates/beamtalk-desktop-broker/src/reap.rs`): `update_record_node_name`'s read-check-write and `remove_record`'s delete could interleave, letting a racing `detach`/`quit` delete a front record that `update_record_node_name` then silently recreated. Closed with a process-wide lock (`record_ops_lock`/`locked_record_ops`, matching the poison-recovery pattern `desktop/src-tauri/src/commands.rs`'s `locked()` already uses) around every record file read/write/delete (`save_record`, `update_record_node_name`, `remove_record`). A new regression test proves the mutual exclusion by holding the lock and confirming a concurrent `remove_record` blocks until released.
- **pid-vs-suffix disambiguation gap** (`crates/beamtalk-desktop-broker/src/sname.rs`, `desktop/src-tauri/src/commands.rs`): investigated threading the caller's `pid` through `resolve_registered_node_name`/`find_unique_match` to validate the resolved epmd name against the expected pid before writing it, per the issue's suggested fix direction. Concluded this doesn't actually work: `resolve_registered_node_name` is only ever called from the Windows-only correction path, and the pid the caller knows (`Child::id()`, `cmd.exe`'s pid on Windows — see `sname.rs`'s own module doc) is not the pid epmd's real registration embeds (`System.pid()`, `erl.exe`'s). A pid-based check would never match in production, silently disabling the correction on every call rather than narrowing the race. Chose the acceptance criteria's documented-alternative path instead — suffix-only matching is retained, with the reasoning (and the residual, accepted race) documented in depth in `sname.rs`'s module doc comment and the relevant function/test doc comments.

## Test plan

- [x] `cargo test -p beamtalk-desktop-broker --lib` — 132 passed (including new regression test `update_and_remove_are_mutually_exclusive_on_the_record_lock`)
- [x] `cargo test` (desktop/src-tauri) — 1 passed
- [x] `cargo clippy --all-targets -- -D warnings` clean on both crates
- [x] `cargo fmt --check` clean on both crates
- [x] `just build && just clippy && just fmt-check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
