### PR TITLE
Remove duplicate find_project_root from version.rs and publish.rs

### DIFF
--- a/crates/beamtalk-cli/src/commands/publish.rs
+++ b/crates/beamtalk-cli/src/commands/publish.rs
@@ -26,13 +26,14 @@
 //! see `deps::registry::resolve_registry_location`), so publishing and
 //! consuming a package always agree on which index is authoritative.
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use std::process::Command;
 
 use crate::commands::deps::registry::{self, RegistryEntry, RegistryLocation};
 use crate::commands::manifest;
 use crate::commands::toml_utils::escape_toml_string;
+use crate::commands::util::find_project_root;
 
 /// Run `beamtalk publish`.
 ///
@@ -624,35 +625,10 @@ fn commit_and_push_index(
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/// Find the project root by requiring a `beamtalk.toml` in the current
-/// directory.
-fn find_project_root() -> Result<Utf8PathBuf> {
-    let cwd = std::env::current_dir()
-        .into_diagnostic()
-        .wrap_err("Failed to determine current directory")?;
-
-    let project_root = Utf8PathBuf::from_path_buf(cwd).map_err(|p| {
-        miette::miette!("Current directory path is not valid UTF-8: {}", p.display())
-    })?;
-
-    let manifest_path = project_root.join("beamtalk.toml");
-    if !manifest_path.exists() {
-        miette::bail!(
-            "No beamtalk.toml found in current directory.\n  \
-             Run this command from a Beamtalk project root, or create one with `beamtalk new`."
-        );
-    }
-
-    Ok(project_root)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use camino::Utf8PathBuf;
     use serial_test::serial;
     use tempfile::TempDir;
 

--- a/crates/beamtalk-cli/src/commands/version.rs
+++ b/crates/beamtalk-cli/src/commands/version.rs
@@ -16,12 +16,13 @@
 //! `deps::cli::append_dependency_to_manifest`) — comments, key order, and
 //! unrelated whitespace elsewhere in `beamtalk.toml` are left untouched.
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use std::cmp::Ordering;
 
 use crate::commands::deps::registry::compare_versions;
 use crate::commands::manifest::{self, validate_exact_version};
+use crate::commands::util::find_project_root;
 
 /// Which segment `bump` increments.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -257,31 +258,10 @@ fn replace_version_value(
     ))
 }
 
-/// Find the project root by requiring a `beamtalk.toml` in the current
-/// directory.
-fn find_project_root() -> Result<Utf8PathBuf> {
-    let cwd = std::env::current_dir()
-        .into_diagnostic()
-        .wrap_err("Failed to determine current directory")?;
-
-    let project_root = Utf8PathBuf::from_path_buf(cwd).map_err(|p| {
-        miette::miette!("Current directory path is not valid UTF-8: {}", p.display())
-    })?;
-
-    let manifest_path = project_root.join("beamtalk.toml");
-    if !manifest_path.exists() {
-        miette::bail!(
-            "No beamtalk.toml found in current directory.\n  \
-             Run this command from a Beamtalk project root, or create one with `beamtalk new`."
-        );
-    }
-
-    Ok(project_root)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use camino::Utf8PathBuf;
     use serial_test::serial;
     use tempfile::TempDir;
 


### PR DESCRIPTION
## Summary

`find_project_root()` was defined three times in `beamtalk-cli`, where a canonical shared version already existed in `commands/util.rs`:

- `commands/util.rs:46` — canonical, `pub(crate)` ✅
- `commands/version.rs:262` — private duplicate, byte-for-byte identical ❌
- `commands/publish.rs:633` — private duplicate, byte-for-byte identical ❌

Both duplicates are removed. Each file now imports the shared implementation via `use crate::commands::util::find_project_root`. The `Utf8PathBuf` import (previously used only inside the removed function) is moved into the `#[cfg(test)]` module in each file where it actually belongs. The empty `// Helpers //` section comment in `publish.rs` is also cleaned up.

## Changes

- `crates/beamtalk-cli/src/commands/version.rs` — remove `fn find_project_root`, import shared; move `Utf8PathBuf` to test module
- `crates/beamtalk-cli/src/commands/publish.rs` — same; also remove now-empty `// Helpers` section header

## Test plan

- [x] `cargo build -p beamtalk-cli` — clean, no warnings
- [x] `cargo clippy -p beamtalk-cli` — clean
- [x] `cargo test -p beamtalk-cli` — all 41 CLI tests pass
- [x] Full test suite — 1289 tests pass, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01KA79uZtwsKQNzCkZHnnKqv)_