### PR TITLE
refactor: store structured DeclaredType in MethodInfo; single type-string parse boundary (BT-3076)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
@@ -1,0 +1,724 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! A span-free, structured representation of a declared type (BT-3076).
+//!
+//! **DDD Context:** Semantic Analysis — Value Object
+//!
+//! [`MethodInfo::return_type`](super::MethodInfo::return_type) and
+//! `param_types` store type signatures as flattened `EcoString`s (see
+//! [`crate::ast::TypeAnnotation::type_name`]). Every consumer that needs
+//! structure back out of one of those strings has historically hand-rolled
+//! its own parser — `TypeChecker::resolve_type_string` (BT-3075) being the
+//! canonical, merged one. `DeclaredType` gives that structure a proper value
+//! type: a span-free mirror of [`TypeAnnotation`] that can be built directly
+//! from an AST annotation ([`From<&TypeAnnotation>`](#impl-From<%26TypeAnnotation>-for-DeclaredType)),
+//! parsed back out of a stored string ([`DeclaredType::parse`]), or partially
+//! recovered from an already-resolved [`InferredType`]
+//! ([`DeclaredType::from_inferred`]).
+//!
+//! This module is purely additive (BT-3076 stage 1): nothing here replaces
+//! `resolve_type_string` or any existing call site yet. Stage 2 re-cores the
+//! canonical annotation resolver
+//! ([`resolve_type_annotation`](crate::semantic_analysis::type_checker::resolve_type_annotation))
+//! onto this type; a later stage migrates `MethodInfo` itself.
+//!
+//! Lives in the `class_hierarchy` layer (not `type_checker`) because
+//! `MethodInfo` — the eventual home for a structured field — lives here, and
+//! `type_checker` already depends downward on `class_hierarchy`, never the
+//! reverse.
+
+use std::fmt;
+
+use ecow::EcoString;
+
+use crate::ast::TypeAnnotation;
+use crate::semantic_analysis::type_checker::InferredType;
+
+/// A span-free, structured type signature — the value-object counterpart to
+/// [`TypeAnnotation`], with every [`crate::source_analysis::Span`] and
+/// [`crate::ast::Identifier`] stripped down to a bare [`EcoString`].
+///
+/// Mirrors every `TypeAnnotation` variant. See the module docs for how a
+/// value is produced (`From<&TypeAnnotation>`, [`DeclaredType::parse`],
+/// [`DeclaredType::from_inferred`]) and displayed ([`Display`](fmt::Display),
+/// byte-identical to [`TypeAnnotation::type_name`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum DeclaredType {
+    /// A simple named type (e.g., `Integer`, `String`, `Counter`). Also the
+    /// degrade-to fallback for any string [`DeclaredType::parse`] cannot
+    /// otherwise make sense of — see that method's doc.
+    Simple(EcoString),
+    /// A union type (e.g., `Integer | String`).
+    Union(Vec<DeclaredType>),
+    /// A singleton/literal type (e.g., `#north`, stored without the `#`).
+    Singleton(EcoString),
+    /// A generic type (e.g., `Collection(Integer)`, `Result(T, E)`).
+    Generic {
+        /// The base type name.
+        base: EcoString,
+        /// Type parameters.
+        parameters: Vec<DeclaredType>,
+    },
+    /// A false-or type (Option/Maybe pattern), e.g. `Integer | False`.
+    FalseOr(Box<DeclaredType>),
+    /// A difference/negation type (e.g., `Symbol \ #foo`) — ADR 0102 §1.
+    Difference {
+        /// The base type being narrowed.
+        base: Box<DeclaredType>,
+        /// The type removed from `base`.
+        excluded: Box<DeclaredType>,
+    },
+    /// An intersection type (e.g., `Collection(Object) & Comparable`) — ADR
+    /// 0068 §Protocol Composition, ADR 0102 §1/§3.
+    Intersection {
+        /// The left-hand operand.
+        left: Box<DeclaredType>,
+        /// The right-hand operand.
+        right: Box<DeclaredType>,
+    },
+    /// The `Self` return type.
+    SelfType,
+    /// The `Self class` metatype.
+    SelfClass,
+    /// The `<ClassName> class` metatype, carrying the named class.
+    ClassOf(EcoString),
+}
+
+impl DeclaredType {
+    /// Parse a stored type-signature string (a `MethodInfo::return_type` /
+    /// `param_types` entry, or a `ClassHierarchy::state_field_type` value)
+    /// into a structured `DeclaredType`.
+    ///
+    /// Grammar mirrors [`TypeChecker::resolve_type_string`]'s parsing (BT-3075):
+    /// split on top-level `|` (respecting parenthesis nesting) for unions,
+    /// then `Base(Arg1, Arg2)` for generics (args themselves split on
+    /// top-level `,`, respecting nesting), with `#name` recognised as a
+    /// [`DeclaredType::Singleton`]. Unlike `resolve_type_string`, this is
+    /// **parse only** — no keyword resolution: `Never`, `Dynamic`, `nil`,
+    /// `true`, `false` all come back as plain `Simple`/`Singleton` names,
+    /// exactly as written. That normalisation is the resolver's job, not the
+    /// parser's (see `resolve_declared_type` in `type_resolver`).
+    ///
+    /// Never panics. `resolve_type_string`'s grammar has no representation
+    /// for `\` (difference), `&` (intersection), bare `Self`, `Self class`,
+    /// or `<Name> class` — strings in exactly those shapes (which *can* occur,
+    /// since [`MethodInfo::return_type`](super::MethodInfo::return_type) is
+    /// populated via [`TypeAnnotation::type_name`], which does render them)
+    /// degrade to an opaque `Simple(whole_string)`, matching
+    /// `resolve_type_string`'s own behaviour for any input it doesn't
+    /// specifically recognise (an unparsed string becomes a nominal class
+    /// name). Malformed/unbalanced input (e.g. `"Array(Integer"`, no closing
+    /// paren) degrades the same way.
+    ///
+    /// [`TypeChecker::resolve_type_string`]: crate::semantic_analysis::type_checker::TypeChecker
+    #[must_use]
+    pub fn parse(s: &str) -> DeclaredType {
+        let trimmed = s.trim();
+
+        // Split on top-level `|` first (respecting parens), matching
+        // `resolve_type_string`'s union-first ordering.
+        let union_parts = split_top_level(trimmed, '|');
+        if union_parts.len() > 1 {
+            return DeclaredType::Union(union_parts.into_iter().map(DeclaredType::parse).collect());
+        }
+
+        // Generic: `Base(Arg1, Arg2)`, nesting-aware.
+        let (base_str, args) = split_generic_base(trimmed);
+        if let Some(inner) = args {
+            let parameters = split_top_level(inner, ',')
+                .into_iter()
+                .map(DeclaredType::parse)
+                .collect();
+            return DeclaredType::Generic {
+                base: base_str.trim().into(),
+                parameters,
+            };
+        }
+
+        // Singleton: `#name`.
+        if let Some(rest) = trimmed.strip_prefix('#') {
+            if !rest.is_empty() {
+                return DeclaredType::Singleton(rest.into());
+            }
+        }
+
+        // Fallback: opaque nominal name, including for constructs this
+        // grammar doesn't parse (`\`, `&`, `Self`, `Self class`, `<Name>
+        // class`) and malformed input.
+        DeclaredType::Simple(trimmed.into())
+    }
+
+    /// Partially convert an already-resolved [`InferredType`] back into a
+    /// `DeclaredType`, for writeback-style call sites that only have an
+    /// `InferredType` in hand.
+    ///
+    /// Matches the current writeback filter in
+    /// [`ClassHierarchy::apply_inferred_return_types`](super::ClassHierarchy::apply_inferred_return_types)
+    /// (only `Known` and `Never` are ever written back today):
+    /// - [`InferredType::Known`] → [`DeclaredType::Simple`] (no type args) or
+    ///   [`DeclaredType::Generic`] (with type args, recursively converted;
+    ///   `None` if any argument is unconvertible).
+    /// - [`InferredType::Never`] → `Simple("Never")`.
+    /// - [`InferredType::Union`] → `Union` of converted members, `None` if
+    ///   any member is unconvertible.
+    /// - Everything else (`Dynamic`, `Meta`, `Negation`, `Intersection`) →
+    ///   `None` — these don't have a single canonical declared-type spelling
+    ///   the writeback path should commit to.
+    #[must_use]
+    pub fn from_inferred(ty: &InferredType) -> Option<DeclaredType> {
+        match ty {
+            InferredType::Known {
+                class_name,
+                type_args,
+                ..
+            } if type_args.is_empty() => Some(DeclaredType::Simple(class_name.clone())),
+            InferredType::Known {
+                class_name,
+                type_args,
+                ..
+            } => {
+                let parameters = type_args
+                    .iter()
+                    .map(DeclaredType::from_inferred)
+                    .collect::<Option<Vec<_>>>()?;
+                Some(DeclaredType::Generic {
+                    base: class_name.clone(),
+                    parameters,
+                })
+            }
+            InferredType::Never => Some(DeclaredType::Simple("Never".into())),
+            InferredType::Union { members, .. } => {
+                let converted = members
+                    .iter()
+                    .map(DeclaredType::from_inferred)
+                    .collect::<Option<Vec<_>>>()?;
+                Some(DeclaredType::Union(converted))
+            }
+            _ => None,
+        }
+    }
+
+    /// `true` when `self`, used as an operand of `\`, must be parenthesised
+    /// for the printed form to re-parse to the same value — mirrors
+    /// [`TypeAnnotation::needs_parens_in_difference`].
+    fn needs_parens_in_difference(&self, is_excluded: bool) -> bool {
+        match self {
+            Self::Union(_) | Self::FalseOr(_) | Self::Intersection { .. } => true,
+            Self::Difference { .. } => is_excluded,
+            _ => false,
+        }
+    }
+
+    /// `true` when `self`, used as an operand of `&`, must be parenthesised
+    /// — mirrors [`TypeAnnotation::needs_parens_in_intersection`].
+    fn needs_parens_in_intersection(&self, is_right: bool) -> bool {
+        match self {
+            Self::Union(_) | Self::FalseOr(_) | Self::Difference { .. } => true,
+            Self::Intersection { .. } => is_right,
+            _ => false,
+        }
+    }
+}
+
+/// Byte-identical to [`TypeAnnotation::type_name`] — see that method for the
+/// per-variant rendering rules this mirrors (the single source of truth for
+/// both is documented there; keep them in sync by hand, matching what
+/// `TypeAnnotation` itself does across `type_name` / `needs_parens_in_*`).
+impl fmt::Display for DeclaredType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Simple(name) => write!(f, "{name}"),
+            Self::Singleton(name) => write!(f, "#{name}"),
+            Self::Union(types) => {
+                for (i, ty) in types.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " | ")?;
+                    }
+                    write!(f, "{ty}")?;
+                }
+                Ok(())
+            }
+            Self::Generic { base, parameters } => {
+                write!(f, "{base}(")?;
+                for (i, ty) in parameters.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{ty}")?;
+                }
+                write!(f, ")")
+            }
+            Self::FalseOr(inner) => match inner.as_ref() {
+                Self::Union(_) | Self::FalseOr(_) => write!(f, "({inner}) | False"),
+                _ => write!(f, "{inner} | False"),
+            },
+            Self::Difference { base, excluded } => {
+                if base.needs_parens_in_difference(false) {
+                    write!(f, "({base})")?;
+                } else {
+                    write!(f, "{base}")?;
+                }
+                write!(f, " \\ ")?;
+                if excluded.needs_parens_in_difference(true) {
+                    write!(f, "({excluded})")
+                } else {
+                    write!(f, "{excluded}")
+                }
+            }
+            Self::Intersection { left, right } => {
+                if left.needs_parens_in_intersection(false) {
+                    write!(f, "({left})")?;
+                } else {
+                    write!(f, "{left}")?;
+                }
+                write!(f, " & ")?;
+                if right.needs_parens_in_intersection(true) {
+                    write!(f, "({right})")
+                } else {
+                    write!(f, "{right}")
+                }
+            }
+            Self::SelfType => write!(f, "Self"),
+            Self::SelfClass => write!(f, "Self class"),
+            Self::ClassOf(name) => write!(f, "{name} class"),
+        }
+    }
+}
+
+impl From<&TypeAnnotation> for DeclaredType {
+    /// Span-strip conversion: every `TypeAnnotation` variant maps to its
+    /// `DeclaredType` counterpart 1:1, dropping spans and unwrapping
+    /// `Identifier`s down to their bare `EcoString` name.
+    fn from(ann: &TypeAnnotation) -> Self {
+        match ann {
+            TypeAnnotation::Simple(id) => DeclaredType::Simple(id.name.clone()),
+            TypeAnnotation::Union { types, .. } => {
+                DeclaredType::Union(types.iter().map(DeclaredType::from).collect())
+            }
+            TypeAnnotation::Singleton { name, .. } => DeclaredType::Singleton(name.clone()),
+            TypeAnnotation::Generic {
+                base, parameters, ..
+            } => DeclaredType::Generic {
+                base: base.name.clone(),
+                parameters: parameters.iter().map(DeclaredType::from).collect(),
+            },
+            TypeAnnotation::FalseOr { inner, .. } => {
+                DeclaredType::FalseOr(Box::new(DeclaredType::from(inner.as_ref())))
+            }
+            TypeAnnotation::Difference { base, excluded, .. } => DeclaredType::Difference {
+                base: Box::new(DeclaredType::from(base.as_ref())),
+                excluded: Box::new(DeclaredType::from(excluded.as_ref())),
+            },
+            TypeAnnotation::Intersection { left, right, .. } => DeclaredType::Intersection {
+                left: Box::new(DeclaredType::from(left.as_ref())),
+                right: Box::new(DeclaredType::from(right.as_ref())),
+            },
+            TypeAnnotation::SelfType { .. } => DeclaredType::SelfType,
+            TypeAnnotation::SelfClass { .. } => DeclaredType::SelfClass,
+            TypeAnnotation::ClassOf { class_name, .. } => {
+                DeclaredType::ClassOf(class_name.name.clone())
+            }
+        }
+    }
+}
+
+/// Split a type-parameter/argument string on `,` while respecting
+/// parenthesis nesting — e.g. `"Outer(Inner(A, B), C), D"` splits into
+/// `["Outer(Inner(A, B), C)", "D"]`, not four pieces.
+///
+/// Shared implementation for [`split_top_level`]'s `,` case; kept as one
+/// function (parameterised on the separator char) since the nesting-aware
+/// scan is otherwise identical for `|` and `,`.
+fn split_top_level(s: &str, sep: char) -> Vec<&str> {
+    let mut result = Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0;
+    for (i, c) in s.char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => depth = depth.saturating_sub(1),
+            c if c == sep && depth == 0 => {
+                result.push(s[start..i].trim());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    let last = s[start..].trim();
+    if !last.is_empty() {
+        result.push(last);
+    }
+    result
+}
+
+/// Split a stored type-name string into `(base, args_slice)`.
+///
+/// Given `"Array(Integer)"` returns `("Array", Some("Integer"))`. Given
+/// `"Integer"` (no parentheses) returns `("Integer", None)`. Given
+/// `"Array(Integer)extra"` (not terminated by `)`) falls back to
+/// `("Array(Integer)extra", None)` — the caller treats the string as opaque.
+///
+/// Mirrors `type_resolver::split_generic_base` — duplicated here (rather
+/// than imported) because `class_hierarchy` sits below `type_checker` in the
+/// dependency graph and must not reach up into it.
+fn split_generic_base(type_name: &str) -> (&str, Option<&str>) {
+    match type_name.split_once('(') {
+        Some((base, rest)) if rest.ends_with(')') => {
+            let args = &rest[..rest.len() - 1];
+            (base, Some(args))
+        }
+        _ => (type_name, None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::Identifier;
+    use crate::source_analysis::Span;
+
+    fn span() -> Span {
+        Span::new(0, 1)
+    }
+
+    fn ident(name: &str) -> Identifier {
+        Identifier {
+            name: name.into(),
+            span: span(),
+        }
+    }
+
+    // ---- parse ∘ to_string round-trips ----
+
+    #[test]
+    fn round_trip_simple() {
+        assert_round_trip("Integer");
+    }
+
+    #[test]
+    fn round_trip_generic_two_params() {
+        assert_round_trip("Result(T, E)");
+    }
+
+    #[test]
+    fn round_trip_nested_generic() {
+        assert_round_trip("List(Result(Integer, String))");
+    }
+
+    #[test]
+    fn round_trip_union() {
+        assert_round_trip("String | UndefinedObject");
+    }
+
+    #[test]
+    fn round_trip_union_with_singleton() {
+        assert_round_trip("Integer | #infinity");
+    }
+
+    #[test]
+    fn round_trip_bare_singleton() {
+        assert_round_trip("#north");
+    }
+
+    #[test]
+    fn round_trip_union_nested_in_generic() {
+        // `Result(Integer | String, Error)` — union inside a generic
+        // argument; the top-level split must not fire on the inner `|`.
+        assert_round_trip("Result(Integer | String, Error)");
+    }
+
+    #[test]
+    fn round_trip_union_of_generics() {
+        assert_round_trip("List(Integer) | Dictionary(String, Integer)");
+    }
+
+    #[test]
+    fn round_trip_false_or_rendering() {
+        // `DeclaredType::FalseOr` can't be produced by `parse` (the string
+        // grammar doesn't distinguish it from a plain `Union`), but its
+        // `Display` form must still match `TypeAnnotation::type_name`'s
+        // exactly — pinned directly against a `TypeAnnotation` built via the
+        // real parser in `display_parity_false_or` below. Here we only check
+        // that re-parsing the *displayed* text is stable (round-trips to the
+        // same text), since `Simple`/`Union` are what parsing that text
+        // actually yields.
+        let false_or = DeclaredType::FalseOr(Box::new(DeclaredType::Simple("Integer".into())));
+        let text = false_or.to_string();
+        assert_eq!(text, "Integer | False");
+        let reparsed = DeclaredType::parse(&text);
+        assert_eq!(reparsed.to_string(), text);
+    }
+
+    #[test]
+    fn round_trip_difference_rendering() {
+        let diff = DeclaredType::Difference {
+            base: Box::new(DeclaredType::Simple("Symbol".into())),
+            excluded: Box::new(DeclaredType::Singleton("foo".into())),
+        };
+        let text = diff.to_string();
+        assert_eq!(text, "Symbol \\ #foo");
+        // The `\` grammar isn't understood by `parse`, so this degrades to
+        // an opaque `Simple` — but the *text* stays stable across the trip.
+        let reparsed = DeclaredType::parse(&text);
+        assert_eq!(reparsed, DeclaredType::Simple(text.clone().into()));
+        assert_eq!(reparsed.to_string(), text);
+    }
+
+    fn assert_round_trip(s: &str) {
+        let parsed = DeclaredType::parse(s);
+        assert_eq!(
+            parsed.to_string(),
+            s,
+            "round-trip mismatch for {s:?}: parsed as {parsed:?}"
+        );
+    }
+
+    // ---- parse: malformed input never panics, degrades to Simple ----
+
+    #[test]
+    fn parse_unterminated_generic_degrades_to_simple() {
+        let result = DeclaredType::parse("Array(Integer");
+        assert_eq!(result, DeclaredType::Simple("Array(Integer".into()));
+    }
+
+    #[test]
+    fn parse_empty_string_degrades_to_simple_empty() {
+        let result = DeclaredType::parse("");
+        assert_eq!(result, DeclaredType::Simple("".into()));
+    }
+
+    #[test]
+    fn parse_bare_hash_degrades_to_simple() {
+        // `#` alone has no singleton name to strip — falls back to Simple("#").
+        let result = DeclaredType::parse("#");
+        assert_eq!(result, DeclaredType::Simple("#".into()));
+    }
+
+    #[test]
+    fn parse_self_class_degrades_to_simple() {
+        let result = DeclaredType::parse("Self class");
+        assert_eq!(result, DeclaredType::Simple("Self class".into()));
+        assert_eq!(result.to_string(), "Self class");
+    }
+
+    // ---- Display parity with TypeAnnotation::type_name() ----
+
+    /// Parses `src` (a full class definition with one method) and returns
+    /// that method's return-type annotation.
+    fn parse_return_type(src: &str) -> TypeAnnotation {
+        let tokens = crate::source_analysis::lex_with_eof(src);
+        let (module, diags) = crate::source_analysis::parse(tokens);
+        let errors: Vec<_> = diags
+            .iter()
+            .filter(|d| d.severity == crate::source_analysis::Severity::Error)
+            .collect();
+        assert!(errors.is_empty(), "parse failed for {src:?}: {errors:?}");
+        module.classes[0].methods[0]
+            .return_type
+            .clone()
+            .unwrap_or_else(|| panic!("no return type annotation parsed from {src:?}"))
+    }
+
+    fn assert_display_parity(src: &str) {
+        let ann = parse_return_type(src);
+        let declared = DeclaredType::from(&ann);
+        assert_eq!(
+            declared.to_string(),
+            ann.type_name(),
+            "Display parity mismatch for {src:?}"
+        );
+    }
+
+    #[test]
+    fn display_parity_simple() {
+        assert_display_parity("Object subclass: Foo\n  bar -> Integer => 1\n");
+    }
+
+    #[test]
+    fn display_parity_generic() {
+        assert_display_parity("Object subclass: Foo\n  bar -> Result(Integer, String) => 1\n");
+    }
+
+    #[test]
+    fn display_parity_union() {
+        assert_display_parity("Object subclass: Foo\n  bar -> Integer | String => 1\n");
+    }
+
+    #[test]
+    fn display_parity_singleton_union() {
+        assert_display_parity("Object subclass: Foo\n  bar -> Integer | #infinity => 1\n");
+    }
+
+    #[test]
+    fn display_parity_false_or() {
+        assert_display_parity("Object subclass: Foo\n  bar -> Integer | False => 1\n");
+    }
+
+    #[test]
+    fn display_parity_difference() {
+        assert_display_parity("Object subclass: Foo\n  bar -> Symbol \\ #foo => 1\n");
+    }
+
+    #[test]
+    fn display_parity_intersection() {
+        assert_display_parity(
+            "Protocol define: Comparable\n\nObject subclass: Foo\n  bar -> Foo & Comparable => self\n",
+        );
+    }
+
+    #[test]
+    fn display_parity_self_type() {
+        assert_display_parity("Object subclass: Foo\n  bar -> Self => self\n");
+    }
+
+    #[test]
+    fn display_parity_self_class() {
+        assert_display_parity("Object subclass: Foo\n  class -> Self class => self class\n");
+    }
+
+    #[test]
+    fn display_parity_class_of() {
+        assert_display_parity("Object subclass: Foo\n  actorClass -> Foo class => self class\n");
+    }
+
+    #[test]
+    fn display_parity_nested_generic() {
+        assert_display_parity(
+            "Object subclass: Foo\n  bar -> List(Result(Integer, String)) => 1\n",
+        );
+    }
+
+    // ---- From<&TypeAnnotation> structural conversion ----
+
+    #[test]
+    fn from_type_annotation_simple() {
+        let ann = TypeAnnotation::Simple(ident("Integer"));
+        assert_eq!(
+            DeclaredType::from(&ann),
+            DeclaredType::Simple("Integer".into())
+        );
+    }
+
+    #[test]
+    fn from_type_annotation_singleton_strips_hash() {
+        let ann = TypeAnnotation::Singleton {
+            name: "north".into(),
+            span: span(),
+        };
+        assert_eq!(
+            DeclaredType::from(&ann),
+            DeclaredType::Singleton("north".into())
+        );
+    }
+
+    #[test]
+    fn from_type_annotation_generic_preserves_structure() {
+        let ann = TypeAnnotation::Generic {
+            base: ident("Result"),
+            parameters: vec![
+                TypeAnnotation::Simple(ident("Integer")),
+                TypeAnnotation::Simple(ident("String")),
+            ],
+            span: span(),
+        };
+        assert_eq!(
+            DeclaredType::from(&ann),
+            DeclaredType::Generic {
+                base: "Result".into(),
+                parameters: vec![
+                    DeclaredType::Simple("Integer".into()),
+                    DeclaredType::Simple("String".into()),
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn from_type_annotation_self_variants() {
+        assert_eq!(
+            DeclaredType::from(&TypeAnnotation::SelfType { span: span() }),
+            DeclaredType::SelfType
+        );
+        assert_eq!(
+            DeclaredType::from(&TypeAnnotation::SelfClass { span: span() }),
+            DeclaredType::SelfClass
+        );
+        assert_eq!(
+            DeclaredType::from(&TypeAnnotation::ClassOf {
+                class_name: ident("Actor"),
+                span: span(),
+            }),
+            DeclaredType::ClassOf("Actor".into())
+        );
+    }
+
+    // ---- from_inferred ----
+
+    #[test]
+    fn from_inferred_known_no_args() {
+        let ty = InferredType::known("Integer");
+        assert_eq!(
+            DeclaredType::from_inferred(&ty),
+            Some(DeclaredType::Simple("Integer".into()))
+        );
+    }
+
+    #[test]
+    fn from_inferred_known_with_args() {
+        use crate::semantic_analysis::type_checker::TypeProvenance;
+        let ty = InferredType::Known {
+            class_name: "List".into(),
+            type_args: vec![InferredType::known("String")],
+            provenance: TypeProvenance::Inferred(span()),
+        };
+        assert_eq!(
+            DeclaredType::from_inferred(&ty),
+            Some(DeclaredType::Generic {
+                base: "List".into(),
+                parameters: vec![DeclaredType::Simple("String".into())],
+            })
+        );
+    }
+
+    #[test]
+    fn from_inferred_never() {
+        assert_eq!(
+            DeclaredType::from_inferred(&InferredType::Never),
+            Some(DeclaredType::Simple("Never".into()))
+        );
+    }
+
+    #[test]
+    fn from_inferred_union_of_convertible_members() {
+        use crate::semantic_analysis::type_checker::TypeProvenance;
+        let ty = InferredType::Union {
+            members: vec![InferredType::known("Integer"), InferredType::Never],
+            provenance: TypeProvenance::Inferred(span()),
+        };
+        let result = DeclaredType::from_inferred(&ty).expect("expected Some");
+        let DeclaredType::Union(members) = result else {
+            panic!("expected Union");
+        };
+        assert_eq!(members.len(), 2);
+        assert!(members.contains(&DeclaredType::Simple("Integer".into())));
+        assert!(members.contains(&DeclaredType::Simple("Never".into())));
+    }
+
+    #[test]
+    fn from_inferred_dynamic_and_meta_are_none() {
+        use crate::semantic_analysis::type_checker::{DynamicReason, TypeProvenance};
+        assert_eq!(
+            DeclaredType::from_inferred(&InferredType::Dynamic(DynamicReason::Unknown)),
+            None
+        );
+        assert_eq!(
+            DeclaredType::from_inferred(&InferredType::Meta {
+                class_name: "Foo".into(),
+                provenance: TypeProvenance::Inferred(span()),
+            }),
+            None
+        );
+    }
+}

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/mod.rs
@@ -20,11 +20,13 @@ use std::collections::{HashMap, HashSet};
 use std::sync::OnceLock;
 mod builtins;
 pub(crate) mod class_info;
+pub(crate) mod declared_type;
 mod hierarchy_queries;
 mod method_resolution;
 #[cfg(test)]
 mod tests;
 pub use class_info::{ClassInfo, MethodInfo, SuperclassTypeArg, format_default_value};
+pub use declared_type::DeclaredType;
 /// Per-class selector index: maps class name → (selector → method vec position).
 type SelectorIndexMap = HashMap<EcoString, HashMap<EcoString, usize>>;
 /// Static class hierarchy built during semantic analysis.

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
@@ -27,11 +27,13 @@ use ecow::{EcoString, eco_format};
 
 use crate::ast::TypeAnnotation;
 use crate::semantic_analysis::alias_registry::AliasRegistry;
-use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
+use crate::semantic_analysis::class_hierarchy::{ClassHierarchy, DeclaredType};
 use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
+use crate::source_analysis::Span;
 
+use super::is_generic_type_param;
 use super::well_known::WellKnownClass;
-use super::{DynamicReason, InferredType, TypeProvenance};
+use super::{DynamicReason, InferredType, TypeProvenance, TypeStringContext};
 
 /// Substitution map from a generic type parameter name to its concrete
 /// [`InferredType`].
@@ -123,15 +125,13 @@ pub(in crate::semantic_analysis) fn resolve_type_annotation(
     protocol_registry: Option<&ProtocolRegistry>,
     alias_registry: Option<&AliasRegistry>,
 ) -> InferredType {
-    let mut expanding = Vec::new();
-    let mut memo = HashMap::new();
-    resolve_type_annotation_inner(
-        ann,
+    let declared = DeclaredType::from(ann);
+    resolve_declared_type(
+        &declared,
         subst,
         protocol_registry,
         alias_registry,
-        &mut expanding,
-        &mut memo,
+        TypeStringContext::Declared,
     )
 }
 
@@ -164,19 +164,93 @@ pub(in crate::semantic_analysis) fn resolve_type_annotation_with_alias_deps(
     protocol_registry: Option<&ProtocolRegistry>,
     alias_registry: Option<&AliasRegistry>,
 ) -> (InferredType, Vec<EcoString>) {
-    let mut expanding = Vec::new();
-    let mut memo = HashMap::new();
-    let resolved = resolve_type_annotation_inner(
-        ann,
+    let declared = DeclaredType::from(ann);
+    resolve_declared_type_with_alias_deps(
+        &declared,
         subst,
         protocol_registry,
         alias_registry,
+        TypeStringContext::Declared,
+    )
+}
+
+/// [`resolve_declared_type`] additionally returning the full transitive set
+/// of alias names touched while resolving `dt` — the [`DeclaredType`]
+/// counterpart of [`resolve_type_annotation_with_alias_deps`] (ADR 0108
+/// hot-reload re-check trigger, BT-2899). See that function's doc for the
+/// full rationale; identical here, just walking `DeclaredType` instead of
+/// `TypeAnnotation`.
+pub(in crate::semantic_analysis) fn resolve_declared_type_with_alias_deps(
+    dt: &DeclaredType,
+    subst: &SubstitutionMap,
+    protocol_registry: Option<&ProtocolRegistry>,
+    alias_registry: Option<&AliasRegistry>,
+    ctx: TypeStringContext,
+) -> (InferredType, Vec<EcoString>) {
+    let mut expanding = Vec::new();
+    let mut memo = HashMap::new();
+    let resolved = resolve_declared_type_inner(
+        dt,
+        subst,
+        protocol_registry,
+        alias_registry,
+        ctx,
         &mut expanding,
         &mut memo,
     );
     let mut touched: Vec<EcoString> = memo.into_keys().collect();
     touched.sort();
     (resolved, touched)
+}
+
+/// Resolve a [`DeclaredType`] into a fully-parameterised [`InferredType`]
+/// (BT-3076) — the canonical, span-free recursion that
+/// [`resolve_type_annotation`] now delegates to (via `DeclaredType::from`)
+/// and that a future caller may drive directly from a stored
+/// `MethodInfo::return_type` / `param_types` string (via
+/// [`DeclaredType::parse`](crate::semantic_analysis::class_hierarchy::DeclaredType::parse))
+/// without re-parsing through the AST at all.
+///
+/// Behaviour is the [`TypeAnnotation`]-based resolver's, verbatim, per
+/// variant — see [`resolve_type_annotation`]'s doc for the full per-variant
+/// rundown (`Simple`, `Generic`, `Union`, `FalseOr`, `Difference`,
+/// `Intersection`, `SelfType`, `SelfClass`, `ClassOf`, `Singleton`) — plus
+/// the [`TypeStringContext`] provenance rules `TypeChecker::resolve_type_string`
+/// established (BT-3075): in [`TypeStringContext::Substitution`], an
+/// unresolved bare single-letter type-param name collapses to `Dynamic`
+/// (BT-1834, checked only for a bare `Simple` node — a `Generic` base is
+/// never a type param) and constructed types are stamped `Substituted`
+/// provenance instead of `Declared`.
+///
+/// **Span degradation.** `DeclaredType` carries no source location, so every
+/// provenance this resolver stamps uses [`Span::default()`] rather than a
+/// real span — unlike the annotation-based recursion this replaces, which
+/// stamped each node's own span. This mirrors `resolve_type_string`'s own
+/// convention (it has only ever had `Span::default()` to work with, being
+/// string-based) and is behaviourally inert: [`InferredType`]'s `PartialEq`
+/// ignores provenance entirely, and the one production reader of a
+/// `TypeProvenance`'s payload (`check_impossible_class_comparison`'s
+/// `Inferred`-only gate) matches on the *variant*, never the span value.
+///
+/// [`resolve_type_annotation`]: self::resolve_type_annotation
+pub(in crate::semantic_analysis) fn resolve_declared_type(
+    dt: &DeclaredType,
+    subst: &SubstitutionMap,
+    protocol_registry: Option<&ProtocolRegistry>,
+    alias_registry: Option<&AliasRegistry>,
+    ctx: TypeStringContext,
+) -> InferredType {
+    let mut expanding = Vec::new();
+    let mut memo = HashMap::new();
+    resolve_declared_type_inner(
+        dt,
+        subst,
+        protocol_registry,
+        alias_registry,
+        ctx,
+        &mut expanding,
+        &mut memo,
+    )
 }
 
 /// The actual resolution recursion, guarded by `expanding` — the stack of
@@ -205,25 +279,34 @@ pub(in crate::semantic_analysis) fn resolve_type_annotation_with_alias_deps(
 /// the work at each level (`O(2ⁿ)` total). `expanding` (a path stack) does
 /// not prevent this — it only rejects a name that is an *ancestor* of
 /// itself, and `L(n-1)`'s two references here are siblings, not nested.
-/// Since resolution is a pure function of `(annotation, subst,
-/// alias_registry)` and `subst` never changes across a single top-level
-/// [`resolve_type_annotation`] call (every recursive call above threads the
-/// same `subst` unchanged), caching by alias name alone is sound *within*
-/// one call: the first full resolution of a name is reused verbatim for
-/// every subsequent reference, turning the exponential re-walk into one
-/// resolution per distinct alias name.
-#[allow(clippy::too_many_lines)] // one match arm per TypeAnnotation variant — see resolve_type_annotation's doc
-fn resolve_type_annotation_inner(
-    ann: &TypeAnnotation,
+/// Since resolution is a pure function of `(declared_type, subst,
+/// alias_registry, ctx)` and neither changes across a single top-level
+/// [`resolve_declared_type`] call (every recursive call below threads them
+/// unchanged), caching by alias name alone is sound *within* one call: the
+/// first full resolution of a name is reused verbatim for every subsequent
+/// reference, turning the exponential re-walk into one resolution per
+/// distinct alias name.
+///
+/// Alias expansion threads `subst`, `protocol_registry`, `alias_registry`,
+/// and `ctx` through unchanged into the recursive call on the alias's own
+/// (converted) declared body — the same threading
+/// `resolve_type_annotation_inner` used. This is *not* what
+/// `TypeChecker::resolve_type_string`'s alias branch does (it resets to an
+/// empty `SubstitutionMap`, drops `protocol_registry`, and always resolves
+/// through the `Declared`-context AST path) — that divergence is pre-existing
+/// and out of scope here (BT-3076 stage 2 does not touch `resolve_type_string`).
+#[allow(clippy::too_many_lines)] // one match arm per DeclaredType variant — see resolve_declared_type's doc
+fn resolve_declared_type_inner(
+    dt: &DeclaredType,
     subst: &SubstitutionMap,
     protocol_registry: Option<&ProtocolRegistry>,
     alias_registry: Option<&AliasRegistry>,
+    ctx: TypeStringContext,
     expanding: &mut Vec<EcoString>,
     memo: &mut HashMap<EcoString, InferredType>,
 ) -> InferredType {
-    match ann {
-        TypeAnnotation::Simple(type_id) => {
-            let name = &type_id.name;
+    match dt {
+        DeclaredType::Simple(name) => {
             if WellKnownClass::from_str(name) == Some(WellKnownClass::Never) {
                 return InferredType::Never;
             }
@@ -248,6 +331,15 @@ fn resolve_type_annotation_inner(
             if let Some(resolved) = subst.get(name) {
                 return resolved.clone();
             }
+            // BT-1834 / BT-3075: an unresolved bare type param (single
+            // uppercase letter) collapses to Dynamic in substitution contexts
+            // only, so downstream sends don't get false DNU warnings. The
+            // `Declared`-context callers (`resolve_type_annotation`'s
+            // wrapper) never hit this — an unmapped bare param there passes
+            // through as a nominal class name, matching pre-BT-3076 behaviour.
+            if ctx == TypeStringContext::Substitution && is_generic_type_param(name) {
+                return InferredType::Dynamic(DynamicReason::Unknown);
+            }
             // ADR 0108 / BT-2895: alias table comes next in the resolution
             // order (`subst` → alias table → nominal class). A reference to
             // an alias name expands eagerly to its declared annotation,
@@ -256,7 +348,7 @@ fn resolve_type_annotation_inner(
             // the way down to a plain structural `InferredType`.
             if let Some(registry) = alias_registry {
                 if let Some(alias_info) = registry.get(name) {
-                    // See `resolve_type_annotation_inner`'s doc: a name
+                    // See `resolve_declared_type_inner`'s doc: a name
                     // already fully resolved earlier in this call is reused
                     // verbatim, avoiding the exponential re-walk a chain of
                     // doubling aliases would otherwise trigger.
@@ -267,15 +359,17 @@ fn resolve_type_annotation_inner(
                         // A cycle slipped through declaration-time checking
                         // (e.g. a live redefinition that bypassed
                         // `AliasRegistry::redefine_alias`) — never hang. See
-                        // `resolve_type_annotation_inner`'s doc.
+                        // `resolve_declared_type_inner`'s doc.
                         return InferredType::Dynamic(DynamicReason::Unknown);
                     }
                     expanding.push(name.clone());
-                    let resolved = resolve_type_annotation_inner(
-                        &alias_info.annotation,
+                    let alias_declared = DeclaredType::from(&alias_info.annotation);
+                    let resolved = resolve_declared_type_inner(
+                        &alias_declared,
                         subst,
                         protocol_registry,
                         alias_registry,
+                        ctx,
                         expanding,
                         memo,
                     );
@@ -289,7 +383,9 @@ fn resolve_type_annotation_inner(
                     // the bare expansion. Tagged *before* memoizing so a
                     // later reference to the same alias reuses the tagged
                     // value verbatim (see the `memo.get` early-return above).
-                    let resolved = resolved.tag_alias_expansion(name.clone(), type_id.span);
+                    // Span degradation: `Span::default()` — see
+                    // `resolve_declared_type`'s doc.
+                    let resolved = resolved.tag_alias_expansion(name.clone(), Span::default());
                     memo.insert(name.clone(), resolved.clone());
                     return resolved;
                 }
@@ -298,128 +394,138 @@ fn resolve_type_annotation_inner(
             InferredType::Known {
                 class_name: resolved_name,
                 type_args: vec![],
-                provenance: TypeProvenance::Declared(ann.span()),
+                provenance: declared_type_provenance(ctx),
             }
         }
-        TypeAnnotation::Generic {
-            base, parameters, ..
-        } => {
+        DeclaredType::Generic { base, parameters } => {
             let type_args: Vec<InferredType> = parameters
                 .iter()
                 .map(|p| {
-                    resolve_type_annotation_inner(
+                    resolve_declared_type_inner(
                         p,
                         subst,
                         protocol_registry,
                         alias_registry,
+                        ctx,
                         expanding,
                         memo,
                     )
                 })
                 .collect();
             InferredType::Known {
-                class_name: base.name.clone(),
+                class_name: base.clone(),
                 type_args,
-                provenance: TypeProvenance::Declared(ann.span()),
+                provenance: declared_type_provenance(ctx),
             }
         }
-        TypeAnnotation::Union { types, .. } => {
+        DeclaredType::Union(types) => {
             let members: Vec<InferredType> = types
                 .iter()
                 .map(|t| {
-                    resolve_type_annotation_inner(
+                    resolve_declared_type_inner(
                         t,
                         subst,
                         protocol_registry,
                         alias_registry,
+                        ctx,
                         expanding,
                         memo,
                     )
                 })
                 .collect();
-            InferredType::union_of(&members)
+            let unioned = InferredType::union_of(&members);
+            if ctx == TypeStringContext::Substitution {
+                stamp_substituted_provenance(unioned)
+            } else {
+                unioned
+            }
         }
-        TypeAnnotation::FalseOr { inner, .. } => {
-            let inner_ty = resolve_type_annotation_inner(
+        DeclaredType::FalseOr(inner) => {
+            let inner_ty = resolve_declared_type_inner(
                 inner,
                 subst,
                 protocol_registry,
                 alias_registry,
+                ctx,
                 expanding,
                 memo,
             );
-            InferredType::union_of(&[inner_ty, InferredType::known("False")])
+            let unioned = InferredType::union_of(&[inner_ty, InferredType::known("False")]);
+            if ctx == TypeStringContext::Substitution {
+                stamp_substituted_provenance(unioned)
+            } else {
+                unioned
+            }
         }
-        TypeAnnotation::Difference { base, excluded, .. } => {
+        DeclaredType::Difference { base, excluded } => {
             // ADR 0102 §1: `base \ excluded` resolves through the shared
             // `difference` set operation (BT-2739). Reducible cases normalise —
             // e.g. an excluded member that drops a union member, or `T \ T`
             // collapsing to `Never`.
-            let base_ty = resolve_type_annotation_inner(
+            let base_ty = resolve_declared_type_inner(
                 base,
                 subst,
                 protocol_registry,
                 alias_registry,
+                ctx,
                 expanding,
                 memo,
             );
-            let excluded_ty = resolve_type_annotation_inner(
+            let excluded_ty = resolve_declared_type_inner(
                 excluded,
                 subst,
                 protocol_registry,
                 alias_registry,
+                ctx,
                 expanding,
                 memo,
             );
-            InferredType::difference(
-                &base_ty,
-                &excluded_ty,
-                TypeProvenance::Declared(ann.span()),
-                None,
-            )
+            InferredType::difference(&base_ty, &excluded_ty, declared_type_provenance(ctx), None)
         }
-        TypeAnnotation::Intersection { left, right, .. } => {
+        DeclaredType::Intersection { left, right } => {
             // ADR 0102 §1/§3, BT-2743: `left & right` resolves through the
             // shared `intersect` set operation. `hierarchy` is `None` (this
             // resolver never consults it); `protocol_registry` is passed
             // through so class ∩ protocol resolves to the stored
             // `Intersection` instead of falling through to `Never`.
-            let left_ty = resolve_type_annotation_inner(
+            let left_ty = resolve_declared_type_inner(
                 left,
                 subst,
                 protocol_registry,
                 alias_registry,
+                ctx,
                 expanding,
                 memo,
             );
-            let right_ty = resolve_type_annotation_inner(
+            let right_ty = resolve_declared_type_inner(
                 right,
                 subst,
                 protocol_registry,
                 alias_registry,
+                ctx,
                 expanding,
                 memo,
             );
             InferredType::intersect(
                 &left_ty,
                 &right_ty,
-                TypeProvenance::Declared(ann.span()),
+                declared_type_provenance(ctx),
                 None,
                 protocol_registry,
             )
         }
-        TypeAnnotation::ClassOf { class_name, .. } => {
+        DeclaredType::ClassOf(class_name) => {
             // ADR 0083: `<ClassName> class` is the metatype of the named class.
             // The name is carried directly in the annotation, so resolve it to a
             // dedicated `Meta` here (no enclosing-class context needed). A
             // metatype value still satisfies `:: Class` / `:: Behaviour`
             // parameters via the tower subtyping in `validation.rs`.
             InferredType::Meta {
-                class_name: class_name.name.clone(),
-                provenance: TypeProvenance::Declared(ann.span()),
+                class_name: class_name.clone(),
+                provenance: declared_type_provenance(ctx),
             }
         }
-        TypeAnnotation::SelfClass { .. } => {
+        DeclaredType::SelfClass => {
             // ADR 0083: `Self class` is the metatype of the *enclosing* class.
             // That class isn't known to the free-function resolver, so callers
             // that have the receiver class thread it through `subst` under the
@@ -428,20 +534,60 @@ fn resolve_type_annotation_inner(
             if let Some(InferredType::Known { class_name, .. }) = subst.get("Self") {
                 return InferredType::Meta {
                     class_name: class_name.clone(),
-                    provenance: TypeProvenance::Declared(ann.span()),
+                    provenance: declared_type_provenance(ctx),
                 };
             }
             InferredType::Dynamic(DynamicReason::Unknown)
         }
-        TypeAnnotation::SelfType { .. } => {
+        DeclaredType::SelfType => {
             // `Self` needs the static receiver class, which the annotation
             // resolver does not have. Call sites that do know it (e.g.
             // return-type validation, nested-Self substitution) handle it
             // directly.
             InferredType::Dynamic(DynamicReason::Unknown)
         }
-        TypeAnnotation::Singleton { name, .. } => InferredType::known(eco_format!("#{name}")),
+        DeclaredType::Singleton(name) => InferredType::known(eco_format!("#{name}")),
     }
+}
+
+/// `Declared` or `Substituted` provenance (both `Span::default()`, per
+/// `resolve_declared_type`'s doc), chosen by `ctx` — the `DeclaredType`
+/// recursion's single construction point for "this was a constructed nominal
+/// / generic / metatype / set-op result", mirroring
+/// `TypeChecker::resolve_type_string`'s equivalent inline `if` at its
+/// generic-parse arm (BT-3075).
+fn declared_type_provenance(ctx: TypeStringContext) -> TypeProvenance {
+    if ctx == TypeStringContext::Substitution {
+        TypeProvenance::Substituted(Span::default())
+    } else {
+        TypeProvenance::Declared(Span::default())
+    }
+}
+
+/// Re-stamp `Substituted` provenance on a substitution-context union/false-or
+/// result — the `DeclaredType`-recursion counterpart of
+/// `TypeChecker::stamp_substituted_provenance` (inference.rs), duplicated
+/// rather than shared since that helper is private to `inference.rs`'s
+/// `impl TypeChecker` block. See its doc for the full rationale: `union_of`
+/// derives provenance from the members, and a plain nominal member never
+/// wins, so a substituted `V | Nil` would otherwise read as `Inferred`;
+/// `Aliased` results keep their tag (re-stamping would lose the alias
+/// display name); `Dynamic` and `Never` results carry no provenance and pass
+/// through unchanged.
+fn stamp_substituted_provenance(mut ty: InferredType) -> InferredType {
+    match &mut ty {
+        InferredType::Known { provenance, .. }
+        | InferredType::Union { provenance, .. }
+        | InferredType::Meta { provenance, .. }
+        | InferredType::Negation { provenance, .. }
+        | InferredType::Intersection { provenance, .. }
+            if !matches!(provenance, TypeProvenance::Aliased { .. }) =>
+        {
+            *provenance = TypeProvenance::Substituted(Span::default());
+        }
+        _ => {}
+    }
+    ty
 }
 
 /// Build an [`InferredType`] for a method receiver from a class definition.
@@ -1812,5 +1958,248 @@ mod tests {
     fn base_name_of_string_discards_args() {
         assert_eq!(base_name_of_string("Dictionary(K, V)"), "Dictionary");
         assert_eq!(base_name_of_string("Integer"), "Integer");
+    }
+
+    // ---- resolve_declared_type (BT-3076 stage 2) ----
+    //
+    // `resolve_type_annotation` is now a thin `DeclaredType::from` + this
+    // function wrapper (always `TypeStringContext::Declared`), so every test
+    // above already exercises this recursion indirectly. These tests target
+    // `resolve_declared_type` directly, including the `Substitution` context
+    // no existing `TypeAnnotation`-based caller reaches yet.
+
+    #[test]
+    fn declared_type_simple_matches_annotation_resolution() {
+        let dt = DeclaredType::Simple("Integer".into());
+        let result =
+            resolve_declared_type(&dt, &empty_subst(), None, None, TypeStringContext::Declared);
+        assert_eq!(result, InferredType::known("Integer"));
+    }
+
+    #[test]
+    fn declared_type_never_and_dynamic_keywords() {
+        let never = resolve_declared_type(
+            &DeclaredType::Simple("Never".into()),
+            &empty_subst(),
+            None,
+            None,
+            TypeStringContext::Declared,
+        );
+        assert_eq!(never, InferredType::Never);
+
+        let dynamic = resolve_declared_type(
+            &DeclaredType::Simple("Dynamic".into()),
+            &empty_subst(),
+            None,
+            None,
+            TypeStringContext::Declared,
+        );
+        assert!(matches!(dynamic, InferredType::Dynamic(_)));
+    }
+
+    #[test]
+    fn declared_type_generic_preserves_type_args() {
+        let dt = DeclaredType::Generic {
+            base: "Result".into(),
+            parameters: vec![
+                DeclaredType::Simple("Integer".into()),
+                DeclaredType::Simple("String".into()),
+            ],
+        };
+        let result =
+            resolve_declared_type(&dt, &empty_subst(), None, None, TypeStringContext::Declared);
+        let InferredType::Known {
+            class_name,
+            type_args,
+            ..
+        } = result
+        else {
+            panic!("expected Known");
+        };
+        assert_eq!(class_name.as_str(), "Result");
+        assert_eq!(type_args.len(), 2);
+    }
+
+    #[test]
+    fn declared_type_singleton_resolves_with_hash_prefix() {
+        let dt = DeclaredType::Singleton("ok".into());
+        let result =
+            resolve_declared_type(&dt, &empty_subst(), None, None, TypeStringContext::Declared);
+        assert_eq!(result, InferredType::known("#ok"));
+    }
+
+    #[test]
+    fn declared_type_substitution_context_collapses_bare_type_param_to_dynamic() {
+        // BT-1834: an unmapped bare single-letter param collapses to Dynamic
+        // only in `Substitution` context — `Declared` context (what
+        // `resolve_type_annotation` always uses) passes it through unchanged
+        // as a nominal class name.
+        let dt = DeclaredType::Simple("T".into());
+        let declared =
+            resolve_declared_type(&dt, &empty_subst(), None, None, TypeStringContext::Declared);
+        assert_eq!(declared, InferredType::known("T"));
+
+        let substituted = resolve_declared_type(
+            &dt,
+            &empty_subst(),
+            None,
+            None,
+            TypeStringContext::Substitution,
+        );
+        assert!(matches!(substituted, InferredType::Dynamic(_)));
+    }
+
+    #[test]
+    fn declared_type_substitution_context_still_honours_subst_map() {
+        // Substitution wins over the bare-param collapse when the map does
+        // have an entry for the name.
+        let dt = DeclaredType::Simple("T".into());
+        let mut subst = SubstitutionMap::new();
+        subst.insert("T".into(), InferredType::known("Integer"));
+        let result =
+            resolve_declared_type(&dt, &subst, None, None, TypeStringContext::Substitution);
+        assert_eq!(result, InferredType::known("Integer"));
+    }
+
+    #[test]
+    fn declared_type_alias_expansion_matches_annotation_based_resolution() {
+        let expansion = TypeAnnotation::Union {
+            types: vec![
+                TypeAnnotation::Singleton {
+                    name: "temporary".into(),
+                    span: span(),
+                },
+                TypeAnnotation::Singleton {
+                    name: "permanent".into(),
+                    span: span(),
+                },
+            ],
+            span: span(),
+        };
+        let mut registry = AliasRegistry::new();
+        registry.register_test_alias(AliasInfo {
+            name: "RestartStrategy".into(),
+            annotation: expansion,
+            is_internal: false,
+            package: None,
+            span: span(),
+        });
+
+        let dt = DeclaredType::Simple("RestartStrategy".into());
+        let via_declared_type = resolve_declared_type(
+            &dt,
+            &empty_subst(),
+            None,
+            Some(&registry),
+            TypeStringContext::Declared,
+        );
+
+        let ann = TypeAnnotation::Simple(ident("RestartStrategy"));
+        let via_annotation = resolve_type_annotation(&ann, &empty_subst(), None, Some(&registry));
+
+        assert_eq!(via_declared_type, via_annotation);
+        let InferredType::Union { members, .. } = via_declared_type else {
+            panic!("expected Union");
+        };
+        assert_eq!(members.len(), 2);
+    }
+
+    #[test]
+    fn declared_type_with_alias_deps_records_transitive_names() {
+        let mut registry = AliasRegistry::new();
+        registry.register_test_alias(AliasInfo {
+            name: "A".into(),
+            annotation: TypeAnnotation::Simple(ident("Integer")),
+            is_internal: false,
+            package: None,
+            span: span(),
+        });
+        registry.register_test_alias(AliasInfo {
+            name: "B".into(),
+            annotation: TypeAnnotation::Simple(ident("A")),
+            is_internal: false,
+            package: None,
+            span: span(),
+        });
+
+        let dt = DeclaredType::Simple("B".into());
+        let (resolved, deps) = resolve_declared_type_with_alias_deps(
+            &dt,
+            &empty_subst(),
+            None,
+            Some(&registry),
+            TypeStringContext::Declared,
+        );
+        assert_eq!(resolved, InferredType::known("Integer"));
+        assert_eq!(deps, vec![EcoString::from("A"), EcoString::from("B")]);
+    }
+
+    #[test]
+    fn declared_type_union_in_substitution_context_stamps_substituted_provenance() {
+        // Mirrors `resolve_type_string`'s own `Substitution`-context
+        // re-stamping (BT-3075): a substituted `V | Nil` reads as
+        // `Substituted`, not `Inferred`, so `check_impossible_class_comparison`'s
+        // provenance gate stays silent for it.
+        let dt = DeclaredType::Union(vec![
+            DeclaredType::Simple("Integer".into()),
+            DeclaredType::Simple("String".into()),
+        ]);
+        let result = resolve_declared_type(
+            &dt,
+            &empty_subst(),
+            None,
+            None,
+            TypeStringContext::Substitution,
+        );
+        assert_eq!(
+            result.provenance(),
+            Some(TypeProvenance::Substituted(Span::default()))
+        );
+    }
+
+    #[test]
+    fn declared_type_difference_and_intersection_match_annotation_resolution() {
+        let dt_diff = DeclaredType::Difference {
+            base: Box::new(DeclaredType::Simple("Symbol".into())),
+            excluded: Box::new(DeclaredType::Singleton("foo".into())),
+        };
+        let ann_diff = TypeAnnotation::difference(
+            TypeAnnotation::Simple(ident("Symbol")),
+            TypeAnnotation::Singleton {
+                name: "foo".into(),
+                span: span(),
+            },
+            span(),
+        );
+        assert_eq!(
+            resolve_declared_type(
+                &dt_diff,
+                &empty_subst(),
+                None,
+                None,
+                TypeStringContext::Declared
+            ),
+            resolve_type_annotation(&ann_diff, &empty_subst(), None, None)
+        );
+
+        let dt_inter = DeclaredType::Intersection {
+            left: Box::new(DeclaredType::Simple("Integer".into())),
+            right: Box::new(DeclaredType::Simple("Integer".into())),
+        };
+        let ann_inter = TypeAnnotation::intersection(
+            TypeAnnotation::Simple(ident("Integer")),
+            TypeAnnotation::Simple(ident("Integer")),
+            span(),
+        );
+        assert_eq!(
+            resolve_declared_type(
+                &dt_inter,
+                &empty_subst(),
+                None,
+                None,
+                TypeStringContext::Declared
+            ),
+            resolve_type_annotation(&ann_inter, &empty_subst(), None, None)
+        );
     }
 }


### PR DESCRIPTION
Implements [BT-3076](https://linear.app/beamtalk/issue/BT-3076/store-structured-types-in-methodinfo-parse-type-strings-once-at-the): replace the string-typed method signature fields in the class hierarchy with a span-free structured `DeclaredType`, so exactly one resolver recursion exists and type strings are parsed at a single genuine serialization boundary. Follow-up to BT-3075, which merged the two string resolvers this PR now makes unnecessary.

## Staged landing (in progress)

- [x] **Stage 1** — introduce `DeclaredType`: span-free mirror of all 10 `TypeAnnotation` variants, `Display` byte-identical to `TypeAnnotation::type_name()`, panic-free `parse`, `From<&TypeAnnotation>`, partial `InferredType` conversion. Round-trip + display-parity tests.
- [x] **Stage 2** — re-core the canonical resolver onto `DeclaredType` (`resolve_declared_type` / `_with_alias_deps`); `resolve_type_annotation` becomes a thin conversion wrapper. Alias memo/expanding machinery, `TypeStringContext` provenance rules, and Never/Dynamic keyword handling preserved; all pre-existing tests pass unchanged.
- [ ] **Stage 3** — flip `MethodInfo.return_type`/`param_types`, `ClassInfo.state_types`, `SuperclassTypeArg::Concrete` to `DeclaredType`; builtins generator emits structured constructors; compiler-port parses full `MetaTypeRepr` term shapes (fixes latent loss of generic return types across the REPL boundary); migrate ~20 `resolve_type_string` call sites; delete `TypeChecker::resolve_type_string`.
- [ ] **Stage 4** — cleanup: confine `is_generic_type_param` heuristics, dedupe provenance stamping, stale-comment sweep.

Remaining stages land on this branch shortly; the checklist above will be kept current.

## Why

`MethodInfo` signatures crossing file boundaries as strings is why multiple type resolvers existed and drifted (root cause analysis in BT-3075: BT-1945/BT-2865/BT-2928 each had to be retrofitted into string re-parsers). Storing structure removes the reason string resolvers exist, and makes the AST → string → re-parse lossiness (e.g. `Self class`, generic args over the ETF boundary) structurally impossible.

## Verification

- Behaviour-preserving bar: all pre-existing type-checker, LSP, stdlib, BUnit, and REPL-protocol tests pass **unchanged**; hover/completion/signature-help/`describe` rendering is byte-identical via `DeclaredType`'s `Display`.
- Stages 1–2: 5492 core tests + 231 stdlib tests green, clippy (warnings-as-errors) and fmt clean.
- Full `just ci` gate before the final stage is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFGGuJFsUTKV1VropLbqck

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFGGuJFsUTKV1VropLbqck)_