### PR TITLE
Windows desktop broker: hard-fail on missing node_name like bin/server (BT-3060)

### DIFF
--- a/crates/beamtalk-desktop-broker/src/discovery.rs
+++ b/crates/beamtalk-desktop-broker/src/discovery.rs
@@ -19,10 +19,19 @@
 //! (Erlang) later adds `node_name` (plus settings, loaded modules, …) via
 //! debounced writes once it has booted at least once
 //! (`beamtalk_workspace_meta.erl`). A workspace that has never been started
-//! therefore has no `node_name` field yet — this module falls back to the
-//! deterministic `beamtalk_workspace_<id>@localhost` naming convention the
-//! CLI itself uses (`process.rs`/`lifecycle.rs`), and epmd liveness will
-//! correctly report it as dead regardless of which name was used to look it up.
+//! therefore has no `node_name` field yet. [`discover_workspaces`]'s
+//! best-effort picker listing falls back to the deterministic
+//! `beamtalk_workspace_<id>@localhost` naming convention the CLI itself uses
+//! (`process.rs`/`lifecycle.rs`) in that case, and epmd liveness will
+//! correctly report it as dead regardless of which name was used to look it
+//! up. [`read_node_name`] — the single-workspace lookup the Windows spawn
+//! path uses to actually dist-connect — does **not** fall back: it hard-fails
+//! with [`crate::error::BrokerError::MissingNodeName`] instead, matching
+//! `bin/server`'s Unix fail-fast behavior (ADR 0097 Broker §1b) rather than
+//! silently connecting to a guessed name that only *usually* matches the
+//! CLI's own naming convention (BT-3060 adversarial-review follow-up: a
+//! listing can afford to guess and let epmd sort out liveness, but an actual
+//! connection attempt should not).
 //!
 //! **DDD Context:** Desktop Shell
 
@@ -30,7 +39,7 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 
-use crate::error::Result;
+use crate::error::{BrokerError, Result};
 
 /// One discovered workspace.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -99,17 +108,36 @@ fn parse_metadata(dir_name: &str, content: &str) -> Result<WorkspaceSummary> {
 /// `bin/server` shell script on Windows to do the equivalent `sed`
 /// extraction (ADR 0097 Implementation §5b), so the broker resolves
 /// `BT_WORKSPACE_NODE` itself before invoking `bin\bt_attach.bat` directly.
-/// Falls back to [`default_node_name`], same as [`discover_workspaces`], when
-/// `metadata.json` doesn't yet carry a `node_name` field.
+///
+/// Unlike [`parse_metadata`] (used by [`discover_workspaces`]'s best-effort
+/// picker listing), this does **not** fall back to [`default_node_name`] when
+/// `metadata.json` has no `node_name` field — it hard-fails instead, matching
+/// `bin/server`'s Unix behavior (which `exit 1`s rather than guessing, see
+/// this module's doc comment). A workspace that has never been started has
+/// no real node to dist-connect to yet, and the two naming conventions (this
+/// crate's guess vs. the CLI's actual scheme) are independently maintained —
+/// a coincidental match today is not a guarantee (BT-3060).
+///
+/// A present-but-blank `node_name` (`""`, or whitespace-only) is treated the
+/// same as a missing field, matching both `bin/server`'s own `[ -z "${node}"
+/// ]` check (empty extraction fails the same way as no match) and this
+/// crate's own [`beamtalk_workspace::read_cookie_file`] convention for the
+/// sibling `cookie` file.
 ///
 /// # Errors
 ///
-/// Returns an error if `metadata.json` doesn't exist or can't be parsed.
+/// Returns [`BrokerError::Io`] if `metadata.json` doesn't exist,
+/// [`BrokerError::Json`] if it can't be parsed, or
+/// [`BrokerError::MissingNodeName`] if it parses but has no non-blank
+/// `node_name` field.
 pub fn read_node_name(workspace_id: &str) -> Result<String> {
     let meta_path = beamtalk_workspace::workspace_dir(workspace_id)?.join("metadata.json");
     let content = std::fs::read_to_string(&meta_path)?;
-    let summary = parse_metadata(workspace_id, &content)?;
-    Ok(summary.node_name)
+    let raw: RawMetadata = serde_json::from_str(&content)?;
+    match raw.node_name {
+        Some(name) if !name.trim().is_empty() => Ok(name),
+        _ => Err(BrokerError::MissingNodeName(workspace_id.to_string())),
+    }
 }
 
 /// Enumerate `~/.beamtalk/workspaces/*/metadata.json`, parse each with a real
@@ -245,17 +273,44 @@ mod tests {
         assert_eq!(result, "bt_attach_x_123@localhost");
     }
 
+    /// BT-3060: `read_node_name` (the Windows spawn path's lookup) must
+    /// hard-fail here, matching `bin/server`'s Unix behavior — unlike
+    /// `parse_metadata`'s picker-listing fallback (tested above), a real
+    /// spawn attempt must not silently guess at a node name.
     #[test]
-    fn read_node_name_falls_back_to_default_when_metadata_has_no_node_name() {
-        let id = format!("read_node_name_fallback_{}", std::process::id());
+    fn read_node_name_errors_when_metadata_has_no_node_name() {
+        let id = format!("read_node_name_missing_field_{}", std::process::id());
         let dir = beamtalk_workspace::workspace_dir(&id).unwrap();
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("metadata.json"), r#"{"created_at":1}"#).unwrap();
 
-        let result = read_node_name(&id).unwrap();
+        let result = read_node_name(&id);
 
         let _ = std::fs::remove_dir_all(&dir);
-        assert_eq!(result, default_node_name(&id));
+        assert!(
+            matches!(result, Err(BrokerError::MissingNodeName(ref w)) if w == &id),
+            "expected MissingNodeName({id}), got {result:?}"
+        );
+    }
+
+    /// A present-but-blank `node_name` must fail exactly like an absent one
+    /// — matching `bin/server`'s `[ -z "${node}" ]` check and this crate's
+    /// own `read_cookie_file` empty-is-missing convention (BT-3060 review
+    /// follow-up).
+    #[test]
+    fn read_node_name_errors_when_metadata_has_a_blank_node_name() {
+        let id = format!("read_node_name_blank_field_{}", std::process::id());
+        let dir = beamtalk_workspace::workspace_dir(&id).unwrap();
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("metadata.json"), r#"{"node_name":"   "}"#).unwrap();
+
+        let result = read_node_name(&id);
+
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(
+            matches!(result, Err(BrokerError::MissingNodeName(ref w)) if w == &id),
+            "expected MissingNodeName({id}), got {result:?}"
+        );
     }
 
     #[test]

--- a/crates/beamtalk-desktop-broker/src/error.rs
+++ b/crates/beamtalk-desktop-broker/src/error.rs
@@ -54,6 +54,22 @@ pub enum BrokerError {
     #[error("workspace '{0}' has no cookie file under ~/.beamtalk/workspaces/{0}/cookie")]
     MissingCookie(String),
 
+    /// A workspace directory exists but `metadata.json` has no `node_name`
+    /// field yet — the workspace was created but never started, so
+    /// `beamtalk_workspace_meta` (Erlang) never wrote a real node name back
+    /// to disk. The Windows spawn path (BT-2988) needs `node_name` itself
+    /// before invoking `bin\bt_attach.bat` directly (there is no `bin/server`
+    /// shell script there to resolve it), and hard-fails here rather than
+    /// guessing at a name via [`crate::discovery::default_node_name`] —
+    /// matching `bin/server`'s Unix fail-fast behavior instead of silently
+    /// dist-connecting to a name that only *usually* matches the CLI's own
+    /// naming convention (BT-3060 adversarial-review follow-up).
+    #[error(
+        "workspace '{0}' has no node_name in ~/.beamtalk/workspaces/{0}/metadata.json yet — \
+         start it first: beamtalk workspace create {0} --background --persistent"
+    )]
+    MissingNodeName(String),
+
     /// Ran out of port-allocation attempts (see [`crate::port::allocate_port_with_retry`]).
     ///
     /// `last_exit_status`, when available, is the most recent spawn attempt's

--- a/crates/beamtalk-desktop-broker/src/spawn.rs
+++ b/crates/beamtalk-desktop-broker/src/spawn.rs
@@ -388,8 +388,11 @@ fn check_launcher_platform(launcher: &std::path::Path) -> Result<()> {
 /// Returns [`BrokerError::LauncherPlatformMismatch`] if `config.launcher`
 /// doesn't look like a Windows entry point, [`BrokerError::MissingCookie`] if
 /// the workspace directory has no (or an empty) `cookie` file, propagates a
-/// [`crate::discovery::read_node_name`] failure (malformed `metadata.json` —
-/// `spawn_front` already checked it exists before calling this), or
+/// [`crate::discovery::read_node_name`] failure — malformed `metadata.json`
+/// (`spawn_front` already checked it exists before calling this), or
+/// [`BrokerError::MissingNodeName`] when it exists but has no `node_name`
+/// field yet (a workspace created but never started — BT-3060, matching
+/// `bin/server`'s Unix fail-fast behavior instead of guessing) — or
 /// [`BrokerError::Io`] if the per-front [`release_tmp_dir`] can't be created.
 #[cfg(windows)]
 fn build_launch_command(config: &SpawnConfig) -> Result<Command> {
@@ -910,7 +913,11 @@ mod tests {
         // doc comment), so this uses an absolute tempdir path instead, the
         // same shape `desktop/src-tauri/src/launcher.rs::resolve_launcher_path`
         // always produces in production.
-        let ws = WindowsTestWorkspaceDir::new("win_launch_cwd", None, Some("c"));
+        let ws = WindowsTestWorkspaceDir::new(
+            "win_launch_cwd",
+            Some("bt_attach_win_launch_cwd@localhost"),
+            Some("c"),
+        );
         let release_root = tempfile::TempDir::new().unwrap();
         let launcher = release_root.path().join("bin").join("bt_attach.bat");
         let config = SpawnConfig::new(launcher, ws.id.clone(), 4567);
@@ -1059,7 +1066,11 @@ mod tests {
             );
         }
 
-        let ws = WindowsTestWorkspaceDir::new("win_launch_contract", None, Some("c"));
+        let ws = WindowsTestWorkspaceDir::new(
+            "win_launch_contract",
+            Some("bt_attach_win_launch_contract@localhost"),
+            Some("c"),
+        );
         let config = SpawnConfig::new(PathBuf::from(r"bin\bt_attach.bat"), ws.id.clone(), 4567);
         let cmd = build_launch_command(&config).expect("should build a command");
         let env_names: std::collections::HashSet<String> = cmd
@@ -1110,35 +1121,33 @@ mod tests {
         );
     }
 
+    /// BT-3060: the Windows spawn path must hard-fail — not silently guess a
+    /// node name via [`crate::discovery::default_node_name`] — when a
+    /// workspace's `metadata.json` has no `node_name` yet (created but never
+    /// started), matching `bin/server`'s Unix fail-fast behavior.
     #[cfg(windows)]
     #[test]
-    fn build_launch_command_falls_back_to_default_node_name_when_metadata_lacks_one() {
-        let ws = WindowsTestWorkspaceDir::new("win_launch_default_node", None, Some("c"));
+    fn build_launch_command_errors_when_metadata_lacks_node_name() {
+        let ws = WindowsTestWorkspaceDir::new("win_launch_no_node_name", None, Some("c"));
         let config = SpawnConfig::new(PathBuf::from(r"bin\bt_attach.bat"), ws.id.clone(), 4567);
 
-        let cmd = build_launch_command(&config).expect("should build a command");
+        let result = build_launch_command(&config);
 
-        let envs: std::collections::HashMap<String, String> = cmd
-            .get_envs()
-            .filter_map(|(k, v)| {
-                v.map(|v| {
-                    (
-                        k.to_string_lossy().into_owned(),
-                        v.to_string_lossy().into_owned(),
-                    )
-                })
-            })
-            .collect();
-        assert_eq!(
-            envs.get("BT_WORKSPACE_NODE").map(String::as_str),
-            Some(crate::discovery::default_node_name(&ws.id)).as_deref()
+        assert!(
+            matches!(result, Err(BrokerError::MissingNodeName(ref w)) if w == &ws.id),
+            "expected MissingNodeName({}), got {result:?}",
+            ws.id
         );
     }
 
     #[cfg(windows)]
     #[test]
     fn build_launch_command_errors_when_cookie_file_missing() {
-        let ws = WindowsTestWorkspaceDir::new("win_launch_no_cookie", None, None);
+        let ws = WindowsTestWorkspaceDir::new(
+            "win_launch_no_cookie",
+            Some("bt_attach_win_launch_no_cookie@localhost"),
+            None,
+        );
         let config = SpawnConfig::new(PathBuf::from(r"bin\bt_attach.bat"), ws.id.clone(), 4567);
 
         let result = build_launch_command(&config);


### PR DESCRIPTION
https://linear.app/beamtalk/issue/BT-3060

## Summary

`editors/liveview/rel/overlays/bin/server` (the Unix launcher) hard-fails when a workspace's `metadata.json` has no `node_name` field yet (a workspace created but never started). The Windows spawn path's `discovery::read_node_name` instead silently fell back to a deterministic `default_node_name(workspace_id)` guess — which only *coincidentally* matches the CLI's real naming convention, since the two are independently maintained. This meant a Windows attach to a never-started workspace would spawn a front that tries to dist-connect to a guessed node name instead of failing clearly, unlike the Unix path.

This PR makes the Windows spawn path fail the same way as `bin/server`.

## Key changes

- `crates/beamtalk-desktop-broker/src/discovery.rs`: `read_node_name` (the single-workspace lookup the Windows spawn path uses to actually dist-connect) no longer falls back to `default_node_name` — it returns `BrokerError::MissingNodeName` instead. `discover_workspaces`'/`parse_metadata`'s best-effort picker listing keeps its lenient fallback (a listing can afford to guess and let epmd report liveness; an actual connection attempt should not). A present-but-blank `node_name` is treated the same as a missing field, matching both `bin/server`'s `[ -z "${node}" ]` check and this crate's own `read_cookie_file` empty-is-missing convention.
- `crates/beamtalk-desktop-broker/src/error.rs`: new `BrokerError::MissingNodeName` variant with an actionable message pointing at `beamtalk workspace create <id> --background --persistent`.
- `crates/beamtalk-desktop-broker/src/spawn.rs`: doc-comment updates for `build_launch_command`'s Windows arm, plus test fixture updates (tests that don't care about node-name resolution now supply an explicit one) and a new test covering the hard-fail.

## Test plan

- [x] `cargo test -p beamtalk-desktop-broker` — 132/132 pass (was 131; added a blank-`node_name` edge case test)
- [x] `cargo clippy -p beamtalk-desktop-broker --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Full `just build`, `just clippy`, `just fmt-check` (workspace-wide) — clean
- [x] `just test-stdlib`, `just test-bunit`, `just test-runtime`, `just test-integration`, `just test-mcp`, `just test-repl-protocol`, `check-surface-drift` — all clean (BUnit's one flaky failure under heavy machine load, `ParallelTest testAnyKillsLosingCompetitors`, passes in isolation — unrelated to this change)
- Two pre-existing, unrelated Windows-only local-CI failures were found and confirmed (via `git stash`, reproduced identically against unmodified `main` tip) to predate this branch; filed as follow-ups rather than fixed here (out of scope): BT-3063 (`cli_lint` `@expect` staleness check) and BT-3069 (`test-parity` LSP diagnostic read timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)