### PR TITLE
Finish hierarchy-walker consolidation (BT-3087)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
@@ -1192,9 +1192,19 @@ Fun receives (ClassName, ClassPid, Acc) and returns:
   {cont, NewAcc}   — continue walking to superclass
   {halt, Result}   — stop and return Result immediately
 
-Returns Acc when the chain is exhausted (none or unregistered class), or
-when the walk exhausts `?MAX_HIERARCHY_DEPTH` (a hierarchy cycle) — the
-latter case also logs a `?LOG_WARNING`.
+When the chain is exhausted (none or unregistered class), returns the fully
+folded accumulator built up through every ancestor visited.
+
+When the walk instead exhausts `?MAX_HIERARCHY_DEPTH` (a hierarchy cycle),
+returns the ORIGINAL `Acc` passed into this call — not the partial
+accumulator folded up through the ~`?MAX_HIERARCHY_DEPTH` ancestors visited
+before the guard tripped — and logs a `?LOG_WARNING`. This is a deliberate,
+narrower contract than the hand-rolled recursion this function replaced
+(which did return the partial fold): `walk_ancestors/3`'s `max_depth_exceeded`
+carries no payload, so every caller here falls back to a fixed default on
+this already-anomalous path rather than threading partial state back out.
+Only reachable via an actual hierarchy cycle or a legitimately
+`?MAX_HIERARCHY_DEPTH`-level-deep hierarchy.
 
 BT-3087: The walk itself (depth guard, cycle warning, advance-to-superclass)
 is `beamtalk_hierarchy:walk_ancestors/3`; this function supplies only the

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
@@ -1192,41 +1192,52 @@ Fun receives (ClassName, ClassPid, Acc) and returns:
   {cont, NewAcc}   — continue walking to superclass
   {halt, Result}   — stop and return Result immediately
 
-Returns Acc when the chain is exhausted (none or unregistered class).
-Guards against cycles via ?MAX_HIERARCHY_DEPTH.
+Returns Acc when the chain is exhausted (none or unregistered class), or
+when the walk exhausts `?MAX_HIERARCHY_DEPTH` (a hierarchy cycle) — the
+latter case also logs a `?LOG_WARNING`.
+
+BT-3087: The walk itself (depth guard, cycle warning, advance-to-superclass)
+is `beamtalk_hierarchy:walk_ancestors/3`; this function supplies only the
+per-ancestor registry lookup and threads Acc through the walk. Since
+`walk_ancestors/3` only threads a bare node id between steps (not a
+separate accumulator), Acc rides along inside the node as `{ClassName, Acc}`.
 """.
 -spec walk_hierarchy(atom() | none, fun((atom(), pid(), Acc) -> {cont, Acc} | {halt, Result}), Acc) ->
     Acc | Result.
+walk_hierarchy(none, _Fun, Acc) ->
+    Acc;
 walk_hierarchy(ClassName, Fun, Acc) ->
-    walk_hierarchy(ClassName, Fun, Acc, 0).
-
--spec walk_hierarchy(
-    atom() | none,
-    fun((atom(), pid(), Acc) -> {cont, Acc} | {halt, Result}),
-    Acc,
-    non_neg_integer()
-) -> Acc | Result.
-walk_hierarchy(none, _Fun, Acc, _Depth) ->
-    Acc;
-walk_hierarchy(_ClassName, _Fun, Acc, Depth) when Depth > ?MAX_HIERARCHY_DEPTH ->
-    ?LOG_WARNING(
-        "walk_hierarchy: max hierarchy depth ~p exceeded — possible cycle",
-        [?MAX_HIERARCHY_DEPTH],
-        #{domain => [beamtalk, runtime]}
-    ),
-    Acc;
-walk_hierarchy(ClassName, Fun, Acc, Depth) ->
-    case beamtalk_class_registry:whereis_class(ClassName) of
-        undefined ->
+    StepFun = fun({CurrentClassName, CurrentAcc}, _Depth) ->
+        case beamtalk_class_registry:whereis_class(CurrentClassName) of
+            undefined ->
+                {found, {result, CurrentAcc}};
+            ClassPid ->
+                case Fun(CurrentClassName, ClassPid, CurrentAcc) of
+                    {halt, Result} ->
+                        {found, {result, Result}};
+                    {cont, NewAcc} ->
+                        case gen_server:call(ClassPid, superclass) of
+                            none -> {found, {result, NewAcc}};
+                            Super -> {next, {Super, NewAcc}}
+                        end
+                end
+        end
+    end,
+    case beamtalk_hierarchy:walk_ancestors({ClassName, Acc}, StepFun, ?MAX_HIERARCHY_DEPTH) of
+        {found, {result, Result}} ->
+            Result;
+        max_depth_exceeded ->
+            ?LOG_WARNING(
+                "walk_hierarchy: max hierarchy depth ~p exceeded — possible cycle",
+                [?MAX_HIERARCHY_DEPTH],
+                #{domain => [beamtalk, runtime]}
+            ),
             Acc;
-        ClassPid ->
-            case Fun(ClassName, ClassPid, Acc) of
-                {halt, Result} ->
-                    Result;
-                {cont, NewAcc} ->
-                    Super = gen_server:call(ClassPid, superclass),
-                    walk_hierarchy(Super, Fun, NewAcc, Depth + 1)
-            end
+        not_found ->
+            %% Unreachable: StepFun above always resolves to {found, _} — a
+            %% `none` superclass or an unregistered ancestor is translated to
+            %% a terminal {found, {result, _}}, never a bare `none` node.
+            erlang:error({unreachable, not_found, ClassName})
     end.
 
 -doc """

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_hierarchy_docs.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_hierarchy_docs.erl
@@ -1,0 +1,194 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_hierarchy_docs).
+
+%%% **DDD Context:** Object System Context
+
+-moduledoc """
+Shared hierarchy-walking helpers for documentation/reflection lookups (BT-3087).
+
+`beamtalk_stdlib`'s `beamtalk_interface` (backs the programmatic `Beamtalk
+help:` / `Beamtalk help:selector:` reflection API) and `beamtalk_workspace`'s
+`beamtalk_repl_docs` (backs the REPL's `:help` command) each hand-rolled an
+identical set of helpers for walking the superclass chain to resolve
+documentation — literally byte-identical apart from which lookup mechanism
+(direct `gen_server:call` vs the `beamtalk_runtime_api` facade) each used to
+reach the same class-registry/gen_server state.
+
+Both apps depend on `beamtalk_runtime` (see the `applications` list in each
+app's `.app.src`: `beamtalk_stdlib` depends on `beamtalk_runtime`, and
+`beamtalk_workspace` depends on both), so this module lives here as the
+single shared implementation both callers delegate to, rather than the
+mirrored copies + "mirrors ..." comments that used to stand in for a test.
+
+Each helper delegates its walk (depth guard, cycle warning, advance-to-
+superclass) to `beamtalk_hierarchy:walk_ancestors/3`, supplying only the
+per-ancestor probe. Depth-exhaustion is intentionally uniform across all of
+them: BT-3087 found `beamtalk_interface`'s copies silently swallowing a
+hierarchy cycle (returning the receiver's own class / an empty map) while
+`beamtalk_repl_docs`'s copies warned via `?LOG_WARNING` — a hierarchy cycle
+was diagnosable via `:help` in the REPL but invisible via the programmatic
+`Beamtalk help:` call. Every helper here now logs on depth exhaustion,
+matching `beamtalk_hierarchy`'s own convention.
+""".
+
+-include("beamtalk.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+-export([
+    find_defining_class/2,
+    find_defining_class_method/2,
+    collect_flattened_methods/2,
+    metaclass_method_doc/1
+]).
+
+%%% ============================================================================
+%%% Public API
+%%% ============================================================================
+
+-doc """
+Find which class in the hierarchy (starting at ClassPid) defines Selector as
+an instance method. Returns the defining class's name atom.
+
+If Selector is not found anywhere in the chain, or the walk exhausts
+`?MAX_HIERARCHY_DEPTH` (a hierarchy cycle), returns ClassPid's own class name
+and — in the cycle case only — logs a `?LOG_WARNING`.
+""".
+-spec find_defining_class(pid(), atom()) -> atom().
+find_defining_class(ClassPid, Selector) ->
+    ReceiverName = beamtalk_object_class:class_name(ClassPid),
+    StepFun = fun(CurrentPid, _Depth) ->
+        CurrentName = beamtalk_object_class:class_name(CurrentPid),
+        case gen_server:call(CurrentPid, {method, Selector}, 5000) of
+            nil ->
+                case gen_server:call(CurrentPid, superclass, 5000) of
+                    none ->
+                        {found, CurrentName};
+                    SuperName ->
+                        case beamtalk_class_registry:whereis_class(SuperName) of
+                            undefined -> {found, CurrentName};
+                            SuperPid -> {next, SuperPid}
+                        end
+                end;
+            _MethodInfo ->
+                {found, CurrentName}
+        end
+    end,
+    case beamtalk_hierarchy:walk_ancestors(ClassPid, StepFun, ?MAX_HIERARCHY_DEPTH) of
+        {found, DefiningClass} ->
+            DefiningClass;
+        max_depth_exceeded ->
+            ?LOG_WARNING(
+                "find_defining_class: max hierarchy depth ~p exceeded at ~p for selector ~p — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, ReceiverName, Selector],
+                #{domain => [beamtalk, runtime]}
+            ),
+            ReceiverName;
+        not_found ->
+            %% Unreachable: StepFun above always resolves to {found, _} — a
+            %% `none` superclass or an unregistered ancestor is translated to
+            %% a terminal {found, CurrentName}, never a bare `none` node.
+            erlang:error({unreachable, not_found, ReceiverName, Selector})
+    end.
+
+-doc """
+Find which class in the hierarchy (starting at ClassPid) defines Selector as
+a class-side method. Mirrors `find_defining_class/2` for the class side —
+walks `get_local_class_methods` at each level instead of the instance
+method table.
+""".
+-spec find_defining_class_method(pid(), atom()) -> atom().
+find_defining_class_method(ClassPid, Selector) ->
+    ReceiverName = beamtalk_object_class:class_name(ClassPid),
+    StepFun = fun(CurrentPid, _Depth) ->
+        CurrentName = beamtalk_object_class:class_name(CurrentPid),
+        LocalClassMethods = gen_server:call(CurrentPid, get_local_class_methods, 5000),
+        case maps:is_key(Selector, LocalClassMethods) of
+            true ->
+                {found, CurrentName};
+            false ->
+                case gen_server:call(CurrentPid, superclass, 5000) of
+                    none ->
+                        {found, CurrentName};
+                    SuperName ->
+                        case beamtalk_class_registry:whereis_class(SuperName) of
+                            undefined -> {found, CurrentName};
+                            SuperPid -> {next, SuperPid}
+                        end
+                end
+        end
+    end,
+    case beamtalk_hierarchy:walk_ancestors(ClassPid, StepFun, ?MAX_HIERARCHY_DEPTH) of
+        {found, DefiningClass} ->
+            DefiningClass;
+        max_depth_exceeded ->
+            ?LOG_WARNING(
+                "find_defining_class_method: max hierarchy depth ~p exceeded at ~p for selector ~p — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, ReceiverName, Selector],
+                #{domain => [beamtalk, runtime]}
+            ),
+            ReceiverName;
+        not_found ->
+            %% Unreachable: see find_defining_class/2.
+            erlang:error({unreachable, not_found, ReceiverName, Selector})
+    end.
+
+-doc """
+Walk the class hierarchy from ClassName/ClassPid upward, building a
+flattened `#{Selector => {DefiningClass, MethodInfo}}` map of instance
+methods. Local methods shadow inherited ones (Smalltalk-style override):
+a selector redefined by a subclass is tagged with the subclass as its
+`DefiningClass`, never the ancestor it shadows.
+
+Returns `#{}` if the walk exhausts `?MAX_HIERARCHY_DEPTH` (a hierarchy
+cycle), logging a `?LOG_WARNING`.
+""".
+-spec collect_flattened_methods(atom(), pid()) -> map().
+collect_flattened_methods(ClassName, ClassPid) ->
+    StepFun = fun({CurrentName, CurrentPid, AccMap}, _Depth) ->
+        {ok, LocalMethods} = gen_server:call(CurrentPid, get_instance_methods, 5000),
+        LocalFlat = maps:map(fun(_Sel, Info) -> {CurrentName, Info} end, LocalMethods),
+        %% AccMap already reflects every closer (lower-depth) ancestor
+        %% winning over farther ones; putting it second keeps that
+        %% invariant as this (farther) level's LocalFlat is folded in.
+        NewAcc = maps:merge(LocalFlat, AccMap),
+        case gen_server:call(CurrentPid, superclass, 5000) of
+            none ->
+                {found, NewAcc};
+            SuperName ->
+                case beamtalk_class_registry:whereis_class(SuperName) of
+                    undefined -> {found, NewAcc};
+                    SuperPid -> {next, {SuperName, SuperPid, NewAcc}}
+                end
+        end
+    end,
+    case
+        beamtalk_hierarchy:walk_ancestors(
+            {ClassName, ClassPid, #{}}, StepFun, ?MAX_HIERARCHY_DEPTH
+        )
+    of
+        {found, Result} ->
+            Result;
+        max_depth_exceeded ->
+            ?LOG_WARNING(
+                "collect_flattened_methods: max hierarchy depth ~p exceeded at ~p — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, ClassName],
+                #{domain => [beamtalk, runtime]}
+            ),
+            #{};
+        not_found ->
+            %% Unreachable: see find_defining_class/2.
+            erlang:error({unreachable, not_found, ClassName})
+    end.
+
+-doc "Lookup doc text for the hardcoded Metaclass class-side methods.".
+-spec metaclass_method_doc(binary()) -> {ok, binary()} | not_found.
+metaclass_method_doc(<<"new">>) ->
+    {ok, <<"Create a new instance of the class.">>};
+metaclass_method_doc(<<"spawn">>) ->
+    {ok, <<"Create a new actor instance. Returns an actor reference.">>};
+metaclass_method_doc(<<"spawnWith:">>) ->
+    {ok, <<"Create a new actor with initial state from a Dictionary.">>};
+metaclass_method_doc(_) ->
+    not_found.

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
@@ -902,33 +902,16 @@ resolve_help_method(ClassName, ClassPid, SelectorAtom) ->
 
 %% BT-2091: Walk the class hierarchy looking at *class-side* method tables
 %% so the help header attributes the method to the class that actually
-%% defines it (mirrors find_defining_class/3 for the instance side).
+%% defines it (mirrors find_defining_class/2 for the instance side).
+%% BT-3087: Delegates to beamtalk_hierarchy_docs:find_defining_class_method/2,
+%% the implementation shared with beamtalk_repl_docs.
 -spec find_defining_class_method(pid(), atom()) -> atom().
 find_defining_class_method(ClassPid, Selector) ->
-    find_defining_class_method(ClassPid, Selector, 0).
+    beamtalk_hierarchy_docs:find_defining_class_method(ClassPid, Selector).
 
--spec find_defining_class_method(pid(), atom(), non_neg_integer()) -> atom().
-find_defining_class_method(ClassPid, _Selector, Depth) when Depth > ?MAX_HIERARCHY_DEPTH ->
-    beamtalk_object_class:class_name(ClassPid);
-find_defining_class_method(ClassPid, Selector, Depth) ->
-    Name = beamtalk_object_class:class_name(ClassPid),
-    LocalClassMethods = gen_server:call(ClassPid, get_local_class_methods, 5000),
-    case maps:is_key(Selector, LocalClassMethods) of
-        true ->
-            Name;
-        false ->
-            case gen_server:call(ClassPid, superclass, 5000) of
-                none ->
-                    Name;
-                SuperName ->
-                    case beamtalk_class_registry:whereis_class(SuperName) of
-                        undefined -> Name;
-                        SuperPid -> find_defining_class_method(SuperPid, Selector, Depth + 1)
-                    end
-            end
-    end.
-
-%% BT-2091: Hardcoded Metaclass method docs (mirrors beamtalk_repl_docs').
+%% BT-2091: Hardcoded Metaclass method docs.
+%% BT-3087: metaclass_method_doc/1 itself is shared with beamtalk_repl_docs
+%% via beamtalk_hierarchy_docs.
 %% Caller must normalise SelectorArg via ensure_atom/1 first so a binary
 %% selector cannot reach this path; that keeps make_method_not_found_error
 %% unable to crash on a binary input.
@@ -936,7 +919,7 @@ find_defining_class_method(ClassPid, Selector, Depth) ->
     binary() | {error, #beamtalk_error{}}.
 handle_metaclass_help_selector(SelectorAtom) ->
     SelectorBin = atom_to_binary(SelectorAtom, utf8),
-    case metaclass_method_doc(SelectorBin) of
+    case beamtalk_hierarchy_docs:metaclass_method_doc(SelectorBin) of
         {ok, Doc} ->
             iolist_to_binary([
                 <<"== Metaclass >> ">>,
@@ -950,16 +933,6 @@ handle_metaclass_help_selector(SelectorAtom) ->
         not_found ->
             {error, make_method_not_found_error('Metaclass', SelectorAtom)}
     end.
-
--spec metaclass_method_doc(binary()) -> {ok, binary()} | not_found.
-metaclass_method_doc(<<"new">>) ->
-    {ok, <<"Create a new instance of the class.">>};
-metaclass_method_doc(<<"spawn">>) ->
-    {ok, <<"Create a new actor instance. Returns an actor reference.">>};
-metaclass_method_doc(<<"spawnWith:">>) ->
-    {ok, <<"Create a new actor with initial state from a Dictionary.">>};
-metaclass_method_doc(_) ->
-    not_found.
 
 -doc "Resolve a class argument to an atom class name.".
 -spec resolve_class_name(term()) -> {ok, atom()} | {error, #beamtalk_error{}}.
@@ -1193,54 +1166,25 @@ get_method_sig(ClassPid, Selector) ->
             {atom_to_binary(Selector, utf8), Doc}
     end.
 
--doc "Walk the class hierarchy to collect flattened method map.".
+-doc """
+Walk the class hierarchy to collect flattened method map.
+
+BT-3087: Delegates to `beamtalk_hierarchy_docs:collect_flattened_methods/2`,
+the implementation shared with `beamtalk_repl_docs` (both apps depend on
+`beamtalk_runtime`).
+""".
 -spec collect_flattened_methods(atom(), pid()) -> map().
 collect_flattened_methods(ClassName, ClassPid) ->
-    collect_flattened_methods(ClassName, ClassPid, 0).
+    beamtalk_hierarchy_docs:collect_flattened_methods(ClassName, ClassPid).
 
--spec collect_flattened_methods(atom(), pid(), non_neg_integer()) -> map().
-collect_flattened_methods(_ClassName, _ClassPid, Depth) when Depth > ?MAX_HIERARCHY_DEPTH ->
-    #{};
-collect_flattened_methods(ClassName, ClassPid, Depth) ->
-    {ok, LocalMethods} = gen_server:call(ClassPid, get_instance_methods, 5000),
-    LocalFlat = maps:map(fun(_Sel, Info) -> {ClassName, Info} end, LocalMethods),
-    Superclass = gen_server:call(ClassPid, superclass, 5000),
-    SuperFlat = collect_chain_methods(Superclass, Depth + 1),
-    maps:merge(SuperFlat, LocalFlat).
+-doc """
+Find which class in the hierarchy defines a selector.
 
--spec collect_chain_methods(atom() | none, non_neg_integer()) -> map().
-collect_chain_methods(none, _Depth) ->
-    #{};
-collect_chain_methods(SuperName, Depth) ->
-    case beamtalk_class_registry:whereis_class(SuperName) of
-        undefined -> #{};
-        SuperPid -> collect_flattened_methods(SuperName, SuperPid, Depth)
-    end.
-
--doc "Find which class in the hierarchy defines a selector.".
+BT-3087: Delegates to `beamtalk_hierarchy_docs:find_defining_class/2`.
+""".
 -spec find_defining_class(pid(), atom()) -> atom().
 find_defining_class(ClassPid, Selector) ->
-    find_defining_class(ClassPid, Selector, 0).
-
--spec find_defining_class(pid(), atom(), non_neg_integer()) -> atom().
-find_defining_class(ClassPid, _Selector, Depth) when Depth > ?MAX_HIERARCHY_DEPTH ->
-    gen_server:call(ClassPid, class_name, 5000);
-find_defining_class(ClassPid, Selector, Depth) ->
-    ClassName = gen_server:call(ClassPid, class_name, 5000),
-    case gen_server:call(ClassPid, {method, Selector}, 5000) of
-        nil ->
-            case gen_server:call(ClassPid, superclass, 5000) of
-                none ->
-                    ClassName;
-                Super ->
-                    case beamtalk_class_registry:whereis_class(Super) of
-                        undefined -> ClassName;
-                        SuperPid -> find_defining_class(SuperPid, Selector, Depth + 1)
-                    end
-            end;
-        _MethodInfo ->
-            ClassName
-    end.
+    beamtalk_hierarchy_docs:find_defining_class(ClassPid, Selector).
 
 -doc "Group inherited methods by defining class.".
 -spec group_by_class([{atom(), atom()}]) -> [{atom(), [atom()]}].

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_docs.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_docs.erl
@@ -962,6 +962,13 @@ format_class_side_output(ClassName, Modifiers, OwnCM, InhCMGrouped, ProtoGrouped
 Walk the class hierarchy collecting class-side methods.
 Returns #{Selector => DefiningClass} — local methods shadow inherited ones.
 
+On depth exhaustion (`?MAX_HIERARCHY_DEPTH`, a hierarchy cycle) returns `#{}`
+— not the partial map folded up through the ancestors visited before the
+guard tripped — and logs a `?LOG_WARNING`. Deliberately narrower than
+returning partial results: `walk_ancestors/3`'s `max_depth_exceeded` carries
+no payload, so every caller falls back to a fixed default on this
+already-anomalous path.
+
 BT-3087: Built on `beamtalk_hierarchy:walk_ancestors/3` (the shared depth
 guard + cycle warning) rather than a hand-rolled recursion, matching the
 instance-side `collect_flattened_methods/2` (now in `beamtalk_hierarchy_docs`)

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_docs.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_docs.erl
@@ -39,7 +39,6 @@ Method docs are retrieved via `>> #selector` (CompiledMethod maps).
     format_method_line/1,
     format_metaclass_docs/0,
     format_metaclass_method_doc/1,
-    metaclass_method_doc/1,
     format_selector_summary/2,
     format_class_side_output/5,
     extract_see_also/1,
@@ -342,7 +341,9 @@ format_metaclass_docs() ->
 -doc "Return documentation for a Metaclass method.".
 -spec format_metaclass_method_doc(binary()) -> {ok, binary()} | {error, term()}.
 format_metaclass_method_doc(SelectorBin) ->
-    case metaclass_method_doc(SelectorBin) of
+    %% BT-3087: metaclass_method_doc/1 is shared with beamtalk_interface via
+    %% beamtalk_hierarchy_docs (both apps depend on beamtalk_runtime).
+    case beamtalk_hierarchy_docs:metaclass_method_doc(SelectorBin) of
         {ok, Doc} ->
             {ok,
                 iolist_to_binary([
@@ -357,17 +358,6 @@ format_metaclass_method_doc(SelectorBin) ->
         not_found ->
             {error, {method_not_found, 'Metaclass', SelectorBin}}
     end.
-
--doc "Lookup doc text for known Metaclass class-side methods.".
--spec metaclass_method_doc(binary()) -> {ok, binary()} | not_found.
-metaclass_method_doc(<<"new">>) ->
-    {ok, <<"Create a new instance of the class.">>};
-metaclass_method_doc(<<"spawn">>) ->
-    {ok, <<"Create a new actor instance. Returns an actor reference.">>};
-metaclass_method_doc(<<"spawnWith:">>) ->
-    {ok, <<"Create a new actor with initial state from a Dictionary.">>};
-metaclass_method_doc(_) ->
-    not_found.
 
 -doc """
 Safe atom conversion — returns error instead of creating new atoms.
@@ -479,68 +469,26 @@ get_method_doc_from_class(ClassPid, Selector) ->
 -doc """
 Find which class in the hierarchy defines a selector.
 Returns the class name atom.
+
+BT-3087: Delegates to `beamtalk_hierarchy_docs:find_defining_class/2`, the
+implementation shared with `beamtalk_interface`'s programmatic reflection
+path (both apps depend on `beamtalk_runtime`).
 """.
 -spec find_defining_class(pid(), atom()) -> atom().
 find_defining_class(ClassPid, Selector) ->
-    find_defining_class(ClassPid, Selector, 0).
-
--spec find_defining_class(pid(), atom(), non_neg_integer()) -> atom().
-find_defining_class(ClassPid, Selector, Depth) when Depth > ?MAX_HIERARCHY_DEPTH ->
-    ClassName = beamtalk_runtime_api:class_name(ClassPid),
-    ?LOG_WARNING(
-        "find_defining_class: max hierarchy depth ~p exceeded at ~p for selector ~p — possible cycle",
-        [?MAX_HIERARCHY_DEPTH, ClassName, Selector],
-        #{domain => [beamtalk, runtime]}
-    ),
-    ClassName;
-find_defining_class(ClassPid, Selector, Depth) ->
-    ClassName = beamtalk_runtime_api:class_name(ClassPid),
-    case gen_server:call(ClassPid, {method, Selector}, 5000) of
-        nil ->
-            %% Not in local instance_methods — check superclass
-            case beamtalk_runtime_api:superclass(ClassPid) of
-                none ->
-                    ClassName;
-                Super ->
-                    case beamtalk_runtime_api:whereis_class(Super) of
-                        undefined -> ClassName;
-                        SuperPid -> find_defining_class(SuperPid, Selector, Depth + 1)
-                    end
-            end;
-        _MethodInfo ->
-            ClassName
-    end.
+    beamtalk_hierarchy_docs:find_defining_class(ClassPid, Selector).
 
 -doc """
 Find which class in the hierarchy defines a class-side method.
 Uses {class_method, Selector} which walks the chain internally;
 we query each class locally via get_local_class_methods to find
 exactly where the method is defined.
+
+BT-3087: Delegates to `beamtalk_hierarchy_docs:find_defining_class_method/2`.
 """.
 -spec find_defining_class_method(pid(), atom()) -> atom().
 find_defining_class_method(ClassPid, Selector) ->
-    find_defining_class_method(ClassPid, Selector, 0).
-
--spec find_defining_class_method(pid(), atom(), non_neg_integer()) -> atom().
-find_defining_class_method(ClassPid, _Selector, Depth) when Depth > ?MAX_HIERARCHY_DEPTH ->
-    beamtalk_runtime_api:class_name(ClassPid);
-find_defining_class_method(ClassPid, Selector, Depth) ->
-    ClassName = beamtalk_runtime_api:class_name(ClassPid),
-    LocalClassMethods = gen_server:call(ClassPid, get_local_class_methods, 5000),
-    case maps:is_key(Selector, LocalClassMethods) of
-        true ->
-            ClassName;
-        false ->
-            case beamtalk_runtime_api:superclass(ClassPid) of
-                none ->
-                    ClassName;
-                Super ->
-                    case beamtalk_runtime_api:whereis_class(Super) of
-                        undefined -> ClassName;
-                        SuperPid -> find_defining_class_method(SuperPid, Selector, Depth + 1)
-                    end
-            end
-    end.
+    beamtalk_hierarchy_docs:find_defining_class_method(ClassPid, Selector).
 
 -doc """
 Find which class in the Class chain defines a class-protocol method.
@@ -556,7 +504,7 @@ exact defining class.
 find_class_protocol_defining_class(Selector) ->
     case beamtalk_runtime_api:whereis_class('Class') of
         undefined -> 'Class';
-        ClassPid -> find_defining_class(ClassPid, Selector, 0)
+        ClassPid -> find_defining_class(ClassPid, Selector)
     end.
 
 -doc "Group inherited methods by defining class.".
@@ -867,34 +815,13 @@ Walk the class hierarchy and build a flattened method map.
 ADR 0032 Phase 1: Replaces get_flattened_methods gen_server call.
 Returns #{Selector => {DefiningClass, MethodInfo}} where local methods
 shadow inherited ones, walking from ClassName upward.
+
+BT-3087: Delegates to `beamtalk_hierarchy_docs:collect_flattened_methods/2`,
+the implementation shared with `beamtalk_interface`.
 """.
 -spec collect_flattened_methods(atom(), pid()) -> map().
 collect_flattened_methods(ClassName, ClassPid) ->
-    collect_flattened_methods(ClassName, ClassPid, 0).
-
--spec collect_flattened_methods(atom(), pid(), non_neg_integer()) -> map().
-collect_flattened_methods(ClassName, _ClassPid, Depth) when Depth > ?MAX_HIERARCHY_DEPTH ->
-    ?LOG_WARNING(
-        "collect_flattened_methods: max hierarchy depth ~p exceeded at ~p — possible cycle",
-        [?MAX_HIERARCHY_DEPTH, ClassName],
-        #{domain => [beamtalk, runtime]}
-    ),
-    #{};
-collect_flattened_methods(ClassName, ClassPid, Depth) ->
-    {ok, LocalMethods} = gen_server:call(ClassPid, get_instance_methods, 5000),
-    LocalFlat = maps:map(fun(_Sel, Info) -> {ClassName, Info} end, LocalMethods),
-    Superclass = beamtalk_runtime_api:superclass(ClassPid),
-    SuperFlat = collect_chain_methods(Superclass, Depth + 1),
-    maps:merge(SuperFlat, LocalFlat).
-
--spec collect_chain_methods(atom() | none, non_neg_integer()) -> map().
-collect_chain_methods(none, _Depth) ->
-    #{};
-collect_chain_methods(SuperName, Depth) ->
-    case beamtalk_runtime_api:whereis_class(SuperName) of
-        undefined -> #{};
-        SuperPid -> collect_flattened_methods(SuperName, SuperPid, Depth)
-    end.
+    beamtalk_hierarchy_docs:collect_flattened_methods(ClassName, ClassPid).
 
 -doc "Format method-specific documentation output.".
 -spec format_method_output(
@@ -1034,26 +961,48 @@ format_class_side_output(ClassName, Modifiers, OwnCM, InhCMGrouped, ProtoGrouped
 -doc """
 Walk the class hierarchy collecting class-side methods.
 Returns #{Selector => DefiningClass} — local methods shadow inherited ones.
+
+BT-3087: Built on `beamtalk_hierarchy:walk_ancestors/3` (the shared depth
+guard + cycle warning) rather than a hand-rolled recursion, matching the
+instance-side `collect_flattened_methods/2` (now in `beamtalk_hierarchy_docs`)
+and every other consolidated hierarchy walker.
 """.
 -spec collect_flattened_class_methods(atom(), pid()) -> #{atom() => atom()}.
 collect_flattened_class_methods(ClassName, ClassPid) ->
-    collect_flattened_class_methods(ClassName, ClassPid, 0).
-
--spec collect_flattened_class_methods(atom(), pid(), non_neg_integer()) -> #{atom() => atom()}.
-collect_flattened_class_methods(_ClassName, _ClassPid, Depth) when Depth > ?MAX_HIERARCHY_DEPTH ->
-    #{};
-collect_flattened_class_methods(ClassName, ClassPid, Depth) ->
-    LocalMethods = gen_server:call(ClassPid, get_local_class_methods, 5000),
-    LocalFlat = maps:map(fun(_Sel, _Info) -> ClassName end, LocalMethods),
-    Superclass = beamtalk_runtime_api:superclass(ClassPid),
-    SuperFlat = collect_class_method_superchain(Superclass, Depth + 1),
-    maps:merge(SuperFlat, LocalFlat).
-
--spec collect_class_method_superchain(atom() | none, non_neg_integer()) -> #{atom() => atom()}.
-collect_class_method_superchain(none, _Depth) ->
-    #{};
-collect_class_method_superchain(SuperName, Depth) ->
-    case beamtalk_runtime_api:whereis_class(SuperName) of
-        undefined -> #{};
-        SuperPid -> collect_flattened_class_methods(SuperName, SuperPid, Depth)
+    StepFun = fun({CurrentName, CurrentPid, AccMap}, _Depth) ->
+        LocalMethods = gen_server:call(CurrentPid, get_local_class_methods, 5000),
+        LocalFlat = maps:map(fun(_Sel, _Info) -> CurrentName end, LocalMethods),
+        %% AccMap already reflects every closer (lower-depth) ancestor
+        %% winning over farther ones; keep that invariant as this
+        %% (farther) level's LocalFlat is folded in.
+        NewAcc = maps:merge(LocalFlat, AccMap),
+        case beamtalk_runtime_api:superclass(CurrentPid) of
+            none ->
+                {found, NewAcc};
+            SuperName ->
+                case beamtalk_runtime_api:whereis_class(SuperName) of
+                    undefined -> {found, NewAcc};
+                    SuperPid -> {next, {SuperName, SuperPid, NewAcc}}
+                end
+        end
+    end,
+    case
+        beamtalk_hierarchy:walk_ancestors(
+            {ClassName, ClassPid, #{}}, StepFun, ?MAX_HIERARCHY_DEPTH
+        )
+    of
+        {found, Result} ->
+            Result;
+        max_depth_exceeded ->
+            ?LOG_WARNING(
+                "collect_flattened_class_methods: max hierarchy depth ~p exceeded at ~p — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, ClassName],
+                #{domain => [beamtalk, runtime]}
+            ),
+            #{};
+        not_found ->
+            %% Unreachable: StepFun above always resolves to {found, _} — a
+            %% `none` superclass or an unregistered ancestor is translated to
+            %% a terminal {found, NewAcc}, never a bare `none` node.
+            erlang:error({unreachable, not_found, ClassName})
     end.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
@@ -50,7 +50,10 @@ Extracted from beamtalk_repl_server (BT-705).
     is_identifier_char/1,
     %% BT-3083: white-box test of the completion keyword vocabulary against
     %% the shared Rust/Erlang conformance corpus.
-    builtin_keywords/0
+    builtin_keywords/0,
+    %% BT-3087: white-box test of the local-overrides-wins dedup fix for
+    %% "all methods including inherited".
+    collect_all_methods/2
 ]).
 -endif.
 
@@ -1834,39 +1837,73 @@ Guards against excessive depth via ?MAX_HIERARCHY_DEPTH (codebase convention).
 collect_all_methods(ClassName, Depth) ->
     collect_methods_with_fun(ClassName, Depth, fun beamtalk_runtime_api:class_methods/1).
 
--doc "Walk the superclass chain collecting methods via a caller-supplied getter fun.".
+-doc """
+Walk the superclass chain collecting methods via a caller-supplied getter fun.
+
+Local methods shadow inherited ones (Smalltalk-style override): a selector
+redefined by a subclass appears exactly once in the result, attributed to
+the subclass. BT-3087: previously `LocalMethods ++ InheritedMethods` with no
+dedup at all, so an overridden selector appeared twice — a real user-visible
+bug in method-listing completions.
+
+BT-3087: Built on `beamtalk_hierarchy:walk_ancestors/3` — one depth guard,
+one `?LOG_WARNING`-on-exhaustion policy, matching every other consolidated
+hierarchy walker (`beamtalk_behaviour_intrinsics:walk_hierarchy/3`,
+`beamtalk_hierarchy_docs`). `Depth` is accepted for API compatibility with
+existing callers (always 0) but the walk itself always starts fresh at 0 —
+`walk_ancestors/3` owns depth-counting internally.
+""".
 -spec collect_methods_with_fun(atom(), non_neg_integer(), fun((pid()) -> [atom()])) -> [atom()].
-collect_methods_with_fun(_ClassName, Depth, _Fun) when Depth > ?MAX_HIERARCHY_DEPTH ->
-    [];
-collect_methods_with_fun(ClassName, Depth, Fun) ->
-    case
-        try
-            beamtalk_runtime_api:whereis_class(ClassName)
-        catch
-            _:_ -> undefined
-        end
-    of
-        undefined ->
-            [];
-        ClassPid ->
-            LocalMethods =
-                try
-                    Fun(ClassPid)
-                catch
-                    _:_ -> []
-                end,
-            Superclass =
-                try
-                    beamtalk_runtime_api:superclass(ClassPid)
-                catch
-                    _:_ -> none
-                end,
-            InheritedMethods =
+collect_methods_with_fun(ClassName, _Depth, Fun) ->
+    StepFun = fun({CurrentClassName, AccMap}, _WalkDepth) ->
+        case
+            try
+                beamtalk_runtime_api:whereis_class(CurrentClassName)
+            catch
+                _:_ -> undefined
+            end
+        of
+            undefined ->
+                {found, AccMap};
+            ClassPid ->
+                LocalMethods =
+                    try
+                        Fun(ClassPid)
+                    catch
+                        _:_ -> []
+                    end,
+                LocalMap = maps:from_keys(LocalMethods, true),
+                %% AccMap already reflects every closer (subclass-side)
+                %% selector winning over farther ancestors; keep that
+                %% invariant as this (farther) level's LocalMap is folded in.
+                NewAcc = maps:merge(LocalMap, AccMap),
+                Superclass =
+                    try
+                        beamtalk_runtime_api:superclass(ClassPid)
+                    catch
+                        _:_ -> none
+                    end,
                 case Superclass of
-                    none -> [];
-                    Super -> collect_methods_with_fun(Super, Depth + 1, Fun)
-                end,
-            LocalMethods ++ InheritedMethods
+                    none -> {found, NewAcc};
+                    Super -> {next, {Super, NewAcc}}
+                end
+        end
+    end,
+    case beamtalk_hierarchy:walk_ancestors({ClassName, #{}}, StepFun, ?MAX_HIERARCHY_DEPTH) of
+        {found, ResultMap} ->
+            maps:keys(ResultMap);
+        max_depth_exceeded ->
+            ?LOG_WARNING(
+                "collect_methods_with_fun: max hierarchy depth ~p exceeded at ~p — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, ClassName],
+                #{domain => [beamtalk, runtime]}
+            ),
+            [];
+        not_found ->
+            %% Unreachable: StepFun above always resolves to {found, _} — an
+            %% unregistered class or a `none` superclass is translated to a
+            %% terminal {found, _}, never a bare `none` node.
+            erlang:error({unreachable, not_found, ClassName})
     end.
 
 -doc """

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
@@ -1852,6 +1852,13 @@ hierarchy walker (`beamtalk_behaviour_intrinsics:walk_hierarchy/3`,
 `beamtalk_hierarchy_docs`). `Depth` is accepted for API compatibility with
 existing callers (always 0) but the walk itself always starts fresh at 0 —
 `walk_ancestors/3` owns depth-counting internally.
+
+On depth exhaustion (`?MAX_HIERARCHY_DEPTH`, a hierarchy cycle) returns `[]`
+— not the partial set of selectors collected from the ancestors visited
+before the guard tripped — and logs a `?LOG_WARNING`. Deliberately narrower
+than returning partial results: `walk_ancestors/3`'s `max_depth_exceeded`
+carries no payload, so every caller falls back to a fixed default on this
+already-anomalous path.
 """.
 -spec collect_methods_with_fun(atom(), non_neg_integer(), fun((pid()) -> [atom()])) -> [atom()].
 collect_methods_with_fun(ClassName, _Depth, Fun) ->

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_dev_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_dev_tests.erl
@@ -1230,9 +1230,25 @@ dev_runtime_test_() ->
             {"type-annotation position with empty prefix offers all candidates",
                 fun type_annotation_completion_empty_prefix/0},
             {"single-colon keyword-selector prefix is not annotation position",
-                fun single_colon_not_annotation_position/0}
+                fun single_colon_not_annotation_position/0},
+            {"collect_all_methods dedups an overridden inherited selector",
+                fun collect_all_methods_dedups_override/0}
         ]
     end}.
+
+collect_all_methods_dedups_override() ->
+    %% BT-3087 regression: WidgetDev overrides WidgetDevBase's inheritedGreet
+    %% (see setup_dev_runtime/0). Before the fix, collect_methods_with_fun
+    %% built the result as `LocalMethods ++ InheritedMethods` with no dedup,
+    %% so the overridden selector appeared twice — once from WidgetDev's own
+    %% local methods, once from WidgetDevBase's. Local-overrides-wins
+    %% shadowing means it must appear exactly once now.
+    Result = beamtalk_repl_ops_dev:collect_all_methods('WidgetDev', 0),
+    Occurrences = [S || S <- Result, S =:= 'inheritedGreet'],
+    ?assertEqual(1, length(Occurrences)),
+    %% Sanity: non-overridden local and inherited methods are still present.
+    ?assert(lists:member('render', Result)),
+    ?assert(lists:member('next', Result)).
 
 context_completion_expression_empty_prefix() ->
     %% "WidgetDev create " — resolved instance receiver with empty prefix returns
@@ -1361,7 +1377,12 @@ setup_dev_runtime() ->
         instance_methods => #{
             'render' => #{block => fun(_, _) -> ok end, arity => 0},
             'resize' => #{block => fun(_, _, _) -> ok end, arity => 2},
-            'next' => #{block => fun(_, _) -> ok end, arity => 0}
+            'next' => #{block => fun(_, _) -> ok end, arity => 0},
+            %% BT-3087: overrides WidgetDevBase's inheritedGreet — regression
+            %% fixture for the duplicate-listing bug (collect_all_methods
+            %% used to return an overridden selector twice, once from
+            %% LocalMethods and once from InheritedMethods).
+            'inheritedGreet' => #{block => fun(_, _) -> ok end, arity => 0}
         },
         method_return_types => #{
             'next' => 'WidgetDev'


### PR DESCRIPTION
## Summary

Finishes the BT-2786 hierarchy-walker consolidation and fixes semantic drift that accumulated since:

- **`beamtalk_behaviour_intrinsics:walk_hierarchy/3`** and **`beamtalk_repl_ops_dev:collect_methods_with_fun/3`** are now built on `beamtalk_hierarchy:walk_ancestors/3` instead of hand-rolled recursion, sharing one depth guard and one `?LOG_WARNING`-on-exhaustion policy with the three call sites BT-2786 already converted.
- New **`beamtalk_hierarchy_docs`** module (in `beamtalk_runtime`, since both `beamtalk_stdlib` and `beamtalk_workspace` depend on it) replaces four byte-identical helper pairs that were duplicated between `beamtalk_interface` (`beamtalk_stdlib`) and `beamtalk_repl_docs` (`beamtalk_workspace`): `find_defining_class/2`, `find_defining_class_method/2`, `collect_flattened_methods/2`, and `metaclass_method_doc/1`. Both callers now delegate. Every helper logs on depth exhaustion — `beamtalk_interface`'s copies previously swallowed a hierarchy cycle silently, so a cycle was diagnosable via `:help` in the REPL but invisible via the programmatic `Beamtalk help:` call.
- `beamtalk_repl_docs`'s own `collect_flattened_class_methods/2` (not duplicated elsewhere, so out of the shared-module scope) gets the same `walk_ancestors/3` + logging treatment for consistency with every other walker touched here.
- **Bug fix:** `collect_methods_with_fun` built its result as `LocalMethods ++ InheritedMethods` with no dedup at all, so an overridden inherited selector appeared twice in method-listing completions. It now uses local-overrides-wins map-based shadowing (the same semantic `collect_flattened_methods`/`collect_chain_methods` already used), so each selector appears exactly once, matching Smalltalk-style override shadowing.

## Test plan

- [x] `rebar3 compile` — clean
- [x] `rebar3 eunit --app=beamtalk_runtime,beamtalk_workspace,beamtalk_compiler` — 5573 tests, 0 failures
- [x] `rebar3 eunit --dir=apps/beamtalk_stdlib/test` — 1807 tests, 0 failures
- [x] `rebar3 fmt --check` — clean
- [x] `rebar3 dialyzer` — clean, zero warnings
- [x] New regression test `collect_all_methods_dedups_override` (`beamtalk_repl_ops_dev_tests.erl`): overrides `WidgetDevBase`'s `inheritedGreet` on `WidgetDev` and asserts the selector appears exactly once in `collect_all_methods/2`
- [x] Existing `walk_hierarchy_cycle_guard_test_` (self-referential class hierarchy) still passes against the `walk_ancestors/3`-based reimplementation


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL7GE5XvKMame4UzYFb1dJ)_