### PR TITLE
test-parity: fix Windows verbatim-path URI corruption in LSP driver (BT-3069)

### DIFF
--- a/crates/beamtalk-parity-tests/src/drivers/lsp.rs
+++ b/crates/beamtalk-parity-tests/src/drivers/lsp.rs
@@ -459,14 +459,50 @@ async fn read_lsp_frame(stream: &mut ChildStdout) -> Result<Vec<u8>, String> {
 
 /// Render a path as a `file://` URI. Good enough for LSP rootUri / textDocument.uri
 /// — only used for absolute paths from `tempfile::TempDir`.
+///
+/// BT-3069: `Path::canonicalize()` strips the verbatim (`\\?\`) prefix
+/// Windows adds via [`strip_verbatim_prefix`] before it ever reaches the
+/// slash-replacement below — see that function's doc for why the raw
+/// prefix silently breaks `beamtalk-lsp`.
 fn path_to_uri(p: &Path) -> String {
     let abs = p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
-    let s = abs.to_string_lossy().replace('\\', "/");
+    let s = strip_verbatim_prefix(&abs.to_string_lossy()).replace('\\', "/");
     if s.starts_with('/') {
         format!("file://{s}")
     } else {
         // Windows drive paths (`C:/foo`).
         format!("file:///{s}")
+    }
+}
+
+/// Strips the `\\?\` extended-length ("verbatim") path prefix that
+/// `Path::canonicalize()` adds on Windows (BT-3069).
+///
+/// Left in place, the embedded `?` is indistinguishable from a URL
+/// query-string delimiter once folded into a `file://` URI: RFC 3986
+/// parsers — including the one `beamtalk-lsp`'s `uri_to_path` uses via
+/// `Url::to_file_path()` — read everything from that `?` onward as the
+/// query string rather than the path. `uri_to_path` then fails to resolve
+/// the file, `textDocument/didOpen` silently no-ops instead of publishing
+/// diagnostics, and the parity harness's `diagnose()` call times out
+/// waiting for a `publishDiagnostics` notification that was never going to
+/// arrive — no amount of extending that timeout budget would fix it. Unix
+/// `canonicalize()` never adds this prefix, so the bug was invisible on
+/// Linux CI.
+///
+/// `pub` (not `pub(crate)`) because `tests/lsp_parity.rs` — a separate
+/// integration-test crate — hits the exact same prefix when it
+/// canonicalizes a staged project directory to check that an LSP
+/// `definition` response's URI resolves inside it.
+pub fn strip_verbatim_prefix(s: &str) -> String {
+    if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+        // `\\?\UNC\server\share\...` denotes the same target as the regular
+        // UNC form `\\server\share\...`.
+        format!(r"\\{rest}")
+    } else if let Some(rest) = s.strip_prefix(r"\\?\") {
+        rest.to_string()
+    } else {
+        s.to_string()
     }
 }
 
@@ -478,5 +514,44 @@ mod tests {
     fn path_to_uri_handles_unix_absolute() {
         let uri = path_to_uri(Path::new("/tmp/x.bt"));
         assert!(uri.starts_with("file:///") || uri.starts_with("file:////"));
+    }
+
+    #[test]
+    fn strip_verbatim_prefix_strips_windows_drive_form() {
+        assert_eq!(
+            strip_verbatim_prefix(r"\\?\C:\Users\x\bad_syntax.bt"),
+            r"C:\Users\x\bad_syntax.bt"
+        );
+    }
+
+    #[test]
+    fn strip_verbatim_prefix_strips_windows_unc_form() {
+        assert_eq!(
+            strip_verbatim_prefix(r"\\?\UNC\server\share\file.bt"),
+            r"\\server\share\file.bt"
+        );
+    }
+
+    #[test]
+    fn strip_verbatim_prefix_leaves_non_verbatim_paths_untouched() {
+        assert_eq!(
+            strip_verbatim_prefix(r"C:\Users\x\bad_syntax.bt"),
+            r"C:\Users\x\bad_syntax.bt"
+        );
+        assert_eq!(strip_verbatim_prefix("/tmp/x.bt"), "/tmp/x.bt");
+    }
+
+    #[test]
+    fn path_to_uri_never_embeds_a_query_delimiter_for_verbatim_paths() {
+        // `canonicalize()` fails for this nonexistent path (on every
+        // platform), so `path_to_uri` falls back to the raw input
+        // untouched — exercising the same string shape a real
+        // `\\?\`-prefixed canonicalized Windows path would have, without
+        // needing `#[cfg(windows)]` or a file that actually exists.
+        let uri = path_to_uri(Path::new(r"\\?\C:\Users\x\bad_syntax.bt"));
+        assert!(
+            !uri.contains('?'),
+            "URI must not embed a verbatim-path `?`: {uri}"
+        );
     }
 }

--- a/crates/beamtalk-parity-tests/tests/lsp_parity.rs
+++ b/crates/beamtalk-parity-tests/tests/lsp_parity.rs
@@ -33,7 +33,10 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use beamtalk_parity_tests::drivers::{lsp::LspDriver, mcp::McpDriver};
+use beamtalk_parity_tests::drivers::{
+    lsp::{LspDriver, strip_verbatim_prefix},
+    mcp::McpDriver,
+};
 use beamtalk_parity_tests::pool::{SharedRepl, beamtalk_binary, shared_repl};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -229,10 +232,14 @@ async fn check_definition_parity(
     }
     // The resolved URI must point at the staged project tree. We canonicalise
     // both because tempfile may round-trip through `/private/var` on macOS.
+    // BT-3069: `canonicalize()` returns a `\\?\`-prefixed verbatim path on
+    // Windows; strip it before comparing against `target_uri` (a normal
+    // `file://` URI with no such prefix), or the `contains` check below
+    // always fails on Windows even when the definition resolved correctly.
     let staged_canonical = staged
         .canonicalize()
         .unwrap_or_else(|_| staged.to_path_buf());
-    let staged_str = staged_canonical.to_string_lossy().replace('\\', "/");
+    let staged_str = strip_verbatim_prefix(&staged_canonical.to_string_lossy()).replace('\\', "/");
     if !target_uri.contains(&*staged_str) {
         return Err(format!(
             "LSP definition uri `{target_uri}` does not point inside staged project `{staged_str}`"


### PR DESCRIPTION
Fixes https://linear.app/beamtalk/issue/BT-3069

## Root cause

`just test-parity`'s `diagnostic.parity.bt` LSP case failed deterministically on native Windows with `lsp read timed out`, reproduced 3/3 times independently of BT-3060/BT-3061 (see issue). Root-caused via an instrumented `beamtalk-lsp` build plus a throwaway hand-rolled LSP client (bypassing `LspDriver`'s own timeouts) to trace exactly where the notification stalled.

`crates/beamtalk-parity-tests/src/drivers/lsp.rs`'s `path_to_uri()` calls `Path::canonicalize()` before building a `file://` URI. On Windows, `canonicalize()` returns an extended-length ("verbatim") path prefixed with `\?\` (e.g. `\?\C:\Users\...`). The existing string-replace logic didn't strip this prefix, so it survived into the URI as an embedded `?` — which RFC 3986 URI parsers (including the `url` crate's `Url::to_file_path()`, used by `beamtalk-lsp`'s `uri_to_path`) read as the start of a query string, not as path content.

The result: `beamtalk-lsp`'s `resolve_path_for_uri` silently returned `None` for the malformed `textDocument/didOpen` URI, so `did_open` no-op'd instead of ever calling `publish_diagnostics` — no `publishDiagnostics` notification was ever going to be sent. The harness's 20s timeout then fired correctly, but no timeout budget would have fixed it: the notification simply never arrives. Unix's `canonicalize()` never adds this prefix, which is why Linux CI never caught it.

The same root cause independently broke `tests/lsp_parity.rs`'s `check_definition_parity`, which also canonicalizes a staged project path and does a raw substring comparison against an LSP `definition` response URI — fixed by reusing the same helper (confirmed via `just test-parity`, which chains all three parity test binaries and would not be green on Windows otherwise, per the issue's acceptance criteria).

## Fix

- Added `strip_verbatim_prefix()` in `lsp.rs`, handling both the `\?\C:\...` drive form and the `\?\UNC\server\share\...` form, and wired it into `path_to_uri()`.
- Made it `pub` and reused it in `tests/lsp_parity.rs` for the same reason.
- Added unit tests for both prefix forms, the untouched-passthrough case, and a regression test asserting `path_to_uri` never embeds a literal `?` for a verbatim-shaped input (works cross-platform, no `#[cfg(windows)]` needed).

## Verification (native Windows machine)

- `just test-parity` (all three binaries: `parity`, `diagnostic_parity`, `lsp_parity`) green, run twice.
- `cargo test -p beamtalk-parity-tests --lib` green (including new tests).
- `just clippy`, `just fmt-check` clean.
- `just test-mcp`, `just test-integration`, `just test-repl-protocol`, `just check-surface-drift` all green.
- Full `cargo test --all-targets` green except two known pre-existing Windows-only failures unrelated to this change (see note below).

### Note on unrelated pre-existing failures observed during verification

While validating on this shared Windows machine (multiple agents running full builds/tests concurrently):
- `cli_lint::expect_type_on_ffi_arg_mismatch_is_not_stale_across_lint_and_build_bt_2851` — this is BT-3066, already tracked and being worked by another agent in parallel; not touched here.
- `commands::workspace::epmd::tests::bt2424_default_deployment_keeps_epmd_off_public_interfaces` — failed reproducibly, traced to an actual system `epmd.exe` bound to `0.0.0.0:4369` on this shared machine (confirmed via `netstat`). Given multiple agents are spawning real BEAM/workspace nodes concurrently on this box, this looks like shared-machine epmd state from another agent's process rather than a bug in this repo, but I can't fully rule that out from here. Flagging for the parent to triage rather than guessing at a fix or touching a live epmd instance other agents may depend on.

Neither is related to `beamtalk-parity-tests` or the LSP surface, and neither is modified by this PR.