### PR TITLE
Move Windows RELEASE_TMP retry-cleanup off synchronous app-startup/detach/quit paths (BT-3059)

### DIFF
--- a/crates/beamtalk-desktop-broker/src/reap.rs
+++ b/crates/beamtalk-desktop-broker/src/reap.rs
@@ -250,9 +250,13 @@ pub fn remove_record(dir: &Path, workspace_id: &str, port: u16) -> Result<()> {
     #[cfg(windows)]
     {
         let workspace_id = workspace_id.to_string();
-        std::thread::spawn(move || {
+        let handle = std::thread::spawn(move || {
             remove_release_tmp_dir_with_retry(&workspace_id, port);
         });
+        pending_release_tmp_cleanups()
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(handle);
     }
 
     let path = record_path(dir, workspace_id, port);
@@ -261,6 +265,82 @@ pub fn remove_record(dir: &Path, workspace_id: &str, port: u16) -> Result<()> {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e.into()),
+    }
+}
+
+/// Registry of [`remove_record`]'s in-flight background `RELEASE_TMP`
+/// cleanup threads (BT-3059), so [`wait_for_release_tmp_cleanup`] can find
+/// and join them. Windows-only, since the cleanup itself only exists there —
+/// see [`remove_record`]'s doc comment.
+///
+/// One process-wide `Vec`, not per-call bookkeeping: the only reader
+/// ([`wait_for_release_tmp_cleanup`]) exists specifically for the app's exit
+/// paths, which want to wait for *every* cleanup still in flight regardless
+/// of which `remove_record` call started it.
+#[cfg(windows)]
+fn pending_release_tmp_cleanups() -> &'static Mutex<Vec<std::thread::JoinHandle<()>>> {
+    static PENDING: OnceLock<Mutex<Vec<std::thread::JoinHandle<()>>>> = OnceLock::new();
+    PENDING.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Total wall-clock budget [`wait_for_release_tmp_cleanup`] gives pending
+/// cleanup threads — the same ~1s cap [`remove_release_tmp_dir_with_retry`]'s
+/// own retry loop is bounded by (`RELEASE_TMP_REMOVE_ATTEMPTS` ×
+/// `RELEASE_TMP_REMOVE_RETRY_DELAY`), plus headroom for thread-scheduling
+/// jitter under load.
+#[cfg(windows)]
+const RELEASE_TMP_CLEANUP_WAIT: Duration = Duration::from_millis(1500);
+
+/// Best-effort wait for [`remove_record`]'s backgrounded `RELEASE_TMP`
+/// cleanup threads (BT-3059) to finish, up to [`RELEASE_TMP_CLEANUP_WAIT`]
+/// **total** — not per-thread, since every registered thread already runs
+/// concurrently, so this bounds the slowest one, not their sum.
+///
+/// Backgrounding that cleanup off `remove_record` fixed the latency problem
+/// (up to `N`×1s blocking `sweep`/`detach_internal`/`detach_all`) but opened
+/// a correctness gap on the app's actual exit paths: `desktop/src-tauri`'s
+/// `quit` command calls `app.exit(0)` right after its `detach_all`, and
+/// `main.rs`'s `RunEvent::ExitRequested` handler lets Tauri's normal
+/// post-handler teardown terminate the process just as promptly — both end
+/// the OS process itself almost immediately, abandoning any cleanup thread
+/// still mid-retry rather than letting it run to completion. Since that
+/// retry exists to remove a `SECRET_KEY_BASE`/workspace-cookie-bearing
+/// directory (BT-3046), silently abandoning it on every ordinary quit that
+/// raced `erl.exe`'s asynchronous kill-on-close — precisely the case the
+/// retry was added for — would defeat the whole point of retrying. Calling
+/// this after `detach_all`'s loop and before the process actually exits
+/// restores that guarantee for the common case without reintroducing the
+/// `N`×1s sequential block: every registered thread already started
+/// concurrently, so this call's own wall-clock cost is bounded by
+/// [`RELEASE_TMP_CLEANUP_WAIT`] regardless of how many fronts were detached.
+///
+/// A no-op on non-Windows (nothing is ever registered there — the
+/// `RELEASE_TMP` cleanup this waits for is Windows-only).
+///
+/// Not required for correctness of the exit itself: a handle still running
+/// when the deadline elapses is simply abandoned (dropping a
+/// `std::thread::JoinHandle` detaches the thread rather than joining it) —
+/// matching the retry loop's own best-effort, log-and-move-on stance.
+pub fn wait_for_release_tmp_cleanup() {
+    #[cfg(windows)]
+    {
+        let handles: Vec<_> = std::mem::take(
+            &mut *pending_release_tmp_cleanups()
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner),
+        );
+        let deadline = std::time::Instant::now() + RELEASE_TMP_CLEANUP_WAIT;
+        for handle in handles {
+            while !handle.is_finished() && std::time::Instant::now() < deadline {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            if handle.is_finished() {
+                let _ = handle.join();
+            }
+            // else: still running past the deadline — abandon it (dropping
+            // `handle` here detaches the thread), matching remove_record's
+            // own best-effort stance.
+        }
     }
 }
 
@@ -908,7 +988,21 @@ mod tests {
     #[test]
     fn remove_record_also_removes_the_release_tmp_directory() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let rec = record(4242, Some(555));
+        // A workspace_id/port exclusive to this test (BT-3059), deliberately
+        // *not* `record()`'s shared "abc123"/4567 pair every other test in
+        // this module uses. That sharing is harmless for the FrontRecord
+        // JSON file (isolated per test via its own `tmp` TempDir), but
+        // `crate::spawn::release_tmp_dir` is a real, absolute path keyed
+        // only on `(workspace_id, port)` — not scoped to `tmp` at all. Now
+        // that `remove_record` backgrounds a *retrying* (up to ~1s)
+        // `remove_dir_all` against that path on every call, reusing the
+        // shared pair here would race this test's own create/write below
+        // against every other parallel test's cleanup thread contending for
+        // the same real directory — reproduced as a flake (`NotFound` on the
+        // `write` below) before this was made exclusive.
+        let mut rec = record(4242, Some(555));
+        "bt3059_release_tmp_test".clone_into(&mut rec.workspace_id);
+        rec.port = 32100;
         let release_tmp = crate::spawn::release_tmp_dir(&rec.workspace_id, rec.port);
         std::fs::create_dir_all(&release_tmp).unwrap();
         std::fs::write(release_tmp.join("sys.config"), b"secrets").unwrap();
@@ -930,6 +1024,44 @@ mod tests {
         assert!(
             !release_tmp.exists(),
             "RELEASE_TMP directory should be removed along with the front record"
+        );
+    }
+
+    /// Regression test for the exit-path gap [`wait_for_release_tmp_cleanup`]
+    /// fixes (BT-3059, adversarial-review follow-up): without it,
+    /// `remove_record`'s backgrounded `RELEASE_TMP` cleanup thread is purely
+    /// best-effort with no way for a caller to know it finished — exactly
+    /// the situation `desktop/src-tauri`'s `quit` command is in right before
+    /// `app.exit(0)` terminates the process and abandons any thread still
+    /// mid-retry. Unlike `remove_record_also_removes_the_release_tmp_directory`
+    /// above (which has to bounded-poll because it asserts with no such
+    /// wait), this asserts **immediately** and synchronously after
+    /// `wait_for_release_tmp_cleanup()` returns — proving it actually joins
+    /// the backgrounded thread rather than merely sleeping a fixed amount
+    /// and hoping.
+    #[cfg(windows)]
+    #[test]
+    fn wait_for_release_tmp_cleanup_blocks_until_pending_cleanup_finishes() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Exclusive workspace_id/port — see the comment on
+        // `remove_record_also_removes_the_release_tmp_directory` above for
+        // why sharing `record()`'s default pair would race sibling tests.
+        let mut rec = record(4243, Some(556));
+        "bt3059_wait_test".clone_into(&mut rec.workspace_id);
+        rec.port = 32101;
+        let release_tmp = crate::spawn::release_tmp_dir(&rec.workspace_id, rec.port);
+        std::fs::create_dir_all(&release_tmp).unwrap();
+        std::fs::write(release_tmp.join("sys.config"), b"secrets").unwrap();
+
+        save_record(tmp.path(), &rec).unwrap();
+        remove_record(tmp.path(), &rec.workspace_id, rec.port).unwrap();
+        wait_for_release_tmp_cleanup();
+
+        assert!(
+            !release_tmp.exists(),
+            "wait_for_release_tmp_cleanup should block until remove_record's \
+             backgrounded RELEASE_TMP removal has actually finished, not just \
+             return immediately"
         );
     }
 

--- a/crates/beamtalk-desktop-broker/src/reap.rs
+++ b/crates/beamtalk-desktop-broker/src/reap.rs
@@ -253,10 +253,16 @@ pub fn remove_record(dir: &Path, workspace_id: &str, port: u16) -> Result<()> {
         let handle = std::thread::spawn(move || {
             remove_release_tmp_dir_with_retry(&workspace_id, port);
         });
-        pending_release_tmp_cleanups()
+        let mut pending = pending_release_tmp_cleanups()
             .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .push(handle);
+            .unwrap_or_else(PoisonError::into_inner);
+        // Opportunistic prune (adversarial-review follow-up): this Vec is
+        // only otherwise drained by `wait_for_release_tmp_cleanup` on app
+        // exit, so over a long-running session with many attach/detach
+        // cycles it would otherwise grow monotonically, never freeing
+        // already-finished handles' small allocations.
+        pending.retain(|h| !h.is_finished());
+        pending.push(handle);
     }
 
     let path = record_path(dir, workspace_id, port);
@@ -1039,6 +1045,18 @@ mod tests {
     /// `wait_for_release_tmp_cleanup()` returns — proving it actually joins
     /// the backgrounded thread rather than merely sleeping a fixed amount
     /// and hoping.
+    ///
+    /// Shared-state caveat (adversarial-review follow-up, not fixed): both
+    /// this test and `remove_record_also_removes_the_release_tmp_directory`
+    /// register handles in the same process-wide `pending_release_tmp_cleanups`
+    /// Vec, so under default parallel `cargo test` execution this test's own
+    /// `wait_for_release_tmp_cleanup()` call could drain and join the
+    /// *other* test's handle instead of (or in addition to) this one's. The
+    /// assertion below still checks this test's own `release_tmp` directory,
+    /// not which handle got joined, so it doesn't produce a false failure —
+    /// but it means a passing run doesn't strictly guarantee *this* call
+    /// waited on *this* test's handle, only that the directory was gone by
+    /// the time it checked.
     #[cfg(windows)]
     #[test]
     fn wait_for_release_tmp_cleanup_blocks_until_pending_cleanup_finishes() {

--- a/crates/beamtalk-desktop-broker/src/reap.rs
+++ b/crates/beamtalk-desktop-broker/src/reap.rs
@@ -221,13 +221,26 @@ pub fn update_record_node_name(
 /// sites in `desktop/src-tauri/src/commands.rs`) goes through here, so this
 /// one hook covers all of them.
 ///
-/// The actual record-file delete below takes [`locked_record_ops`] (BT-3062)
-/// — the `RELEASE_TMP` removal above deliberately does not, since it can
-/// legitimately retry for up to ~1s (see
-/// [`remove_release_tmp_dir_with_retry`]) and doesn't touch the record file
-/// itself, so there's no reason to hold up an unrelated
-/// [`update_record_node_name`] call for that long over a resource it never
-/// touches.
+/// The `RELEASE_TMP` removal runs on a detached background thread (BT-3059)
+/// rather than inline: `remove_release_tmp_dir_with_retry` can legitimately
+/// retry for up to ~1s absorbing `JobHandle`'s asynchronous kill-on-close,
+/// but this function sits on latency-sensitive *synchronous* callers — the
+/// Tauri `.setup()` hook's `sweep` runs before the picker window is created
+/// (up to `N`×1s of app-startup stall after a crash left `N` workspaces
+/// attached), and `detach_internal`/`detach_all` call this inline per
+/// workspace on "Quit" (up to `N`×1s of added quit latency). This cleanup is
+/// already best-effort — it only ever logs a `tracing::warn!` and moves on,
+/// never a hard error surfaced to the caller — so nothing here depended on
+/// it finishing before this function returns; the on-disk record-file
+/// removal below (the part sweep/detach actually need to observe
+/// synchronously — see [`load_all_records`]) is unaffected and still
+/// happens inline.
+///
+/// The record-file delete below still takes [`locked_record_ops`] (BT-3062);
+/// the backgrounded `RELEASE_TMP` removal deliberately does not, matching
+/// its previous inline reasoning — it doesn't touch the record file itself,
+/// so there's no reason to hold up an unrelated [`update_record_node_name`]
+/// call for up to ~1s over a resource it never touches.
 ///
 /// # Errors
 ///
@@ -235,7 +248,12 @@ pub fn update_record_node_name(
 /// (anything other than "already gone").
 pub fn remove_record(dir: &Path, workspace_id: &str, port: u16) -> Result<()> {
     #[cfg(windows)]
-    remove_release_tmp_dir_with_retry(workspace_id, port);
+    {
+        let workspace_id = workspace_id.to_string();
+        std::thread::spawn(move || {
+            remove_release_tmp_dir_with_retry(&workspace_id, port);
+        });
+    }
 
     let path = record_path(dir, workspace_id, port);
     let _guard = locked_record_ops();
@@ -257,17 +275,19 @@ const RELEASE_TMP_REMOVE_RETRY_DELAY: Duration = Duration::from_millis(100);
 /// Best-effort removal of a front's `RELEASE_TMP` directory, retrying briefly
 /// on failure (BT-3046 adversarial-review follow-up, second pass).
 ///
-/// The caller (`remove_record`) runs immediately after the front's
-/// `SpawnedFront` is dropped, which closes its `JobHandle`
-/// (`crate::winjob`) — `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` then kills
-/// `erl.exe` (the process actually holding files open under `RELEASE_TMP`;
-/// `Child::kill()`/`.wait()` upstream only ever touched `cmd.exe`, see
-/// `winjob.rs`'s doc comment), but that kill-on-close is fire-and-forget —
-/// there is no handle to `erl.exe` available here to wait on directly. A
-/// single immediate `remove_dir_all` attempt can therefore plausibly race
-/// `erl.exe` still exiting and lose with a sharing violation, on an entirely
-/// ordinary detach. Retrying briefly absorbs that race without needing to
-/// discover `erl.exe`'s pid and poll it separately.
+/// The caller (`remove_record`) spawns this on a detached background thread
+/// (BT-3059) immediately after the front's `SpawnedFront` is dropped, which
+/// closes its `JobHandle` (`crate::winjob`) —
+/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` then kills `erl.exe` (the process
+/// actually holding files open under `RELEASE_TMP`; `Child::kill()`/`.wait()`
+/// upstream only ever touched `cmd.exe`, see `winjob.rs`'s doc comment), but
+/// that kill-on-close is fire-and-forget — there is no handle to `erl.exe`
+/// available here to wait on directly. A single immediate `remove_dir_all`
+/// attempt can therefore plausibly race `erl.exe` still exiting and lose with
+/// a sharing violation, on an entirely ordinary detach. Retrying briefly
+/// absorbs that race without needing to discover `erl.exe`'s pid and poll it
+/// separately — backgrounding this (rather than the retry loop itself) is
+/// what keeps that up-to-~1s cost off `remove_record`'s synchronous callers.
 #[cfg(windows)]
 fn remove_release_tmp_dir_with_retry(workspace_id: &str, port: u16) {
     let release_tmp = crate::spawn::release_tmp_dir(workspace_id, port);
@@ -442,12 +462,14 @@ pub fn sweep(dir: &Path) -> Result<SweepReport> {
                 report.pid_reused_skipped.push(record.clone());
             }
         }
-        // `remove_record` below retries its Windows RELEASE_TMP removal
-        // briefly (BT-3046 adversarial-review follow-up), which also
-        // absorbs `TerminateProcess`'s documented asynchronicity here — a
-        // `Reap` disposition's target may not have fully exited (and
-        // released files it held open under RELEASE_TMP) by the time that
-        // call returns above.
+        // `remove_record` below backgrounds its Windows RELEASE_TMP retry
+        // removal onto its own thread (BT-3059) rather than retrying inline,
+        // so it no longer delays this loop — but the retrying itself (BT-3046
+        // adversarial-review follow-up) still matters: it absorbs
+        // `TerminateProcess`'s documented asynchronicity, since a `Reap`
+        // disposition's target may not have fully exited (and released files
+        // it held open under RELEASE_TMP) by the time that call returns
+        // above.
         remove_record(dir, &record.workspace_id, record.port)?;
     }
     Ok(report)
@@ -893,6 +915,17 @@ mod tests {
 
         save_record(tmp.path(), &rec).unwrap();
         remove_record(tmp.path(), &rec.workspace_id, rec.port).unwrap();
+
+        // The RELEASE_TMP removal now runs on a detached background thread
+        // (BT-3059) rather than blocking `remove_record`, so its return no
+        // longer proves the directory is gone — bounded-poll instead of
+        // asserting synchronously. The retry loop itself caps at ~1s
+        // (`RELEASE_TMP_REMOVE_ATTEMPTS` * `RELEASE_TMP_REMOVE_RETRY_DELAY`);
+        // give it generous headroom above that for thread-scheduling jitter.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while release_tmp.exists() && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(50));
+        }
 
         assert!(
             !release_tmp.exists(),

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -463,6 +463,15 @@ pub fn detach_all(app: &AppHandle, state: &AppState) {
     for id in ids {
         let _ = detach_internal(app, state, &id);
     }
+    // BT-3059: `detach_internal`'s per-workspace `RELEASE_TMP` cleanup now
+    // runs on a background thread rather than blocking the loop above, but
+    // both of this function's callers (`quit` below, and `main.rs`'s
+    // `RunEvent::ExitRequested` handler) terminate the OS process shortly
+    // after this returns — which would otherwise abandon that cleanup
+    // mid-retry on every ordinary quit, silently defeating BT-3046's reason
+    // for retrying in the first place (see
+    // `reap::wait_for_release_tmp_cleanup`'s doc comment).
+    reap::wait_for_release_tmp_cleanup();
 }
 
 fn emit_progress(app: &AppHandle, workspace_id: &str, stage: &str) {


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-3059

`reap::remove_record`'s Windows `RELEASE_TMP` retry-removal (BT-3046, up to ~1s per record) sat inline on three latency-sensitive synchronous paths:

- `main.rs`'s Tauri `.setup()` hook (`reap::sweep`) before the picker window is created — app startup could stall up to `N`x1s after a crash left `N` workspaces attached.
- `commands.rs`'s `detach_internal`/`detach_all` — "Quit" with `N` attached workspaces could take up to `N`x1s longer.

- The `RELEASE_TMP` retry-removal now runs on a detached background thread inside `remove_record`, instead of blocking inline. The on-disk `FrontRecord` file removal is unaffected and still happens synchronously.
- Fixed a correctness gap this uncovered: `quit`'s `app.exit(0)` and `main.rs`'s `RunEvent::ExitRequested` handler both terminate the OS process shortly after `detach_all` returns, which would otherwise abandon any cleanup thread still mid-retry — silently defeating BT-3046's reason for retrying (leaving `SECRET_KEY_BASE`/cookie secrets on disk). `reap::wait_for_release_tmp_cleanup()` joins every pending cleanup thread with a single ~1.5s bound (not per-thread, since they already run concurrently) and is called from `detach_all` — the one choke point both exit paths share — right before the process exits.
- Fixed a test-isolation bug surfaced along the way: `reap.rs`'s shared `record()` test helper hardcodes the same `workspace_id`/`port` for every test, which is harmless for the tempdir-scoped JSON record file but collided on the real, non-tempdir `RELEASE_TMP` path once every `remove_record` call started a retrying background thread against it.

## Test plan

- [x] `cargo test -p beamtalk-desktop-broker --lib reap::` — 25 tests, clean across 6+ repeated runs (including a new regression test for `wait_for_release_tmp_cleanup`)
- [x] `just build`, `just clippy`, `just fmt-check-rust` clean
- [x] `just test-desktop` (excluded Tauri crate) builds and passes
- [x] `just test-integration`, `just test-mcp`, `just test-repl-protocol`, `just check-surface-drift` all pass
- [x] Pre-push hook (full lint suite) passed

## Known unrelated pre-existing failures (not caused by this change)

- `commands::workspace::epmd::tests::bt2424_default_deployment_keeps_epmd_off_public_interfaces` fails locally because this shared dev machine currently has an epmd process bound to `0.0.0.0:4369` (environmental, not a code issue).
- `just test-parity`'s `diagnostic.parity.bt` LSP case ("lsp read timed out") — already tracked as BT-3069, a known deterministic Windows failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)