### PR TITLE
refactor: extract shared proptest_config_default() to test_helpers

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang_validity_tests.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang_validity_tests.rs
@@ -137,13 +137,7 @@ const FORMAT_ARTIFACT_PATTERNS: &[&str] = &[
 // Property tests
 // ============================================================================
 
-fn proptest_config() -> ProptestConfig {
-    let default = ProptestConfig::default();
-    ProptestConfig {
-        cases: default.cases.max(512),
-        ..default
-    }
-}
+use crate::test_helpers::test_support::proptest_config_default as proptest_config;
 
 proptest! {
     #![proptest_config(proptest_config())]

--- a/crates/beamtalk-core/src/codegen/property_tests.rs
+++ b/crates/beamtalk-core/src/codegen/property_tests.rs
@@ -89,13 +89,7 @@ fn parse_source(source: &str) -> crate::ast::Module {
 // Property tests
 // ============================================================================
 
-fn proptest_config() -> ProptestConfig {
-    let default = ProptestConfig::default();
-    ProptestConfig {
-        cases: default.cases.max(512),
-        ..default
-    }
-}
+use crate::test_helpers::test_support::proptest_config_default as proptest_config;
 
 proptest! {
     #![proptest_config(proptest_config())]

--- a/crates/beamtalk-core/src/language_service/property_tests.rs
+++ b/crates/beamtalk-core/src/language_service/property_tests.rs
@@ -107,13 +107,7 @@ fn file_id() -> Utf8PathBuf {
 // Property tests
 // ============================================================================
 
-fn proptest_config() -> ProptestConfig {
-    let default = ProptestConfig::default();
-    ProptestConfig {
-        cases: default.cases.max(512),
-        ..default
-    }
-}
+use crate::test_helpers::test_support::proptest_config_default as proptest_config;
 
 proptest! {
     #![proptest_config(proptest_config())]

--- a/crates/beamtalk-core/src/semantic_analysis/property_tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/property_tests.rs
@@ -104,13 +104,7 @@ fn parse_source(source: &str) -> (crate::ast::Module, Vec<crate::source_analysis
 // Property tests
 // ============================================================================
 
-fn proptest_config() -> ProptestConfig {
-    let default = ProptestConfig::default();
-    ProptestConfig {
-        cases: default.cases.max(512),
-        ..default
-    }
-}
+use crate::test_helpers::test_support::proptest_config_default as proptest_config;
 
 proptest! {
     #![proptest_config(proptest_config())]

--- a/crates/beamtalk-core/src/source_analysis/lexer_property_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/lexer_property_tests.rs
@@ -84,14 +84,7 @@ fn valid_expression() -> impl Strategy<Value = String> {
 // Property tests
 // ============================================================================
 
-/// Default is 512 cases; override via `PROPTEST_CASES` env var for nightly runs.
-fn proptest_config() -> ProptestConfig {
-    let default = ProptestConfig::default();
-    ProptestConfig {
-        cases: default.cases.max(512),
-        ..default
-    }
-}
+use crate::test_helpers::test_support::proptest_config_default as proptest_config;
 
 proptest! {
     #![proptest_config(proptest_config())]

--- a/crates/beamtalk-core/src/source_analysis/parser/error_recovery_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/error_recovery_tests.rs
@@ -87,13 +87,7 @@ fn inject_error() -> impl Strategy<Value = String> {
 // Property tests
 // ============================================================================
 
-fn proptest_config() -> ProptestConfig {
-    let default = ProptestConfig::default();
-    ProptestConfig {
-        cases: default.cases.max(512),
-        ..default
-    }
-}
+use crate::test_helpers::test_support::proptest_config_default as proptest_config;
 
 proptest! {
     #![proptest_config(proptest_config())]

--- a/crates/beamtalk-core/src/source_analysis/parser/property_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/property_tests.rs
@@ -251,16 +251,7 @@ const INTERNAL_NAMES: &[&str] = &[
 // Property tests
 // ============================================================================
 
-/// Default is 512 cases for standard CI; override via `PROPTEST_CASES` env var
-/// for nightly extended runs (e.g., `PROPTEST_CASES=10000`).
-fn proptest_config() -> ProptestConfig {
-    let default = ProptestConfig::default();
-    ProptestConfig {
-        // Use at least 512 cases, but allow PROPTEST_CASES to increase beyond that
-        cases: default.cases.max(512),
-        ..default
-    }
-}
+use crate::test_helpers::test_support::proptest_config_default as proptest_config;
 
 proptest! {
     #![proptest_config(proptest_config())]

--- a/crates/beamtalk-core/src/test_helpers.rs
+++ b/crates/beamtalk-core/src/test_helpers.rs
@@ -190,6 +190,22 @@ pub mod test_support {
         ExpressionStatement::bare(expr)
     }
 
+    /// Returns the standard proptest configuration used across beamtalk-core property tests.
+    ///
+    /// Sets `cases` to at least 512 (overridable via `PROPTEST_CASES` env var).
+    ///
+    /// Gated on `#[cfg(test)]` because `proptest` is a dev-dependency; it is not
+    /// available to dependent crates that enable the `"test"` feature.
+    #[cfg(test)]
+    #[must_use]
+    pub fn proptest_config_default() -> proptest::prelude::ProptestConfig {
+        let default = proptest::prelude::ProptestConfig::default();
+        proptest::prelude::ProptestConfig {
+            cases: default.cases.max(512),
+            ..default
+        }
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;

--- a/crates/beamtalk-core/src/unparse/property_tests.rs
+++ b/crates/beamtalk-core/src/unparse/property_tests.rs
@@ -83,18 +83,15 @@ fn near_valid_beamtalk() -> impl Strategy<Value = String> {
 // ============================================================================
 
 fn proptest_config() -> ProptestConfig {
-    let default = ProptestConfig::default();
-    let cases = default.cases.max(512);
-    ProptestConfig {
-        cases,
-        // The round-trip test filters out inputs with parse errors via
-        // `prop_assume!`, so the rejection rate can be high. Scale the
-        // global-reject cap with the case count to avoid "too many rejects"
-        // failures when running with large PROPTEST_CASES values, while
-        // still respecting any higher env/default `max_global_rejects`.
-        max_global_rejects: default.max_global_rejects.max(cases * 2),
-        ..default
-    }
+    let mut config = crate::test_helpers::test_support::proptest_config_default();
+    let cases = config.cases;
+    // The round-trip test filters out inputs with parse errors via
+    // `prop_assume!`, so the rejection rate can be high. Scale the
+    // global-reject cap with the case count to avoid "too many rejects"
+    // failures when running with large PROPTEST_CASES values, while
+    // still respecting any higher env/default `max_global_rejects`.
+    config.max_global_rejects = config.max_global_rejects.max(cases * 2);
+    config
 }
 
 proptest! {


### PR DESCRIPTION
## Summary

- Extracts an identical 5-line `proptest_config()` function that was copied verbatim across 8 property-test files in `beamtalk-core` into a single `proptest_config_default()` helper in `test_helpers::test_support`.
- Seven files now alias it with `use crate::test_helpers::test_support::proptest_config_default as proptest_config`, keeping the `#[proptest_config(proptest_config())]` call sites unchanged.
- The `unparse/property_tests.rs` variant (which additionally overrides `max_global_rejects`) keeps a thin local wrapper that delegates to the shared base.

No behaviour change — all generated `ProptestConfig` values are identical to before.

## Files changed

- `crates/beamtalk-core/src/test_helpers.rs` — new `proptest_config_default()` under `#[cfg(test)]`
- `src/codegen/core_erlang_validity_tests.rs` — replaced local fn with alias
- `src/codegen/property_tests.rs` — replaced local fn with alias
- `src/source_analysis/lexer_property_tests.rs` — replaced local fn with alias
- `src/source_analysis/parser/error_recovery_tests.rs` — replaced local fn with alias
- `src/source_analysis/parser/property_tests.rs` — replaced local fn with alias
- `src/language_service/property_tests.rs` — replaced local fn with alias
- `src/semantic_analysis/property_tests.rs` — replaced local fn with alias
- `src/unparse/property_tests.rs` — updated wrapper to delegate to shared base

Closes #3261

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkU3upjkiupazu666sjjSm)_