### PR TITLE
test: add script_exit and trace-error coverage to beamtalk_repl_ops_eval_tests

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_eval_tests.erl
@@ -15,7 +15,10 @@ Covers:
 * non-empty expression that succeeds → `{ok, Value, Output, Warnings}`;
 * non-empty expression that fails at runtime → `{error, #beamtalk_error{}, Output, Warnings}`
   (verify `beamtalk_repl_errors:ensure_structured_error/1` wrapping);
-* trace mode → `{trace, Steps, Output, Warnings}`;
+* `Program exit: N` in non-trace mode → `{script_exit, N, Output, Warnings}` (BT-2688);
+* trace mode success → `{trace, Steps, Output, Warnings}`;
+* trace mode error → `{error, #beamtalk_error{}, Output, Warnings}` (ensure_structured_error wrap);
+* `Program exit: N` in trace mode → `{script_exit, N, Output, Warnings}` (BT-2688);
 * `handle/4` WebSocket edge wrapper → encodes the term result to a JSON binary.
 """.
 
@@ -38,12 +41,33 @@ setup(SessionId) ->
     {ok, SessionPid} = beamtalk_repl_shell:start_link(SessionId),
     SessionPid.
 
+setup_with_stdlib(SessionId) ->
+    {ok, _} = application:ensure_all_started(compiler),
+    {ok, _} = application:ensure_all_started(beamtalk_runtime),
+    {ok, _} = application:ensure_all_started(beamtalk_compiler),
+    {ok, _} = application:ensure_all_started(beamtalk_stdlib),
+    %% Poll until the Program class is registered (stdlib loads classes asynchronously).
+    ok = wait_for_class('Program', 50, 30),
+    {ok, SessionPid} = beamtalk_repl_shell:start_link(SessionId),
+    SessionPid.
+
 teardown(SessionPid) ->
     catch beamtalk_repl_shell:stop(SessionPid),
     %% Restore baseline "compiler not running" state so subsequent test modules
     %% that test no-compiler error paths see the expected initial state.
     _ = application:stop(beamtalk_compiler),
     ok.
+
+wait_for_class(_Class, _Interval, 0) ->
+    error(class_registry_timeout);
+wait_for_class(Class, Interval, Retries) ->
+    case beamtalk_class_registry:whereis_class(Class) of
+        undefined ->
+            timer:sleep(Interval),
+            wait_for_class(Class, Interval, Retries - 1);
+        _Pid ->
+            ok
+    end.
 
 %%====================================================================
 %% handle_term/4 — empty code (no session required)
@@ -88,6 +112,31 @@ handle_term_eval_error_wraps_in_beamtalk_error_test_() ->
     end}.
 
 %%====================================================================
+%% handle_term/4 — non-trace script_exit path (BT-2688)
+%%
+%% `Program exit: N` in a non-node-owning session throws a tagged
+%% `{beamtalk_script_exit, N}` signal that the shell catches and
+%% converts to `{script_exit, N, Output, Warnings}`. This covers the
+%% uncovered branch at line 72 of beamtalk_repl_ops_eval.erl.
+%% Each script_exit test uses a fresh session because the shell
+%% terminates after surfacing the exit status (BT-2688, ADR 0099 §3).
+%%====================================================================
+
+handle_term_non_trace_script_exit_test_() ->
+    {setup, fun() -> setup_with_stdlib(<<"test-eval-ops-script-exit-nontrace">>) end,
+        fun teardown/1, fun(SessionPid) ->
+            [
+                ?_test(begin
+                    Msg = make_msg(<<"eval">>),
+                    Result = beamtalk_repl_ops_eval:handle_term(
+                        <<"eval">>, #{<<"code">> => <<"Program exit: 5">>}, Msg, SessionPid
+                    ),
+                    ?assertMatch({script_exit, 5, _, _}, Result)
+                end)
+            ]
+        end}.
+
+%%====================================================================
 %% handle_term/4 — trace mode
 %%====================================================================
 
@@ -106,6 +155,47 @@ handle_term_trace_mode_returns_trace_shape_test_() ->
             end)
         ]
     end}.
+
+handle_term_trace_mode_error_wraps_in_beamtalk_error_test_() ->
+    {setup, fun() -> setup(<<"test-eval-ops-trace-error">>) end, fun teardown/1, fun(SessionPid) ->
+        [
+            ?_test(begin
+                Msg = make_msg(<<"eval">>),
+                %% Unary message not understood by Integer in trace mode →
+                %% does_not_understand, wrapped by ensure_structured_error.
+                %% Covers the error branch at lines 63–64 of
+                %% beamtalk_repl_ops_eval.erl.
+                Result = beamtalk_repl_ops_eval:handle_term(
+                    <<"eval">>,
+                    #{<<"code">> => <<"1 unknownMsg">>, <<"trace">> => true},
+                    Msg,
+                    SessionPid
+                ),
+                ?assertMatch({error, #beamtalk_error{}, _, _}, Result)
+            end)
+        ]
+    end}.
+
+handle_term_trace_mode_script_exit_test_() ->
+    {setup, fun() -> setup_with_stdlib(<<"test-eval-ops-script-exit-trace">>) end, fun teardown/1,
+        fun(SessionPid) ->
+            [
+                ?_test(begin
+                    Msg = make_msg(<<"eval">>),
+                    %% `Program exit: N` in trace mode also surfaces as
+                    %% `{script_exit, N, Output, Warnings}` (BT-2688).
+                    %% Covers the uncovered branch at line 61 of
+                    %% beamtalk_repl_ops_eval.erl.
+                    Result = beamtalk_repl_ops_eval:handle_term(
+                        <<"eval">>,
+                        #{<<"code">> => <<"Program exit: 7">>, <<"trace">> => true},
+                        Msg,
+                        SessionPid
+                    ),
+                    ?assertMatch({script_exit, 7, _, _}, Result)
+                end)
+            ]
+        end}.
 
 %%====================================================================
 %% handle/4 — WebSocket edge wrapper


### PR DESCRIPTION
## Summary

Covers four previously-uncovered lines in `beamtalk_repl_ops_eval:handle_term/4`
(identified from the CI coverage artifact, run 31287693163, 2026-08-09):

- **Line 72** — `{script_exit, Code, Output, Warnings}` return in the non-trace branch
- **Lines 63–64** — error wrapping via `ensure_structured_error` in the trace branch
- **Line 61** — `{script_exit, Code, Output, Warnings}` return in the trace branch

## Changes

- Added `setup_with_stdlib/1` helper — starts `beamtalk_stdlib` in addition to the
  existing apps and polls `beamtalk_class_registry:whereis_class('Program')` until
  the class is registered (stdlib loads classes asynchronously). The `Program` class
  is in `beamtalk_stdlib` and is required for evaluating `Program exit: N`.

- Added `wait_for_class/3` — polls the class registry at 50 ms intervals, up to 30
  retries (1 500 ms cap), and errors with `class_registry_timeout` if the class never
  appears.

- Added three new `{setup, …}` EUnit fixtures, each with its own session ID (shell
  terminates after `Program exit:`, so each script_exit test requires an isolated
  session):

  | Test | Code evaluated | Expected shape | Lines covered |
  |---|---|---|---|
  | `handle_term_non_trace_script_exit_test_` | `Program exit: 5` | `{script_exit, 5, _, _}` | 72 |
  | `handle_term_trace_mode_error_wraps_in_beamtalk_error_test_` | `1 unknownMsg` trace=true | `{error, #beamtalk_error{}, _, _}` | 63–64 |
  | `handle_term_trace_mode_script_exit_test_` | `Program exit: 7` trace=true | `{script_exit, 7, _, _}` | 61 |

No production code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ke1XUo4KLKsU5UuXrYUcH)_