### PR TITLE
Single actor/value classification: retire ClassKind::from_superclass_name and codegen's private is_actor_class (BT-3086)

### DIFF
--- a/crates/beamtalk-core/src/ast/class.rs
+++ b/crates/beamtalk-core/src/ast/class.rs
@@ -64,7 +64,22 @@ pub enum ClassKind {
 }
 
 impl ClassKind {
-    /// Derive the class kind from the direct superclass name used in a `subclass:` declaration.
+    /// Derive a **pre-analysis placeholder** class kind from the direct superclass
+    /// name used in a `subclass:` declaration (BT-3086).
+    ///
+    /// This only inspects the literal direct-superclass identifier written in
+    /// source, so e.g. `TestCase subclass: MyTest` gets `ClassKind::Object`
+    /// here even though `TestCase` transitively descends from `Value`. It
+    /// exists solely to give a freshly-parsed `ClassDefinition` *some* answer
+    /// before a `ClassHierarchy` exists to walk the full ancestor chain.
+    ///
+    /// Every value this produces is corrected in place by
+    /// `apply_class_kind_writeback` once the hierarchy is built — see
+    /// `ClassHierarchy::resolve_class_kind`, the single authority for
+    /// actor/value classification. Nothing downstream of that writeback pass
+    /// (codegen, or any pass that runs after semantic analysis) should read
+    /// a class's `class_kind` and assume it reflects the full ancestor chain
+    /// unless writeback has already run on that `Module`.
     ///
     /// - `"Actor"` → [`ClassKind::Actor`]
     /// - `"Value"` → [`ClassKind::Value`]
@@ -131,7 +146,9 @@ pub struct ClassDefinition {
     /// Optional package qualifier on the superclass (ADR 0070).
     /// E.g., `json` in `json@Parser subclass: LenientParser`.
     pub superclass_package: Option<Identifier>,
-    /// The class kind derived from the declaration form (Actor/Value/Object).
+    /// The class kind (Actor/Value/Object). Parser-set to a shallow, direct-superclass-only
+    /// placeholder ([`ClassKind::from_superclass_name`]); corrected in place by
+    /// `apply_class_kind_writeback` before codegen — see that placeholder's doc comment.
     pub class_kind: ClassKind,
     /// Whether this is an abstract class (cannot be instantiated).
     pub is_abstract: bool,

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -114,7 +114,7 @@ pub use util::escape_atom_chars;
 pub use util::escape_erlang_string;
 pub use util::to_module_name;
 
-use crate::ast::{Block, Expression, MessageSelector, Module, WellKnownSelector};
+use crate::ast::{Block, ClassKind, Expression, MessageSelector, Module, WellKnownSelector};
 use crate::docvec;
 use crate::source_analysis::{Diagnostic, DiagnosticCategory, Span};
 use document::leaf;
@@ -2600,74 +2600,54 @@ impl CoreErlangGenerator {
 
     ///
     /// **Actor classes:** Inherit from Actor or its subclasses. Generate `gen_server` code.
-    /// **Value types:** Inherit from Object (but not Actor). Generate plain Erlang maps/records.
+    /// **Value types:** Inherit from Object or Value (but not Actor). Generate plain Erlang
+    /// maps/records via `generate_value_type_module`.
     ///
     /// # Implementation Note
     ///
-    /// Uses the `ClassHierarchy` to walk the full inheritance chain and determine
-    /// if a class is an actor (inherits from `Actor` at any level in the hierarchy).
+    /// BT-3086: Delegates to `ClassHierarchy::resolve_class_kind`, the single authority for
+    /// actor/value classification (see its doc comment for the walk + default-to-`Object`
+    /// policy on a fully-known chain). This used to be a third, independent implementation
+    /// that re-walked the chain itself and consulted a hand-maintained list of "known value
+    /// roots" (`Object`, `Exception`, `RuntimeError`, ...) that went stale every time the
+    /// exception hierarchy grew. Both `ClassKind::Value` and `ClassKind::Object` route to
+    /// `generate_value_type_module` here — the Value/Object distinction only matters for
+    /// auto-slot codegen *within* the value-type path, not for actor-vs-value routing.
+    ///
+    /// The one case `resolve_class_kind` cannot see through is a genuinely incomplete
+    /// ancestor chain — a superclass that isn't registered in this `ClassHierarchy` at all
+    /// (e.g. compiling a subclass file independently of its parent). `resolve_class_kind`
+    /// resolves that to `ClassKind::Object` (neither `Actor` nor `Value` literal is found),
+    /// but codegen has historically defaulted such classes to *actor* instead, for backward
+    /// compatibility with independent per-file compilation. `ClassHierarchy::has_cross_file_parent`
+    /// is the existing, already-tested predicate for "this chain has an unregistered
+    /// ancestor" — reused here rather than re-deriving the same fact from a hardcoded list.
     ///
     /// # Returns
     ///
-    /// - `true` if class inherits from Actor anywhere in the chain
-    /// - `false` if class inherits only from Object/ProtoObject (value type)
+    /// - `true` if class inherits from Actor anywhere in the (fully-known) chain
+    /// - `true` if a concrete (non-abstract) Supervisor/DynamicSupervisor subclass (BT-1220)
+    /// - `true` if the chain has an unregistered ancestor (incomplete-chain default, above)
+    /// - `false` if class resolves to Value or Object on a fully-known chain
     /// - `true` if module contains no class (backward compatibility for REPL)
     fn is_actor_class(
         module: &Module,
         hierarchy: &crate::semantic_analysis::class_hierarchy::ClassHierarchy,
     ) -> bool {
-        if let Some(class) = module.classes.first() {
-            // BT-1220: Concrete Supervisor/DynamicSupervisor subclasses use supervisor codegen,
-            // routed through generate_actor_module which delegates to supervisor_codegen.
-            // Abstract base classes (Supervisor, DynamicSupervisor themselves) remain value types.
-            if class.supervisor_kind.is_some() && !class.is_abstract {
-                return true;
-            }
-            let name = class.name.name.as_str();
-            if name == "Actor" {
-                return true;
-            }
-            let chain = hierarchy.superclass_chain(name);
-            if chain.iter().any(|s| s.as_str() == "Actor") {
-                return true;
-            }
-            // If the chain terminated at a known value-type root (Object/ProtoObject/Value),
-            // this is definitely a value type.
-            // BT-480: Include exception hierarchy classes — these inherit from Object
-            // (Exception → Object) and must compile as value types, not actors.
-            // BT-925: Include "Value" — when cross-file superclass indexing is incomplete
-            // (e.g. independent file compilation), chains for direct Value subclasses
-            // (Collection, Number, Boolean, Exception) can terminate at "Value". Treat
-            // "Value" as a known value-type root so these classes compile as value types
-            // instead of actors.
-            let known_value_roots = [
-                "Object",
-                "ProtoObject",
-                "Value",
-                "Exception",
-                "Error",
-                "RuntimeError",
-                "TypeError",
-                "InstantiationError",
-                "Character",
-            ];
-            if let Some(last) = chain.last() {
-                if known_value_roots.contains(&last.as_str()) {
-                    return false;
-                }
-            }
-            // Also check direct superclass against known value types for incomplete chains
-            // (e.g., `Error subclass: MyCustomError` compiled without Exception in hierarchy).
-            if known_value_roots.contains(&class.superclass_name()) {
-                return false;
-            }
-            // Chain is incomplete (superclass not in hierarchy) or empty with
-            // non-Object superclass. Default to actor for backward compatibility
-            // (e.g. compiling subclass files independently without parent).
-            // Root classes (superclass "none") are value types, not actors.
-            !matches!(class.superclass_name(), "Object" | "none")
-        } else {
-            true
+        let Some(class) = module.classes.first() else {
+            return true;
+        };
+        // BT-1220: Concrete Supervisor/DynamicSupervisor subclasses use supervisor codegen,
+        // routed through generate_actor_module which delegates to supervisor_codegen.
+        // Abstract base classes (Supervisor, DynamicSupervisor themselves) remain value types.
+        if class.supervisor_kind.is_some() && !class.is_abstract {
+            return true;
+        }
+        let name = class.name.name.as_str();
+        match hierarchy.resolve_class_kind(name) {
+            ClassKind::Actor => true,
+            ClassKind::Value => false,
+            ClassKind::Object => hierarchy.has_cross_file_parent(name),
         }
     }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -2012,6 +2012,59 @@ fn test_is_actor_class_root_class_is_value_type() {
 }
 
 #[test]
+fn test_actor_value_classification_consistent_regardless_of_exception_grandchild_declaration_order()
+{
+    // BT-3086: MyBaseError is a grandchild of Exception (Exception -> Error -> MyBaseError);
+    // MySpecificError extends MyBaseError. Neither analysis (`resolve_class_kind`) nor codegen
+    // (`is_actor_class`) should ever classify these as actors, and the answer must not depend
+    // on which order the two classes are declared in — `add_module_classes` registers every
+    // class in a module before any chain is walked (Pass 1), so within-module declaration
+    // order must never change the result.
+    let base_declared_first =
+        "Error subclass: MyBaseError\n\nMyBaseError subclass: MySpecificError\n";
+    let child_declared_first =
+        "MyBaseError subclass: MySpecificError\n\nError subclass: MyBaseError\n";
+
+    for src in [base_declared_first, child_declared_first] {
+        let tokens = crate::source_analysis::lex_with_eof(src);
+        let (module, _diags) = crate::source_analysis::parse(tokens);
+        let hierarchy = crate::semantic_analysis::class_hierarchy::ClassHierarchy::build(&module)
+            .0
+            .unwrap();
+
+        // Analysis: both classes resolve to Object — Exception's hierarchy is neither
+        // Actor nor Value.
+        for name in ["MyBaseError", "MySpecificError"] {
+            assert_eq!(
+                hierarchy.resolve_class_kind(name),
+                ClassKind::Object,
+                "{name} should resolve to ClassKind::Object regardless of declaration order. src:\n{src}"
+            );
+        }
+
+        // Codegen: routing each class's own single-class module through `is_actor_class`
+        // must agree with analysis — neither routes to actor (gen_server) codegen.
+        for class in &module.classes {
+            let single_class_module = Module {
+                classes: vec![class.clone()],
+                method_definitions: Vec::new(),
+                protocols: Vec::new(),
+                type_aliases: Vec::new(),
+                expressions: vec![],
+                span: Span::new(0, 0),
+                file_leading_comments: vec![],
+                file_trailing_comments: Vec::new(),
+            };
+            assert!(
+                !CoreErlangGenerator::is_actor_class(&single_class_module, &hierarchy),
+                "{} should route to value-type codegen, not actor. src:\n{src}",
+                class.name.name
+            );
+        }
+    }
+}
+
+#[test]
 fn test_generate_with_bindings_compiles_value_type() {
     // Test that generate_with_bindings produces valid output for a value type
     let class = ClassDefinition::new(

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/hierarchy_queries.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/hierarchy_queries.rs
@@ -342,11 +342,32 @@ impl ClassHierarchy {
 
     /// Resolve the `ClassKind` for a class by walking its ancestor chain (BT-1528).
     ///
-    /// Returns `ClassKind::Actor` if any ancestor is Actor, `ClassKind::Value` if
-    /// any ancestor is Value, or `ClassKind::Object` otherwise.
+    /// This is the **single authority** for actor/value classification (BT-3086)
+    /// — the only place that should decide whether a class is `Actor`, `Value`,
+    /// or `Object`. Returns `ClassKind::Actor` if any ancestor is `Actor`,
+    /// `ClassKind::Value` if any ancestor is `Value`, or `ClassKind::Object`
+    /// otherwise, walking the *full* transitive chain regardless of how many
+    /// hops away the deciding ancestor is or what order sibling classes were
+    /// declared in (`add_module_classes` registers every class in a module
+    /// before any chain is walked, so within-module order never matters).
     ///
-    /// This supersedes `ClassKind::from_superclass_name` which only checks the
-    /// direct superclass literal.
+    /// This supersedes `ClassKind::from_superclass_name`, which is a
+    /// pre-analysis placeholder that only checks the direct superclass
+    /// literal — nothing downstream of `apply_class_kind_writeback` should
+    /// treat that placeholder as authoritative once this method is available.
+    ///
+    /// **Incomplete-chain default:** when the chain terminates before
+    /// reaching a registered root (an ancestor is missing from this
+    /// `ClassHierarchy` entirely — see [`Self::has_cross_file_parent`]),
+    /// neither the `Actor` nor `Value` literal can be found, so this method
+    /// returns `ClassKind::Object`. That is the one default this method
+    /// documents; callers that need a *different* fallback for a genuinely
+    /// incomplete chain (for example, codegen's `is_actor_class` defaults
+    /// such classes to actor, for backward compatibility with independent
+    /// per-file compilation — see its doc comment) must layer that policy on
+    /// top of this method's result themselves, using
+    /// [`Self::has_cross_file_parent`] to detect the incomplete-chain case,
+    /// rather than re-deriving it from a separate hardcoded list.
     #[must_use]
     pub fn resolve_class_kind(&self, class_name: &str) -> ClassKind {
         if self.is_actor_subclass(class_name) {

--- a/crates/beamtalk-core/src/semantic_analysis/class_kind_writeback.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_kind_writeback.rs
@@ -15,6 +15,14 @@
 //!
 //! Consumed by codegen: `compute_auto_slot_methods` checks `class_kind`
 //! to decide whether to generate `withX:` setters and keyword constructors.
+//!
+//! BT-3086: `ClassHierarchy::resolve_class_kind` is the single authority this
+//! pass and codegen's `CoreErlangGenerator::is_actor_class` both call — this
+//! pass corrects the AST's `class_kind` field in place for consumers that
+//! read it directly (e.g. `value_type_codegen.rs`), while `is_actor_class`
+//! calls `resolve_class_kind` itself for the actor-vs-value routing decision
+//! (plus a codegen-specific incomplete-chain fallback — see its doc comment).
+//! Neither re-derives the Actor/Value walk independently.
 
 use crate::ast::Module;
 use crate::semantic_analysis::class_hierarchy::ClassHierarchy;


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-3086

"Is this class an actor (vs value)?" had three independent implementations that could give different answers for the same class. This PR consolidates them into one authority.

- **`ClassKind::from_superclass_name`** (`crates/beamtalk-core/src/ast/class.rs`) is now explicitly documented as a pre-analysis placeholder — it only matches the literal direct superclass, exists solely to give a freshly-parsed `ClassDefinition` *some* answer before a `ClassHierarchy` can be built, and is always corrected in place by `apply_class_kind_writeback` before codegen.
- **`ClassHierarchy::resolve_class_kind`** (`hierarchy_queries.rs`) is now documented as the single authority for actor/value classification, walking the full superclass chain. Its doc comment is the one place that documents the incomplete-chain default (`ClassKind::Object` when an ancestor is missing entirely).
- **`CoreErlangGenerator::is_actor_class`** (`codegen/core_erlang/mod.rs`) no longer re-walks the chain itself with a hand-maintained `known_value_roots` list (`Object`, `Exception`, `RuntimeError`, `TypeError`, `InstantiationError`, `Character`, ...) that went stale every time the exception hierarchy grew. It now delegates to `resolve_class_kind` and layers only its own codegen-specific incomplete-chain-defaults-to-actor policy on top, using the existing, already-tested `ClassHierarchy::has_cross_file_parent` predicate instead of re-deriving "chain is incomplete" from a separate list.

## Key changes

- `crates/beamtalk-core/src/ast/class.rs` — doc-only: demote `from_superclass_name` to a documented pre-analysis placeholder.
- `crates/beamtalk-core/src/semantic_analysis/class_hierarchy/hierarchy_queries.rs` — doc-only: `resolve_class_kind` documented as the single authority + the one place documenting the incomplete-chain default.
- `crates/beamtalk-core/src/semantic_analysis/class_kind_writeback.rs` — doc-only: cross-references the single authority.
- `crates/beamtalk-core/src/codegen/core_erlang/mod.rs` — `is_actor_class` rewritten to delegate to `resolve_class_kind` + `has_cross_file_parent`; hardcoded `known_value_roots` list deleted (not moved — fully redundant once the real authority is consulted, since builtins are always preloaded into `ClassHierarchy`).
- `crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs` — new regression test: a class extending a grandchild of `Exception` classifies identically via analysis (`resolve_class_kind`) and codegen (`is_actor_class`), regardless of declaration order within the module.

## Verification

- All 9 pre-existing `is_actor_class` unit tests pass unmodified (behavior-preserving).
- `cargo test -p beamtalk-core`: 5493 passed, 0 failed.
- `just test-stdlib`: 231/231 passed.
- `just test-bunit`: 3202/3202 passed.
- `just test-runtime`: 7304/7304 passed.
- `just clippy`, `just fmt-check`, `just check-corpus`, `just check-surface-drift`: all pass.

## Follow-up filed

- [BT-3092](https://linear.app/beamtalk/issue/BT-3092): found during review — `dead_block_assignment` lint reads `class_kind` *before* `apply_class_kind_writeback` runs, so it can miss indirect Actor subclasses (false-positive lint). Out of scope for this PR (different subsystem, not in BT-3086's file list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL7GE5XvKMame4UzYFb1dJ)_