### PR TITLE
Fold map_type_name into the canonical resolver; delete resolve_type_string (BT-3080)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
@@ -8,20 +8,22 @@
 //! [`MethodInfo::return_type`](super::MethodInfo::return_type) and
 //! `param_types` store type signatures as flattened `EcoString`s (see
 //! [`crate::ast::TypeAnnotation::type_name`]). Every consumer that needs
-//! structure back out of one of those strings has historically hand-rolled
-//! its own parser — `TypeChecker::resolve_type_string` (BT-3075) being the
-//! canonical, merged one. `DeclaredType` gives that structure a proper value
+//! structure back out of one of those strings parses through this type —
+//! `TypeChecker::resolve_type_string` (BT-3075's canonical, merged
+//! hand-rolled parser) is deleted (BT-3080); every former call site now goes
+//! through [`DeclaredType::parse`] +
+//! [`resolve_declared_type`](crate::semantic_analysis::type_checker::resolve_type_annotation)-family
+//! resolution instead. `DeclaredType` gives that structure a proper value
 //! type: a span-free mirror of [`TypeAnnotation`] that can be built directly
 //! from an AST annotation ([`From<&TypeAnnotation>`](#impl-From<%26TypeAnnotation>-for-DeclaredType)),
 //! parsed back out of a stored string ([`DeclaredType::parse`]), or partially
 //! recovered from an already-resolved [`InferredType`]
 //! ([`DeclaredType::from_inferred`]).
 //!
-//! This module is purely additive (BT-3076 stage 1): nothing here replaces
-//! `resolve_type_string` or any existing call site yet. Stage 2 re-cores the
-//! canonical annotation resolver
+//! The canonical annotation resolver
 //! ([`resolve_type_annotation`](crate::semantic_analysis::type_checker::resolve_type_annotation))
-//! onto this type; a later stage migrates `MethodInfo` itself.
+//! is built on this type (BT-3076); `MethodInfo`'s string-typed fields
+//! themselves remain a possible future migration.
 //!
 //! Lives in the `class_hierarchy` layer (not `type_checker`) because
 //! `MethodInfo` — the eventual home for a structured field — lives here, and
@@ -91,28 +93,25 @@ impl DeclaredType {
     /// `param_types` entry, or a `ClassHierarchy::state_field_type` value)
     /// into a structured `DeclaredType`.
     ///
-    /// Grammar mirrors [`TypeChecker::resolve_type_string`]'s parsing (BT-3075):
-    /// split on top-level `|` (respecting parenthesis nesting) for unions,
-    /// then `Base(Arg1, Arg2)` for generics (args themselves split on
-    /// top-level `,`, respecting nesting), with `#name` recognised as a
-    /// [`DeclaredType::Singleton`]. Unlike `resolve_type_string`, this is
-    /// **parse only** — no keyword resolution: `Never`, `Dynamic`, `nil`,
-    /// `true`, `false` all come back as plain `Simple`/`Singleton` names,
-    /// exactly as written. That normalisation is the resolver's job, not the
-    /// parser's (see `resolve_declared_type` in `type_resolver`).
+    /// Grammar mirrors the deleted `TypeChecker::resolve_type_string`'s
+    /// parsing (BT-3075, folded into this type BT-3080): split on top-level
+    /// `|` (respecting parenthesis nesting) for unions, then `Base(Arg1,
+    /// Arg2)` for generics (args themselves split on top-level `,`,
+    /// respecting nesting), with `#name` recognised as a
+    /// [`DeclaredType::Singleton`]. This is **parse only** — no keyword
+    /// resolution: `Never`, `Dynamic`, `nil`, `true`, `false` all come back
+    /// as plain `Simple`/`Singleton` names, exactly as written. That
+    /// normalisation is the resolver's job, not the parser's (see
+    /// `resolve_declared_type` in `type_resolver`).
     ///
-    /// Never panics. `resolve_type_string`'s grammar has no representation
-    /// for `\` (difference), `&` (intersection), bare `Self`, `Self class`,
-    /// or `<Name> class` — strings in exactly those shapes (which *can* occur,
+    /// Never panics. This grammar has no representation for `\`
+    /// (difference), `&` (intersection), bare `Self`, `Self class`, or
+    /// `<Name> class` — strings in exactly those shapes (which *can* occur,
     /// since [`MethodInfo::return_type`](super::MethodInfo::return_type) is
     /// populated via [`TypeAnnotation::type_name`], which does render them)
-    /// degrade to an opaque `Simple(whole_string)`, matching
-    /// `resolve_type_string`'s own behaviour for any input it doesn't
-    /// specifically recognise (an unparsed string becomes a nominal class
-    /// name). Malformed/unbalanced input (e.g. `"Array(Integer"`, no closing
-    /// paren) degrades the same way.
-    ///
-    /// [`TypeChecker::resolve_type_string`]: crate::semantic_analysis::type_checker::TypeChecker
+    /// degrade to an opaque `Simple(whole_string)` (an unparsed string
+    /// becomes a nominal class name). Malformed/unbalanced input (e.g.
+    /// `"Array(Integer"`, no closing paren) degrades the same way.
     #[must_use]
     pub fn parse(s: &str) -> DeclaredType {
         let trimmed = s.trim();

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -18,7 +18,7 @@ use crate::ast::{
     TypeAnnotation,
 };
 use crate::semantic_analysis::alias_registry::AliasRegistry;
-use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
+use crate::semantic_analysis::class_hierarchy::{ClassHierarchy, DeclaredType};
 use crate::semantic_analysis::string_utils::edit_distance;
 use crate::semantic_analysis::validators::is_concrete_leaf_class;
 use crate::source_analysis::{Diagnostic, DiagnosticCategory, Span};
@@ -29,23 +29,31 @@ use super::narrowing::extract::unwrap_parens;
 use super::narrowing::refinement::RefinementLayer;
 use super::narrowing::visitors::{block_has_any_return, block_has_return, block_may_reassign};
 use super::narrowing::{ClassTestInfo, ClassTestKind, NarrowingInfo};
+use super::type_resolver;
 use super::well_known::WellKnownClass;
 use super::{DynamicReason, EnvKey, InferredType, TypeChecker, TypeEnv, narrowing};
 
-/// How [`TypeChecker::resolve_type_string`] treats constructs that only make
-/// sense while substituting generics at a send site (BT-3075).
+/// How [`super::type_resolver::resolve_declared_type`] treats constructs that
+/// only make sense in a particular resolution setting (BT-3075, BT-3080).
 ///
 /// `Substitution` collapses an unresolved bare type param (`T`) to `Dynamic`
 /// (BT-1834) and stamps `Substituted` provenance on parsed generics.
 /// `Declared` keeps a bare single-letter name as a nominal class — its
 /// callers guard with `is_generic_type_param` themselves — and stamps
-/// `Declared` provenance.
+/// `Declared` provenance. `Extracted` is `Declared`'s sibling for types that
+/// came from an Erlang `-spec` rather than Beamtalk source text — same
+/// keyword/alias/generic handling, but stamps `Extracted` provenance instead
+/// (BT-3080: folds `native_types::map_type_name`'s parsing into this same
+/// resolver rather than reimplementing it).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TypeStringContext {
     /// Resolving a declared signature/field type string as-is.
     Declared,
     /// Resolving a return type while substituting generic params at a send.
     Substitution,
+    /// Resolving a type name string auto-extracted from `.beam` abstract
+    /// code (ADR 0075) via the Erlang-FFI spec-reader protocol.
+    Extracted,
 }
 
 impl TypeChecker {
@@ -459,228 +467,6 @@ impl TypeChecker {
         resolved
     }
 
-    /// Resolves type-position keywords to their class names.
-    ///
-    /// - `nil` / `Nil` → `UndefinedObject`
-    /// - `false` → `False`
-    /// - `true` → `True`
-    /// - Everything else passes through unchanged.
-    ///
-    /// Both lowercase (`nil`) and capitalised (`Nil`) spellings map to
-    /// `UndefinedObject` so that `Integer | Nil` type annotations narrow
-    /// consistently under `isNil` guards (BT-2016).
-    fn resolve_type_keyword(name: &EcoString) -> EcoString {
-        match name.as_str() {
-            // BT-2016: Both `nil` (lowercase keyword) and `Nil` (class name) map
-            // to the canonical internal name `UndefinedObject` so narrowing,
-            // non_nil_type, and all downstream comparisons work consistently.
-            "nil" | "Nil" => WellKnownClass::UndefinedObject.as_str().into(),
-            "false" => "False".into(),
-            "true" => "True".into(),
-            _ => name.clone(),
-        }
-    }
-
-    /// The single string→`InferredType` resolver (BT-3075).
-    ///
-    /// Converts a type string (a `ClassHierarchy::state_field_type` entry, a
-    /// cross-file `MethodInfo::return_type`/`param_types` signature, or a
-    /// declared return type being substituted at a send site) to a proper
-    /// `InferredType`, splitting unions on `|` and parsing generics.
-    ///
-    /// Examples:
-    /// - `"Integer"` → `Known("Integer")`
-    /// - `"String | nil"` → `Union(["String", "UndefinedObject"])`
-    /// - `"List(String)"` → `Known("List", type_args: [Known("String")])`
-    /// - `"Never"` → [`InferredType::Never`], `"Dynamic"` → the real
-    ///   `Dynamic` variant — never `Known` pseudo-classes
-    ///
-    /// Before BT-3075 this logic lived in two independent parsers — a plain
-    /// one and a substitution one (`substitute_return_type_with_self`) that
-    /// duplicated the union/generic recursion without the leaf handling, so
-    /// a declared `-> Never` reached through a class-side send became a
-    /// `Known("Never")` pseudo-class, and the `Dynamic` (BT-2865), keyword,
-    /// and alias fixes never propagated to it.
-    ///
-    /// Resolution order per node: method-local substitution → class-level
-    /// substitution → `Self` (when a receiver type is threaded, BT-1986 /
-    /// BT-1992) → the `Never`/`Dynamic` keywords (BT-1945 / BT-2865) → union
-    /// split → generic parse → bare-type-param fallback (substitution
-    /// contexts only, BT-1834) → alias expansion (BT-2928, ADR 0108) →
-    /// keyword-normalised nominal class.
-    ///
-    /// `alias_registry` (BT-2928, ADR 0108) is consulted for the bare-name
-    /// case only — an alias is never itself parametric, so a `Base(Args...)`
-    /// generic's base name is resolved as an ordinary nominal class, matching
-    /// `type_resolver::resolve_type_annotation`'s equivalent restriction.
-    /// This is what makes a *cross-file* method/field signature — stored as
-    /// an opaque string extracted once at Pass 1, not a live `TypeAnnotation`
-    /// re-resolved against the current file's alias table — expand a
-    /// same-package alias declared in another file. Pass `None` when no
-    /// registry is available.
-    pub(super) fn resolve_type_string(
-        type_name: &str,
-        class_subst: &HashMap<EcoString, InferredType>,
-        method_local_subst: &HashMap<EcoString, InferredType>,
-        self_type: Option<&InferredType>,
-        alias_registry: Option<&crate::semantic_analysis::alias_registry::AliasRegistry>,
-        context: TypeStringContext,
-    ) -> InferredType {
-        let eco: EcoString = type_name.into();
-
-        // Substitution wins over keyword/alias resolution (matching
-        // `resolve_type_annotation`'s ordering): `T`, `E`, `R` would
-        // otherwise flow through as ordinary class names.
-        if let Some(resolved) = method_local_subst.get(&eco) {
-            return resolved.clone();
-        }
-        if let Some(resolved) = class_subst.get(&eco) {
-            return resolved.clone();
-        }
-
-        // BT-1986 / BT-1992: `Self` as a (possibly nested) type reference
-        // resolves to the full receiver type (including type args) when one
-        // is threaded. Bare top-level `Self` is handled at the call sites to
-        // keep the receiver's type args attached; with no receiver it passes
-        // through as `Known("Self")` (historic behaviour).
-        if type_name == "Self" {
-            if let Some(ty) = self_type {
-                return ty.clone();
-            }
-        }
-
-        // BT-1945 / BT-2865 / BT-3075: `Never` and `Dynamic` must resolve to
-        // their real variants — a `Known` pseudo-class silently defeats every
-        // check written against the variants (divergence detection, dead-code
-        // analysis, `Dynamic`-loses merge rules, the `-> Never` honesty
-        // check in `check_return_type`).
-        if WellKnownClass::from_str(&eco) == Some(WellKnownClass::Never) {
-            return InferredType::Never;
-        }
-        if WellKnownClass::from_str(&eco) == Some(WellKnownClass::Dynamic) {
-            return InferredType::Dynamic(DynamicReason::ExplicitDynamic);
-        }
-
-        // Split on `|` respecting parenthesis nesting, so
-        // `Result(String | Integer, Error)` is not split at the inner `|`.
-        // `union_of` normalises: `Never` members are eliminated (a `T | Never`
-        // with a divergent arm collapses to `T`), an all-`Never` union stays
-        // `Never`, and a `Dynamic` member absorbs the union.
-        if type_name.contains('|') {
-            let parts = Self::split_union_respecting_parens(type_name);
-            if parts.len() > 1 {
-                let members: Vec<InferredType> = parts
-                    .into_iter()
-                    .map(|m| {
-                        Self::resolve_type_string(
-                            m,
-                            class_subst,
-                            method_local_subst,
-                            self_type,
-                            alias_registry,
-                            context,
-                        )
-                    })
-                    .collect();
-                let unioned = InferredType::union_of(&members);
-                return if context == TypeStringContext::Substitution {
-                    Self::stamp_substituted_provenance(unioned)
-                } else {
-                    unioned
-                };
-            }
-            // Single element — the `|` was inside parens, fall through
-        }
-
-        // Parametric type: e.g., "List(String)", "Result(R, E)".
-        // BT-2025: Parenthesis-aware split lives in the centralised resolver
-        // helper so the `no .find('(')` grep check stays clean here. Each
-        // argument recurses (re-applying the substitution maps first), so
-        // nested generics and nested `Self` resolve too (BT-1836 / BT-2018).
-        let (base_str, args_slice) = super::type_resolver::split_generic_base(type_name);
-        if let Some(inner) = args_slice {
-            let base = Self::resolve_type_keyword(&EcoString::from(base_str));
-            let type_args: Vec<InferredType> = Self::split_type_params(inner)
-                .into_iter()
-                .map(|p| {
-                    Self::resolve_type_string(
-                        p,
-                        class_subst,
-                        method_local_subst,
-                        self_type,
-                        alias_registry,
-                        context,
-                    )
-                })
-                .collect();
-            let provenance = if context == TypeStringContext::Substitution {
-                super::TypeProvenance::Substituted(Span::default())
-            } else {
-                super::TypeProvenance::Declared(Span::default())
-            };
-            return InferredType::Known {
-                class_name: base,
-                type_args,
-                provenance,
-            };
-        }
-
-        // BT-1834: an unresolved bare type param (single uppercase letter)
-        // collapses to Dynamic in substitution contexts so downstream sends
-        // don't get false DNU warnings.
-        if context == TypeStringContext::Substitution && super::is_generic_type_param(&eco) {
-            return InferredType::Dynamic(DynamicReason::Unknown);
-        }
-
-        // BT-2928: consult the alias registry before falling back to a
-        // bare nominal class — mirrors `type_resolver::resolve_type_annotation`'s
-        // `subst → alias table → nominal class` order (ADR 0108
-        // Semantics). Resolves through the alias's own stored
-        // `TypeAnnotation` (not this string-based function) so chained
-        // aliases, cycle-guarding, and hover-display tagging all reuse
-        // the same machinery every other alias reference goes through.
-        if let Some(registry) = alias_registry {
-            if let Some(alias_info) = registry.get(&eco) {
-                let resolved = super::type_resolver::resolve_type_annotation(
-                    &alias_info.annotation,
-                    &super::type_resolver::SubstitutionMap::new(),
-                    None,
-                    alias_registry,
-                );
-                return resolved.tag_alias_expansion(eco.clone(), alias_info.span);
-            }
-        }
-        InferredType::known(Self::resolve_type_keyword(&eco))
-    }
-
-    /// Re-stamp `Substituted` provenance on a substituted union result.
-    ///
-    /// `union_of` derives provenance from the members, and plain nominal
-    /// members never win (`provenance_wins_union_default` excludes
-    /// `Inferred`), so a substituted `V | Nil` would otherwise read as
-    /// `Inferred` — un-silencing `check_impossible_class_comparison`, whose
-    /// provenance gate deliberately treats substituted signatures as
-    /// unverified promises. Covers every provenance-carrying variant —
-    /// `union_of` can also collapse a single-member union to a `Meta` /
-    /// `Negation` / `Intersection` (PR #3268 review). `Aliased` results keep
-    /// their tag (re-stamping would lose the alias display name); `Dynamic`
-    /// and `Never` results carry no provenance and pass through.
-    fn stamp_substituted_provenance(mut ty: InferredType) -> InferredType {
-        match &mut ty {
-            InferredType::Known { provenance, .. }
-            | InferredType::Union { provenance, .. }
-            | InferredType::Meta { provenance, .. }
-            | InferredType::Negation { provenance, .. }
-            | InferredType::Intersection { provenance, .. }
-                if !matches!(provenance, super::TypeProvenance::Aliased { .. }) =>
-            {
-                *provenance = super::TypeProvenance::Substituted(Span::default());
-            }
-            _ => {}
-        }
-        ty
-    }
-
     /// Infer the type of an expression, emitting diagnostics for invalid sends.
     ///
     /// `in_abstract_method` suppresses warnings for `self` class-side sends in
@@ -724,10 +510,9 @@ impl TypeChecker {
                                 } else if let Some(field_type) =
                                     hierarchy.state_field_type(&class_name, name)
                                 {
-                                    Self::resolve_type_string(
-                                        &field_type,
-                                        &HashMap::new(),
-                                        &HashMap::new(),
+                                    type_resolver::resolve_declared_type(
+                                        &DeclaredType::parse(&field_type),
+                                        &type_resolver::SubstitutionMap::new(),
                                         None,
                                         self.alias_registry.as_ref(),
                                         TypeStringContext::Declared,
@@ -780,10 +565,9 @@ impl TypeChecker {
                             if let Some(field_type) =
                                 hierarchy.state_field_type(&class_name, &field.name)
                             {
-                                result = Self::resolve_type_string(
-                                    &field_type,
-                                    &HashMap::new(),
-                                    &HashMap::new(),
+                                result = type_resolver::resolve_declared_type(
+                                    &DeclaredType::parse(&field_type),
+                                    &type_resolver::SubstitutionMap::new(),
                                     None,
                                     self.alias_registry.as_ref(),
                                     TypeStringContext::Declared,
@@ -2262,11 +2046,14 @@ impl TypeChecker {
                         // BT-1992: Thread the full receiver type (with type args)
                         // so nested `Self` in generics like `Result(Self, Error)`
                         // resolves to e.g. `Box(Integer)` not bare `Box`.
-                        return Self::resolve_type_string(
-                            ret_ty,
-                            &subst,
-                            &method_subst,
-                            Some(&receiver_ty),
+                        return type_resolver::resolve_declared_type(
+                            &DeclaredType::parse(ret_ty),
+                            &type_resolver::merge_substitutions(
+                                &subst,
+                                &method_subst,
+                                Some(&receiver_ty),
+                            ),
+                            None,
                             self.alias_registry.as_ref(),
                             TypeStringContext::Substitution,
                         );
@@ -2295,10 +2082,9 @@ impl TypeChecker {
                     //  * BT-2928: a cross-file alias name expands to its
                     //    declared union/structural type instead of staying
                     //    an opaque nominal class.
-                    return Self::resolve_type_string(
-                        ret_ty,
-                        &HashMap::new(),
-                        &HashMap::new(),
+                    return type_resolver::resolve_declared_type(
+                        &DeclaredType::parse(ret_ty),
+                        &type_resolver::SubstitutionMap::new(),
                         None,
                         self.alias_registry.as_ref(),
                         TypeStringContext::Declared,
@@ -2842,10 +2628,9 @@ impl TypeChecker {
         // out of scope: the tower's method table is fixed, built-in, and
         // has no alias-typed entries to expand, so there is nothing for a
         // registry to do here.
-        Some(Self::resolve_type_string(
-            ret_ty,
-            &HashMap::new(),
-            &HashMap::new(),
+        Some(type_resolver::resolve_declared_type(
+            &DeclaredType::parse(ret_ty),
+            &type_resolver::SubstitutionMap::new(),
             None,
             None,
             TypeStringContext::Declared,
@@ -3066,11 +2851,14 @@ impl TypeChecker {
                             // is empty.
                             let has_nested_self = Self::return_type_mentions_nested_self(ret_ty);
                             if !subst.is_empty() || has_nested_self {
-                                return_types.push(Self::resolve_type_string(
-                                    ret_ty,
-                                    &subst,
-                                    &HashMap::new(),
-                                    Some(member),
+                                return_types.push(type_resolver::resolve_declared_type(
+                                    &DeclaredType::parse(ret_ty),
+                                    &type_resolver::merge_substitutions(
+                                        &subst,
+                                        &type_resolver::SubstitutionMap::new(),
+                                        Some(member),
+                                    ),
+                                    None,
                                     self.alias_registry.as_ref(),
                                     TypeStringContext::Substitution,
                                 ));
@@ -3084,10 +2872,9 @@ impl TypeChecker {
                                 // parametric type args (`List(String)` keeps
                                 // its element type) and parse union return
                                 // types into `InferredType::Union`.
-                                return_types.push(Self::resolve_type_string(
-                                    ret_ty,
-                                    &HashMap::new(),
-                                    &HashMap::new(),
+                                return_types.push(type_resolver::resolve_declared_type(
+                                    &DeclaredType::parse(ret_ty),
+                                    &type_resolver::SubstitutionMap::new(),
                                     None,
                                     self.alias_registry.as_ref(),
                                     TypeStringContext::Declared,
@@ -3148,10 +2935,9 @@ impl TypeChecker {
                     } else if WellKnownClass::from_str(ret_ty) == Some(WellKnownClass::Never) {
                         InferredType::Never
                     } else {
-                        Self::resolve_type_string(
-                            ret_ty,
-                            &HashMap::new(),
-                            &HashMap::new(),
+                        type_resolver::resolve_declared_type(
+                            &DeclaredType::parse(ret_ty),
+                            &type_resolver::SubstitutionMap::new(),
                             None,
                             self.alias_registry.as_ref(),
                             TypeStringContext::Declared,
@@ -5143,7 +4929,8 @@ impl TypeChecker {
     /// the parameter cannot be resolved.
     ///
     /// BT-2023(B): Handles nested generics (e.g., `List(E)`) by delegating to
-    /// [`Self::resolve_type_string`], which recursively resolves inner type params.
+    /// [`type_resolver::resolve_declared_type`], which recursively resolves
+    /// inner type params.
     pub(super) fn resolve_type_param(
         param: &str,
         class_subst: &HashMap<EcoString, InferredType>,
@@ -5164,12 +4951,12 @@ impl TypeChecker {
             return InferredType::known(eco);
         }
         // BT-2023(B): If the param contains nested generics (e.g., `List(E)`),
-        // delegate to `resolve_type_string` which handles recursive resolution.
+        // delegate to the canonical resolver, which handles recursive
+        // resolution.
         if param.contains('(') {
-            return Self::resolve_type_string(
-                param,
-                class_subst,
-                method_subst,
+            return type_resolver::resolve_declared_type(
+                &DeclaredType::parse(param),
+                &type_resolver::merge_substitutions(class_subst, method_subst, None),
                 None,
                 None,
                 TypeStringContext::Substitution,
@@ -5358,10 +5145,9 @@ impl TypeChecker {
         if let EnvKey::SelfField(field_name) = var_key {
             if let Some(InferredType::Known { class_name, .. }) = env.get_local("self") {
                 if let Some(field_type) = hierarchy.state_field_type(&class_name, field_name) {
-                    return Self::resolve_type_string(
-                        &field_type,
-                        &HashMap::new(),
-                        &HashMap::new(),
+                    return type_resolver::resolve_declared_type(
+                        &DeclaredType::parse(&field_type),
+                        &type_resolver::SubstitutionMap::new(),
                         None,
                         alias_registry,
                         TypeStringContext::Declared,
@@ -6278,10 +6064,9 @@ mod tests {
     #[test]
     fn resolve_type_string_simple() {
         assert_eq!(
-            TypeChecker::resolve_type_string(
-                "Integer",
-                &HashMap::new(),
-                &HashMap::new(),
+            type_resolver::resolve_declared_type(
+                &DeclaredType::parse("Integer"),
+                &type_resolver::SubstitutionMap::new(),
                 None,
                 None,
                 TypeStringContext::Declared
@@ -6293,10 +6078,9 @@ mod tests {
     #[test]
     fn resolve_type_string_nil_keyword() {
         assert_eq!(
-            TypeChecker::resolve_type_string(
-                "nil",
-                &HashMap::new(),
-                &HashMap::new(),
+            type_resolver::resolve_declared_type(
+                &DeclaredType::parse("nil"),
+                &type_resolver::SubstitutionMap::new(),
                 None,
                 None,
                 TypeStringContext::Declared
@@ -6307,10 +6091,9 @@ mod tests {
 
     #[test]
     fn resolve_type_string_union() {
-        let result = TypeChecker::resolve_type_string(
-            "String | nil",
-            &HashMap::new(),
-            &HashMap::new(),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("String | nil"),
+            &type_resolver::SubstitutionMap::new(),
             None,
             None,
             TypeStringContext::Declared,
@@ -6327,10 +6110,9 @@ mod tests {
 
     #[test]
     fn resolve_type_string_three_way_union() {
-        let result = TypeChecker::resolve_type_string(
-            "Integer | String | nil",
-            &HashMap::new(),
-            &HashMap::new(),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("Integer | String | nil"),
+            &type_resolver::SubstitutionMap::new(),
             None,
             None,
             TypeStringContext::Declared,
@@ -6387,10 +6169,9 @@ mod tests {
         let diags = registry.register_module(&module, &hierarchy, &protocol_registry);
         assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
 
-        let result = TypeChecker::resolve_type_string(
-            "RestartStrategy",
-            &HashMap::new(),
-            &HashMap::new(),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("RestartStrategy"),
+            &type_resolver::SubstitutionMap::new(),
             None,
             Some(&registry),
             TypeStringContext::Declared,
@@ -6407,10 +6188,9 @@ mod tests {
         // Without the registry, the same raw string stays an opaque nominal
         // class — the pre-BT-2928 behaviour this test guards against
         // regressing back to.
-        let unresolved = TypeChecker::resolve_type_string(
-            "RestartStrategy",
-            &HashMap::new(),
-            &HashMap::new(),
+        let unresolved = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("RestartStrategy"),
+            &type_resolver::SubstitutionMap::new(),
             None,
             None,
             TypeStringContext::Declared,
@@ -6927,10 +6707,9 @@ mod tests {
     fn substitute_direct_param() {
         let mut subst = HashMap::new();
         subst.insert(EcoString::from("T"), InferredType::known("Integer"));
-        let result = TypeChecker::resolve_type_string(
-            "T",
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("T"),
             &subst,
-            &HashMap::new(),
             None,
             None,
             TypeStringContext::Substitution,
@@ -6942,9 +6721,8 @@ mod tests {
     fn substitute_method_local_param() {
         let mut method_subst = HashMap::new();
         method_subst.insert(EcoString::from("R"), InferredType::known("String"));
-        let result = TypeChecker::resolve_type_string(
-            "R",
-            &HashMap::new(),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("R"),
             &method_subst,
             None,
             None,
@@ -6959,10 +6737,9 @@ mod tests {
         subst.insert(EcoString::from("R"), InferredType::known("Integer"));
         let mut method_subst = HashMap::new();
         method_subst.insert(EcoString::from("R"), InferredType::known("String"));
-        let result = TypeChecker::resolve_type_string(
-            "R",
-            &subst,
-            &method_subst,
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("R"),
+            &type_resolver::merge_substitutions(&subst, &method_subst, None),
             None,
             None,
             TypeStringContext::Substitution,
@@ -6975,10 +6752,9 @@ mod tests {
         let mut subst = HashMap::new();
         subst.insert(EcoString::from("T"), InferredType::known("Integer"));
         subst.insert(EcoString::from("E"), InferredType::known("IOError"));
-        let result = TypeChecker::resolve_type_string(
-            "Result(T, E)",
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("Result(T, E)"),
             &subst,
-            &HashMap::new(),
             None,
             None,
             TypeStringContext::Substitution,
@@ -7000,10 +6776,9 @@ mod tests {
 
     #[test]
     fn substitute_no_match_passes_through() {
-        let result = TypeChecker::resolve_type_string(
-            "String",
-            &HashMap::new(),
-            &HashMap::new(),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("String"),
+            &type_resolver::SubstitutionMap::new(),
             None,
             None,
             TypeStringContext::Substitution,
@@ -7015,10 +6790,9 @@ mod tests {
     fn substitute_generic_base_extracted() {
         // When return type is "Array(R)" and R is not in subst, base "Array" is still extracted
         // BT-1834: Unresolved type param R falls back to Dynamic instead of Known("R")
-        let result = TypeChecker::resolve_type_string(
-            "Array(R)",
-            &HashMap::new(),
-            &HashMap::new(),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("Array(R)"),
+            &type_resolver::SubstitutionMap::new(),
             None,
             None,
             TypeStringContext::Substitution,
@@ -7049,11 +6823,14 @@ mod tests {
             type_args: vec![InferredType::known("Integer")],
             provenance: TypeProvenance::Inferred(Span::default()),
         };
-        let result = TypeChecker::resolve_type_string(
-            "Result(Self, Error)",
-            &HashMap::new(),
-            &HashMap::new(),
-            Some(&receiver_ty),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("Result(Self, Error)"),
+            &type_resolver::merge_substitutions(
+                &type_resolver::SubstitutionMap::new(),
+                &type_resolver::SubstitutionMap::new(),
+                Some(&receiver_ty),
+            ),
+            None,
             None,
             TypeStringContext::Substitution,
         );
@@ -7078,11 +6855,14 @@ mod tests {
         // Non-parameterised receiver: `Result(Self, Error)` on `Counter`
         // should produce `Result(Counter, Error)`.
         let receiver_ty = InferredType::known("Counter");
-        let result = TypeChecker::resolve_type_string(
-            "Result(Self, Error)",
-            &HashMap::new(),
-            &HashMap::new(),
-            Some(&receiver_ty),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("Result(Self, Error)"),
+            &type_resolver::merge_substitutions(
+                &type_resolver::SubstitutionMap::new(),
+                &type_resolver::SubstitutionMap::new(),
+                Some(&receiver_ty),
+            ),
+            None,
             None,
             TypeStringContext::Substitution,
         );
@@ -7110,11 +6890,14 @@ mod tests {
             type_args: vec![InferredType::known("Integer")],
             provenance: TypeProvenance::Inferred(Span::default()),
         };
-        let result = TypeChecker::resolve_type_string(
-            "Self | Error",
-            &HashMap::new(),
-            &HashMap::new(),
-            Some(&receiver_ty),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("Self | Error"),
+            &type_resolver::merge_substitutions(
+                &type_resolver::SubstitutionMap::new(),
+                &type_resolver::SubstitutionMap::new(),
+                Some(&receiver_ty),
+            ),
+            None,
             None,
             TypeStringContext::Substitution,
         );
@@ -7132,10 +6915,9 @@ mod tests {
     fn substitute_self_none_passes_through() {
         // When self_type is None, `Self` should pass through as Known("Self")
         // (backward-compatible behaviour).
-        let result = TypeChecker::resolve_type_string(
-            "Result(Self, Error)",
-            &HashMap::new(),
-            &HashMap::new(),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("Result(Self, Error)"),
+            &type_resolver::SubstitutionMap::new(),
             None,
             None,
             TypeStringContext::Substitution,
@@ -8481,9 +8263,8 @@ mod tests {
         let mut method_subst = HashMap::new();
         method_subst.insert(EcoString::from("T"), InferredType::known("Integer"));
         method_subst.insert(EcoString::from("E"), InferredType::known("Error"));
-        let result = TypeChecker::resolve_type_string(
-            "T",
-            &HashMap::new(),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("T"),
             &method_subst,
             None,
             None,
@@ -8497,9 +8278,8 @@ mod tests {
         // collect: returns Array(R) where R=String → Array(String)
         let mut method_subst = HashMap::new();
         method_subst.insert(EcoString::from("R"), InferredType::known("String"));
-        let result = TypeChecker::resolve_type_string(
-            "Array(R)",
-            &HashMap::new(),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("Array(R)"),
             &method_subst,
             None,
             None,
@@ -8533,9 +8313,8 @@ mod tests {
             },
         );
         method_subst.insert(EcoString::from("E"), InferredType::known("Error"));
-        let result = TypeChecker::resolve_type_string(
-            "Result(T, E)",
-            &HashMap::new(),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("Result(T, E)"),
             &method_subst,
             None,
             None,
@@ -8575,10 +8354,9 @@ mod tests {
         // `isNil`/`ifNil:` narrowing recognises the member.
         let mut subst = HashMap::new();
         subst.insert(EcoString::from("E"), InferredType::known("Integer"));
-        let result = TypeChecker::resolve_type_string(
-            "E | Nil",
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("E | Nil"),
             &subst,
-            &HashMap::new(),
             None,
             None,
             TypeStringContext::Substitution,
@@ -8597,10 +8375,9 @@ mod tests {
     fn substitute_return_type_union_no_params() {
         // "Behaviour | Nil" with no substitutions should pass through as Union
         // (with `Nil` normalised to `UndefinedObject`, BT-3075).
-        let result = TypeChecker::resolve_type_string(
-            "Behaviour | Nil",
-            &HashMap::new(),
-            &HashMap::new(),
+        let result = type_resolver::resolve_declared_type(
+            &DeclaredType::parse("Behaviour | Nil"),
+            &type_resolver::SubstitutionMap::new(),
             None,
             None,
             TypeStringContext::Substitution,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/native_types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/native_types.rs
@@ -29,8 +29,11 @@
 //! ```
 
 use super::native_type_registry::{FunctionSignature, NativeTypeRegistry, ParamType};
-use super::types::{DynamicReason, InferredType, TypeProvenance};
-use super::well_known::WellKnownClass;
+use super::type_resolver;
+#[cfg(test)]
+use super::types::DynamicReason;
+use super::types::{InferredType, TypeProvenance};
+use crate::semantic_analysis::class_hierarchy::DeclaredType;
 use ecow::EcoString;
 use std::collections::HashMap;
 
@@ -42,13 +45,29 @@ const SPECS_MODULE_PREFIX: &str = "beamtalk-specs-module:";
 ///
 /// The Erlang side already maps Erlang abstract types to Beamtalk type name
 /// strings (e.g., `integer()` → `"Integer"`, `binary()` → `"String"`). This
-/// function converts those string names into the Rust type representation.
+/// function parses that string into a [`DeclaredType`] (the same span-free
+/// grammar every other stored type-name string in the checker parses
+/// through) and resolves it via [`type_resolver::resolve_declared_type`] with
+/// [`super::TypeStringContext::Extracted`] — the same canonical resolver
+/// `resolve_type_annotation` and (pre-BT-3080) `TypeChecker::resolve_type_string`
+/// use, rather than a hand-rolled parallel implementation (BT-3080).
+///
+/// Folding onto the canonical resolver means this now also gets, for free:
+/// - **BT-2016 keyword normalisation**: `"Nil"` resolves to `UndefinedObject`
+///   (not a `Known("Nil")` pseudo-class), so `isNil`/`ifNil:` narrowing —
+///   which keys on `UndefinedObject` — recognises FFI-typed values too.
+/// - Alias expansion and type-param substitution, if a future caller threads
+///   an `alias_registry` / `SubstitutionMap` through (today's FFI spec
+///   parsing has neither available, so those lookups are inert — see
+///   `resolve_declared_type`'s doc for the `None`/empty contract).
 ///
 /// ## Type Variable Handling
 ///
 /// - Concrete type names (e.g., `"Integer"`, `"List"`) produce `Known` types
 ///   with `Extracted` provenance.
-/// - `"Dynamic"` produces `InferredType::Dynamic(DynamicReason::DynamicSpec)`.
+/// - `"Dynamic"` produces `InferredType::Dynamic(DynamicReason::DynamicSpec)`
+///   — not `ExplicitDynamic`; see `resolve_declared_type_inner`'s `Extracted`
+///   arm (BT-3080) for why the two `Dynamic` reasons must stay distinct here.
 /// - Union types (e.g., `"Integer | String"`) are split and produce `Union` types.
 /// - Parametric types (e.g., `"List(Integer)"`, `"Tuple(Symbol, Integer)"`,
 ///   `"Result(String, Symbol)"`) parse their element types into `type_args`
@@ -61,72 +80,20 @@ const SPECS_MODULE_PREFIX: &str = "beamtalk-specs-module:";
 /// ```ignore
 /// map_type_name("Integer")           // => Known { class_name: "Integer", .. }
 /// map_type_name("Dynamic")           // => Dynamic
+/// map_type_name("Nil")               // => Known { class_name: "UndefinedObject", .. }
 /// map_type_name("Integer | String")  // => Union { members: [Integer, String], .. }
 /// map_type_name("List(Integer)")     // => Known { class_name: "List", type_args: [Integer] }
 /// ```
 #[must_use]
 pub fn map_type_name(type_name: &str) -> InferredType {
-    let trimmed = type_name.trim();
-
-    if WellKnownClass::from_str(trimmed) == Some(WellKnownClass::Dynamic) {
-        return InferredType::Dynamic(DynamicReason::DynamicSpec);
-    }
-
-    // Handle union types, splitting on `|` while respecting parenthesis nesting
-    // so `List(String | Binary)` and `Result(String, Symbol)` are not split at
-    // an interior `|`.
-    if trimmed.contains('|') {
-        let members = super::TypeChecker::split_union_respecting_parens(trimmed);
-        if members.len() > 1 {
-            let resolved: Vec<InferredType> = members
-                .into_iter()
-                .map(|part| map_single_type_name(part.trim()))
-                .collect();
-            return InferredType::union_of(&resolved);
-        }
-        // Single member — the `|` was inside parens; fall through to the
-        // parametric-type handling below.
-    }
-
-    map_single_type_name(trimmed)
-}
-
-/// Maps a single (non-top-level-union) type name to an [`InferredType`].
-///
-/// Handles bare names (`"Integer"`), `"Dynamic"`/`"Never"` keywords, and
-/// parametric types (`"List(Integer)"`, `"Tuple(Symbol, Integer)"`). Element
-/// types recurse through [`map_type_name`] so nested parametric/union shapes
-/// (`"Result(List(String), Symbol)"`) parse fully.
-fn map_single_type_name(name: &str) -> InferredType {
-    if WellKnownClass::from_str(name) == Some(WellKnownClass::Dynamic) {
-        return InferredType::Dynamic(DynamicReason::DynamicSpec);
-    }
-    if WellKnownClass::from_str(name) == Some(WellKnownClass::Never) {
-        return InferredType::Never;
-    }
-
-    // Parametric type: e.g., `List(Integer)`, `Tuple(Symbol, Integer)`.
-    // BT-2254: parse element types into `type_args` so iteration and
-    // literal-index `at:` can recover them. Parenthesis-aware arg splitting
-    // lives in the centralised resolver helper.
-    let (base, args_slice) = super::type_resolver::split_generic_base(name);
-    if let Some(inner) = args_slice {
-        let type_args: Vec<InferredType> = super::TypeChecker::split_type_params(inner)
-            .into_iter()
-            .map(map_type_name)
-            .collect();
-        return InferredType::Known {
-            class_name: EcoString::from(base),
-            type_args,
-            provenance: TypeProvenance::Extracted,
-        };
-    }
-
-    InferredType::Known {
-        class_name: EcoString::from(name),
-        type_args: vec![],
-        provenance: TypeProvenance::Extracted,
-    }
+    let declared = DeclaredType::parse(type_name.trim());
+    type_resolver::resolve_declared_type(
+        &declared,
+        &type_resolver::SubstitutionMap::new(),
+        None,
+        None,
+        super::TypeStringContext::Extracted,
+    )
 }
 
 /// Parses a `beamtalk-specs-module:` line and registers the specs in the registry.
@@ -536,8 +503,16 @@ mod tests {
 
     #[test]
     fn map_type_name_nil() {
+        // BT-3080: `beamtalk_spec_reader.erl` emits `"Nil"` for the `nil`
+        // atom type. Before this fix, `map_type_name` returned a bare
+        // `Known("Nil")` pseudo-class — this test pinned that wrong
+        // behaviour (BT-2016). Folding onto the canonical resolver's
+        // `resolve_type_keyword` normalisation resolves it to the real nil
+        // class, `UndefinedObject`, so `isNil`/`ifNil:` narrowing recognises
+        // FFI-typed `Nil` members exactly like a source-written `Integer |
+        // Nil` annotation.
         let ty = map_type_name("Nil");
-        assert_eq!(ty, InferredType::known("Nil"));
+        assert_eq!(ty, InferredType::known("UndefinedObject"));
     }
 
     #[test]
@@ -951,6 +926,99 @@ mod tests {
             sig.params[1].keyword.as_deref(),
             Some("arg"),
             "Bare spec's unnamed param should win over keyword alias's 'class'"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // BT-3080: conformance with `beamtalk_spec_reader.erl`'s `map_type/1`
+    // vocabulary — every string shape that function can emit
+    // (runtime/apps/beamtalk_compiler/src/beamtalk_spec_reader.erl:849-948)
+    // must parse *structurally*, not degrade to an opaque nominal class
+    // whose name happens to be the whole string.
+    // -----------------------------------------------------------------------
+
+    /// (wire string, assertion) pair type for
+    /// `map_type_name_conforms_to_spec_reader_vocabulary` below.
+    type VocabCase = (&'static str, fn(&InferredType) -> bool);
+
+    #[test]
+    fn map_type_name_conforms_to_spec_reader_vocabulary() {
+        // (wire string, assertion) pairs mirroring every `map_type/1` clause.
+        // A `Known`/`Union`/`Dynamic`/`Never` result with a *shorter*
+        // class-name than the input string is the structural-parse signal:
+        // an unparsed shape would instead degrade to `Known(<whole string>)`.
+        let cases: &[VocabCase] = &[
+            ("Integer", |t| *t == InferredType::known("Integer")),
+            ("Float", |t| *t == InferredType::known("Float")),
+            ("Number", |t| *t == InferredType::known("Number")),
+            ("String | Binary", |t| {
+                *t == InferredType::simple_union(&["String", "Binary"])
+            }),
+            ("Boolean", |t| *t == InferredType::known("Boolean")),
+            ("Symbol", |t| *t == InferredType::known("Symbol")),
+            ("Pid", |t| *t == InferredType::known("Pid")),
+            ("Block", |t| *t == InferredType::known("Block")),
+            ("List", |t| *t == InferredType::known("List")),
+            ("String | List", |t| {
+                *t == InferredType::simple_union(&["String", "List"])
+            }),
+            ("List(Integer)", |t| {
+                matches!(t, InferredType::Known { class_name, type_args, .. }
+                    if class_name == "List" && type_args == &[InferredType::known("Integer")])
+            }),
+            ("Tuple", |t| *t == InferredType::known("Tuple")),
+            ("Tuple(Symbol, Integer)", |t| {
+                matches!(t, InferredType::Known { class_name, type_args, .. }
+                    if class_name == "Tuple" && type_args.len() == 2)
+            }),
+            ("Dictionary", |t| *t == InferredType::known("Dictionary")),
+            ("True", |t| *t == InferredType::known("True")),
+            ("False", |t| *t == InferredType::known("False")),
+            // BT-2016 / BT-3080: the whole point — `Nil` must resolve to the
+            // canonical nil class, not stay a `Known("Nil")` pseudo-class.
+            ("Nil", |t| *t == InferredType::known("UndefinedObject")),
+            ("Dynamic", |t| matches!(t, InferredType::Dynamic(_))),
+            ("Result(Integer, Symbol)", |t| {
+                matches!(t, InferredType::Known { class_name, type_args, .. }
+                    if class_name == "Result" && type_args.len() == 2)
+            }),
+            ("#permanent | #temporary", |t| {
+                *t == InferredType::simple_union(&["#permanent", "#temporary"])
+            }),
+        ];
+
+        for (wire, check) in cases {
+            let ty = map_type_name(wire);
+            assert!(
+                check(&ty),
+                "wire string {wire:?} did not parse structurally: got {ty:?}"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // BT-3080: FFI Nil narrows correctly under `ifNil:`/`ifNotNil:` — the
+    // fix demonstration for the acceptance criterion. Full checker-level
+    // narrowing coverage (`ifNil:`, `isNil`) lives in `tests/ffi.rs`
+    // (`bt3080_ffi_nil_union_narrows_under_if_nil_if_not_nil`); this is the
+    // registry-level guarantee that test depends on: an FFI spec's `Integer |
+    // Nil` return type resolves its `Nil` member to `UndefinedObject`.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_specs_line_integer_or_nil_return_normalizes_nil_member() {
+        let mut reg = NativeTypeRegistry::new();
+        let line = "beamtalk-specs-module:mymod:[#{arity => 1,name => <<\"maybeInt\">>,\
+            params => [#{name => <<\"x\">>,type => <<\"Dynamic\">>}],\
+            return_type => <<\"Integer | Nil\">>}]";
+        parse_specs_line(line, &mut reg);
+        let sig = reg.lookup("mymod", "maybeInt", 1).unwrap();
+        assert_eq!(
+            sig.return_type,
+            InferredType::simple_union(&["Integer", "UndefinedObject"]),
+            "FFI `Nil` member must canonicalize to `UndefinedObject` so \
+             isNil/ifNil: narrowing (which keys on UndefinedObject) \
+             recognises it"
         );
     }
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/sendability.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/sendability.rs
@@ -29,15 +29,15 @@
 //!   tier), generic `type_args` (`List(Port)` → `HandleScoped`), and user
 //!   `handleScope:` declarations.
 
-use std::collections::HashMap;
-
 use ecow::EcoString;
 
 use crate::ast::ClassKind;
 use crate::semantic_analysis::ClassHierarchy;
 use crate::semantic_analysis::alias_registry::AliasRegistry;
+use crate::semantic_analysis::class_hierarchy::DeclaredType;
 
 use super::InferredType;
+use super::type_resolver;
 
 /// The scope over which a `HandleScoped` value's backing handle stays valid.
 ///
@@ -325,10 +325,9 @@ fn tier_of_known(
                 // to its declared type before tiering, instead of treating
                 // the alias name as an unresolved nominal class.
                 Some(field_ty) => {
-                    let field_type = super::TypeChecker::resolve_type_string(
-                        &field_ty,
-                        &HashMap::new(),
-                        &HashMap::new(),
+                    let field_type = type_resolver::resolve_declared_type(
+                        &DeclaredType::parse(&field_ty),
+                        &type_resolver::SubstitutionMap::new(),
                         None,
                         alias_registry,
                         super::TypeStringContext::Declared,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2865_dynamic_type_arg_iskindof.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt2865_dynamic_type_arg_iskindof.rs
@@ -108,10 +108,9 @@ fn resolve_type_annotation_dynamic_nested_in_generic_resolves_to_dynamic_variant
 /// resolve a bare `Dynamic` to the real `InferredType::Dynamic` variant.
 #[test]
 fn resolve_type_string_dynamic_keyword_resolves_to_dynamic_variant() {
-    let result = TypeChecker::resolve_type_string(
-        &eco_string("Dynamic"),
-        &HashMap::new(),
-        &HashMap::new(),
+    let result = type_resolver::resolve_declared_type(
+        &DeclaredType::parse(&eco_string("Dynamic")),
+        &type_resolver::SubstitutionMap::new(),
         None,
         None,
         TypeStringContext::Declared,
@@ -126,10 +125,9 @@ fn resolve_type_string_dynamic_keyword_resolves_to_dynamic_variant() {
 /// a generic's type args too.
 #[test]
 fn resolve_type_string_dynamic_nested_in_generic_resolves_to_dynamic_variant() {
-    let result = TypeChecker::resolve_type_string(
-        &eco_string("MyResult(Dynamic, Error)"),
-        &HashMap::new(),
-        &HashMap::new(),
+    let result = type_resolver::resolve_declared_type(
+        &DeclaredType::parse(&eco_string("MyResult(Dynamic, Error)")),
+        &type_resolver::SubstitutionMap::new(),
         None,
         None,
         TypeStringContext::Declared,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt3075_never_through_class_side_send.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/bt3075_never_through_class_side_send.rs
@@ -16,7 +16,9 @@
 //! returns Never". The same gap covered `Dynamic` (BT-2865's fix never
 //! reached this resolver), the `nil`/`true`/`false` keywords, and `Never`
 //! nested in substituted generic/union positions. Fixed by merging the two
-//! string resolvers into one (`resolve_type_string`).
+//! string resolvers into one (BT-3075's `resolve_type_string`, itself later
+//! deleted in favour of `DeclaredType::parse` + `resolve_declared_type`,
+//! BT-3080).
 
 use super::common::*;
 use std::collections::HashMap;
@@ -101,10 +103,9 @@ Object subclass: Liar\n\
 /// canonical `InferredType::Never`, not a `Known("Never")` pseudo-class.
 #[test]
 fn substitute_never_resolves_to_never_variant() {
-    let result = TypeChecker::resolve_type_string(
-        "Never",
-        &HashMap::new(),
-        &HashMap::new(),
+    let result = type_resolver::resolve_declared_type(
+        &DeclaredType::parse("Never"),
+        &type_resolver::SubstitutionMap::new(),
         None,
         None,
         TypeStringContext::Substitution,
@@ -119,10 +120,9 @@ fn substitute_never_resolves_to_never_variant() {
 /// real `Dynamic` variant (BT-2865's fix, previously missing here).
 #[test]
 fn substitute_dynamic_resolves_to_dynamic_variant() {
-    let result = TypeChecker::resolve_type_string(
-        "Dynamic",
-        &HashMap::new(),
-        &HashMap::new(),
+    let result = type_resolver::resolve_declared_type(
+        &DeclaredType::parse("Dynamic"),
+        &type_resolver::SubstitutionMap::new(),
         None,
         None,
         TypeStringContext::Substitution,
@@ -138,10 +138,9 @@ fn substitute_dynamic_resolves_to_dynamic_variant() {
 /// `isNil`/`ifNil:` narrowing keeps working on class-method return values.
 #[test]
 fn substitute_union_with_nil_keyword_normalises_to_undefined_object() {
-    let result = TypeChecker::resolve_type_string(
-        "String | nil",
-        &HashMap::new(),
-        &HashMap::new(),
+    let result = type_resolver::resolve_declared_type(
+        &DeclaredType::parse("String | nil"),
+        &type_resolver::SubstitutionMap::new(),
         None,
         None,
         TypeStringContext::Substitution,
@@ -167,10 +166,9 @@ fn substitute_union_with_nil_keyword_normalises_to_undefined_object() {
 fn substitute_union_with_never_member_collapses() {
     let mut subst: HashMap<EcoString, InferredType> = HashMap::new();
     subst.insert("T".into(), InferredType::known("Integer"));
-    let result = TypeChecker::resolve_type_string(
-        "T | Never",
+    let result = type_resolver::resolve_declared_type(
+        &DeclaredType::parse("T | Never"),
         &subst,
-        &HashMap::new(),
         None,
         None,
         TypeStringContext::Substitution,
@@ -188,10 +186,9 @@ fn substitute_union_with_never_member_collapses() {
 fn substitute_never_nested_in_generic_resolves_to_never_variant() {
     let mut subst: HashMap<EcoString, InferredType> = HashMap::new();
     subst.insert("T".into(), InferredType::known("Integer"));
-    let result = TypeChecker::resolve_type_string(
-        "GenResult(T, Never)",
+    let result = type_resolver::resolve_declared_type(
+        &DeclaredType::parse("GenResult(T, Never)"),
         &subst,
-        &HashMap::new(),
         None,
         None,
         TypeStringContext::Substitution,
@@ -265,10 +262,9 @@ typed Object subclass: Repro\n\
 fn substituted_union_collapsing_to_meta_gets_substituted_provenance() {
     let mut subst: HashMap<EcoString, InferredType> = HashMap::new();
     subst.insert("T".into(), InferredType::meta("Counter"));
-    let result = TypeChecker::resolve_type_string(
-        "T | Never",
+    let result = type_resolver::resolve_declared_type(
+        &DeclaredType::parse("T | Never"),
         &subst,
-        &HashMap::new(),
         None,
         None,
         TypeStringContext::Substitution,
@@ -287,10 +283,9 @@ fn substituted_union_collapsing_to_meta_gets_substituted_provenance() {
 /// `UndefinedObject` like every other resolver.
 #[test]
 fn substitute_bare_nil_normalises_to_undefined_object() {
-    let result = TypeChecker::resolve_type_string(
-        "Nil",
-        &HashMap::new(),
-        &HashMap::new(),
+    let result = type_resolver::resolve_declared_type(
+        &DeclaredType::parse("Nil"),
+        &type_resolver::SubstitutionMap::new(),
         None,
         None,
         TypeStringContext::Substitution,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/common.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/common.rs
@@ -7,6 +7,7 @@
 //! monolithic `tests.rs`. They are re-exported into every child test module
 //! via `use super::common::*;`.
 
+pub(super) use super::super::type_resolver;
 pub(super) use super::super::*;
 pub(super) use crate::ast::{
     Block, CascadeMessage, ClassDefinition, ClassKind, ClassModifiers, CommentAttachment,
@@ -14,6 +15,7 @@ pub(super) use crate::ast::{
     MessageSelector, MethodDefinition, MethodKind, Module, ParameterDefinition, Pattern,
     ProtocolDefinition, ProtocolMethodSignature, StateDeclaration, TypeAnnotation,
 };
+pub(super) use crate::semantic_analysis::class_hierarchy::DeclaredType;
 pub(super) use crate::source_analysis::{DiagnosticCategory, Span};
 
 pub(super) fn span() -> Span {

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_and_blocks.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_and_blocks.rs
@@ -282,10 +282,9 @@ fn block_params_remain_dynamic_for_unparameterized_list() {
 #[test]
 fn resolve_type_string_parametric() {
     // List(String) should parse to Known("List") with type_args [Known("String")]
-    let result = TypeChecker::resolve_type_string(
-        "List(String)",
-        &HashMap::new(),
-        &HashMap::new(),
+    let result = type_resolver::resolve_declared_type(
+        &DeclaredType::parse("List(String)"),
+        &type_resolver::SubstitutionMap::new(),
         None,
         None,
         TypeStringContext::Declared,
@@ -307,10 +306,9 @@ fn resolve_type_string_parametric() {
 #[test]
 fn resolve_type_string_nested_parametric() {
     // Result(List(Integer), String) should parse correctly
-    let result = TypeChecker::resolve_type_string(
-        "Result(List(Integer), String)",
-        &HashMap::new(),
-        &HashMap::new(),
+    let result = type_resolver::resolve_declared_type(
+        &DeclaredType::parse("Result(List(Integer), String)"),
+        &type_resolver::SubstitutionMap::new(),
         None,
         None,
         TypeStringContext::Declared,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/ffi.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/ffi.rs
@@ -1193,3 +1193,63 @@ fn test_erlang_lists_still_infers_ffi() {
         "FFI call should still infer correct return type"
     );
 }
+
+/// BT-3080: an FFI function spec'd `-> integer() | nil` — the `"Integer |
+/// Nil"` wire vocabulary `beamtalk_spec_reader:map_type/1` emits for a
+/// `-spec ... -> integer() | nil.` — narrows correctly under
+/// `ifNil:`/`ifNotNil:`, exactly like a source-written `Integer | Nil` field
+/// annotation (BT-2047). Registered via `parse_specs_line` with the exact
+/// wire format (not a hand-built `InferredType`), so this exercises the real
+/// `map_type_name` parsing path. Before this fix, `map_type_name` bypassed
+/// the BT-2016 nil-keyword normalisation and left the union's second member
+/// as the foreign `Known("Nil")` pseudo-class — which narrowing (keyed on
+/// `UndefinedObject`) never matches — so the `ifNotNil:` block param would
+/// have stayed the full `Integer | Nil` union instead of narrowing to plain
+/// `Integer`.
+#[test]
+fn bt3080_ffi_nil_union_narrows_under_if_nil_if_not_nil() {
+    let mut reg = NativeTypeRegistry::new();
+    let line = "beamtalk-specs-module:mymod:[#{arity => 0,name => <<\"maybeInt\">>,\
+        params => [],return_type => <<\"Integer | Nil\">>}]";
+    parse_specs_line(line, &mut reg);
+
+    let src = "typed Object subclass: Nav\n  \
+        run =>\n    \
+          (Erlang mymod) maybeInt\n      \
+            ifNil: [0]\n      \
+            ifNotNil: [:x | x + 1]";
+    let module = parse_source(src);
+    let hierarchy = ClassHierarchy::with_builtins();
+    let mut checker = TypeChecker::new();
+    checker.set_native_type_registry(reg);
+    checker.check_module(&module, &hierarchy);
+
+    let diags = checker.take_diagnostics();
+    let bad: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("understand") || d.message.contains("expects"))
+        .collect();
+    assert!(
+        bad.is_empty(),
+        "ifNotNil: block param should narrow to Integer (excluding the FFI \
+         Nil member) so `x + 1` type-checks cleanly; got diagnostics: {bad:#?}"
+    );
+
+    // The whole `ifNil:ifNotNil:` send's return type should be the plain
+    // `Integer` branch union (BT-2047's dedup rule) — not `Integer |
+    // UndefinedObject` — confirming the FFI `Nil` member was recognised and
+    // excluded from the `ifNotNil:` branch's param type rather than passing
+    // through as an opaque, narrowing-invisible pseudo-class.
+    let send_span = module.classes[0].methods[0]
+        .body
+        .last()
+        .unwrap()
+        .expression
+        .span();
+    let send_type = checker.type_map().get(send_span);
+    assert_eq!(
+        send_type,
+        Some(&InferredType::known("Integer")),
+        "expected ifNil:ifNotNil: branch union to be plain Integer, got {send_type:?}"
+    );
+}

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/local_annotations.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/local_annotations.rs
@@ -480,10 +480,9 @@ fn method_call_union_return_no_false_binary_warning() {
 /// "Integer | Nil" into a proper Union type (not Known("Integer | Nil")).
 #[test]
 fn resolve_type_string_splits_union() {
-    let ty = TypeChecker::resolve_type_string(
-        "Integer | Nil",
-        &HashMap::new(),
-        &HashMap::new(),
+    let ty = type_resolver::resolve_declared_type(
+        &DeclaredType::parse("Integer | Nil"),
+        &type_resolver::SubstitutionMap::new(),
         None,
         None,
         TypeStringContext::Declared,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_display_provenance.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_display_provenance.rs
@@ -457,8 +457,10 @@ fn argument_that_is_itself_an_alias_typed_return_value_is_not_flagged() {
     // no `AliasRegistry` access, so `policy` was inferred as a bare
     // `Known { class_name: "RestartStrategy", .. }` and the argument check
     // had to accept an unexpanded alias name; since BT-3075 the unified
-    // `resolve_type_string` expands the alias at the send site, so `policy`
-    // carries the structural union directly. Either shape must stay green.
+    // resolver (`resolve_declared_type`, folded in from BT-3075's
+    // `resolve_type_string` and BT-3080's FFI path alike) expands the alias
+    // at the send site, so `policy` carries the structural union directly.
+    // Either shape must stay green.
     // Reproduces the exact stdlib shape that surfaced this
     // (`Actor>>supervisionSpec`'s `policy := self supervisionPolicy.
     // spec withRestart: policy`, hit by `just build-stdlib` once

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/union_types.rs
@@ -162,10 +162,9 @@ fn resolve_type_annotation_false_or() {
 
 #[test]
 fn resolve_type_string_simple() {
-    let result = TypeChecker::resolve_type_string(
-        "Integer",
-        &HashMap::new(),
-        &HashMap::new(),
+    let result = type_resolver::resolve_declared_type(
+        &DeclaredType::parse("Integer"),
+        &type_resolver::SubstitutionMap::new(),
         None,
         None,
         TypeStringContext::Declared,
@@ -175,10 +174,9 @@ fn resolve_type_string_simple() {
 
 #[test]
 fn resolve_type_string_union() {
-    let result = TypeChecker::resolve_type_string(
-        "String | nil",
-        &HashMap::new(),
-        &HashMap::new(),
+    let result = type_resolver::resolve_declared_type(
+        &DeclaredType::parse("String | nil"),
+        &type_resolver::SubstitutionMap::new(),
         None,
         None,
         TypeStringContext::Declared,

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
@@ -46,6 +46,38 @@ use super::{DynamicReason, InferredType, TypeProvenance, TypeStringContext};
 /// substitutions apply — all type-parameter identifiers pass through unchanged.
 pub(in crate::semantic_analysis) type SubstitutionMap = HashMap<EcoString, InferredType>;
 
+/// Merge a class-level and a method-local substitution map into the single
+/// [`SubstitutionMap`] [`resolve_declared_type`] takes, with method-local
+/// bindings winning on key collision — the same two-map priority order the
+/// deleted `TypeChecker::resolve_type_string` (BT-3075) used to check
+/// separately (BT-3080: that function's three-parameter shape — class subst,
+/// method subst, `self_type` — collapses to this single map plus the
+/// resolver's existing `subst.get("Self")` convention below).
+///
+/// When `self_type` is `Some`, additionally binds the reserved `"Self"` key
+/// to it. `DeclaredType::parse` has no dedicated `SelfType` production (only
+/// [`TypeAnnotation::SelfType`] does) — a bare `"Self"` string parses to
+/// [`DeclaredType::Simple`], which falls through
+/// [`resolve_declared_type_inner`]'s ordinary `subst.get(name)` lookup.
+/// Binding `"Self"` here reproduces `resolve_type_string`'s dedicated
+/// `type_name == "Self"` special case through that same, already-existing
+/// lookup rather than a second one. `"Self"` is reserved (ADR 0108 forbids it
+/// as a generic type-param or alias name), so this can never collide with a
+/// real substitution entry.
+#[must_use]
+pub(in crate::semantic_analysis) fn merge_substitutions(
+    class_subst: &SubstitutionMap,
+    method_subst: &SubstitutionMap,
+    self_type: Option<&InferredType>,
+) -> SubstitutionMap {
+    let mut merged = class_subst.clone();
+    merged.extend(method_subst.iter().map(|(k, v)| (k.clone(), v.clone())));
+    if let Some(ty) = self_type {
+        merged.insert(EcoString::from("Self"), ty.clone());
+    }
+    merged
+}
+
 /// Resolve a [`TypeAnnotation`] into a fully-parameterised [`InferredType`],
 /// preserving generic arguments end-to-end.
 ///
@@ -290,11 +322,13 @@ pub(in crate::semantic_analysis) fn resolve_declared_type(
 /// Alias expansion threads `subst`, `protocol_registry`, `alias_registry`,
 /// and `ctx` through unchanged into the recursive call on the alias's own
 /// (converted) declared body — the same threading
-/// `resolve_type_annotation_inner` used. This is *not* what
-/// `TypeChecker::resolve_type_string`'s alias branch does (it resets to an
-/// empty `SubstitutionMap`, drops `protocol_registry`, and always resolves
-/// through the `Declared`-context AST path) — that divergence is pre-existing
-/// and out of scope here (BT-3076 stage 2 does not touch `resolve_type_string`).
+/// `resolve_type_annotation_inner` used. Before BT-3080 this diverged from
+/// `TypeChecker::resolve_type_string`'s alias branch, which reset to an empty
+/// `SubstitutionMap`, dropped `protocol_registry`, and always resolved
+/// through the `Declared`-context AST path; `resolve_type_string` is deleted
+/// (BT-3080), so this is now the *only* alias-expansion policy in the type
+/// checker — every former `resolve_type_string` call site resolves through
+/// this same threading.
 #[allow(clippy::too_many_lines)] // one match arm per DeclaredType variant — see resolve_declared_type's doc
 fn resolve_declared_type_inner(
     dt: &DeclaredType,
@@ -322,8 +356,23 @@ fn resolve_declared_type_inner(
             // `Result` never hits this path at all (no type args to resolve),
             // which is why the bug was invisible until a param was partially
             // parameterized.
+            //
+            // BT-3080: an FFI spec's `any()`/`term()` return type ("Dynamic"
+            // in the wire vocabulary) is not the same *reason* as a
+            // user-written `:: Dynamic` — `DynamicSpec` "loses" to a concrete
+            // binding observed elsewhere during merge, where `ExplicitDynamic`
+            // is authoritative (see `DynamicReason::ExplicitDynamic`'s doc).
+            // Folding `native_types::map_type_name` onto this resolver must
+            // not collapse that distinction, so `Extracted` context keeps the
+            // FFI-specific reason; every other context keeps the pre-existing
+            // `ExplicitDynamic`.
             if WellKnownClass::from_str(name) == Some(WellKnownClass::Dynamic) {
-                return InferredType::Dynamic(DynamicReason::ExplicitDynamic);
+                let reason = if ctx == TypeStringContext::Extracted {
+                    DynamicReason::DynamicSpec
+                } else {
+                    DynamicReason::ExplicitDynamic
+                };
+                return InferredType::Dynamic(reason);
             }
             // Method-local / class-level type-parameter substitution wins over
             // keyword resolution, because `T`, `E`, `R` would otherwise flow
@@ -550,17 +599,15 @@ fn resolve_declared_type_inner(
     }
 }
 
-/// `Declared` or `Substituted` provenance (both `Span::default()`, per
-/// `resolve_declared_type`'s doc), chosen by `ctx` — the `DeclaredType`
-/// recursion's single construction point for "this was a constructed nominal
-/// / generic / metatype / set-op result", mirroring
-/// `TypeChecker::resolve_type_string`'s equivalent inline `if` at its
-/// generic-parse arm (BT-3075).
+/// `Declared`, `Substituted`, or `Extracted` provenance, chosen by `ctx` — the
+/// `DeclaredType` recursion's single construction point for "this was a
+/// constructed nominal / generic / metatype / set-op result" (BT-3075,
+/// extended BT-3080 with the `Extracted` arm for the folded-in FFI path).
 fn declared_type_provenance(ctx: TypeStringContext) -> TypeProvenance {
-    if ctx == TypeStringContext::Substitution {
-        TypeProvenance::Substituted(Span::default())
-    } else {
-        TypeProvenance::Declared(Span::default())
+    match ctx {
+        TypeStringContext::Substitution => TypeProvenance::Substituted(Span::default()),
+        TypeStringContext::Extracted => TypeProvenance::Extracted,
+        TypeStringContext::Declared => TypeProvenance::Declared(Span::default()),
     }
 }
 
@@ -694,13 +741,12 @@ pub(in crate::semantic_analysis) fn super_receiver_type(
             // generics (`List(Integer)`), unions (`Integer | Nil`), and `Nil`
             // keyword aliases canonicalise correctly instead of becoming an
             // opaque `Known("List(Integer)")`.
-            SuperclassTypeArg::Concrete { type_name } => super::TypeChecker::resolve_type_string(
-                type_name,
-                &HashMap::new(),
-                &HashMap::new(),
+            SuperclassTypeArg::Concrete { type_name } => resolve_declared_type(
+                &DeclaredType::parse(type_name),
+                &SubstitutionMap::new(),
                 None,
                 alias_registry,
-                super::TypeStringContext::Declared,
+                TypeStringContext::Declared,
             ),
         })
         .collect();
@@ -740,7 +786,7 @@ fn resolve_type_keyword(name: &EcoString) -> EcoString {
 /// `("Array(Integer)extra", None)` — the caller should treat the string as an
 /// opaque class name.
 ///
-/// Used by the string-form parsers (`resolve_type_string`,
+/// Used by the string-form parsers (`resolve_type_param`,
 /// `parse_generic_type_string`, etc.) in
 /// place of manual `.find('(')` slicing. Centralising this keeps the
 /// parenthesis-parsing logic in one place and lets the

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
@@ -612,15 +612,11 @@ fn declared_type_provenance(ctx: TypeStringContext) -> TypeProvenance {
 }
 
 /// Re-stamp `Substituted` provenance on a substitution-context union/false-or
-/// result — the `DeclaredType`-recursion counterpart of
-/// `TypeChecker::stamp_substituted_provenance` (inference.rs), duplicated
-/// rather than shared since that helper is private to `inference.rs`'s
-/// `impl TypeChecker` block. See its doc for the full rationale: `union_of`
-/// derives provenance from the members, and a plain nominal member never
-/// wins, so a substituted `V | Nil` would otherwise read as `Inferred`;
-/// `Aliased` results keep their tag (re-stamping would lose the alias
-/// display name); `Dynamic` and `Never` results carry no provenance and pass
-/// through unchanged.
+/// result. `union_of` derives provenance from the members, and a plain
+/// nominal member never wins, so a substituted `V | Nil` would otherwise
+/// read as `Inferred`; `Aliased` results keep their tag (re-stamping would
+/// lose the alias display name); `Dynamic` and `Never` results carry no
+/// provenance and pass through unchanged.
 fn stamp_substituted_provenance(mut ty: InferredType) -> InferredType {
     match &mut ty {
         InferredType::Known { provenance, .. }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 
 use crate::ast::{Expression, Literal, TypeAnnotation};
 use crate::semantic_analysis::alias_registry::AliasRegistry;
-use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
+use crate::semantic_analysis::class_hierarchy::{ClassHierarchy, DeclaredType};
 use crate::semantic_analysis::protocol_registry::ProtocolRegistry;
 use crate::semantic_analysis::receiver_knowledge;
 use crate::semantic_analysis::string_utils::edit_distance;
@@ -25,6 +25,7 @@ use crate::source_analysis::{Diagnostic, DiagnosticCategory, Span};
 use ecow::EcoString;
 
 use super::sendability;
+use super::type_resolver;
 use super::well_known::WellKnownClass;
 use super::{DynamicReason, InferredType, TypeChecker, TypeEnv};
 
@@ -248,11 +249,14 @@ impl TypeChecker {
                                 ),
                             }
                         };
-                        return super::TypeChecker::resolve_type_string(
-                            ret_ty,
-                            &class_subst,
-                            &HashMap::new(),
-                            Some(&self_type),
+                        return type_resolver::resolve_declared_type(
+                            &DeclaredType::parse(ret_ty),
+                            &type_resolver::merge_substitutions(
+                                &class_subst,
+                                &type_resolver::SubstitutionMap::new(),
+                                Some(&self_type),
+                            ),
+                            None,
                             self.alias_registry.as_ref(),
                             super::TypeStringContext::Substitution,
                         );
@@ -296,7 +300,7 @@ impl TypeChecker {
     /// Walks the method's declared parameter types and, for each parameter
     /// whose declared type is one of the class's type parameters (e.g. `T`
     /// in `Box(T)`), records the mapping `T -> arg_type`. The resulting map
-    /// is threaded into [`super::TypeChecker::resolve_type_string`]
+    /// is threaded into [`super::type_resolver::resolve_declared_type`]
     /// so the return type's references to those params resolve to the
     /// concrete inferred types.
     ///
@@ -1190,7 +1194,7 @@ impl TypeChecker {
             // send whose callee's `MethodInfo::return_type` is the raw alias
             // name `RestartStrategy` (send-site resolution expands aliases
             // only when a registry is threaded through — several
-            // `resolve_type_string` call sites, e.g. the class-object tower,
+            // `resolve_declared_type` call sites, e.g. the class-object tower,
             // pass `None`).
             // Structural compatibility below (`is_type_compatible` and the
             // `InferredType::Union` arm's `classify_union_members`) only
@@ -2890,8 +2894,9 @@ impl TypeChecker {
     /// alias deps, so non-alias assignability/compatibility behavior is
     /// untouched.
     ///
-    /// Deliberately not the more general `inference.rs::resolve_type_string`
-    /// (BT-2928, also alias-registry-aware): that helper additionally
+    /// Deliberately not the more general
+    /// `type_resolver::resolve_declared_type`
+    /// (BT-2928, also alias-registry-aware): that resolver additionally
     /// re-parses keywords (`nil`/`true`/`false`), generics, and pre-spelled
     /// unions, which would change what a *non-alias* declared type resolves
     /// to here (e.g. `"Nil"` -> `"UndefinedObject"`) — a broader behavior


### PR DESCRIPTION
## Summary

`native_types::map_type_name` hand-rolled its own union/parametric-type parsing instead of going through the canonical `type_resolver::resolve_declared_type` path used everywhere else. This caused a keyword-normalisation gap: `map_type_name("Nil")` returned `Known("Nil")` instead of `UndefinedObject`, which broke `isNil`/`ifNil:` narrowing on FFI-typed values.

- `map_type_name` now parses the type string via `DeclaredType::parse` and resolves it via `type_resolver::resolve_declared_type(&parsed, &SubstitutionMap::new(), None, None, TypeStringContext::Extracted)`, so FFI-derived types go through the same keyword normalisation (`Nil`/`True`/`False` → `UndefinedObject`/`True`/`False` classes) as every other type-resolution path.
- Deleted `TypeChecker::resolve_type_string` (477 lines) — it was a second, independently-drifted implementation of the same resolution logic. Its regression tests were retargeted to call `type_resolver::resolve_declared_type` directly.

This is part of the BT-3078 duplication-cleanup epic — same class of bug as the class-side typing fix that started the audit: the same semantic rule (type-string resolution) was implemented twice, and the two implementations had drifted apart.

## Test plan
- [x] `cargo test -p beamtalk-core --lib semantic_analysis::type_checker::` — 1250 passed
- [x] `cargo test -p beamtalk-core --lib` (full suite) — 5522 passed, 1 ignored, 0 failed
- [x] `cargo clippy -p beamtalk-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p beamtalk-core -- --check` — clean
- [x] Erlang runtime/stdlib tests — 5553 + 1807 passed, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL7GE5XvKMame4UzYFb1dJ)_