### PR TITLE
Stdlib default-value rendering: delete format_literal_default in favour of unparse_literal (BT-3088)

### DIFF
--- a/crates/beamtalk-core/src/queries/hover_provider.rs
+++ b/crates/beamtalk-core/src/queries/hover_provider.rs
@@ -791,13 +791,17 @@ fn find_hover_in_expr(
         }
         Expression::Literal(lit, span) => {
             if offset >= span.start() && offset < span.end() {
+                // Render the literal via `unparse_literal_display` — the single
+                // source of truth for literal-to-source rendering (BT-3088) —
+                // so hover text agrees with Beamtalk quoting/escaping rules.
+                let rendered = crate::unparse::unparse_literal_display(lit);
                 let info = match lit {
-                    Literal::Integer(n) => format!("Integer: `{n}`"),
-                    Literal::Float(f) => format!("Float: `{f}`"),
-                    Literal::String(s) => format!("String: `\"{s}\"`"),
-                    Literal::Symbol(s) => format!("Symbol: `#{s}`"),
+                    Literal::Integer(_) => format!("Integer: `{rendered}`"),
+                    Literal::Float(_) => format!("Float: `{rendered}`"),
+                    Literal::String(_) => format!("String: `{rendered}`"),
+                    Literal::Symbol(_) => format!("Symbol: `{rendered}`"),
                     Literal::List(_) => "List literal".to_string(),
-                    Literal::Character(c) => format!("Character: `${c}`"),
+                    Literal::Character(_) => format!("Character: `{rendered}`"),
                 };
                 Some(HoverInfo::new(info, *span))
             } else {

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/class_info.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/class_info.rs
@@ -371,10 +371,7 @@ mod tests {
     fn string_with_embedded_quote_matches_unparse() {
         let lit = Literal::String("say \"hi\"".into());
         let expr = Expression::Literal(lit.clone(), span());
-        assert_eq!(
-            format_default_value(&expr),
-            unparse_literal_display(&lit)
-        );
+        assert_eq!(format_default_value(&expr), unparse_literal_display(&lit));
         assert_eq!(format_default_value(&expr), "\"say \"\"hi\"\"\"");
     }
 
@@ -382,10 +379,7 @@ mod tests {
     fn symbol_with_space_matches_unparse() {
         let lit = Literal::Symbol("with space".into());
         let expr = Expression::Literal(lit.clone(), span());
-        assert_eq!(
-            format_default_value(&expr),
-            unparse_literal_display(&lit)
-        );
+        assert_eq!(format_default_value(&expr), unparse_literal_display(&lit));
         assert_eq!(format_default_value(&expr), "#'with space'");
     }
 
@@ -393,10 +387,7 @@ mod tests {
     fn newline_character_matches_unparse() {
         let lit = Literal::Character('\n');
         let expr = Expression::Literal(lit.clone(), span());
-        assert_eq!(
-            format_default_value(&expr),
-            unparse_literal_display(&lit)
-        );
+        assert_eq!(format_default_value(&expr), unparse_literal_display(&lit));
         assert_eq!(format_default_value(&expr), "$\\n");
     }
 
@@ -404,10 +395,7 @@ mod tests {
     fn integral_float_matches_unparse() {
         let lit = Literal::Float(1.0);
         let expr = Expression::Literal(lit.clone(), span());
-        assert_eq!(
-            format_default_value(&expr),
-            unparse_literal_display(&lit)
-        );
+        assert_eq!(format_default_value(&expr), unparse_literal_display(&lit));
         assert_eq!(format_default_value(&expr), "1.0");
     }
 }

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/class_info.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/class_info.rs
@@ -6,7 +6,7 @@
 //! Contains `MethodInfo`, `SuperclassTypeArg`, and `ClassInfo` — the value objects
 //! that describe classes and methods in the static hierarchy.
 
-use crate::ast::{ClassDefinition, ClassKind, Expression, Literal, MethodKind, TypeAnnotation};
+use crate::ast::{ClassDefinition, ClassKind, Expression, MethodKind, TypeAnnotation};
 use ecow::EcoString;
 use std::collections::HashMap;
 
@@ -328,7 +328,7 @@ impl ClassInfo {
 /// Complex expressions fall back to `"..."`.
 pub fn format_default_value(expr: &Expression) -> String {
     match expr {
-        Expression::Literal(lit, _) => format_literal_default(lit),
+        Expression::Literal(lit, _) => crate::unparse::unparse_literal_display(lit),
         Expression::Identifier(ident) if ident.name == "nil" => "nil".to_string(),
         Expression::Identifier(ident) if ident.name == "true" => "true".to_string(),
         Expression::Identifier(ident) if ident.name == "false" => "false".to_string(),
@@ -351,29 +351,63 @@ pub fn format_default_value(expr: &Expression) -> String {
     }
 }
 
-/// Formats a single literal (recursing into list elements) as Beamtalk source syntax.
-fn format_literal_default(lit: &Literal) -> String {
-    match lit {
-        Literal::Integer(n) => n.to_string(),
-        Literal::Float(f) => {
-            let rendered = f.to_string();
-            // Preserve decimal point so 1.0 stays as "1.0" not "1"
-            if rendered.contains('.') || rendered.contains('e') || rendered.contains('E') {
-                rendered
-            } else {
-                format!("{rendered}.0")
-            }
-        }
-        Literal::String(s) => format!("{s:?}"),
-        Literal::Symbol(s) => format!("#{s}"),
-        Literal::Character(c) => format!("${}", c.escape_default()),
-        Literal::List(items) => {
-            let inner = items
-                .iter()
-                .map(format_literal_default)
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("#({inner})")
-        }
+#[cfg(test)]
+mod tests {
+    use super::format_default_value;
+    use crate::ast::{Expression, Literal};
+    use crate::source_analysis::Span;
+    use crate::unparse::unparse_literal_display;
+
+    fn span() -> Span {
+        Span::new(0, 0)
+    }
+
+    // Parity tests (BT-3088): the stdlib-metadata path (`format_default_value`)
+    // must render literals identically to the unparse path
+    // (`unparse_literal_display`) — they used to disagree because
+    // `format_default_value` had its own hand-rolled, Rust-flavoured escaping.
+
+    #[test]
+    fn string_with_embedded_quote_matches_unparse() {
+        let lit = Literal::String("say \"hi\"".into());
+        let expr = Expression::Literal(lit.clone(), span());
+        assert_eq!(
+            format_default_value(&expr),
+            unparse_literal_display(&lit)
+        );
+        assert_eq!(format_default_value(&expr), "\"say \"\"hi\"\"\"");
+    }
+
+    #[test]
+    fn symbol_with_space_matches_unparse() {
+        let lit = Literal::Symbol("with space".into());
+        let expr = Expression::Literal(lit.clone(), span());
+        assert_eq!(
+            format_default_value(&expr),
+            unparse_literal_display(&lit)
+        );
+        assert_eq!(format_default_value(&expr), "#'with space'");
+    }
+
+    #[test]
+    fn newline_character_matches_unparse() {
+        let lit = Literal::Character('\n');
+        let expr = Expression::Literal(lit.clone(), span());
+        assert_eq!(
+            format_default_value(&expr),
+            unparse_literal_display(&lit)
+        );
+        assert_eq!(format_default_value(&expr), "$\\n");
+    }
+
+    #[test]
+    fn integral_float_matches_unparse() {
+        let lit = Literal::Float(1.0);
+        let expr = Expression::Literal(lit.clone(), span());
+        assert_eq!(
+            format_default_value(&expr),
+            unparse_literal_display(&lit)
+        );
+        assert_eq!(format_default_value(&expr), "1.0");
     }
 }

--- a/crates/beamtalk-core/src/unparse/mod.rs
+++ b/crates/beamtalk-core/src/unparse/mod.rs
@@ -278,6 +278,17 @@ pub fn unparse_type_annotation_display(ty: &TypeAnnotation) -> String {
     unparse_type_annotation(ty).to_pretty_string()
 }
 
+/// Renders a literal AST node as Beamtalk source syntax (e.g. `"a ""quoted"" string"`,
+/// `#'with space'`, `$\n`, `1.0`).
+///
+/// This is the single source of truth for literal-to-source rendering — used by
+/// codegen doc comments, hover info, and generated stdlib metadata alike, so all
+/// three agree on escaping/quoting rules instead of drifting (BT-3088).
+#[must_use]
+pub fn unparse_literal_display(lit: &Literal) -> String {
+    unparse_literal(lit).to_pretty_string()
+}
+
 /// Builds a [`Document`] for a method display signature (no `sealed`, no ` =>`).
 fn unparse_method_display_signature_doc(method: &MethodDefinition) -> Document<'static> {
     let sig = match &method.selector {
@@ -4851,5 +4862,42 @@ mod tests {
             reindent_method_source("  ", "class spawn => self new\n"),
             "  class spawn => self new\n"
         );
+    }
+
+    // --- unparse_literal_display (BT-3088) ---
+    //
+    // These are the single source of truth for literal-to-source rendering;
+    // `format_default_value` (stdlib-metadata path) and hover's literal
+    // rendering both delegate here, so any case fixed here fixes them too.
+
+    #[test]
+    fn unparse_literal_display_string_with_embedded_quote() {
+        // A `"` inside a string literal is doubled per Beamtalk convention,
+        // not backslash-escaped like Rust's `{s:?}` would render it.
+        let lit = Literal::String("say \"hi\"".into());
+        assert_eq!(unparse_literal_display(&lit), "\"say \"\"hi\"\"\"");
+    }
+
+    #[test]
+    fn unparse_literal_display_symbol_with_space_is_quoted() {
+        // A symbol containing a space must be rendered as `#'...'`, never as
+        // an unquoted `#with space` (which isn't valid Beamtalk syntax).
+        let lit = Literal::Symbol("with space".into());
+        assert_eq!(unparse_literal_display(&lit), "#'with space'");
+    }
+
+    #[test]
+    fn unparse_literal_display_newline_character() {
+        // `$\n` uses Beamtalk's own escape rules (via `leaf::char_lit`), not
+        // Rust's `char::escape_default`.
+        let lit = Literal::Character('\n');
+        assert_eq!(unparse_literal_display(&lit), "$\\n");
+    }
+
+    #[test]
+    fn unparse_literal_display_integral_float_keeps_decimal_point() {
+        // `1.0` must round-trip as `1.0`, not collapse to the integer `1`.
+        let lit = Literal::Float(1.0);
+        assert_eq!(unparse_literal_display(&lit), "1.0");
     }
 }


### PR DESCRIPTION
Linear issue: https://linear.app/beamtalk/issue/BT-3088/stdlib-default-value-rendering-format-literal-default-uses-rust

## Summary

Two implementations of "render a literal AST node as Beamtalk source" disagreed:

- `unparse::unparse_literal` — correct Beamtalk rules
- `class_info::format_literal_default` — hand-rolled **Rust** escaping (`{s:?}` for strings, `char::escape_default` for characters, never quoted spaced symbols, a hand-copied float algorithm)

`format_default_value` fed `beamtalk-cli`'s `build-stdlib` command, so any stdlib state default containing quotes, escapes, or a spaced symbol would have been baked into checked-in `generated_builtins.rs` with the wrong (Rust) syntax. A third partial copy lived in `hover_provider.rs`.

## Changes

- Added `unparse::unparse_literal_display` — a public wrapper around the unparser's `unparse_literal`, now the single source of truth for literal-to-source rendering.
- `class_info::format_default_value` now delegates to it; `format_literal_default` deleted entirely.
- `hover_provider.rs`'s literal hover text now delegates to the same function instead of its own partial re-implementation.
- Added parity unit tests covering the four previously-divergent cases: a string containing `"`, a symbol with a space, the `$\n` character, and an integral float (`1.0`).
- Regenerated `generated_builtins.rs` via `beamtalk build-stdlib` — byte-identical to the checked-in version, confirming no stdlib default is currently affected (the fix is forward-looking correctness, not a behavior change today).

## Testing

- `cargo test -p beamtalk-core --lib unparse::` — 216 passed
- `cargo test -p beamtalk-core --lib hover_provider::` — 61 passed
- `cargo test -p beamtalk-core --lib class_hierarchy::` — 169 passed
- `just test` — full suite passed
- Pre-push hook (build, clippy, fmt, lint-erlang, dialyzer) passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL7GE5XvKMame4UzYFb1dJ)_