### PR TITLE
Desktop broker: harden classify_record fallback, launcher existence check, PATH-mutating tests (BT-3056)

### DIFF
--- a/crates/beamtalk-desktop-broker/src/cli_ops.rs
+++ b/crates/beamtalk-desktop-broker/src/cli_ops.rs
@@ -315,6 +315,26 @@ mod tests {
         assert!(matches!(result, Err(BrokerError::CliNotFound)));
     }
 
+    /// Smoke test for the thin `resolve_cli_path()` wrapper itself (BT-3056
+    /// adversarial-review follow-up) — everything above exercises the
+    /// resolution *logic* via the injectable `resolve_cli_path_with` without
+    /// touching process env at all; this proves the wrapper actually reads
+    /// the real `CLI_PATH_OVERRIDE_ENV`/`PATH`/home-dir inputs and threads
+    /// them through without panicking. Deliberately does not set/mutate any
+    /// process-global env itself (that would reintroduce exactly the
+    /// cross-test-flake risk this refactor removed) — so it can't assert on
+    /// a specific resolved path, only that the call completes and returns
+    /// one of its two documented outcome shapes for whatever this test
+    /// machine's real environment happens to be.
+    #[test]
+    fn resolve_cli_path_wrapper_does_not_panic_and_threads_real_env() {
+        let result = resolve_cli_path();
+        assert!(
+            result.is_ok() || matches!(result, Err(BrokerError::CliNotFound)),
+            "resolve_cli_path() should either resolve a path or report CliNotFound, got {result:?}"
+        );
+    }
+
     #[test]
     fn run_cli_reports_failure_with_stderr() {
         // `false` (POSIX) always exits 1 with no output — exercise the

--- a/crates/beamtalk-desktop-broker/src/cli_ops.rs
+++ b/crates/beamtalk-desktop-broker/src/cli_ops.rs
@@ -79,18 +79,54 @@ pub fn candidate_paths(home: Option<&Path>) -> Vec<PathBuf> {
 /// silently falling through) → `PATH` → [`candidate_paths`]. Returns
 /// [`BrokerError::CliNotFound`] if nothing is found.
 ///
+/// A thin wrapper reading the real process environment and handing it to
+/// [`resolve_cli_path_with`] — see that function's doc comment (BT-3056) for
+/// why the actual resolution logic lives there instead, injectable rather
+/// than reading `std::env` directly.
+///
 /// # Errors
 ///
 /// Returns [`BrokerError::CliNotFound`] if the CLI can't be located by any
 /// of the resolution steps above.
 pub fn resolve_cli_path() -> Result<PathBuf> {
-    if let Ok(override_path) = std::env::var(CLI_PATH_OVERRIDE_ENV) {
+    resolve_cli_path_with(
+        std::env::var(CLI_PATH_OVERRIDE_ENV).ok(),
+        std::env::var("PATH").ok(),
+        dirs::home_dir().as_deref(),
+    )
+}
+
+/// Core resolution logic behind [`resolve_cli_path`], with every environment
+/// input ([`CLI_PATH_OVERRIDE_ENV`], `PATH`, the home directory) taken as a
+/// parameter instead of read from the real process environment (BT-3056
+/// adversarial-review follow-up).
+///
+/// This is what makes `resolve_cli_path`'s edge-case tests (an executable
+/// found via a synthetic `PATH`, and none found at all) possible without
+/// mutating process-global `std::env::set_var("PATH", ...)` — the two tests
+/// that used to do that were already RAII-guarded against leaking a clobbered
+/// `PATH` past themselves (BT-3046's `PathRestoreGuard`), but a shared
+/// `ENV_LOCK`-guarded mutation of real global state is still strictly more
+/// fragile than never touching it: any *future* test in this crate that
+/// spawns a process by bare executable name (matching it through shell/`PATH`
+/// resolution — e.g. a Windows `.bat` launcher's `cmd.exe` looking up `ping`)
+/// without also taking `ENV_LOCK` would silently race a real `PATH` mutation
+/// again. Injecting the search inputs here instead removes that risk
+/// entirely for this function's own tests, matching what
+/// [`search_path_var`]/[`candidate_paths`] (this function's own helpers)
+/// already did.
+fn resolve_cli_path_with(
+    override_path: Option<String>,
+    path_var: Option<String>,
+    home: Option<&Path>,
+) -> Result<PathBuf> {
+    if let Some(override_path) = override_path {
         if !override_path.is_empty() {
             return Ok(PathBuf::from(override_path));
         }
     }
 
-    if let Ok(path_var) = std::env::var("PATH") {
+    if let Some(path_var) = path_var {
         for candidate in search_path_var(&path_var, exe_name()) {
             if candidate.is_file() {
                 return Ok(candidate);
@@ -98,7 +134,7 @@ pub fn resolve_cli_path() -> Result<PathBuf> {
         }
     }
 
-    for candidate in candidate_paths(dirs::home_dir().as_deref()) {
+    for candidate in candidate_paths(home) {
         if candidate.is_file() {
             return Ok(candidate);
         }
@@ -181,7 +217,6 @@ pub fn stop_workspace(cli_path: &Path, workspace_id: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::ENV_LOCK;
 
     #[test]
     fn create_workspace_args_shape() {
@@ -250,89 +285,32 @@ mod tests {
 
     #[test]
     fn resolve_cli_path_prefers_the_override_env_var() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        // SAFETY: guarded by ENV_LOCK.
-        unsafe { std::env::set_var(CLI_PATH_OVERRIDE_ENV, "/custom/path/to/beamtalk") };
-        let result = resolve_cli_path();
-        // SAFETY: guarded by ENV_LOCK.
-        unsafe { std::env::remove_var(CLI_PATH_OVERRIDE_ENV) };
+        // BT-3056: no process-global env touched — the override is injected
+        // directly into resolve_cli_path_with.
+        let result =
+            resolve_cli_path_with(Some("/custom/path/to/beamtalk".to_string()), None, None);
 
         assert_eq!(result.unwrap(), PathBuf::from("/custom/path/to/beamtalk"));
     }
 
-    /// RAII guard that restores `PATH` to the value captured at construction
-    /// (or removes it if it wasn't set to begin with) when dropped (BT-3046).
-    ///
-    /// The two tests below used to just `remove_var("PATH")` on cleanup,
-    /// reasoning that was "restoring" it — but this test binary inherits a
-    /// real `PATH` from the process that launched it (cargo/the shell), so
-    /// unconditionally removing it instead of restoring that inherited value
-    /// leaves `PATH` unset for the rest of the binary's process lifetime,
-    /// not just for the guarded critical section. That silently broke any
-    /// *later* test in this binary relying on shell/PATH-based command
-    /// resolution (e.g. a Windows `.bat` launcher's `cmd.exe` looking up
-    /// `ping`) regardless of `ENV_LOCK` — the lock only serializes the
-    /// mutation window, it doesn't undo a mutation that outlives it.
-    ///
-    /// A `Drop` guard rather than a plain restore-on-success call
-    /// (adversarial-review follow-up): a test assertion panicking between the
-    /// `set_var` and an explicit restore call would skip that call entirely,
-    /// leaving `PATH` clobbered *and*, since the panic unwinds through the
-    /// `ENV_LOCK` guard too, poisoning the mutex — every later test's
-    /// `.lock().unwrap()` would then panic immediately, the same class of
-    /// binary-wide breakage this fix exists to close. `Drop` runs during
-    /// unwinding too, so the restore happens either way.
-    struct PathRestoreGuard(Option<std::ffi::OsString>);
-
-    impl PathRestoreGuard {
-        /// Capture the current `PATH` for later restoration.
-        fn capture() -> Self {
-            Self(std::env::var_os("PATH"))
-        }
-    }
-
-    impl Drop for PathRestoreGuard {
-        fn drop(&mut self) {
-            // SAFETY: guarded by ENV_LOCK — every call site below holds it
-            // for the guard's entire lifetime.
-            unsafe {
-                match self.0.take() {
-                    Some(v) => std::env::set_var("PATH", v),
-                    None => std::env::remove_var("PATH"),
-                }
-            }
-        }
-    }
-
     #[test]
     fn resolve_cli_path_finds_an_executable_on_path() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        let _path_guard = PathRestoreGuard::capture();
         let tmp = tempfile::TempDir::new().unwrap();
         let fake_cli = tmp.path().join(exe_name());
         std::fs::write(&fake_cli, b"#!/bin/sh\n").unwrap();
 
-        // SAFETY: guarded by ENV_LOCK.
-        unsafe {
-            std::env::remove_var(CLI_PATH_OVERRIDE_ENV);
-            std::env::set_var("PATH", tmp.path());
-        }
-        let result = resolve_cli_path();
+        // BT-3056: the synthetic PATH is injected, not written to the real
+        // process environment — no ENV_LOCK, no restore-on-drop guard, no
+        // risk of leaking a clobbered PATH to any other test in this binary.
+        let result = resolve_cli_path_with(None, Some(tmp.path().display().to_string()), None);
 
         assert_eq!(result.unwrap(), fake_cli);
     }
 
     #[test]
     fn resolve_cli_path_errors_when_nothing_found() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        let _path_guard = PathRestoreGuard::capture();
         let tmp = tempfile::TempDir::new().unwrap(); // empty directory
-        // SAFETY: guarded by ENV_LOCK.
-        unsafe {
-            std::env::remove_var(CLI_PATH_OVERRIDE_ENV);
-            std::env::set_var("PATH", tmp.path());
-        }
-        let result = resolve_cli_path();
+        let result = resolve_cli_path_with(None, Some(tmp.path().display().to_string()), None);
 
         assert!(matches!(result, Err(BrokerError::CliNotFound)));
     }

--- a/crates/beamtalk-desktop-broker/src/error.rs
+++ b/crates/beamtalk-desktop-broker/src/error.rs
@@ -134,6 +134,25 @@ pub enum BrokerError {
     /// heuristic misreading every immediate exit as a port conflict.
     #[error("launcher path '{0}' does not look like a valid entry point for this platform — {1}")]
     LauncherPlatformMismatch(String, &'static str),
+
+    /// `SpawnConfig::launcher` looks like a valid entry point for this
+    /// platform ([`BrokerError::LauncherPlatformMismatch`] already passed),
+    /// but no file exists there (BT-3056 adversarial-review follow-up) —
+    /// the far more common real-world spawn failure in practice: an
+    /// unpackaged dev build where `BEAMTALK_ATTACH_LAUNCHER` /
+    /// `desktop/src-tauri/src/launcher.rs`'s `resolve_launcher_path` fallback
+    /// path hasn't been built yet. Checked in `spawn::spawn_front`
+    /// immediately before `Command::spawn` (deliberately *not* inside
+    /// `build_launch_command`, which several of that function's own unit
+    /// tests exercise against synthetic non-existent launcher paths purely
+    /// for `Command` introspection) — this named variant replaces what used
+    /// to surface as an opaque [`BrokerError::Io`] from the failed
+    /// `Command::spawn` call itself.
+    #[error(
+        "launcher '{0}' does not exist — is the release built/bundled yet? \
+         (see BEAMTALK_ATTACH_LAUNCHER for pointing at a local dev build)"
+    )]
+    LauncherNotFound(String),
 }
 
 impl From<miette::Report> for BrokerError {

--- a/crates/beamtalk-desktop-broker/src/reap.rs
+++ b/crates/beamtalk-desktop-broker/src/reap.rs
@@ -24,6 +24,48 @@
 //! "unknown, trust liveness" — every sweep matched, closing nothing); it now
 //! reads a real value there via `GetProcessTimes`.
 //!
+//! **A narrower race survived BT-3046's fix too, closed here (BT-3056):**
+//! `sweep` calls [`is_process_alive`] and [`read_start_time`] as two separate
+//! syscalls — if the process exits in that exact window, `read_start_time`
+//! returns `None` even though a `start_time` *was* recorded for it
+//! (`record.start_time: Some(_)`). Treating that as "unknown, trust
+//! liveness" (the pre-BT-3056 fallback) would classify it as
+//! [`Disposition::Reap`], and if a third, unrelated process grabs the
+//! recycled PID before `terminate_process` runs, it gets killed. The fix
+//! doesn't need a platform `cfg` to tell "genuinely can't read start time"
+//! apart from "raced a process exit": a record only ever has `start_time:
+//! Some(_)` if *this* platform's own [`read_start_time`] produced a real
+//! value when the record was saved, so a `Some(_)`-recorded, `None`-observed
+//! pairing can only mean the observation itself failed this one time — it
+//! is never a platform-incapability signal, which is `start_time: None`
+//! instead (see [`start_time_matches`]'s doc comment for the exact
+//! contract). `classify_record` now maps that specific pairing to
+//! [`Disposition::SkipPidReused`] rather than [`Disposition::Reap`].
+//!
+//! **Trade-off, deliberate and worth stating plainly** (BT-3056
+//! adversarial-review follow-up): [`sweep`] clears a record's on-disk file
+//! for *every* disposition, including `SkipPidReused` — so this fix's
+//! failure mode is "silently stop tracking a front this sweep couldn't
+//! prove was safe to kill," not just "skip killing it this one time." A
+//! `None` observation isn't always the exit-race above; it can also come
+//! from something more persistent — a permissions restriction, a sandboxed/
+//! namespaced process this broker can no longer introspect, or a record
+//! whose `Some(_)` start time was captured on a different machine sharing
+//! this `state_dir` over a network filesystem. In every one of those cases
+//! this still fails *safe* (no wrong-process kill), but a front that
+//! genuinely was the intended orphan escapes reaping for good, since
+//! [`sweep`] only runs once at broker startup with no later retry of a
+//! cleared record. That is judged the correct trade for this module's stated
+//! goal (never kill an unrelated process, even at the cost of occasionally
+//! leaving a real orphan for the user to notice and clean up by hand) — but
+//! it does depend on an invariant this file cannot enforce at compile time:
+//! every [`read_start_time`] platform arm must be "all-or-nothing" for a
+//! given PID — either it reliably produces a real value for a process this
+//! broker can see, or it never does (`None` unconditionally, like the
+//! `cfg(not(any(target_os = "linux", windows)))` arm below). A future arm
+//! that succeeds for *some* still-alive, still-visible processes but not
+//! others would quietly widen this gap without any test here catching it.
+//!
 //! **What "the recorded PID" means on Windows** (BT-2988): the caller
 //! persists `Child::id()` after `spawn_front`, which per [`crate::winjob`]'s
 //! doc comment is `cmd.exe`'s PID, not `erl.exe`'s (`.bat` launches can only
@@ -454,14 +496,21 @@ pub enum Disposition {
 /// [`is_process_alive`]/[`read_start_time`], injected here so the decision
 /// logic itself needs no process I/O to test).
 ///
-/// When either the recorded or the observed start time is unavailable (a
-/// platform without the cheap read, or an old record predating this field),
-/// this falls back to trusting liveness alone — the same "best effort"
-/// stance `beamtalk-cli`'s own `NodeInfo.start_time` handling takes for
-/// backward compatibility. This means PID-reuse detection is
-/// best-effort, not a hard guarantee, on platforms/records where start time
-/// isn't available — matching the spike's own framing of this as hardening
-/// a known gap, not eliminating it outright.
+/// When the *recorded* start time is unavailable (a platform without the
+/// cheap read, or an old record predating this field), this falls back to
+/// trusting liveness alone — the same "best effort" stance `beamtalk-cli`'s
+/// own `NodeInfo.start_time` handling takes for backward compatibility. This
+/// means PID-reuse detection is best-effort, not a hard guarantee, on
+/// platforms/records where start time was never available — matching the
+/// spike's own framing of this as hardening a known gap, not eliminating it
+/// outright.
+///
+/// A recorded start time with no matching *observed* value (`record.start_time:
+/// Some(_)`, `actual_start_time: None`) is treated differently (BT-3056),
+/// **not** as "unknown, trust liveness": see [`start_time_matches`]'s doc
+/// comment for why that pairing unambiguously means the observation raced a
+/// process exit, not a platform limitation, and lands in
+/// [`Disposition::SkipPidReused`] instead.
 #[must_use]
 pub fn classify_record(
     record: &FrontRecord,
@@ -479,14 +528,29 @@ pub fn classify_record(
 }
 
 /// Pure comparison shared by [`classify_record`] and `terminate_process`'s
-/// pre-`SIGKILL` re-check: is `actual` consistent with `expected`? `None` on
-/// either side means "unknown" and is treated as a match — the same
-/// best-effort stance `beamtalk-cli`'s own `NodeInfo.start_time` handling
-/// takes when start time isn't available (old record, unsupported platform).
+/// pre-`SIGKILL` re-check: is `actual` consistent with `expected`?
+///
+/// - `(None, _)` — no recorded start time (old record predating this field,
+///   or a platform [`read_start_time`] never returns a real value on) —
+///   treated as a match, the same best-effort stance `beamtalk-cli`'s own
+///   `NodeInfo.start_time` handling takes when start time isn't available.
+/// - `(Some(_), None)` — a start time *was* recorded, but this observation
+///   came back empty (BT-3056). Unlike the case above, this is **not**
+///   ambiguous: `expected` can only be `Some(_)` if this exact platform's
+///   [`read_start_time`] already produced a real value once, for this same
+///   PID, when the record was saved — so a platform that genuinely can't
+///   read start time would have recorded `None` to begin with, never
+///   `Some(_)`. The only way to reach `Some(_)` here paired with an observed
+///   `None` is `read_start_time` racing the process actually exiting between
+///   `sweep`'s `is_process_alive` check and its own call (see this module's
+///   doc comment) — treated as a **mismatch**, so the caller skips signaling
+///   rather than trusting a liveness snapshot that may already be stale.
+/// - `(Some(e), Some(a))` — compared directly.
 fn start_time_matches(expected: Option<u64>, actual: Option<u64>) -> bool {
     match (expected, actual) {
         (Some(e), Some(a)) => e == a,
-        _ => true,
+        (Some(_), None) => false,
+        (None, _) => true,
     }
 }
 
@@ -810,10 +874,21 @@ mod tests {
         assert_eq!(disposition, Disposition::Reap);
     }
 
+    /// BT-3056: this used to fall back to trusting liveness (`Reap`), the
+    /// same as `alive_with_no_recorded_start_time_falls_back_to_reap` above —
+    /// but the two cases aren't actually equivalent. Here a start time *was*
+    /// recorded (`Some(100)`), so this platform's `read_start_time`
+    /// definitely produced a real value once for this PID; an observed
+    /// `None` now can only mean the read raced the process exiting (see
+    /// `start_time_matches`'s doc comment), not a platform limitation. That
+    /// must not be trusted as "still the same process" — `SkipPidReused`
+    /// clears the record without signaling anything, closing the exact gap
+    /// the spike flagged: a third, unrelated process could otherwise grab
+    /// the just-vacated PID before `terminate_process` runs.
     #[test]
-    fn alive_with_no_observed_start_time_falls_back_to_reap() {
+    fn alive_with_no_observed_start_time_is_pid_reused_not_reaped() {
         let disposition = classify_record(&record(1234, Some(100)), true, None);
-        assert_eq!(disposition, Disposition::Reap);
+        assert_eq!(disposition, Disposition::SkipPidReused);
     }
 
     #[test]
@@ -1133,7 +1208,7 @@ mod tests {
     // real `read_start_time` would make this test SIGTERM/TerminateProcess
     // its own test process. Gating this way keeps that real behavior safe to
     // exercise here; `classify_record`'s fallback branch itself is covered
-    // platform-independently by `alive_with_no_observed_start_time_falls_back_to_reap`
+    // platform-independently by `alive_with_no_observed_start_time_is_pid_reused_not_reaped`
     // above.
     #[cfg(any(target_os = "linux", windows))]
     #[test]

--- a/crates/beamtalk-desktop-broker/src/spawn.rs
+++ b/crates/beamtalk-desktop-broker/src/spawn.rs
@@ -245,7 +245,11 @@ impl std::ops::DerefMut for SpawnedFront {
 /// (no `cookie` file), [`BrokerError::Json`] (malformed `metadata.json`),
 /// [`BrokerError::Workspace`] (a `beamtalk-workspace` failure), or
 /// [`BrokerError::Io`] (failed to create the `RELEASE_TMP` directory) before
-/// any process is spawned.
+/// any process is spawned. Also returns [`BrokerError::LauncherNotFound`]
+/// (BT-3056) if `config.launcher` looks right for this platform but no file
+/// actually exists there — the common unpackaged-dev-build failure mode,
+/// checked explicitly rather than left to surface as a generic `Io` error
+/// out of `Command::spawn` below.
 pub fn spawn_front(config: &SpawnConfig) -> Result<SpawnedFront> {
     if let Some(source) = oidc_configured(&config.ide_toml_path) {
         return Err(BrokerError::OidcConfigured(source.to_string()));
@@ -259,6 +263,35 @@ pub fn spawn_front(config: &SpawnConfig) -> Result<SpawnedFront> {
     }
 
     let mut cmd = build_launch_command(config)?;
+
+    // BT-3056 adversarial-review follow-up: checked here, immediately after
+    // `build_launch_command` succeeds, rather than inside it — that function
+    // has its own unit tests exercising synthetic non-existent launcher
+    // paths (e.g. `bin\bt_attach.bat`, `bin/server`) purely for `Command`
+    // introspection (program/args/env), which a check inside
+    // `build_launch_command` itself would break. `config.launcher` and
+    // `cmd`'s resolved program are always the same path on both platforms
+    // (see `build_launch_command`'s two arms), so checking the former here
+    // is equivalent to checking the latter.
+    if !config.launcher.is_file() {
+        // Second adversarial-review follow-up (BT-3056): on Windows,
+        // `build_launch_command` above already created this attempt's
+        // per-front `RELEASE_TMP` directory (`std::fs::create_dir_all`) —
+        // returning here without removing it would leave that directory
+        // behind forever: no `FrontRecord` is ever written for a
+        // `spawn_front` call that fails this early, so `remove_record`'s own
+        // `RELEASE_TMP` cleanup hook (BT-3046/BT-3059) never runs for it.
+        // Same cleanup the job-object-assign failure path below already
+        // does for the identical reason, just inlined here too.
+        #[cfg(windows)]
+        {
+            let _ = std::fs::remove_dir_all(release_tmp_dir(&config.workspace_id, config.port));
+        }
+        return Err(BrokerError::LauncherNotFound(
+            config.launcher.display().to_string(),
+        ));
+    }
+
     detach(&mut cmd);
 
     // Created before `cmd.spawn()` (not after) so there is no
@@ -1121,6 +1154,50 @@ mod tests {
         );
     }
 
+    /// BT-3056: `build_launch_command` on its own never checks the launcher
+    /// actually exists (it only cares that the *path* looks right — see
+    /// `check_launcher_platform`) — that check lives in `spawn_front`
+    /// instead, deliberately, so it doesn't break the many
+    /// `build_launch_command_*` tests in this file that pass synthetic
+    /// non-existent launcher paths purely for `Command` introspection. This
+    /// exercises `spawn_front` end-to-end with a real (never-written)
+    /// absolute launcher path and a fully valid workspace, so the *only*
+    /// thing standing between it and a real `Command::spawn` call is the
+    /// missing file.
+    ///
+    /// Holds `ENV_LOCK` (adversarial-review follow-up): `spawn_front` reads
+    /// `BT_OIDC_*` process-globals via `oidc_configured`, which
+    /// `oidc_guard::tests` mutates concurrently in this same test binary —
+    /// without the lock this could spuriously observe `OidcConfigured`
+    /// instead of reaching the launcher-existence check this test exists to
+    /// exercise, matching every other `spawn_front`-calling test in this
+    /// file (e.g. `spawn_front_refuses_when_oidc_env_present`).
+    #[cfg(windows)]
+    #[test]
+    fn spawn_front_errors_with_launcher_not_found_when_file_is_missing() {
+        let _guard = crate::test_support::ENV_LOCK.lock().unwrap();
+        let ws = WindowsTestWorkspaceDir::new(
+            "win_launcher_missing",
+            Some("bt_attach_win_launcher_missing@localhost"),
+            Some("testcookie"),
+        );
+        let tmp = tempfile::TempDir::new().unwrap();
+        // A well-formed, absolute .bat path — passes check_launcher_platform
+        // — that is simply never written to disk.
+        let launcher = tmp.path().join("bin").join("bt_attach.bat");
+        let mut config = SpawnConfig::new(launcher.clone(), ws.id.clone(), 4567);
+        config.ide_toml_path = tmp.path().join("ide.toml"); // doesn't exist: no OIDC
+        // SAFETY: guarded by ENV_LOCK above.
+        unsafe { std::env::remove_var("BT_OIDC_ISSUER") };
+
+        let result = spawn_front(&config);
+
+        assert!(
+            matches!(result, Err(BrokerError::LauncherNotFound(ref p)) if *p == launcher.display().to_string()),
+            "expected LauncherNotFound({launcher:?}), got {result:?}"
+        );
+    }
+
     /// BT-3060: the Windows spawn path must hard-fail — not silently guess a
     /// node name via [`crate::discovery::default_node_name`] — when a
     /// workspace's `metadata.json` has no `node_name` yet (created but never
@@ -1271,6 +1348,32 @@ mod tests {
         assert!(
             matches!(result, Err(BrokerError::LauncherPlatformMismatch(_, _))),
             "expected LauncherPlatformMismatch, got {result:?}"
+        );
+    }
+
+    /// BT-3056: see the Windows counterpart
+    /// (`spawn_front_errors_with_launcher_not_found_when_file_is_missing`)
+    /// for the full rationale, including why this holds `ENV_LOCK` — this
+    /// checks the same `spawn_front`-level existence guard on the Unix arm,
+    /// with a well-formed (no `.bat`/`.cmd`/`.exe` extension) but
+    /// never-written launcher path.
+    #[cfg(unix)]
+    #[test]
+    fn spawn_front_errors_with_launcher_not_found_when_file_is_missing() {
+        let _guard = crate::test_support::ENV_LOCK.lock().unwrap();
+        let ws = TestWorkspaceDir::new("launcher_missing");
+        let tmp = tempfile::TempDir::new().unwrap();
+        let launcher = tmp.path().join("server"); // deliberately never written
+        let mut config = SpawnConfig::new(launcher.clone(), ws.id.clone(), 4567);
+        config.ide_toml_path = tmp.path().join("ide.toml"); // doesn't exist: no OIDC
+        // SAFETY: guarded by ENV_LOCK above.
+        unsafe { std::env::remove_var("BT_OIDC_ISSUER") };
+
+        let result = spawn_front(&config);
+
+        assert!(
+            matches!(result, Err(BrokerError::LauncherNotFound(ref p)) if *p == launcher.display().to_string()),
+            "expected LauncherNotFound({launcher:?}), got {result:?}"
         );
     }
 

--- a/desktop/src-tauri/src/launcher.rs
+++ b/desktop/src-tauri/src/launcher.rs
@@ -42,8 +42,11 @@ const BUNDLED_LAUNCHER_RELATIVE_PATH: &str = "dist-liveview/bin/bt_attach.bat";
 ///
 /// Never fails outright — an unresolvable resource dir falls back to the
 /// bare relative path as a last resort, so startup doesn't crash; the
-/// resulting path simply won't exist yet on an unpackaged dev build, and
-/// `attach` surfaces that as a normal spawn-I/O error rather than a panic.
+/// resulting path simply won't exist yet on an unpackaged dev build.
+/// `beamtalk_desktop_broker::spawn::spawn_front` now checks for that
+/// explicitly (BT-3056) and surfaces it as a named
+/// `BrokerError::LauncherNotFound`, not a panic and — unlike before that
+/// check existed — not an opaque spawn-I/O error either.
 #[must_use]
 pub fn resolve_launcher_path(app: &AppHandle) -> PathBuf {
     if let Ok(override_path) = std::env::var(LAUNCHER_PATH_OVERRIDE_ENV) {


### PR DESCRIPTION
Fixes https://linear.app/beamtalk/issue/BT-3056

## Summary

Follow-up hardening items from BT-3046's adversarial review pass, re-verified against current `main` before implementing (per this issue's own instructions).

**Item #2 (RELEASE_TMP cleanup) was already fully resolved by BT-3046/BT-3059** before this issue was picked up — `reap::remove_record` already removes each front's per-front `RELEASE_TMP` directory, with retry, backgrounded off the synchronous sweep/detach paths. Not re-implemented. See the Linear comment for the full scope-recheck writeup.

Items #1, #3, #4 were re-checked and still genuinely open:

- **#1** — `reap::classify_record`'s fallback for an alive PID with a recorded start time but an unreadable *observed* one now lands in `SkipPidReused` instead of `Reap` (closing the narrow window where `sweep`'s `is_process_alive`/`read_start_time` race a process exit and could kill an unrelated PID-reused process). No `cfg` needed — the invariant is structural: a `Some(_)`-recorded start time only exists if this platform's own `read_start_time` produced a real value once. Documented the resulting trade-off (a persistently-unreadable, not just raced, case means that front escapes reaping until a later broker restart — judged correct since it fails safe).
- **#3** — `spawn::spawn_front` now checks the launcher path actually exists right before spawning, returning a new `BrokerError::LauncherNotFound` instead of an opaque `Io` error. Checked in `spawn_front`, not `build_launch_command`, so existing `Command`-introspection unit tests (which use synthetic non-existent launcher paths) are unaffected. Cleans up the just-created per-front `RELEASE_TMP` directory on this path too.
- **#4** — `cli_ops::resolve_cli_path`'s PATH/override/home resolution moved into an injectable `resolve_cli_path_with`, so its tests no longer mutate process-global `std::env` at all (previously guarded by a shared `ENV_LOCK` + RAII restore guard).

An adversarial second-opinion review pass caught two follow-on issues in the #1/#3 implementation, both fixed: `LauncherNotFound` was leaking the per-front `RELEASE_TMP` directory on Windows (now cleaned up inline), and two new tests weren't holding `ENV_LOCK` around a `spawn_front` call that reads `BT_OIDC_*` env vars (now fixed).

## Key changes

- `crates/beamtalk-desktop-broker/src/reap.rs` — `classify_record`/`start_time_matches` behavior change + doc
- `crates/beamtalk-desktop-broker/src/spawn.rs` — launcher-existence check in `spawn_front`
- `crates/beamtalk-desktop-broker/src/cli_ops.rs` — injectable `resolve_cli_path_with`
- `crates/beamtalk-desktop-broker/src/error.rs` — new `BrokerError::LauncherNotFound`
- `desktop/src-tauri/src/launcher.rs` — doc comment updated for the new error contract

## Test plan

- [x] `cargo test -p beamtalk-desktop-broker` — 135/135 passing, including new tests for the changed `classify_record` disposition and the new `LauncherNotFound` path (Windows + Unix)
- [x] `just test-desktop` (desktop-tauri crate, with stub `dist-liveview`) — passing
- [x] `just build && just clippy && just fmt-check` — clean
- [x] `just check-surface-drift`, `just test-integration`, `just test-mcp`, `just test-parity`, `just test-repl-protocol` run individually — all pass except a pre-existing, unrelated `test-parity` LSP timeout already tracked as BT-3069
- [x] Full local `cargo test --all-targets` — one pre-existing, unrelated failure (`bt2424_default_deployment_keeps_epmd_off_public_interfaces`) caused by a stray `epmd.exe` already bound to `0.0.0.0:4369` on the dev machine, confirmed via `netstat`/`Get-Process`, not a code issue
- [x] Pre-push hook (full CI incl. Elixir/Erlang/JS lint) passed clean on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)