### PR TITLE
One raw-error formatting table in workspace; canonical does-not-understand message (BT-3084)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_error.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_error.erl
@@ -294,8 +294,17 @@ Example:
 is_does_not_understand(#beamtalk_error{kind = does_not_understand}) -> true;
 is_does_not_understand(#beamtalk_error{}) -> false.
 
--doc "Generate a human-readable error message from kind, class, and optional selector.".
--spec generate_message(atom(), atom(), atom() | undefined) -> binary().
+-doc """
+Generate a human-readable error message from kind, class, and optional selector.
+
+Selector is normally an atom, but callers that only have an unregistered
+method name as a binary (e.g. `binary_to_existing_atom/2` failed, so there is
+no atom to attach to the record's `selector` field) may pass a binary
+instead — both format identically via `~s`. BT-3084: this keeps the
+canonical `does_not_understand` wording (quoted selector) reachable from
+call sites that can't safely mint a new atom.
+""".
+-spec generate_message(atom(), atom(), atom() | binary() | undefined) -> binary().
 generate_message(does_not_understand, Class, undefined) ->
     iolist_to_binary(io_lib:format("~s does not understand message", [Class]));
 generate_message(does_not_understand, Class, Selector) ->

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
@@ -55,8 +55,12 @@ dictionary or ETS state is required.
 ]).
 
 -ifdef(TEST).
-%% Expose internal helpers for EUnit testing (BT-2219, BT-2467).
--export([log_compiler_diagnostics/2, class_object_for_pid/2]).
+%% Expose internal helpers for EUnit testing (BT-2219, BT-2467, BT-3084).
+-export([
+    log_compiler_diagnostics/2,
+    class_object_for_pid/2,
+    make_method_not_found_error/2
+]).
 -endif.
 
 %%% ============================================================================
@@ -1277,14 +1281,12 @@ make_class_not_found_error(ClassName) ->
 -spec make_method_not_found_error(atom(), atom()) -> #beamtalk_error{}.
 make_method_not_found_error(ClassName, Selector) ->
     NameBin = atom_to_binary(ClassName, utf8),
-    SelBin = atom_to_binary(Selector, utf8),
+    %% BT-3084: don't hand-roll (and unquote) the DNU message — with_selector/2
+    %% already regenerates it via the canonical beamtalk_error:generate_message/3,
+    %% which quotes the selector (e.g. "Counter does not understand 'increment'").
     Err0 = beamtalk_error:new(does_not_understand, ClassName),
     Err1 = beamtalk_error:with_selector(Err0, Selector),
-    Err2 = beamtalk_error:with_message(
-        Err1,
-        iolist_to_binary([NameBin, <<" does not understand ">>, SelBin])
-    ),
     beamtalk_error:with_hint(
-        Err2,
+        Err1,
         iolist_to_binary([<<"Use Beamtalk help: ">>, NameBin, <<" to see available methods.">>])
     ).

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_interface_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_interface_tests.erl
@@ -554,3 +554,16 @@ live_registry_test_() ->
             end}
         ]
     end}.
+
+%%% ============================================================================
+%%% BT-3084: make_method_not_found_error/2 renders the canonical (quoted) DNU
+%%% message instead of hand-rolling its own unquoted copy.
+%%% ============================================================================
+
+make_method_not_found_error_quotes_selector_test() ->
+    Error = beamtalk_interface:make_method_not_found_error('Counter', increment),
+    ?assertEqual(<<"Counter does not understand 'increment'">>, Error#beamtalk_error.message),
+    ?assertEqual(increment, Error#beamtalk_error.selector),
+    ?assertEqual(
+        <<"Use Beamtalk help: Counter to see available methods.">>, Error#beamtalk_error.hint
+    ).

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_errors.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_errors.erl
@@ -27,8 +27,9 @@ Used by protocol handlers and op modules.
 %% elsewhere in the codebase (e.g. a hypothetical unrelated 2-arity
 %% `{method_not_found, Reason}`) must NOT be misidentified as "known" just
 %% because the atom matches — that would silently route it through
-%% is_known_error_reason into a dead end (no clause for that arity) instead
-%% of the intended generic wrapper.
+%% is_known_error_reason into ensure_structured_error/1's generic catch-all
+%% clause (a degraded `~p` dump), dropping the eval_error `Class:` context,
+%% instead of the intended generic "Evaluation error: Class:Reason" wrapper.
 -define(KNOWN_ERROR_TUPLE_TAGS, [
     {compile_error, 2},
     {undefined_variable, 2},

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_errors.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_errors.erl
@@ -15,6 +15,35 @@ Used by protocol handlers and op modules.
 
 -include_lib("beamtalk_runtime/include/beamtalk.hrl").
 
+%% BT-3084: raw-error-tuple tags recognized by ensure_structured_error/1
+%% (excluding the map/#beamtalk_error{}/eval_error wrapper shapes handled by
+%% earlier, more specific clauses). Shared by is_known_error_reason/1 so a
+%% `{eval_error, Class, Reason}` whose Reason is itself one of these keeps its
+%% specific structured kind instead of collapsing into the generic
+%% "Evaluation error: Class:Reason" wrapper.
+-define(KNOWN_ERROR_TUPLE_TAGS, [
+    compile_error,
+    undefined_variable,
+    file_not_found,
+    read_error,
+    load_error,
+    registration_error,
+    parse_error,
+    invalid_request,
+    module_not_found,
+    invalid_module_name,
+    actors_exist,
+    class_not_found,
+    method_not_found,
+    unknown_op,
+    inspect_failed,
+    actor_not_alive,
+    no_source_file,
+    module_not_loaded,
+    missing_module_name,
+    session_creation_failed
+]).
+
 -export([
     make/3,
     make/4,
@@ -64,8 +93,13 @@ safe_to_existing_atom(_) ->
 -doc """
 Ensure an error reason is a structured #beamtalk_error{} record.
 If already structured (or a wrapped exception), passes through unchanged.
-Handles known bare tuple error patterns from the compile pipeline.
-Otherwise wraps the raw term in an internal_error.
+
+BT-3084: this is the single canonical dispatch table for the REPL's raw
+error-tuple vocabulary — compile/eval failures, undefined variables, file and
+module I/O, class/method lookups, actor ops, and session/request errors.
+`beamtalk_repl_json:format_error_message/1` derives from this table rather
+than maintaining a second one, so a tuple handled here is guaranteed to also
+render correctly there. Otherwise wraps the raw term in an internal_error.
 """.
 -spec ensure_structured_error(term()) -> #beamtalk_error{}.
 ensure_structured_error(#beamtalk_error{} = Err) ->
@@ -78,9 +112,31 @@ ensure_structured_error(
     Err;
 ensure_structured_error({eval_error, _Class, #beamtalk_error{} = Err}) ->
     Err;
-ensure_structured_error({eval_error, _Class, Reason}) ->
-    %% Delegate to /1 for known tuple patterns; fall back to generic wrapper.
-    ensure_structured_error(Reason);
+ensure_structured_error({eval_error, Class, Reason}) ->
+    case is_known_error_reason(Reason) of
+        true ->
+            %% Reason is itself one of the recognized raw-error-tuple shapes
+            %% (or empty_expression/timeout) — delegate so it keeps its
+            %% specific structured kind/message instead of flattening into
+            %% the generic wrapper below.
+            ensure_structured_error(Reason);
+        false ->
+            %% BT-3084: opaque/unrecognized Reason — preserve the exception
+            %% class in the message. Previously this clause dropped `Class`
+            %% entirely, which diverged from beamtalk_repl_json's separate
+            %% "Evaluation error: Class:Reason" wording for the same shape;
+            %% unify on that wording here so both callers agree.
+            make(
+                internal_error,
+                'REPL',
+                iolist_to_binary([
+                    <<"Evaluation error: ">>,
+                    atom_to_binary(Class, utf8),
+                    <<":">>,
+                    format_name(Reason)
+                ])
+            )
+    end;
 ensure_structured_error({compile_error, [#{message := Msg} = Diag | _]}) ->
     %% BT-1235: structured diagnostic list — extract message and hint from first diagnostic
     % elp:fixme W0032 maps:find with complex branch logic
@@ -134,6 +190,123 @@ ensure_structured_error({parse_error, Details}) ->
     make(compile_error, 'Compiler', iolist_to_binary([<<"Parse error: ">>, format_name(Details)]));
 ensure_structured_error({invalid_request, Reason}) ->
     make(internal_error, 'REPL', iolist_to_binary([<<"Invalid request: ">>, format_name(Reason)]));
+%% BT-3084: the remaining clauses below were previously only handled by
+%% beamtalk_repl_json:format_error_message/1's separate dispatch table —
+%% absent here, they fell through to the generic `~p` wrapper just below
+%% (silently dropping the vocabulary, e.g. `{registration_error, ...}` was
+%% the reverse case: handled here but absent from the JSON table). Folding
+%% them into this one canonical table closes both gaps.
+ensure_structured_error({module_not_found, ModuleName}) ->
+    make(
+        module_not_found,
+        'Module',
+        iolist_to_binary([<<"Module not loaded: ">>, format_name(ModuleName)])
+    );
+ensure_structured_error({invalid_module_name, ModuleName}) ->
+    make(
+        invalid_module_name,
+        'Module',
+        iolist_to_binary([<<"Invalid module name: ">>, format_name(ModuleName)])
+    );
+ensure_structured_error({actors_exist, ModuleName, Count}) ->
+    ActorWord =
+        case Count of
+            1 -> <<"actor">>;
+            _ -> <<"actors">>
+        end,
+    make(
+        actors_exist,
+        'Module',
+        iolist_to_binary([
+            <<"Cannot unload ">>,
+            format_name(ModuleName),
+            <<": ">>,
+            integer_to_binary(Count),
+            <<" ">>,
+            ActorWord,
+            <<" still running. Kill them first with :kill">>
+        ])
+    );
+ensure_structured_error({class_not_found, ClassName}) ->
+    make(
+        class_not_found,
+        'REPL',
+        iolist_to_binary([
+            <<"Unknown class: ">>,
+            format_name(ClassName),
+            <<". Use Workspace classes to see loaded classes.">>
+        ])
+    );
+ensure_structured_error({method_not_found, ClassName, Selector}) ->
+    %% BT-3084: canonical DNU message — call beamtalk_error:generate_message/3
+    %% (via with_selector/2 when Selector is an atom) instead of hand-rolling
+    %% the "does not understand" text a third time.
+    Err0 = beamtalk_error:new(does_not_understand, ClassName),
+    Err1 =
+        case Selector of
+            S when is_atom(S) ->
+                beamtalk_error:with_selector(Err0, S);
+            _ ->
+                %% Selector arrived as a binary (e.g. no existing atom for it,
+                %% so the caller couldn't safely mint one) — still render via
+                %% generate_message/3 rather than reimplementing the quoting.
+                beamtalk_error:with_message(
+                    Err0,
+                    beamtalk_error:generate_message(does_not_understand, ClassName, Selector)
+                )
+        end,
+    beamtalk_error:with_hint(
+        Err1,
+        iolist_to_binary([
+            <<"Use :help ">>, format_name(ClassName), <<" to see available methods.">>
+        ])
+    );
+ensure_structured_error({unknown_op, Op}) ->
+    make(unknown_op, 'REPL', iolist_to_binary([<<"Unknown operation: ">>, format_name(Op)]));
+ensure_structured_error({inspect_failed, PidStr}) ->
+    make(
+        inspect_failed,
+        'Actor',
+        iolist_to_binary([<<"Failed to inspect actor: ">>, format_name(PidStr)])
+    );
+ensure_structured_error({actor_not_alive, PidStr}) ->
+    make(
+        actor_not_alive,
+        'Actor',
+        iolist_to_binary([<<"Actor is not alive: ">>, format_name(PidStr)])
+    );
+ensure_structured_error({no_source_file, Module}) ->
+    make(
+        no_source_file,
+        'Module',
+        iolist_to_binary([
+            <<"No source file recorded for module: ">>,
+            format_name(Module),
+            <<". Try :load <path> to load it first.">>
+        ])
+    );
+ensure_structured_error({module_not_loaded, Module}) ->
+    make(
+        module_not_loaded,
+        'Module',
+        iolist_to_binary([
+            <<"Module not loaded: ">>,
+            format_name(Module),
+            <<". Use :load <path> to load it first.">>
+        ])
+    );
+ensure_structured_error({missing_module_name, reload}) ->
+    make(
+        missing_module_name,
+        'REPL',
+        <<"Usage: :reload <ModuleName> or :reload (to reload last file)">>
+    );
+ensure_structured_error({session_creation_failed, Reason}) ->
+    make(
+        session_creation_failed,
+        'REPL',
+        iolist_to_binary([<<"Failed to create session: ">>, format_name(Reason)])
+    );
 ensure_structured_error(empty_expression) ->
     make(empty_expression, 'REPL', <<"Empty expression">>);
 ensure_structured_error(timeout) ->
@@ -169,6 +342,30 @@ ensure_structured_error({invalid_request, _} = Reason, _Class) ->
     ensure_structured_error(Reason);
 ensure_structured_error({registration_error, _} = Reason, _Class) ->
     ensure_structured_error(Reason);
+ensure_structured_error({module_not_found, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({invalid_module_name, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({actors_exist, _, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({class_not_found, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({method_not_found, _, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({unknown_op, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({inspect_failed, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({actor_not_alive, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({no_source_file, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({module_not_loaded, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({missing_module_name, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
+ensure_structured_error({session_creation_failed, _} = Reason, _Class) ->
+    ensure_structured_error(Reason);
 ensure_structured_error(Reason, Class) ->
     make(
         internal_error,
@@ -179,6 +376,23 @@ ensure_structured_error(Reason, Class) ->
             io_lib:format("~p", [Reason])
         ])
     ).
+
+-doc """
+Is this term one of the raw-error-tuple shapes ensure_structured_error/1
+recognizes (or the bare `empty_expression`/`timeout` atoms)? Used to decide
+whether a `{eval_error, Class, Reason}`'s Reason should delegate to /1
+(keeping its specific kind) or fall back to the generic
+"Evaluation error: Class:Reason" wrapper.
+""".
+-spec is_known_error_reason(term()) -> boolean().
+is_known_error_reason(empty_expression) ->
+    true;
+is_known_error_reason(timeout) ->
+    true;
+is_known_error_reason(Reason) when is_tuple(Reason), tuple_size(Reason) > 0 ->
+    lists:member(element(1, Reason), ?KNOWN_ERROR_TUPLE_TAGS);
+is_known_error_reason(_) ->
+    false.
 
 -doc "Format a name for error messages.".
 -spec format_name(term()) -> binary().

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_errors.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_errors.erl
@@ -15,33 +15,41 @@ Used by protocol handlers and op modules.
 
 -include_lib("beamtalk_runtime/include/beamtalk.hrl").
 
-%% BT-3084: raw-error-tuple tags recognized by ensure_structured_error/1
-%% (excluding the map/#beamtalk_error{}/eval_error wrapper shapes handled by
-%% earlier, more specific clauses). Shared by is_known_error_reason/1 so a
-%% `{eval_error, Class, Reason}` whose Reason is itself one of these keeps its
-%% specific structured kind instead of collapsing into the generic
-%% "Evaluation error: Class:Reason" wrapper.
+%% BT-3084: {Tag, Arity} pairs recognized by ensure_structured_error/1's
+%% specific clauses (excluding the map/#beamtalk_error{}/eval_error wrapper
+%% shapes handled by earlier, more specific clauses). Shared by
+%% is_known_error_reason/1 so a `{eval_error, Class, Reason}` whose Reason is
+%% itself one of these keeps its specific structured kind instead of
+%% collapsing into the generic "Evaluation error: Class:Reason" wrapper.
+%%
+%% Matched as {Tag, Arity} rather than bare Tag: every tag here happens to map
+%% to exactly one arity today, but a same-named tag at a different arity
+%% elsewhere in the codebase (e.g. a hypothetical unrelated 2-arity
+%% `{method_not_found, Reason}`) must NOT be misidentified as "known" just
+%% because the atom matches — that would silently route it through
+%% is_known_error_reason into a dead end (no clause for that arity) instead
+%% of the intended generic wrapper.
 -define(KNOWN_ERROR_TUPLE_TAGS, [
-    compile_error,
-    undefined_variable,
-    file_not_found,
-    read_error,
-    load_error,
-    registration_error,
-    parse_error,
-    invalid_request,
-    module_not_found,
-    invalid_module_name,
-    actors_exist,
-    class_not_found,
-    method_not_found,
-    unknown_op,
-    inspect_failed,
-    actor_not_alive,
-    no_source_file,
-    module_not_loaded,
-    missing_module_name,
-    session_creation_failed
+    {compile_error, 2},
+    {undefined_variable, 2},
+    {file_not_found, 2},
+    {read_error, 2},
+    {load_error, 2},
+    {registration_error, 2},
+    {parse_error, 2},
+    {invalid_request, 2},
+    {module_not_found, 2},
+    {invalid_module_name, 2},
+    {actors_exist, 3},
+    {class_not_found, 2},
+    {method_not_found, 3},
+    {unknown_op, 2},
+    {inspect_failed, 2},
+    {actor_not_alive, 2},
+    {no_source_file, 2},
+    {module_not_loaded, 2},
+    {missing_module_name, 2},
+    {session_creation_failed, 2}
 ]).
 
 -export([
@@ -390,7 +398,7 @@ is_known_error_reason(empty_expression) ->
 is_known_error_reason(timeout) ->
     true;
 is_known_error_reason(Reason) when is_tuple(Reason), tuple_size(Reason) > 0 ->
-    lists:member(element(1, Reason), ?KNOWN_ERROR_TUPLE_TAGS);
+    lists:member({element(1, Reason), tuple_size(Reason)}, ?KNOWN_ERROR_TUPLE_TAGS);
 is_known_error_reason(_) ->
     false.
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_json.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_json.erl
@@ -445,117 +445,32 @@ is_local_process_alive(Pid) ->
 
 %%% Error Formatting
 
--doc "Format an error reason as a human-readable message.".
+-doc """
+Format an error reason as a human-readable message.
+
+BT-3084: this is a thin wrapper over `beamtalk_repl_errors:ensure_structured_error/1`
+— the single canonical raw-error-tuple dispatch table — plus `beamtalk_error:format/1`.
+Previously this function carried its own duplicate dispatch table that had drifted
+from `ensure_structured_error/1` (some tuples handled only here, some only there,
+each silently falling through to a raw `~p` dump on the other path). The only
+cases still handled directly below are the two exception-map shapes that need a
+"ClassName: " prefix prepended in front of the formatted message — a JSON-REPL
+display concern `ensure_structured_error/1` deliberately doesn't apply, since
+its callers want the bare `#beamtalk_error{}` for programmatic use.
+""".
 -spec format_error_message(term()) -> binary().
 format_error_message(#{'$beamtalk_class' := Class, error := Error}) ->
     Enriched = maybe_use_singleton_binding_name(Error),
     ClassName = atom_to_binary(Class, utf8),
     iolist_to_binary([ClassName, <<": ">>, beamtalk_error:format(Enriched)]);
-format_error_message(#beamtalk_error{} = Error) ->
-    Enriched = maybe_use_singleton_binding_name(Error),
-    iolist_to_binary(beamtalk_error:format(Enriched));
-format_error_message(empty_expression) ->
-    <<"Empty expression">>;
-format_error_message(timeout) ->
-    <<"Request timed out">>;
-format_error_message({compile_error, [#{message := Msg} | _]}) ->
-    %% BT-1235: structured diagnostic list — use the first diagnostic's message
-    Msg;
-format_error_message({compile_error, Msg}) when is_binary(Msg) ->
-    Msg;
-format_error_message({compile_error, Msg}) when is_list(Msg) ->
-    try
-        list_to_binary(Msg)
-    catch
-        error:badarg -> iolist_to_binary(io_lib:format("~p", [Msg]))
-    end;
-format_error_message({undefined_variable, Name}) ->
-    iolist_to_binary([<<"Undefined variable: ">>, beamtalk_repl_errors:format_name(Name)]);
-format_error_message({invalid_request, Reason}) ->
-    iolist_to_binary([<<"Invalid request: ">>, beamtalk_repl_errors:format_name(Reason)]);
-format_error_message({parse_error, Details}) ->
-    iolist_to_binary([<<"Parse error: ">>, beamtalk_repl_errors:format_name(Details)]);
 format_error_message({eval_error, _Class, #{'$beamtalk_class' := ExClass, error := Error}}) ->
     Enriched = maybe_use_singleton_binding_name(Error),
     ClassName = atom_to_binary(ExClass, utf8),
     iolist_to_binary([ClassName, <<": ">>, beamtalk_error:format(Enriched)]);
-format_error_message({eval_error, _Class, #beamtalk_error{} = Error}) ->
-    Enriched = maybe_use_singleton_binding_name(Error),
-    iolist_to_binary(beamtalk_error:format(Enriched));
-format_error_message({eval_error, Class, Reason}) ->
-    iolist_to_binary([
-        <<"Evaluation error: ">>,
-        atom_to_binary(Class, utf8),
-        <<":">>,
-        beamtalk_repl_errors:format_name(Reason)
-    ]);
-format_error_message({load_error, Reason}) ->
-    iolist_to_binary([<<"Failed to load bytecode: ">>, beamtalk_repl_errors:format_name(Reason)]);
-format_error_message({file_not_found, Path}) ->
-    iolist_to_binary([<<"File not found: ">>, beamtalk_repl_errors:format_name(Path)]);
-format_error_message({read_error, Reason}) ->
-    iolist_to_binary([<<"Failed to read file: ">>, beamtalk_repl_errors:format_name(Reason)]);
-format_error_message({module_not_found, ModuleName}) ->
-    iolist_to_binary([<<"Module not loaded: ">>, ModuleName]);
-format_error_message({invalid_module_name, ModuleName}) ->
-    iolist_to_binary([<<"Invalid module name: ">>, ModuleName]);
-format_error_message({actors_exist, ModuleName, Count}) ->
-    CountStr = integer_to_list(Count),
-    ActorWord =
-        if
-            Count == 1 -> <<"actor">>;
-            true -> <<"actors">>
-        end,
-    iolist_to_binary([
-        <<"Cannot unload ">>,
-        atom_to_binary(ModuleName, utf8),
-        <<": ">>,
-        CountStr,
-        <<" ">>,
-        ActorWord,
-        <<" still running. Kill them first with :kill">>
-    ]);
-format_error_message({class_not_found, ClassName}) ->
-    NameBin = to_binary(ClassName),
-    iolist_to_binary([
-        <<"Unknown class: ">>,
-        NameBin,
-        <<". Use Workspace classes to see loaded classes.">>
-    ]);
-format_error_message({method_not_found, ClassName, Selector}) ->
-    NameBin = to_binary(ClassName),
-    iolist_to_binary([
-        NameBin,
-        <<" does not understand ">>,
-        Selector,
-        <<". Use :help ">>,
-        NameBin,
-        <<" to see available methods.">>
-    ]);
-format_error_message({unknown_op, Op}) ->
-    iolist_to_binary([<<"Unknown operation: ">>, Op]);
-format_error_message({inspect_failed, PidStr}) ->
-    iolist_to_binary([<<"Failed to inspect actor: ">>, list_to_binary(PidStr)]);
-format_error_message({actor_not_alive, PidStr}) ->
-    iolist_to_binary([<<"Actor is not alive: ">>, list_to_binary(PidStr)]);
-format_error_message({no_source_file, Module}) ->
-    iolist_to_binary([
-        <<"No source file recorded for module: ">>,
-        list_to_binary(Module),
-        <<". Try :load <path> to load it first.">>
-    ]);
-format_error_message({module_not_loaded, Module}) ->
-    iolist_to_binary([
-        <<"Module not loaded: ">>,
-        beamtalk_repl_errors:format_name(Module),
-        <<". Use :load <path> to load it first.">>
-    ]);
-format_error_message({missing_module_name, reload}) ->
-    <<"Usage: :reload <ModuleName> or :reload (to reload last file)">>;
-format_error_message({session_creation_failed, Reason}) ->
-    iolist_to_binary([<<"Failed to create session: ">>, beamtalk_repl_errors:format_name(Reason)]);
 format_error_message(Reason) ->
-    iolist_to_binary(io_lib:format("~p", [Reason])).
+    Error = beamtalk_repl_errors:ensure_structured_error(Reason),
+    Enriched = maybe_use_singleton_binding_name(Error),
+    beamtalk_error:format(Enriched).
 
 %%% Internal Helpers
 
@@ -577,11 +492,6 @@ format_rejection_reason(#beamtalk_error{} = Error) ->
     beamtalk_error:format(Error);
 format_rejection_reason(Reason) ->
     iolist_to_binary(io_lib:format("~p", [Reason])).
-
--doc "Convert atom or binary to binary.".
--spec to_binary(atom() | binary()) -> binary().
-to_binary(V) when is_atom(V) -> atom_to_binary(V, utf8);
-to_binary(V) when is_binary(V) -> V.
 
 -doc """
 Rewrite DNU error class names for singleton instances.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_errors_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_errors_tests.erl
@@ -102,6 +102,24 @@ ensure_structured_error_eval_error_unknown_reason_test() ->
     Result = beamtalk_repl_errors:ensure_structured_error({eval_error, error, some_weird_reason}),
     ?assertMatch(#beamtalk_error{kind = internal_error}, Result).
 
+ensure_structured_error_eval_error_same_tag_different_arity_test() ->
+    %% BT-3084: is_known_error_reason/1 matches {Tag, Arity} pairs, not bare
+    %% Tag. beamtalk_behaviour_intrinsics.erl:706 constructs a 4-arity
+    %% {class_not_found, _, Path, Defined}, distinct from the REPL's own
+    %% 2-arity {class_not_found, ClassName} clause in ensure_structured_error/1.
+    %% A 4-arity reason must NOT be misidentified as "known" and delegated
+    %% (there is no ensure_structured_error/1 clause for that arity) — it
+    %% should fall through to the generic "Evaluation error: Class:Reason"
+    %% wrapper, preserving the eval_error Class context.
+    Result = beamtalk_repl_errors:ensure_structured_error(
+        {eval_error, error, {class_not_found, some_mod, "path", true}}
+    ),
+    ?assertMatch(#beamtalk_error{kind = internal_error}, Result),
+    ?assertMatch(
+        <<"Evaluation error: error:", _/binary>>,
+        Result#beamtalk_error.message
+    ).
+
 %%% ============================================================================
 %%% ensure_structured_error/1 — compile_error variants
 %%% ============================================================================

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_errors_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_errors_tests.erl
@@ -314,3 +314,145 @@ ensure_structured_error_2_fallback_different_classes_test() ->
     ResultExit = beamtalk_repl_errors:ensure_structured_error(unknown_reason, exit),
     ?assert(binary:match(ResultErr#beamtalk_error.message, <<"error">>) =/= nomatch),
     ?assert(binary:match(ResultExit#beamtalk_error.message, <<"exit">>) =/= nomatch).
+
+%%% ============================================================================
+%%% BT-3084: vocabulary previously only handled by
+%%% beamtalk_repl_json:format_error_message/1's separate dispatch table.
+%%% Folded into ensure_structured_error/1 so there is one canonical table.
+%%% ============================================================================
+
+ensure_structured_error_module_not_found_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error({module_not_found, <<"counter">>}),
+    ?assertMatch(#beamtalk_error{kind = module_not_found}, Result),
+    ?assertEqual(<<"Module not loaded: counter">>, Result#beamtalk_error.message).
+
+ensure_structured_error_invalid_module_name_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error({invalid_module_name, <<"123bad">>}),
+    ?assertMatch(#beamtalk_error{kind = invalid_module_name}, Result),
+    ?assertEqual(<<"Invalid module name: 123bad">>, Result#beamtalk_error.message).
+
+ensure_structured_error_actors_exist_singular_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error({actors_exist, counter, 1}),
+    ?assertMatch(#beamtalk_error{kind = actors_exist}, Result),
+    ?assertNotEqual(
+        nomatch, binary:match(Result#beamtalk_error.message, <<"1 actor still running">>)
+    ).
+
+ensure_structured_error_actors_exist_plural_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error({actors_exist, counter, 3}),
+    ?assertNotEqual(
+        nomatch, binary:match(Result#beamtalk_error.message, <<"3 actors still running">>)
+    ),
+    ?assertNotEqual(nomatch, binary:match(Result#beamtalk_error.message, <<":kill">>)).
+
+ensure_structured_error_class_not_found_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error({class_not_found, 'Foo'}),
+    ?assertMatch(#beamtalk_error{kind = class_not_found}, Result),
+    ?assertEqual(
+        <<"Unknown class: Foo. Use Workspace classes to see loaded classes.">>,
+        Result#beamtalk_error.message
+    ).
+
+%% BT-3084 acceptance criteria: DNU rendered only by
+%% beamtalk_error:generate_message/3 — the selector is quoted, and the
+%% record's `selector` field is populated when the selector is an atom.
+ensure_structured_error_method_not_found_atom_selector_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error(
+        {method_not_found, 'Counter', increment}
+    ),
+    ?assertMatch(#beamtalk_error{kind = does_not_understand}, Result),
+    ?assertEqual(<<"Counter does not understand 'increment'">>, Result#beamtalk_error.message),
+    ?assertEqual(increment, Result#beamtalk_error.selector).
+
+%% Selector arriving as a binary (no existing atom to attach to the record)
+%% still renders the canonical quoted wording via generate_message/3.
+ensure_structured_error_method_not_found_binary_selector_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error(
+        {method_not_found, 'Counter', <<"increment">>}
+    ),
+    ?assertMatch(#beamtalk_error{kind = does_not_understand}, Result),
+    ?assertEqual(<<"Counter does not understand 'increment'">>, Result#beamtalk_error.message).
+
+ensure_structured_error_unknown_op_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error({unknown_op, <<"badop">>}),
+    ?assertMatch(#beamtalk_error{kind = unknown_op}, Result),
+    ?assertEqual(<<"Unknown operation: badop">>, Result#beamtalk_error.message).
+
+ensure_structured_error_inspect_failed_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error({inspect_failed, "<0.100.0>"}),
+    ?assertMatch(#beamtalk_error{kind = inspect_failed}, Result),
+    ?assertEqual(<<"Failed to inspect actor: <0.100.0>">>, Result#beamtalk_error.message).
+
+ensure_structured_error_actor_not_alive_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error({actor_not_alive, "<0.100.0>"}),
+    ?assertMatch(#beamtalk_error{kind = actor_not_alive}, Result),
+    ?assertEqual(<<"Actor is not alive: <0.100.0>">>, Result#beamtalk_error.message).
+
+ensure_structured_error_no_source_file_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error({no_source_file, "counter"}),
+    ?assertMatch(#beamtalk_error{kind = no_source_file}, Result),
+    ?assertNotEqual(
+        nomatch,
+        binary:match(Result#beamtalk_error.message, <<"No source file recorded for module">>)
+    ).
+
+ensure_structured_error_module_not_loaded_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error({module_not_loaded, <<"counter">>}),
+    ?assertMatch(#beamtalk_error{kind = module_not_loaded}, Result),
+    ?assertNotEqual(
+        nomatch, binary:match(Result#beamtalk_error.message, <<"Module not loaded: counter">>)
+    ).
+
+ensure_structured_error_missing_module_name_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error({missing_module_name, reload}),
+    ?assertMatch(#beamtalk_error{kind = missing_module_name}, Result),
+    ?assertNotEqual(nomatch, binary:match(Result#beamtalk_error.message, <<":reload">>)).
+
+ensure_structured_error_session_creation_failed_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error({session_creation_failed, timeout}),
+    ?assertMatch(#beamtalk_error{kind = session_creation_failed}, Result),
+    ?assertEqual(<<"Failed to create session: timeout">>, Result#beamtalk_error.message).
+
+%% BT-3084 acceptance criteria: no raw-`~p` fallthrough for known tuples —
+%% {registration_error, ...} was already structured here, but was previously
+%% absent from beamtalk_repl_json's separate table (fixed by unifying on
+%% this one). Assert the message never degrades to a bare tuple dump.
+ensure_structured_error_registration_error_no_raw_fallthrough_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error(
+        {registration_error, {'Counter', already_registered}}
+    ),
+    ?assertMatch(#beamtalk_error{kind = registration_error}, Result),
+    ?assertEqual(nomatch, binary:match(Result#beamtalk_error.message, <<"{registration_error">>)).
+
+%% BT-3084: previously this clause silently dropped the exception Class,
+%% diverging from beamtalk_repl_json's separate "Evaluation error: Class:Reason"
+%% wording for the same shape. Assert Class now survives.
+ensure_structured_error_eval_error_generic_preserves_class_test() ->
+    Result = beamtalk_repl_errors:ensure_structured_error({eval_error, error, badarg}),
+    ?assertMatch(#beamtalk_error{kind = internal_error}, Result),
+    ?assertEqual(<<"Evaluation error: error:badarg">>, Result#beamtalk_error.message).
+
+%%% ============================================================================
+%%% ensure_structured_error/2 — delegation for the BT-3084 vocabulary above
+%%% ============================================================================
+
+ensure_structured_error_2_delegates_module_not_found_test() ->
+    Reason = {module_not_found, <<"counter">>},
+    ?assertEqual(
+        beamtalk_repl_errors:ensure_structured_error(Reason),
+        beamtalk_repl_errors:ensure_structured_error(Reason, error)
+    ).
+
+ensure_structured_error_2_delegates_method_not_found_test() ->
+    Reason = {method_not_found, 'Counter', increment},
+    ?assertEqual(
+        beamtalk_repl_errors:ensure_structured_error(Reason),
+        beamtalk_repl_errors:ensure_structured_error(Reason, error)
+    ).
+
+ensure_structured_error_2_delegates_actors_exist_test() ->
+    Reason = {actors_exist, counter, 1},
+    ?assertEqual(
+        beamtalk_repl_errors:ensure_structured_error(Reason),
+        beamtalk_repl_errors:ensure_structured_error(Reason, error)
+    ).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_json_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_json_tests.erl
@@ -922,6 +922,66 @@ format_error_message_fallback_test() ->
     ?assert(is_binary(Msg)),
     ?assert(byte_size(Msg) > 0).
 
+%%% ============================================================================
+%%% BT-3084 regression tests: format_error_message/1 derives from
+%%% beamtalk_repl_errors:ensure_structured_error/1 (one canonical table)
+%%% ============================================================================
+
+%% Previously {registration_error, ...} was handled by ensure_structured_error/1
+%% but absent from format_error_message/1's separate table, so it fell through
+%% to a raw `~p` dump instead of the structured message.
+format_error_message_registration_error_tuple_test() ->
+    Msg = beamtalk_repl_json:format_error_message(
+        {registration_error, {'Counter', already_registered}}
+    ),
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"Class registration failed for Counter">>)),
+    %% A raw `~p` fallthrough would render as a bare `{registration_error, {...}}`
+    %% tuple — assert the structured prose replaced it, not just co-exists with it.
+    ?assertEqual(nomatch, binary:match(Msg, <<"{registration_error">>)).
+
+format_error_message_registration_error_reason_only_test() ->
+    Msg = beamtalk_repl_json:format_error_message({registration_error, bad_module}),
+    ?assertEqual(<<"Class registration failed: bad_module">>, Msg).
+
+%% The structured (ensure_structured_error/1) path always extracted a `hint`
+%% from a compile_error diagnostic map; format_error_message/1 used to drop it
+%% via its own separate clause. Assert the hint now survives end-to-end.
+format_error_message_compile_error_hint_propagation_test() ->
+    Msg = beamtalk_repl_json:format_error_message(
+        {compile_error, [
+            #{
+                message => <<"Unused variable `x`">>,
+                line => 3,
+                hint => <<"Prefix with _ to ignore">>
+            }
+        ]}
+    ),
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"Unused variable `x`">>)),
+    ?assertNotEqual(nomatch, binary:match(Msg, <<"Hint: Prefix with _ to ignore">>)).
+
+%% DNU rendered by beamtalk_error:generate_message/3 only — the selector is
+%% quoted, matching the canonical wording (previously this hand-rolled copy
+%% left it unquoted).
+format_error_message_method_not_found_quoted_selector_test() ->
+    Msg = beamtalk_repl_json:format_error_message(
+        {method_not_found, 'Counter', <<"increment">>}
+    ),
+    ?assertEqual(
+        <<"Counter does not understand 'increment'\nHint: Use :help Counter to see available methods.">>,
+        Msg
+    ).
+
+%% BT-3084: the two eval_error prose variants ("Evaluation error: Class:Reason")
+%% previously drifted between ensure_structured_error/1 (dropped Class) and
+%% format_error_message/1 (kept it). Assert both entry points now agree.
+format_error_message_eval_error_generic_matches_ensure_structured_error_test() ->
+    ViaJson = beamtalk_repl_json:format_error_message({eval_error, error, badarg}),
+    ViaErrors = beamtalk_error:format(
+        beamtalk_repl_errors:ensure_structured_error({eval_error, error, badarg})
+    ),
+    ?assertEqual(ViaErrors, ViaJson),
+    ?assertMatch(<<"Evaluation error: error:badarg">>, ViaJson).
+
 %% BT-237: eval_error with #beamtalk_error{} formatting
 
 format_error_message_eval_error_beamtalk_error_test() ->

--- a/tests/repl-protocol/cases/help_docs.btscript
+++ b/tests/repl-protocol/cases/help_docs.btscript
@@ -27,8 +27,10 @@
 // => ERROR: Class 'FakeClassName' not found
 
 // :help with an unknown method — should show helpful error
+// BT-3084: DNU message now rendered only by beamtalk_error:generate_message/3
+// (canonical, quoted selector).
 :help Integer nonExistentMethod
-// => ERROR: Integer does not understand nonExistentMethod
+// => ERROR: Integer does not understand 'nonExistentMethod'
 
 // :help Metaclass — should show metaclass documentation (BT-618)
 // BT-2091: After migrating to Beamtalk help:, Metaclass renders with its
@@ -41,8 +43,10 @@
 // => == Metaclass >> spawn ==_
 
 // :help Metaclass with unknown method — should show error (BT-618)
+// BT-3084: DNU message now rendered only by beamtalk_error:generate_message/3
+// (canonical, quoted selector).
 :help Metaclass nonExistentMethod
-// => ERROR: Metaclass does not understand nonExistentMethod
+// => ERROR: Metaclass does not understand 'nonExistentMethod'
 
 // BT-990: Class-side method signatures in :help
 // @load tests/repl-protocol/fixtures/class_method_help_fixture.bt

--- a/tests/repl-protocol/cases/help_methods.btscript
+++ b/tests/repl-protocol/cases/help_methods.btscript
@@ -48,5 +48,7 @@ Beamtalk help: #NoSuchClass
 // ===========================================================================
 
 // help:selector: with unknown selector raises does_not_understand error
+// BT-3084: the DNU message is now rendered only by beamtalk_error:generate_message/3
+// (canonical, quoted selector) instead of a hand-rolled unquoted copy.
 Beamtalk help: Integer selector: #noSuchMethod
-// => ERROR: does not understand noSuchMethod
+// => ERROR: does not understand 'noSuchMethod'


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-3084

`beamtalk_repl_json:format_error_message/1` maintained its own raw-error-tuple dispatch table, separate from `beamtalk_repl_errors:ensure_structured_error/1`, and the two had drifted:
- `{registration_error, ...}` was structured in one table, absent (raw `~p` dump) in the other.
- Several REPL-op tuples (`module_not_found`, `actors_exist`, `class_not_found`, `method_not_found`, `unknown_op`, `inspect_failed`, `actor_not_alive`, `no_source_file`, `module_not_loaded`, `missing_module_name`, `session_creation_failed`) were only in the JSON table.
- `compile_error` diagnostic hints were extracted on one path and dropped on the other.
- The "X does not understand Y" DNU message was hand-rolled unquoted in two places (`beamtalk_interface:make_method_not_found_error/2`, the REPL JSON formatter) instead of calling the canonical `beamtalk_error:generate_message/3`.

## Key changes

- `beamtalk_repl_json:format_error_message/1` is now a thin wrapper over `beamtalk_repl_errors:ensure_structured_error/1` + `beamtalk_error:format/1` — one canonical table, so no tuple can be handled on only one path.
- Folded the JSON-only tuple shapes into `ensure_structured_error/1`.
- DNU message rendered only by `beamtalk_error:generate_message/3` (quoted selector); both hand-rolled copies now call it. Widened its selector type to accept a binary for the one call site that can't safely mint a new atom.
- Unified the two divergent "Evaluation error: Class:Reason" prose variants for generic `eval_error` reasons, while still delegating to the specific structured kind when the wrapped reason is itself a known tuple shape.
- `compile_error` diagnostic hints now propagate through `format_error_message/1`.
- Updated 3 REPL-protocol e2e fixtures (`help_docs.btscript`, `help_methods.btscript`) whose expected DNU text was unquoted, to match the corrected canonical wording — verified via `just test-repl-protocol`.

## Testing

- `just build`, `just clippy`, `just dialyzer`, `just fmt-check` — clean
- `just test` (Rust/stdlib/BUnit/runtime EUnit) — all green
- `just test-integration`, `just test-mcp`, `just test-repl-protocol`, `just test-parity` — all green
- `just check-corpus`, `just check-surface-drift` — clean
- Added regression tests for `{registration_error, ...}` no-raw-fallthrough and compile_error hint propagation per the issue's acceptance criteria

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL7GE5XvKMame4UzYFb1dJ)_