### PR TITLE
beamtalk_stdlib.app.src type-alias source_file paths use native separators on Windows (BT-3067)

### DIFF
--- a/crates/beamtalk-cli/src/commands/build.rs
+++ b/crates/beamtalk-cli/src/commands/build.rs
@@ -2105,12 +2105,26 @@ pub(crate) fn build_alias_metadata(source_files: &[Utf8PathBuf]) -> Vec<app_file
                     &alias_def.annotation,
                 ),
                 doc: alias_def.doc_comment.clone(),
-                source_file: file.to_string(),
+                source_file: to_forward_slash(file),
                 internal: alias_def.is_internal,
             });
         }
     }
     result
+}
+
+/// Render a `Utf8Path` as forward-slash-separated text regardless of host OS.
+///
+/// `Utf8PathBuf`'s `Display`/`ToString` preserve native separators (backslash
+/// on Windows), which is wrong for values embedded in generated, checked-in
+/// artifacts like `beamtalk_stdlib.app.src` — those must be byte-identical
+/// regardless of the developer's OS (BT-3067). `Utf8Path` guarantees valid
+/// UTF-8, so a plain byte-level replace is safe here: backslash can't appear
+/// as a legitimate path separator component on any of our supported
+/// platforms. Same fix pattern as `make_git_index` in
+/// `deps/registry.rs`'s tests.
+fn to_forward_slash(path: &Utf8Path) -> String {
+    path.as_str().replace('\\', "/")
 }
 
 /// Collect `ClassInfo` from multiple sources into a single unified vector.
@@ -3187,6 +3201,54 @@ mod tests {
         let result = build_alias_metadata(&[alias_file]);
         let names: Vec<&str> = result.iter().map(|a| a.name.as_str()).collect();
         assert_eq!(names, vec!["Zebra", "Alpha"]);
+    }
+
+    // BT-3067: `source_file` is written verbatim into the checked-in
+    // `beamtalk_stdlib.app.src`, so it must be identical regardless of the
+    // host OS that generated it. Uses a `Utf8PathBuf` built directly from a
+    // backslash-containing string (rather than `Utf8Path::join`, whose
+    // separator behavior itself varies by host OS) so the test exercises the
+    // Windows-native-path case deterministically on every platform, including
+    // Linux CI.
+    #[test]
+    fn test_to_forward_slash_normalizes_backslashes() {
+        let path = Utf8PathBuf::from("stdlib/src\\Ets.bt");
+        assert_eq!(to_forward_slash(&path), "stdlib/src/Ets.bt");
+    }
+
+    #[test]
+    fn test_to_forward_slash_normalizes_all_backslash_components() {
+        let path = Utf8PathBuf::from("stdlib\\src\\Ets.bt");
+        assert_eq!(to_forward_slash(&path), "stdlib/src/Ets.bt");
+    }
+
+    #[test]
+    fn test_to_forward_slash_leaves_forward_slash_paths_unchanged() {
+        let path = Utf8PathBuf::from("stdlib/src/Ets.bt");
+        assert_eq!(to_forward_slash(&path), "stdlib/src/Ets.bt");
+    }
+
+    #[test]
+    fn test_build_alias_metadata_source_file_uses_forward_slashes() {
+        // Exercises the real join-based path (not a hand-built string) so
+        // this also catches the bug as originally reported: on Windows,
+        // `src_path.join("aliases.bt")` yields a `Utf8PathBuf` whose
+        // `Display`/`to_string()` uses `\`, which used to leak straight into
+        // `source_file` before the `to_forward_slash` fix.
+        let temp = TempDir::new().unwrap();
+        let project_path = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let src_path = project_path.join("src");
+        fs::create_dir_all(&src_path).unwrap();
+        let alias_file = src_path.join("aliases.bt");
+        write_test_file(&alias_file, "type Zebra = Integer\n");
+
+        let result = build_alias_metadata(&[alias_file]);
+        assert_eq!(result.len(), 1);
+        assert!(
+            !result[0].source_file.contains('\\'),
+            "source_file should never contain a backslash, got: {:?}",
+            result[0].source_file
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes BT-3067: https://linear.app/beamtalk/issue/BT-3067

`build_alias_metadata` in `crates/beamtalk-cli/src/commands/build.rs` wrote each type alias's `source_file` field via `Utf8PathBuf::to_string()`, which preserves native OS path separators. On Windows this produced `stdlib/src\Ets.bt` instead of `stdlib/src/Ets.bt`, so every `beamtalk build`/`build-stdlib` run on a Windows dev machine generated a spurious diff against the checked-in `runtime/apps/beamtalk_stdlib/src/beamtalk_stdlib.app.src`.

## Changes

- Extracted a `to_forward_slash(path: &Utf8Path) -> String` helper in `build.rs` that normalizes separators regardless of host OS (same pattern already used by `make_git_index` in `deps/registry.rs`'s tests).
- Used it for `AliasMetadata.source_file` in `build_alias_metadata` — the sole call site producing this field (shared by both the ordinary package build pipeline and `build_stdlib.rs`; confirmed no sibling occurrence in `app_file.rs`'s `ClassMetadata` or the example-corpus generator, which carry no raw file paths).
- Added unit tests: three on the helper directly (backslash, mixed-separator, and already-forward-slash inputs) plus one exercising the real `Utf8Path::join`-based path through `build_alias_metadata`, asserting the resulting `source_file` never contains a backslash.

## Verification

Ran on a native Windows dev machine:
- `just build-stdlib` regenerates `beamtalk_stdlib.app.src` — `git diff --stat` on that file shows **zero changes** (byte-identical to the committed, Linux/macOS-generated version).
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `cargo run -p beamtalk-surface-drift`, and corpus freshness all pass clean.
- `just test` passes except one pre-existing, unrelated failure (`commands::workspace::epmd::tests::bt2424_default_deployment_keeps_epmd_off_public_interfaces`), reproduced identically on `main` with this change stashed out — a live probe of this shared dev machine's ambient epmd daemon state (a stray promiscuous epmd left running by concurrent test activity on the host), not a code regression.

## Test plan

- [x] `just build-stdlib` + `git diff --stat` shows no changes to `beamtalk_stdlib.app.src`
- [x] New unit tests for `to_forward_slash` / `build_alias_metadata` pass
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo run -p beamtalk-surface-drift`
- [x] Corpus freshness (`build-corpus` produces no diff)
- [x] `just test` (1074 passed; 1 pre-existing unrelated failure, see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)