### PR TITLE
BT-3089: Batch — Rust-side mechanical dedup (6 of 7)

### DIFF
--- a/crates/beamtalk-cli/src/commands/test_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/test_stdlib.rs
@@ -255,9 +255,18 @@ pub(crate) fn extract_assignment_var(expression: &str) -> Option<String> {
 
 /// Format an Erlang atom literal for use in generated assertion specs.
 ///
-/// Wraps the name in single quotes for Erlang atom safety.
+/// Wraps the name in single quotes for Erlang atom safety. Escaping goes
+/// through beamtalk-core's canonical `escape_atom_chars` funnel (BT-3089)
+/// rather than a hand-rolled/no-op rule of its own — every caller here
+/// currently only ever passes compiler-generated module names or
+/// already-validated identifier-like variable names, but routing through
+/// the shared funnel means that stays true by construction rather than by
+/// accident if a future caller passes less-trusted text.
 pub(crate) fn erlang_atom(name: &str) -> String {
-    format!("'{name}'")
+    format!(
+        "'{}'",
+        beamtalk_core::codegen::core_erlang::escape_atom_chars(name)
+    )
 }
 
 /// A single `EUnit` assertion case in normalised form.
@@ -1052,6 +1061,20 @@ fn find_test_files(path: &Utf8Path) -> Result<Vec<Utf8PathBuf>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_erlang_atom_plain() {
+        assert_eq!(erlang_atom("beamtalk_eval_0"), "'beamtalk_eval_0'");
+    }
+
+    /// BT-3089: `erlang_atom` used to do zero escaping (`format!("'{name}'")`)
+    /// — a latent bug if it ever received an atom needing escape. It now
+    /// routes through beamtalk-core's canonical `escape_atom_chars` funnel.
+    #[test]
+    fn test_erlang_atom_escapes_special_characters() {
+        assert_eq!(erlang_atom("it's"), "'it\\'s'");
+        assert_eq!(erlang_atom("back\\slash"), "'back\\\\slash'");
+    }
 
     #[test]
     fn test_parse_empty_file() {

--- a/crates/beamtalk-core/src/ast/expression.rs
+++ b/crates/beamtalk-core/src/ast/expression.rs
@@ -564,6 +564,15 @@ impl MessageSelector {
     ///
     /// For keyword messages, this concatenates all keyword parts.
     /// For unary and binary messages, returns the operator/name directly.
+    ///
+    /// This is the single authority for selector → string text (BT-3089):
+    /// codegen also uses it directly (e.g. `leaf::atom(selector.name())`) as
+    /// the Erlang atom's textual content — Beamtalk selector characters
+    /// (letters, digits, `:`, operator symbols) never need escaping to be
+    /// valid atom *content*; `leaf::atom` (the BT-875-sanctioned funnel, see
+    /// `codegen::core_erlang::util::escape_atom_chars`) is what decides
+    /// whether/how the text gets quoted for Core Erlang output. There is no
+    /// separate "mangling" step.
     #[must_use]
     pub fn name(&self) -> EcoString {
         match self {
@@ -585,51 +594,6 @@ impl MessageSelector {
             Self::Unary(_) => 0,
             Self::Binary(_) => 1,
             Self::Keyword(parts) => parts.len(),
-        }
-    }
-
-    /// Converts this selector to a Core Erlang atom representation.
-    ///
-    /// This is the **domain service** for selector mangling - converting Beamtalk
-    /// selectors to valid Erlang atoms. The returned string is ready to be wrapped
-    /// in single quotes for Core Erlang output.
-    ///
-    /// # DDD: `SelectorMangler` Domain Service
-    ///
-    /// In the Code Generation bounded context, selector mangling is a key domain
-    /// operation. This method encapsulates the domain knowledge of how Beamtalk
-    /// selectors map to Erlang atoms.
-    ///
-    /// # Returns
-    ///
-    /// The selector as a string suitable for use as an Erlang atom:
-    /// - Unary: `"increment"` → `'increment'`
-    /// - Binary: `"+"` → `'+'`
-    /// - Keyword: `["at:", "put:"]` → `'at:put:'`
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use beamtalk_core::ast::{MessageSelector, KeywordPart};
-    /// use beamtalk_core::source_analysis::Span;
-    ///
-    /// // Unary selector
-    /// let selector = MessageSelector::Unary("increment".into());
-    /// assert_eq!(selector.to_erlang_atom(), "increment");
-    ///
-    /// // Keyword selector
-    /// let selector = MessageSelector::Keyword(vec![
-    ///     KeywordPart::new("at:", Span::new(0, 3)),
-    ///     KeywordPart::new("put:", Span::new(5, 9)),
-    /// ]);
-    /// assert_eq!(selector.to_erlang_atom(), "at:put:");
-    /// ```
-    #[must_use]
-    pub fn to_erlang_atom(&self) -> String {
-        match self {
-            Self::Unary(name) => name.to_string(),
-            Self::Binary(op) => op.to_string(),
-            Self::Keyword(parts) => parts.iter().map(|p| p.keyword.as_str()).collect(),
         }
     }
 

--- a/crates/beamtalk-core/src/ast/expression.rs
+++ b/crates/beamtalk-core/src/ast/expression.rs
@@ -1027,6 +1027,16 @@ impl TypeAnnotation {
     ///
     /// Used by the class hierarchy to store declared state field types
     /// and method parameter/return types.
+    ///
+    /// Two other renderers must produce byte-identical text for the same
+    /// type: `DeclaredType`'s `Display` impl (a separate, span-free type —
+    /// see `semantic_analysis::class_hierarchy::declared_type`) and
+    /// `unparse::unparse_type_annotation_display` (the `Document`-based
+    /// pretty-printer). All three are independent implementations for
+    /// structural reasons (different input types / rendering mechanisms),
+    /// not accidental duplication — kept honest by the
+    /// `assert_display_parity` fixture tests in `declared_type`'s test
+    /// module (BT-3089) rather than by comment alone.
     #[must_use]
     pub fn type_name(&self) -> EcoString {
         match self {

--- a/crates/beamtalk-core/src/ast/expression.rs
+++ b/crates/beamtalk-core/src/ast/expression.rs
@@ -417,6 +417,27 @@ impl Expression {
     pub const fn is_error(&self) -> bool {
         matches!(self, Self::Error { .. })
     }
+
+    /// Peels any number of `Parenthesized` wrappers, returning the inner
+    /// expression. `(Erlang lists)` and `Erlang lists`, or `(x)` and `x`,
+    /// must be recognized identically by any shape-matching code.
+    ///
+    /// Single authority for "unwrap parens" (BT-3089) — this was
+    /// independently reimplemented in `ffi_receiver.rs`,
+    /// `codegen::core_erlang` (`CoreErlangGenerator::peel_parens`),
+    /// `queries::ffi_sites_query`, and
+    /// `semantic_analysis::type_checker::narrowing::extract`. Lives on
+    /// `Expression` itself, in `ast` — the bottom of the dependency graph —
+    /// so every consumer above it (codegen, queries, `semantic_analysis`) can
+    /// call it directly instead of duplicating the loop.
+    #[must_use]
+    pub fn unwrap_parens(&self) -> &Expression {
+        let mut current = self;
+        while let Self::Parenthesized { expression, .. } = current {
+            current = expression;
+        }
+        current
+    }
 }
 
 /// A literal value.

--- a/crates/beamtalk-core/src/ast/expression.rs
+++ b/crates/beamtalk-core/src/ast/expression.rs
@@ -608,6 +608,44 @@ impl MessageSelector {
         }
     }
 
+    /// The selector's "leading word" — the bare unary/binary selector text,
+    /// or a keyword selector's *first* keyword with its trailing colon
+    /// stripped.
+    ///
+    /// `select: pred` → `select`; `inject: i into: b` → `inject`; unary
+    /// `asList` → `asList`; binary `+` → `+`. Distinct from [`name()`](Self::name),
+    /// which concatenates *all* keyword parts (`at:put:` stays `at:put:`
+    /// there) — this takes only the first.
+    ///
+    /// This is the naming convention `native: self delegate` methods use to
+    /// name their backing Erlang function (ADR 0101 / BT-2720,
+    /// `docs/beamtalk-native-erlang.md`). Single authority (BT-3089) for a
+    /// rule previously reimplemented in both
+    /// `codegen::core_erlang::value_type_codegen::native_delegate_fn_name`
+    /// and `semantic_analysis::validators::native_validators`'s
+    /// reserved-word check — moved down onto `MessageSelector` itself (the
+    /// bottom of the dependency graph) since neither of those two modules
+    /// may depend on the other (`semantic_analysis` must not depend on
+    /// `codegen`).
+    ///
+    /// Note this is a distinct concept from
+    /// [`erlang_function_name`](crate::semantic_analysis::validators::erlang_function_name):
+    /// that function is scoped to the `Erlang <module> <selector>` FFI-proxy
+    /// call shape and deliberately returns `None` for a binary selector
+    /// (there is no `(Erlang mod) + arg` FFI-call syntax); this method has
+    /// no such exclusion because the `native: self delegate` mechanism *can*
+    /// legitimately delegate a binary operator like `+` to a same-named
+    /// native function.
+    #[must_use]
+    pub fn leading_word(&self) -> &str {
+        match self {
+            Self::Unary(name) | Self::Binary(name) => name.as_str(),
+            Self::Keyword(parts) => parts
+                .first()
+                .map_or("", |kp| kp.keyword.trim_end_matches(':')),
+        }
+    }
+
     /// Returns the number of arguments this selector expects.
     #[must_use]
     pub fn arity(&self) -> usize {

--- a/crates/beamtalk-core/src/ast/mod.rs
+++ b/crates/beamtalk-core/src/ast/mod.rs
@@ -487,6 +487,35 @@ mod tests {
     }
 
     #[test]
+    fn unwrap_parens_bare_expression_is_identity() {
+        let ident = Expression::Identifier(Identifier::new("x", Span::new(0, 1)));
+        assert_eq!(ident.unwrap_parens(), &ident);
+    }
+
+    #[test]
+    fn unwrap_parens_single_layer() {
+        let inner = Expression::Identifier(Identifier::new("x", Span::new(1, 2)));
+        let wrapped = Expression::Parenthesized {
+            expression: Box::new(inner.clone()),
+            span: Span::new(0, 3),
+        };
+        assert_eq!(wrapped.unwrap_parens(), &inner);
+    }
+
+    #[test]
+    fn unwrap_parens_multiple_nested_layers() {
+        let inner = Expression::Identifier(Identifier::new("x", Span::new(2, 3)));
+        let wrapped = Expression::Parenthesized {
+            expression: Box::new(Expression::Parenthesized {
+                expression: Box::new(inner.clone()),
+                span: Span::new(1, 4),
+            }),
+            span: Span::new(0, 5),
+        };
+        assert_eq!(wrapped.unwrap_parens(), &inner);
+    }
+
+    #[test]
     fn identifier_creation() {
         let id = Identifier::new("myVar", Span::new(0, 5));
         assert_eq!(id.name, "myVar");

--- a/crates/beamtalk-core/src/ast/mod.rs
+++ b/crates/beamtalk-core/src/ast/mod.rs
@@ -487,6 +487,29 @@ mod tests {
     }
 
     #[test]
+    fn leading_word_unary() {
+        let selector = MessageSelector::Unary("asList".into());
+        assert_eq!(selector.leading_word(), "asList");
+    }
+
+    #[test]
+    fn leading_word_binary() {
+        let selector = MessageSelector::Binary("+".into());
+        assert_eq!(selector.leading_word(), "+");
+    }
+
+    #[test]
+    fn leading_word_keyword_takes_only_first_part() {
+        let selector = MessageSelector::Keyword(vec![
+            KeywordPart::new("inject:", Span::new(0, 7)),
+            KeywordPart::new("into:", Span::new(8, 13)),
+        ]);
+        assert_eq!(selector.leading_word(), "inject");
+        // Unlike leading_word, name() concatenates every part.
+        assert_eq!(selector.name(), "inject:into:");
+    }
+
+    #[test]
     fn unwrap_parens_bare_expression_is_identity() {
         let ident = Expression::Identifier(Identifier::new("x", Span::new(0, 1)));
         assert_eq!(ident.unwrap_parens(), &ident);

--- a/crates/beamtalk-core/src/ast/mod.rs
+++ b/crates/beamtalk-core/src/ast/mod.rs
@@ -518,27 +518,6 @@ mod tests {
     }
 
     #[test]
-    fn message_selector_to_erlang_atom_unary() {
-        let selector = MessageSelector::Unary("increment".into());
-        assert_eq!(selector.to_erlang_atom(), "increment");
-    }
-
-    #[test]
-    fn message_selector_to_erlang_atom_binary() {
-        let selector = MessageSelector::Binary("+".into());
-        assert_eq!(selector.to_erlang_atom(), "+");
-    }
-
-    #[test]
-    fn message_selector_to_erlang_atom_keyword() {
-        let selector = MessageSelector::Keyword(vec![
-            KeywordPart::new("at:", Span::new(0, 3)),
-            KeywordPart::new("put:", Span::new(5, 9)),
-        ]);
-        assert_eq!(selector.to_erlang_atom(), "at:put:");
-    }
-
-    #[test]
     fn block_creation() {
         let block = Block::new(
             vec![

--- a/crates/beamtalk-core/src/codegen/core_erlang/actor_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/actor_codegen.rs
@@ -435,7 +435,7 @@ impl CoreErlangGenerator {
             parts.push(docvec![
                 ", ",
                 fname(
-                    safe_class_method_fn_name(&m.selector.to_erlang_atom()),
+                    safe_class_method_fn_name(m.selector.name().as_ref()),
                     m.selector.arity() + 2
                 ),
             ]);

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -3390,8 +3390,8 @@ impl CoreErlangGenerator {
     ) -> bool {
         use crate::ast::MessageSelector;
 
-        let inner = match Self::peel_parens(expr) {
-            Expression::Assignment { value, .. } => Self::peel_parens(value),
+        let inner = match expr.unwrap_parens() {
+            Expression::Assignment { value, .. } => value.unwrap_parens(),
             other => other,
         };
         let Expression::MessageSend {

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -1160,7 +1160,7 @@ impl CoreErlangGenerator {
         }
         // Extract selector name from the message send
         if let Expression::MessageSend { selector, .. } = expr {
-            let sel_name = selector.to_erlang_atom();
+            let sel_name = selector.name().to_string();
             let line_info = self
                 .span_to_line(span)
                 .map_or(String::new(), |l| format!(" at line {l}"));

--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -707,7 +707,7 @@ impl CoreErlangGenerator {
         selector: &MessageSelector,
         arguments: &[Expression],
     ) -> Result<Document<'static>> {
-        let selector_atom = selector.to_erlang_atom();
+        let selector_atom = selector.name().to_string();
 
         let mut all_exprs: Vec<&Expression> = Vec::with_capacity(arguments.len() + 1);
         all_exprs.push(receiver);
@@ -784,7 +784,7 @@ impl CoreErlangGenerator {
         selector: &MessageSelector,
         arguments: &[Expression],
     ) -> Result<Document<'static>> {
-        let selector_atom = selector.to_erlang_atom();
+        let selector_atom = selector.name().to_string();
         let discard_var = self.fresh_temp_var("Cast");
         let current_state = self.current_state_var();
         let module = self.module_name.clone();
@@ -818,7 +818,7 @@ impl CoreErlangGenerator {
         selector: &MessageSelector,
         arguments: &[Expression],
     ) -> Result<Document<'static>> {
-        let selector_atom = selector.to_erlang_atom();
+        let selector_atom = selector.name().to_string();
         // BT-1937: Capture receiver + args as one ordered sub-expression
         // sequence so left-to-right evaluation order is preserved when ANY
         // sub-expression has an open scope from a class method self-send.
@@ -858,7 +858,7 @@ impl CoreErlangGenerator {
         selector: &MessageSelector,
         arguments: &[Expression],
     ) -> Result<Document<'static>> {
-        let selector_atom = selector.to_erlang_atom();
+        let selector_atom = selector.name().to_string();
         if matches!(selector, MessageSelector::Binary(_)) {
             return Err(CodeGenError::Internal(format!(
                 "unexpected binary selector in generate_message_send: {selector_atom}"
@@ -1170,7 +1170,7 @@ impl CoreErlangGenerator {
         if class_name != "File" || package.is_some() {
             return Ok(None);
         }
-        let selector_atom = selector.to_erlang_atom();
+        let selector_atom = selector.name().to_string();
         if !matches!(selector_atom.as_str(), "open:do:" | "open:mode:do:") {
             return Ok(None);
         }
@@ -1314,7 +1314,7 @@ impl CoreErlangGenerator {
         selector: &MessageSelector,
         arguments: &[Expression],
     ) -> Result<Document<'static>> {
-        let selector_atom = selector.to_erlang_atom();
+        let selector_atom = selector.name().to_string();
 
         // ADR 0084 / BT-2267: inside a programmatic ClassBuilder class-method fun
         // there is no `class_<sel>` module export to call, so self-sends route
@@ -1717,7 +1717,7 @@ impl CoreErlangGenerator {
             return self.generate_sealed_self_dispatch(selector, arguments);
         }
 
-        let selector_atom = selector.to_erlang_atom();
+        let selector_atom = selector.name().to_string();
         let result_var = self.fresh_var("SelfResult");
         let state_var = self.fresh_var("SelfState");
         let current_state = self.current_state_var();
@@ -1782,7 +1782,7 @@ impl CoreErlangGenerator {
             ..
         } = expr
         {
-            let selector_atom = selector.to_erlang_atom();
+            let selector_atom = selector.name().to_string();
             // BT-2822: `selector_atom` is moved into `call_doc` below (some
             // branches consume it via `leaf::atom`), so clone the value
             // needed for the error-clause breadcrumb before that happens.
@@ -1911,12 +1911,12 @@ impl CoreErlangGenerator {
 
         // Level 1: Direct call to standalone sealed method function
         if self.sealed_method_selectors().contains(&selector_name) {
-            let selector_atom = selector.to_erlang_atom();
+            let selector_atom = selector.name().to_string();
             return self.generate_direct_sealed_call(&selector_name, &selector_atom, arguments);
         }
 
         // Level 2: Direct dispatch/4 call (skip safe_dispatch try/catch)
-        let selector_atom = selector.to_erlang_atom();
+        let selector_atom = selector.name().to_string();
         let result_var = self.fresh_var("SealedResult");
         let self_var = self.fresh_temp_var("SealedSelf");
         let current_state = self.current_state_var();
@@ -1971,7 +1971,7 @@ impl CoreErlangGenerator {
 
         let args_doc = self.capture_argument_list_doc(arguments)?;
         let comma = if arguments.is_empty() { "" } else { ", " };
-        // BT-2822: `selector_atom` (from `MessageSelector::to_erlang_atom`) is
+        // BT-2822: `selector_atom` (from `MessageSelector::name`) is
         // the breadcrumb value — kept independent of `selector_name` (used
         // below for `sealed_fn_name` mangling) so a future change to either
         // mangling scheme can't silently desync the breadcrumb from the
@@ -2068,7 +2068,7 @@ impl CoreErlangGenerator {
         {
             if let Expression::Identifier(id) = receiver.as_ref() {
                 if id.name == "self" {
-                    let sel_atom = selector.to_erlang_atom();
+                    let sel_atom = selector.name().to_string();
                     return self.class_method_selectors().contains(&sel_atom);
                 }
             }
@@ -2460,7 +2460,7 @@ impl CoreErlangGenerator {
         selector: &MessageSelector,
         arguments: &[Expression],
     ) -> Result<Document<'static>> {
-        let selector_atom = selector.to_erlang_atom();
+        let selector_atom = selector.name().to_string();
 
         // ADR 0084 / BT-2267: `super` inside a builder class-method fun resolves
         // up the metaclass chain via the runtime helper, keyed on the builder
@@ -2695,7 +2695,7 @@ impl CoreErlangGenerator {
         // lookup works normally.  The class_send fallback uses the class-method
         // mangled selector which triggers earlier (when "class_" + selector
         // exceeds the limit).
-        let raw = selector.to_erlang_atom();
+        let raw = selector.name().to_string();
         let instance_selector = super::selector_mangler::safe_atom_name(&raw);
         let binding_val_var = self.fresh_var("BindingVal");
         let state_var = self.current_state_var();
@@ -2830,7 +2830,7 @@ impl CoreErlangGenerator {
         selector: &MessageSelector,
         arguments: &[Expression],
     ) -> Result<Document<'static>> {
-        let raw_selector = selector.to_erlang_atom();
+        let raw_selector = selector.name().to_string();
 
         // BT-1639: Direct call optimization for sealed class methods
         if let Some(info) = self.direct_call_eligible.get(class_name) {
@@ -2924,7 +2924,7 @@ impl CoreErlangGenerator {
         selector: &MessageSelector,
         arguments: &[Expression],
     ) -> Result<Document<'static>> {
-        let raw_selector = selector.to_erlang_atom();
+        let raw_selector = selector.name().to_string();
 
         // BT-1639: Check if this class method is eligible for direct call optimization.
         if let Some(info) = self.direct_call_eligible.get(class_name) {
@@ -3290,7 +3290,7 @@ impl CoreErlangGenerator {
             }
 
             // Step 2: Generate argument list with Tier 2 blocks
-            let selector_atom = selector.to_erlang_atom();
+            let selector_atom = selector.name().to_string();
             let dispatch_var = self.fresh_temp_var("SD");
             let result_var = self.fresh_var("SDResult");
             let state_var = self.fresh_var("SDState");

--- a/crates/beamtalk-core/src/codegen/core_erlang/erlang_types.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/erlang_types.rs
@@ -59,7 +59,7 @@
 
 use std::fmt;
 
-use super::util::to_module_name;
+use super::util::{escape_atom_chars, to_module_name};
 
 /// A Core Erlang atom value object.
 ///
@@ -112,19 +112,10 @@ impl ErlangAtom {
 
 impl fmt::Display for ErlangAtom {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Escape special characters in atom names
-        write!(f, "'")?;
-        for c in self.name.chars() {
-            match c {
-                '\'' => write!(f, "\\'")?,
-                '\\' => write!(f, "\\\\")?,
-                '\n' => write!(f, "\\n")?,
-                '\r' => write!(f, "\\r")?,
-                '\t' => write!(f, "\\t")?,
-                _ => write!(f, "{c}")?,
-            }
-        }
-        write!(f, "'")
+        // BT-3089: delegate to the one canonical atom-escaping funnel
+        // (`util::escape_atom_chars`, also used by `leaf::atom`) instead of
+        // hand-rolling a second escape table here.
+        write!(f, "'{}'", escape_atom_chars(&self.name))
     }
 }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/erlang_types.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/erlang_types.rs
@@ -106,7 +106,7 @@ impl ErlangAtom {
     /// Beamtalk selectors to Erlang atoms.
     #[must_use]
     pub fn from_selector(selector: &crate::ast::MessageSelector) -> Self {
-        Self::new(selector.to_erlang_atom())
+        Self::new(selector.name().to_string())
     }
 }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -1398,7 +1398,7 @@ impl CoreErlangGenerator {
         for (index, (selector, arguments)) in all_messages.into_iter().enumerate() {
             let is_last = index == total_messages - 1;
 
-            let selector_atom = selector.to_erlang_atom();
+            let selector_atom = selector.name().to_string();
             if matches!(selector, MessageSelector::Binary(_)) {
                 return Err(CodeGenError::UnsupportedFeature {
                     feature: "binary selectors in cascades".to_string(),

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -1577,7 +1577,7 @@ impl CoreErlangGenerator {
             ..
         } = expr
         {
-            let selector_atom = selector.to_erlang_atom();
+            let selector_atom = selector.name().to_string();
             let mut arg_docs: Vec<Document<'static>> = Vec::with_capacity(arguments.len());
             for (j, arg) in arguments.iter().enumerate() {
                 if j > 0 {
@@ -2888,7 +2888,7 @@ impl CoreErlangGenerator {
             .class_methods
             .iter()
             .filter(|m| m.kind == MethodKind::Primary)
-            .map(|m| m.selector.to_erlang_atom())
+            .map(|m| m.selector.name().to_string())
             .collect();
 
         // BT-996: Populate auto-generated keyword constructor selector for Value subclass: classes.
@@ -4691,7 +4691,7 @@ impl CoreErlangGenerator {
             })
             .collect();
         (
-            m.selector.to_erlang_atom(),
+            m.selector.name().to_string(),
             m.selector.arity(),
             return_type,
             param_types,

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -4091,7 +4091,7 @@ impl CoreErlangGenerator {
         // BT-2355: see through parentheses so `_r := (1 to: 5 do: [...])` is still
         // classified as control flow with mutations (and thus unpacked + threaded)
         // rather than falling through to a plain pure local assignment.
-        let expr = Self::peel_parens(expr);
+        let expr = expr.unwrap_parens();
 
         // BT-2880: `match:` is a dedicated `Expression::Match` node, not a
         // `MessageSend`, so it's otherwise invisible to this classifier — a

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -2265,7 +2265,7 @@ impl CoreErlangGenerator {
         facts: &crate::semantic_analysis::SemanticFacts,
         out: &mut std::collections::HashSet<String>,
     ) {
-        match Self::peel_parens(expr) {
+        match expr.unwrap_parens() {
             Expression::Assignment { value, .. } => {
                 Self::collect_list_op_cross_scope_mutations_recursive(value, facts, out);
             }
@@ -2298,8 +2298,8 @@ impl CoreErlangGenerator {
         // Peel parens then an assignment RHS (which may itself be parenthesized) so
         // forms like `_r := (1 to: 5 do: [...])` are still inspected — mirrors
         // `expr_has_nested_counted_loop_threading`.
-        let inner = match Self::peel_parens(expr) {
-            Expression::Assignment { value, .. } => Self::peel_parens(value),
+        let inner = match expr.unwrap_parens() {
+            Expression::Assignment { value, .. } => value.unwrap_parens(),
             other => other,
         };
         let Expression::MessageSend {
@@ -3140,7 +3140,7 @@ impl CoreErlangGenerator {
         // BT-2355: `_r := (loop)` wraps the construct in parentheses; peel them so
         // the threaded locals are still discovered when the construct is an
         // assignment RHS or sub-expression.
-        let expr = Self::peel_parens(expr);
+        let expr = expr.unwrap_parens();
         let Expression::MessageSend {
             receiver,
             selector,
@@ -3247,17 +3247,6 @@ impl CoreErlangGenerator {
     /// the Actor method-body sequencer consumes, where empty and absent are equivalent.
     fn non_empty(v: Vec<String>) -> Option<Vec<String>> {
         if v.is_empty() { None } else { Some(v) }
-    }
-
-    /// BT-2355: Peels any `Expression::Parenthesized` wrappers, returning the inner
-    /// expression. Used so control-flow classification/threading sees through the
-    /// parentheses in forms like `_r := (1 to: 5 do: [...])`.
-    pub(super) fn peel_parens(expr: &Expression) -> &Expression {
-        let mut current = expr;
-        while let Expression::Parenthesized { expression, .. } = current {
-            current = expression;
-        }
-        current
     }
 
     /// BT-2355: Collects the `Block` arguments of a message send (e.g. the branch

--- a/crates/beamtalk-core/src/codegen/core_erlang/primitive_bindings.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/primitive_bindings.rs
@@ -88,7 +88,7 @@ impl PrimitiveBindingTable {
                         name, is_quoted, ..
                     } = &method.body[0].expression
                     {
-                        let selector = method.selector.to_erlang_atom();
+                        let selector = method.selector.name().to_string();
                         let binding = if *is_quoted {
                             PrimitiveBinding::SelectorBased {
                                 selector: name.to_string(),

--- a/crates/beamtalk-core/src/codegen/core_erlang/selector_mangler.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/selector_mangler.rs
@@ -18,8 +18,10 @@
 //! # Usage
 //!
 //! Selectors are converted to Erlang atom *strings* by
-//! [`MessageSelector::to_erlang_atom()`], defined on the AST type itself. This
-//! module provides the atom-length-safe mangling utilities layered on top —
+//! [`MessageSelector::name()`](crate::ast::MessageSelector::name), the single
+//! selector→string authority (BT-3089; selector text needs no mangling of
+//! its own to become atom content). This module provides the
+//! atom-*length*-safe mangling utilities layered on top —
 //! [`safe_class_method_selector`] and [`safe_class_method_fn_name`].
 //!
 //! Quoting an atom string for Core Erlang output is **not** done here: that is

--- a/crates/beamtalk-core/src/codegen/core_erlang/spec_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/spec_codegen.rs
@@ -312,7 +312,7 @@ pub fn generate_method_spec(
         return None;
     }
 
-    let erlang_name = method.selector.to_erlang_atom();
+    let erlang_name = method.selector.name().to_string();
 
     let mut param_types: Vec<Document<'static>> = Vec::new();
 
@@ -394,7 +394,7 @@ fn generate_class_method_spec(
         return None;
     }
 
-    let erlang_name = safe_class_method_fn_name(&method.selector.to_erlang_atom());
+    let erlang_name = safe_class_method_fn_name(method.selector.name().as_ref());
 
     let mut param_types: Vec<Document<'static>> = vec![
         Document::Str("{'type', 0, 'any', []}"),    // ClassSelf

--- a/crates/beamtalk-core/src/codegen/core_erlang/supervisor_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/supervisor_codegen.rs
@@ -81,10 +81,7 @@ impl CoreErlangGenerator {
             class_method_exports = docvec![
                 class_method_exports,
                 ", ",
-                fname(
-                    safe_class_method_fn_name(&m.selector.to_erlang_atom()),
-                    arity
-                ),
+                fname(safe_class_method_fn_name(m.selector.name().as_ref()), arity),
             ];
         }
 
@@ -185,10 +182,7 @@ impl CoreErlangGenerator {
             class_method_exports = docvec![
                 class_method_exports,
                 ", ",
-                fname(
-                    safe_class_method_fn_name(&m.selector.to_erlang_atom()),
-                    arity
-                ),
+                fname(safe_class_method_fn_name(m.selector.name().as_ref()), arity),
             ];
         }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/threaded_expr.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/threaded_expr.rs
@@ -158,7 +158,7 @@ impl CoreErlangGenerator {
         if matches!(boundary, ThreadingBoundary::Actor) {
             return self.lower_actor_threaded_last(expr, position);
         }
-        let expr = Self::peel_parens(expr);
+        let expr = expr.unwrap_parens();
         let mut parts: Vec<Document<'static>> = Vec::new();
         let result_var = if self.expr_yields_vt_threaded_tuple(expr) {
             self.emit_vt_threaded_tuple_unwrap_to_var(expr, &mut parts)?
@@ -280,7 +280,7 @@ impl CoreErlangGenerator {
                 self.emit_vt_threaded_local_assignment(var_name, value, body_parts)?,
             ));
         }
-        let rhs = Self::peel_parens(value);
+        let rhs = value.unwrap_parens();
         if self.is_conditional_with_vt_local_threading(rhs) {
             return Ok(Some(
                 self.emit_vt_conditional_assign_rhs(var_name, rhs, body_parts)?,

--- a/crates/beamtalk-core/src/codegen/core_erlang/util.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/util.rs
@@ -111,8 +111,25 @@ pub fn escape_erlang_string(s: &str) -> String {
 
 /// Escapes special characters in an atom name for Core Erlang.
 ///
-/// Replaces `\` with `\\` and `'` with `\'` so the result is safe to embed
-/// between `'...'` in generated `.core` source.
+/// This is the single canonical funnel for atom escaping (BT-875, BT-3089):
+/// every atom emitted through [`leaf::atom`](super::document::leaf::atom)
+/// passes through here, and other atom-formatting call sites (e.g.
+/// `beamtalk-cli`'s generated-EUnit-source atom formatter) should reuse this
+/// function rather than hand-rolling their own escape table.
+///
+/// Escapes:
+/// - `\` → `\\`, `'` → `\'` — required to keep the surrounding `'...'`
+///   delimiters and any embedded backslash unambiguous.
+/// - `\n`, `\r`, `\t`, `\0` — **necessary, not just cosmetic** (BT-3089):
+///   Beamtalk quoted-symbol literals (`#'foo bar'`) have no backslash-escape
+///   syntax of their own — the lexer (`lex_symbol_or_hash`) accepts *any*
+///   literal character up to the closing `'`, including a raw newline typed
+///   directly in the source. A `Literal::Symbol` carrying one of these
+///   characters reaches `leaf::atom` unchanged; without escaping them here,
+///   the generated `.core` source would contain a literal control character
+///   embedded inside a quoted atom, breaking the "one term per line"
+///   assumption the rest of the pipeline (and any downstream tooling) relies
+///   on. Mirrors [`escape_core_erlang_string`]'s equivalent table.
 #[must_use]
 pub fn escape_atom_chars(name: &str) -> String {
     let mut result = String::with_capacity(name.len());
@@ -120,6 +137,10 @@ pub fn escape_atom_chars(name: &str) -> String {
         match c {
             '\'' => result.push_str("\\'"),
             '\\' => result.push_str("\\\\"),
+            '\n' => result.push_str("\\n"),
+            '\r' => result.push_str("\\r"),
+            '\t' => result.push_str("\\t"),
+            '\0' => result.push_str("\\0"),
             _ => result.push(c),
         }
     }
@@ -569,6 +590,23 @@ mod tests {
     #[test]
     fn test_escape_atom_chars_backslash() {
         assert_eq!(escape_atom_chars("back\\slash"), "back\\\\slash");
+    }
+
+    /// BT-3089: a quoted symbol literal (`#'foo\nbar'`, real newline typed
+    /// in source — Beamtalk quoted symbols have no backslash-escape syntax
+    /// of their own) must not reach the generated `.core` source as a raw
+    /// embedded control character.
+    #[test]
+    fn test_escape_atom_chars_control_characters() {
+        assert_eq!(escape_atom_chars("foo\nbar"), "foo\\nbar");
+        assert_eq!(escape_atom_chars("foo\rbar"), "foo\\rbar");
+        assert_eq!(escape_atom_chars("foo\tbar"), "foo\\tbar");
+        assert_eq!(escape_atom_chars("foo\0bar"), "foo\\0bar");
+    }
+
+    #[test]
+    fn test_escape_atom_chars_mixed() {
+        assert_eq!(escape_atom_chars("it's\na\\b"), "it\\'s\\na\\\\b");
     }
 
     #[test]

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -1264,7 +1264,7 @@ impl CoreErlangGenerator {
         // `_r := (1 to: 5 do: [...])` — wraps the construct in `Expression::Parenthesized`.
         // Peel the wrappers so the `{value, StateAcc}` predicates (which only match
         // `MessageSend`) see the real construct.
-        let expr = Self::peel_parens(expr);
+        let expr = expr.unwrap_parens();
         self.is_while_with_vt_local_threading(expr)
             || self.is_counted_loop_with_vt_local_threading(expr)
             || self.is_foldl_list_op_with_vt_local_threading(expr)
@@ -2050,7 +2050,7 @@ impl CoreErlangGenerator {
     ) -> Vec<String> {
         // BT-2359: peel `Expression::Parenthesized` so a parenthesized construct
         // (`(1 to: 5 do: [...])`) reports the same threaded locals its codegen packed.
-        let expr = Self::peel_parens(expr);
+        let expr = expr.unwrap_parens();
         if self.is_while_with_vt_local_threading(expr) {
             self.get_while_threaded_locals(expr)
         } else if self.is_counted_loop_with_vt_local_threading(expr) {
@@ -2963,7 +2963,7 @@ impl CoreErlangGenerator {
                             // is rebound (loop/foldl via emit_vt_threaded_local_assignment,
                             // conditional via emit_vt_conditional_assign_rhs) instead of being
                             // bound to the raw {value, StateAcc} tuple.
-                            let rhs = Self::peel_parens(value);
+                            let rhs = value.unwrap_parens();
                             if self.expr_yields_vt_threaded_tuple(value) {
                                 self.emit_vt_threaded_local_assignment(
                                     &id.name, value, &mut parts,
@@ -3014,7 +3014,7 @@ impl CoreErlangGenerator {
                         // BT-2359: a threaded construct as the final assignment RHS rebinds the
                         // target via element 1 of its {value, StateAcc} tuple and threads any
                         // sibling local; the block value is the rebound target.
-                        let rhs = Self::peel_parens(value);
+                        let rhs = value.unwrap_parens();
                         if self.expr_yields_vt_threaded_tuple(value) {
                             let core_var = self
                                 .emit_vt_threaded_local_assignment(&id.name, value, &mut parts)?;

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -1565,7 +1565,7 @@ impl CoreErlangGenerator {
         selector: &MessageSelector,
         arg_vars: &[String],
     ) -> Document<'static> {
-        let fn_name = Self::native_delegate_fn_name(selector);
+        let fn_name = selector.leading_word();
         let args_list = join(
             arg_vars.iter().map(|v| leaf::var(v.clone())),
             &Document::Str(", "),
@@ -1583,20 +1583,6 @@ impl CoreErlangGenerator {
             leaf::atom(selector.name().to_string()),
             "})"
         ]
-    }
-
-    /// ADR 0101 / BT-2720: the Erlang function name a `native:` `self delegate`
-    /// method calls — the first keyword with its colon removed (or the bare
-    /// unary/binary selector). Mirrors the inline-FFI naming convention
-    /// (`docs/beamtalk-native-erlang.md`): `select: pred` → `select`,
-    /// `inject: i into: b` → `inject`, unary `asList` → `asList`.
-    pub(in crate::codegen::core_erlang) fn native_delegate_fn_name(
-        selector: &MessageSelector,
-    ) -> String {
-        match selector {
-            MessageSelector::Unary(name) | MessageSelector::Binary(name) => name.to_string(),
-            MessageSelector::Keyword(parts) => parts[0].keyword.trim_end_matches(':').to_string(),
-        }
     }
 
     fn generate_value_type_method(

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -456,7 +456,7 @@ impl CoreErlangGenerator {
         // Add instance method exports (each takes Self as first parameter)
         for method in &class.methods {
             let arity = method.parameters.len() + 1; // +1 for Self parameter
-            let mangled = method.selector.to_erlang_atom();
+            let mangled = method.selector.name().to_string();
             parts.push(leaf::fname(mangled, arity));
         }
 
@@ -1580,7 +1580,7 @@ impl CoreErlangGenerator {
             "], {",
             leaf::atom(class_name.to_string()),
             ", ",
-            leaf::atom(selector.to_erlang_atom()),
+            leaf::atom(selector.name().to_string()),
             "})"
         ]
     }
@@ -1604,7 +1604,7 @@ impl CoreErlangGenerator {
         method: &MethodDefinition,
         class_def: &ClassDefinition,
     ) -> Result<Document<'static>> {
-        let mangled = method.selector.to_erlang_atom();
+        let mangled = method.selector.name().to_string();
         let arity = method.parameters.len() + 1; // +1 for Self
 
         // BT-833: Reset Self-threading version so each method starts with Self (version 0).
@@ -3590,7 +3590,7 @@ impl CoreErlangGenerator {
     ) -> Vec<Document<'static>> {
         let mut method_branches: Vec<Document<'static>> = Vec::new();
         for method in &class.methods {
-            let mangled = method.selector.to_erlang_atom();
+            let mangled = method.selector.name().to_string();
             method_branches.push(docvec![
                 "        <",
                 leaf::atom(mangled.clone()),
@@ -3929,7 +3929,7 @@ impl CoreErlangGenerator {
 
         // Add class-defined methods
         for method in &class.methods {
-            let mangled = method.selector.to_erlang_atom();
+            let mangled = method.selector.name().to_string();
             selectors.push(leaf::atom(mangled));
         }
 

--- a/crates/beamtalk-core/src/ffi_receiver.rs
+++ b/crates/beamtalk-core/src/ffi_receiver.rs
@@ -66,17 +66,6 @@ pub(crate) fn is_class_protocol_selector(selector: &str) -> bool {
     CLASS_PROTOCOL_SELECTORS.contains(&selector)
 }
 
-/// Peels any number of `Parenthesized` wrappers, returning the inner
-/// expression. `(Erlang lists)` and `Erlang lists` must be recognized
-/// identically.
-fn peel_parens(expr: &Expression) -> &Expression {
-    let mut current = expr;
-    while let Expression::Parenthesized { expression, .. } = current {
-        current = expression;
-    }
-    current
-}
-
 /// True when `expr` (after peeling any parentheses) is the bare, unqualified
 /// `Erlang` class reference — the compiler's built-in FFI bridge entry
 /// point. A package-qualified reference (`json@Erlang`) is excluded: it
@@ -84,7 +73,7 @@ fn peel_parens(expr: &Expression) -> &Expression {
 #[must_use]
 pub(crate) fn is_erlang_class_reference(expr: &Expression) -> bool {
     matches!(
-        peel_parens(expr),
+        expr.unwrap_parens(),
         Expression::ClassReference { name, package, .. }
             if package.is_none() && name.name == "Erlang"
     )
@@ -110,7 +99,7 @@ pub(crate) fn erlang_module_of_receiver(expr: &Expression) -> Option<&str> {
         receiver,
         selector: MessageSelector::Unary(module_name),
         ..
-    } = peel_parens(expr)
+    } = expr.unwrap_parens()
     {
         if is_erlang_class_reference(receiver) && !is_class_protocol_selector(module_name) {
             return Some(module_name.as_str());

--- a/crates/beamtalk-core/src/queries/ffi_sites_query.rs
+++ b/crates/beamtalk-core/src/queries/ffi_sites_query.rs
@@ -126,15 +126,6 @@ struct FfiTarget<'a> {
     arity: Option<usize>,
 }
 
-/// Strip `Parenthesized` wrappers so a `(Erlang lists)` cascade receiver is
-/// matched the same as a bare `Erlang lists` one.
-fn unwrap_parens(mut expr: &Expression) -> &Expression {
-    while let Expression::Parenthesized { expression, .. } = expr {
-        expr = expression;
-    }
-    expr
-}
-
 /// Recover the Erlang module name from an FFI proxy receiver.
 ///
 /// Matches `Erlang <module>` or `(Erlang <module>)` — a `MessageSend` whose
@@ -230,7 +221,7 @@ fn collect_ffi_sites(expr: &Expression, target: &FfiTarget, source: &str, lines:
             // `(Erlang lists) reverse: xs; sort: ys`), so resolve the shared
             // module from there and match each cascade message against it.
             collect_ffi_sites(receiver, target, source, lines);
-            let shared_module = match unwrap_parens(receiver) {
+            let shared_module = match receiver.unwrap_parens() {
                 Expression::MessageSend {
                     receiver: inner, ..
                 } => extract_erlang_module(inner),

--- a/crates/beamtalk-core/src/semantic_analysis/analyser.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/analyser.rs
@@ -175,7 +175,7 @@ impl Analyser {
                 self.analyse_expression(receiver, None);
 
                 // Determine context for block arguments
-                let selector_str = block_context::selector_to_string(selector);
+                let selector_str = selector.name();
 
                 // Run method-specific validators (reuse selector_str to avoid extra allocation)
                 if let Some(validator) = self.method_validators.get(&selector_str) {
@@ -219,7 +219,7 @@ impl Analyser {
                 self.analyse_expression(receiver, None);
                 for msg in messages {
                     // Apply selector-based context detection for cascade messages
-                    let selector_str = block_context::selector_to_string(&msg.selector);
+                    let selector_str = msg.selector.name();
 
                     // Run method-specific validators for cascade messages
                     if let Some(validator) = self.method_validators.get(&selector_str) {

--- a/crates/beamtalk-core/src/semantic_analysis/block_context.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/block_context.rs
@@ -18,7 +18,7 @@
 //! — it is not a correctness gate. New collection methods get Tier 2 state threading
 //! automatically without whitelist additions.
 
-use crate::ast::{Expression, MessageSelector};
+use crate::ast::Expression;
 use crate::semantic_analysis::BlockContext;
 use crate::source_analysis::Span;
 
@@ -95,15 +95,6 @@ pub(crate) fn is_collection_hof_selector(selector: &str, arg_index: usize) -> bo
         "collect:" | "do:" | "select:" | "reject:" | "detect:" => arg_index == 0,
         "inject:into:" | "detect:ifNone:" => arg_index == 1,
         _ => false,
-    }
-}
-
-/// Extracts the selector string from a message selector.
-pub(crate) fn selector_to_string(selector: &MessageSelector) -> String {
-    match selector {
-        MessageSelector::Unary(name) => name.to_string(),
-        MessageSelector::Binary(op) => op.to_string(),
-        MessageSelector::Keyword(parts) => parts.iter().map(|p| p.keyword.as_str()).collect(),
     }
 }
 
@@ -192,7 +183,7 @@ pub(crate) fn classify_block(
         ..
     } = parent_expr
     {
-        let selector_str = selector_to_string(selector);
+        let selector_str = selector.name();
 
         // Check each argument to see if it's our block
         for (i, arg) in arguments.iter().enumerate() {
@@ -236,7 +227,7 @@ pub(crate) fn classify_block(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{Block, BlockParameter, Identifier, KeywordPart};
+    use crate::ast::{Block, BlockParameter, Identifier, MessageSelector};
     use crate::source_analysis::Span;
 
     #[test]
@@ -311,27 +302,6 @@ mod tests {
     fn test_is_literal_block_with_identifier() {
         let expr = Expression::Identifier(Identifier::new("block", Span::default()));
         assert!(!is_literal_block(&expr));
-    }
-
-    #[test]
-    fn test_selector_to_string_unary() {
-        let selector = MessageSelector::Unary("value".into());
-        assert_eq!(selector_to_string(&selector), "value");
-    }
-
-    #[test]
-    fn test_selector_to_string_binary() {
-        let selector = MessageSelector::Binary("+".into());
-        assert_eq!(selector_to_string(&selector), "+");
-    }
-
-    #[test]
-    fn test_selector_to_string_keyword() {
-        let selector = MessageSelector::Keyword(vec![
-            KeywordPart::new("at:", Span::default()),
-            KeywordPart::new("put:", Span::default()),
-        ]);
-        assert_eq!(selector_to_string(&selector), "at:put:");
     }
 
     #[test]

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
@@ -223,9 +223,14 @@ impl DeclaredType {
 }
 
 /// Byte-identical to [`TypeAnnotation::type_name`] — see that method for the
-/// per-variant rendering rules this mirrors (the single source of truth for
-/// both is documented there; keep them in sync by hand, matching what
-/// `TypeAnnotation` itself does across `type_name` / `needs_parens_in_*`).
+/// per-variant rendering rules this mirrors. `DeclaredType` is a separate,
+/// span-free type (see the module docs), so this can't literally call
+/// `TypeAnnotation::type_name` — keep them in sync by hand, matching what
+/// `TypeAnnotation` itself does across `type_name` / `needs_parens_in_*`.
+/// This invariant (and parity with the third independent renderer,
+/// `unparse::unparse_type_annotation_display`) is enforced by the
+/// `assert_display_parity` fixture tests below (BT-3089) — not just this
+/// comment, per this repo's "No duplicate implementations" rule.
 impl fmt::Display for DeclaredType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -472,13 +477,35 @@ mod tests {
             .unwrap_or_else(|| panic!("no return type annotation parsed from {src:?}"))
     }
 
+    /// Enforces the "byte-identical, keep in sync by hand" claim this
+    /// module's own doc comments make about `DeclaredType::Display` vs
+    /// `TypeAnnotation::type_name` — and additionally against the third
+    /// independent renderer, `unparse::unparse_type_annotation_display`
+    /// (BT-3089; per this repo's "No duplicate implementations" rule, a
+    /// "keep in sync" comment needs an enforcing test, not just a comment).
+    ///
+    /// All three are legitimately separate *implementations* — they operate
+    /// on different types (`TypeAnnotation` carries spans/`Identifier`s;
+    /// `DeclaredType` is a span-free structural mirror parsed back out of a
+    /// stored string; `unparse_type_annotation_display` builds a `Document`
+    /// through the same pretty-printer used for full source unparsing) — so
+    /// collapsing them into one function isn't a safe mechanical change.
+    /// What they share is a rendering *contract* (same text for the same
+    /// type), which this test pins directly instead of trusting the doc
+    /// comment.
     fn assert_display_parity(src: &str) {
         let ann = parse_return_type(src);
         let declared = DeclaredType::from(&ann);
+        let expected = ann.type_name();
         assert_eq!(
             declared.to_string(),
-            ann.type_name(),
-            "Display parity mismatch for {src:?}"
+            expected,
+            "DeclaredType::Display parity mismatch for {src:?}"
+        );
+        assert_eq!(
+            crate::unparse::unparse_type_annotation_display(&ann),
+            expected,
+            "unparse_type_annotation_display parity mismatch for {src:?}"
         );
     }
 

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
@@ -35,6 +35,7 @@ use std::fmt;
 use ecow::EcoString;
 
 use crate::ast::TypeAnnotation;
+use crate::semantic_analysis::string_utils::{split_generic_base, split_top_level};
 use crate::semantic_analysis::type_checker::InferredType;
 
 /// A span-free, structured type signature — the value-object counterpart to
@@ -320,55 +321,6 @@ impl From<&TypeAnnotation> for DeclaredType {
                 DeclaredType::ClassOf(class_name.name.clone())
             }
         }
-    }
-}
-
-/// Split a type-parameter/argument string on `,` while respecting
-/// parenthesis nesting — e.g. `"Outer(Inner(A, B), C), D"` splits into
-/// `["Outer(Inner(A, B), C)", "D"]`, not four pieces.
-///
-/// Shared implementation for [`split_top_level`]'s `,` case; kept as one
-/// function (parameterised on the separator char) since the nesting-aware
-/// scan is otherwise identical for `|` and `,`.
-fn split_top_level(s: &str, sep: char) -> Vec<&str> {
-    let mut result = Vec::new();
-    let mut depth = 0i32;
-    let mut start = 0;
-    for (i, c) in s.char_indices() {
-        match c {
-            '(' => depth += 1,
-            ')' => depth = depth.saturating_sub(1),
-            c if c == sep && depth == 0 => {
-                result.push(s[start..i].trim());
-                start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    let last = s[start..].trim();
-    if !last.is_empty() {
-        result.push(last);
-    }
-    result
-}
-
-/// Split a stored type-name string into `(base, args_slice)`.
-///
-/// Given `"Array(Integer)"` returns `("Array", Some("Integer"))`. Given
-/// `"Integer"` (no parentheses) returns `("Integer", None)`. Given
-/// `"Array(Integer)extra"` (not terminated by `)`) falls back to
-/// `("Array(Integer)extra", None)` — the caller treats the string as opaque.
-///
-/// Mirrors `type_resolver::split_generic_base` — duplicated here (rather
-/// than imported) because `class_hierarchy` sits below `type_checker` in the
-/// dependency graph and must not reach up into it.
-fn split_generic_base(type_name: &str) -> (&str, Option<&str>) {
-    match type_name.split_once('(') {
-        Some((base, rest)) if rest.ends_with(')') => {
-            let args = &rest[..rest.len() - 1];
-            (base, Some(args))
-        }
-        _ => (type_name, None),
     }
 }
 

--- a/crates/beamtalk-core/src/semantic_analysis/string_utils.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/string_utils.rs
@@ -7,6 +7,78 @@
 //!
 //! Contains general-purpose string algorithms used across analysis modules.
 
+/// Split a type-string on `sep` while respecting parenthesis nesting.
+///
+/// e.g. `split_top_level("Outer(Inner(A, B), C), D", ',')` returns
+/// `["Outer(Inner(A, B), C)", "D"]`, not four pieces. Empty trailing
+/// segments are dropped (so `split_top_level("", sep)` is `[]`), and each
+/// segment is trimmed.
+///
+/// This is the single nesting-aware scanner behind every "split a stored
+/// type-name string on some top-level separator" need in the type checker:
+/// type-parameter lists (`,`), union members (`|`), and intersection members
+/// (`&`, see [`super::type_checker::validation`]'s
+/// `split_intersection_type_string`, which layers "no separator found ⇒
+/// `None`" semantics on top for its caller).
+///
+/// **Unbalanced-parens behaviour (BT-3089):** a stray extra `)` clamps depth
+/// at zero via `saturating_sub` rather than going negative. Depth is only
+/// ever incremented by `(`, so once it reaches zero a further unmatched `)`
+/// cannot make later separators look "more nested" than they are — the
+/// scanner recovers immediately instead of requiring an equal number of
+/// extra `(` to compensate. Prior copies of this scanner disagreed here
+/// (plain `depth -= 1` vs `saturating_sub`); `saturating_sub` is the
+/// deliberately-chosen canonical behaviour since it degrades gracefully on
+/// malformed input instead of compounding the damage.
+pub(crate) fn split_top_level(s: &str, sep: char) -> Vec<&str> {
+    let mut result = Vec::new();
+    let mut depth: u32 = 0;
+    let mut start = 0;
+    for (i, c) in s.char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => depth = depth.saturating_sub(1),
+            c if c == sep && depth == 0 => {
+                result.push(s[start..i].trim());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    let last = s[start..].trim();
+    if !last.is_empty() {
+        result.push(last);
+    }
+    result
+}
+
+/// Split a stored-string type name into `(base, args_slice)`.
+///
+/// Given `"Array(Integer)"` returns `("Array", Some("Integer"))`.
+/// Given `"Result(Integer, Error)"` returns `("Result", Some("Integer, Error"))`.
+/// Given `"Integer"` (no parentheses) returns `("Integer", None)`.
+/// Given `"Array(Integer)extra"` (not terminated by `)`) falls back to
+/// `("Array(Integer)extra", None)` — the caller should treat the string as an
+/// opaque class name.
+///
+/// Shared by [`class_hierarchy::declared_type`](super::class_hierarchy::declared_type)
+/// and [`type_checker::type_resolver`](super::type_checker::type_resolver) —
+/// lives here, below both, rather than being duplicated upward into either
+/// (BT-3089; `class_hierarchy` sits below `type_checker` in the dependency
+/// graph and must not reach up into it).
+///
+/// **References:** BT-2025, BT-3089.
+#[must_use]
+pub(crate) fn split_generic_base(type_name: &str) -> (&str, Option<&str>) {
+    match type_name.split_once('(') {
+        Some((base, rest)) if rest.ends_with(')') => {
+            let args = &rest[..rest.len() - 1];
+            (base, Some(args))
+        }
+        _ => (type_name, None),
+    }
+}
+
 /// Simple edit distance (Levenshtein) for "did you mean" suggestions.
 pub(crate) fn edit_distance(a: &str, b: &str) -> usize {
     let a_chars: Vec<char> = a.chars().collect();
@@ -45,5 +117,105 @@ mod tests {
         assert_eq!(edit_distance("abc", "abcd"), 1);
         assert_eq!(edit_distance("abc", "xyz"), 3);
         assert_eq!(edit_distance("lenght", "length"), 2);
+    }
+
+    // ---- split_top_level ----
+
+    #[test]
+    fn split_top_level_comma_simple() {
+        assert_eq!(split_top_level("T, E", ','), vec!["T", "E"]);
+    }
+
+    #[test]
+    fn split_top_level_comma_single() {
+        assert_eq!(split_top_level("Integer", ','), vec!["Integer"]);
+    }
+
+    #[test]
+    fn split_top_level_comma_nested() {
+        assert_eq!(
+            split_top_level("GenResult(A, B), E", ','),
+            vec!["GenResult(A, B)", "E"]
+        );
+    }
+
+    #[test]
+    fn split_top_level_comma_empty() {
+        assert_eq!(split_top_level("", ','), Vec::<&str>::new());
+    }
+
+    #[test]
+    fn split_top_level_comma_deeply_nested() {
+        assert_eq!(
+            split_top_level("Outer(Inner(A, B), C), D", ','),
+            vec!["Outer(Inner(A, B), C)", "D"]
+        );
+    }
+
+    #[test]
+    fn split_top_level_pipe_simple() {
+        assert_eq!(split_top_level("String | nil", '|'), vec!["String", "nil"]);
+    }
+
+    #[test]
+    fn split_top_level_pipe_inside_parametric_not_split() {
+        assert_eq!(
+            split_top_level("Result(String | Integer, Error)", '|'),
+            vec!["Result(String | Integer, Error)"]
+        );
+    }
+
+    #[test]
+    fn split_top_level_pipe_mixed() {
+        assert_eq!(
+            split_top_level("List(String) | nil", '|'),
+            vec!["List(String)", "nil"]
+        );
+    }
+
+    #[test]
+    fn split_top_level_ampersand() {
+        assert_eq!(
+            split_top_level("Printable & Serializable", '&'),
+            vec!["Printable", "Serializable"]
+        );
+    }
+
+    /// BT-3089: a stray unmatched `)` clamps depth at zero (`saturating_sub`)
+    /// rather than going negative — so the very next top-level separator is
+    /// still recognised as top-level, instead of requiring a matching extra
+    /// `(` to "recover" first (the behaviour of the old plain `depth -= 1`
+    /// copy this scanner replaces).
+    #[test]
+    fn split_top_level_unbalanced_closing_paren_recovers_immediately() {
+        assert_eq!(split_top_level("A), B", ','), vec!["A)", "B"]);
+    }
+
+    // ---- split_generic_base ----
+
+    #[test]
+    fn split_generic_base_plain_name() {
+        assert_eq!(split_generic_base("Integer"), ("Integer", None));
+    }
+
+    #[test]
+    fn split_generic_base_single_arg() {
+        assert_eq!(
+            split_generic_base("Array(Integer)"),
+            ("Array", Some("Integer"))
+        );
+    }
+
+    #[test]
+    fn split_generic_base_multiple_args() {
+        assert_eq!(
+            split_generic_base("Result(Integer, Error)"),
+            ("Result", Some("Integer, Error"))
+        );
+    }
+
+    #[test]
+    fn split_generic_base_unterminated_treats_as_opaque() {
+        assert_eq!(split_generic_base("Array(Integer"), ("Array(Integer", None));
     }
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -5499,52 +5499,24 @@ impl TypeChecker {
     ///
     /// `"T, E"` → `["T", "E"]`
     /// `"GenResult(A, B), E"` → `["GenResult(A, B)", "E"]`
+    ///
+    /// Thin wrapper over the shared nesting-aware scanner
+    /// (`string_utils::split_top_level`, BT-3089) — kept as a method so the
+    /// many `Self::split_type_params` call sites in this module don't need
+    /// to change.
     pub(super) fn split_type_params(s: &str) -> Vec<&str> {
-        let mut result = Vec::new();
-        let mut depth = 0;
-        let mut start = 0;
-        for (i, c) in s.char_indices() {
-            match c {
-                '(' => depth += 1,
-                ')' => depth -= 1,
-                ',' if depth == 0 => {
-                    result.push(s[start..i].trim());
-                    start = i + 1;
-                }
-                _ => {}
-            }
-        }
-        let last = s[start..].trim();
-        if !last.is_empty() {
-            result.push(last);
-        }
-        result
+        crate::semantic_analysis::string_utils::split_top_level(s, ',')
     }
 
     /// Split a type string on `|` while respecting parenthesis nesting.
     ///
     /// This ensures `Result(String | Integer, Error)` is NOT split at the inner `|`,
     /// but `String | nil` IS split into `["String", "nil"]`.
+    ///
+    /// Thin wrapper over the shared nesting-aware scanner
+    /// (`string_utils::split_top_level`, BT-3089).
     pub(super) fn split_union_respecting_parens(s: &str) -> Vec<&str> {
-        let mut result = Vec::new();
-        let mut depth = 0i32;
-        let mut start = 0;
-        for (i, c) in s.char_indices() {
-            match c {
-                '(' => depth += 1,
-                ')' => depth = depth.saturating_sub(1),
-                '|' if depth == 0 => {
-                    result.push(s[start..i].trim());
-                    start = i + 1;
-                }
-                _ => {}
-            }
-        }
-        let last = s[start..].trim();
-        if !last.is_empty() {
-            result.push(last);
-        }
-        result
+        crate::semantic_analysis::string_utils::split_top_level(s, '|')
     }
 
     /// BT-1986: Does the return type mention `Self` *nested* inside a
@@ -6670,35 +6642,15 @@ mod tests {
     }
 
     // ---- split_type_params ----
-
-    #[test]
-    fn split_type_params_simple() {
-        let result = TypeChecker::split_type_params("T, E");
-        assert_eq!(result, vec!["T", "E"]);
-    }
-
-    #[test]
-    fn split_type_params_single() {
-        let result = TypeChecker::split_type_params("Integer");
-        assert_eq!(result, vec!["Integer"]);
-    }
+    //
+    // Thin wrapper over `string_utils::split_top_level`, whose exhaustive
+    // nesting/edge-case coverage lives at its definition site (BT-3089).
+    // This is a smoke test that the wrapper is wired up correctly.
 
     #[test]
     fn split_type_params_nested() {
         let result = TypeChecker::split_type_params("GenResult(A, B), E");
         assert_eq!(result, vec!["GenResult(A, B)", "E"]);
-    }
-
-    #[test]
-    fn split_type_params_empty() {
-        let result = TypeChecker::split_type_params("");
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn split_type_params_deeply_nested() {
-        let result = TypeChecker::split_type_params("Outer(Inner(A, B), C), D");
-        assert_eq!(result, vec!["Outer(Inner(A, B), C)", "D"]);
     }
 
     // ---- resolve_type_string (substitution) ----

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -25,7 +25,6 @@ use crate::source_analysis::{Diagnostic, DiagnosticCategory, Span};
 use ecow::{EcoString, eco_format};
 
 use super::narrowing::extract::extract_variable_name;
-use super::narrowing::extract::unwrap_parens;
 use super::narrowing::refinement::RefinementLayer;
 use super::narrowing::visitors::{block_has_any_return, block_has_return, block_may_reassign};
 use super::narrowing::{ClassTestInfo, ClassTestKind, NarrowingInfo};
@@ -824,7 +823,7 @@ impl TypeChecker {
                 // class references (`(HTTPRouter) build: [...]; ...`) are
                 // treated as class-side both for block-param inference and
                 // downstream selector validation.
-                let unwrapped_target = unwrap_parens(cascade_target);
+                let unwrapped_target = cascade_target.unwrap_parens();
                 let is_class_ref = matches!(unwrapped_target, Expression::ClassReference { .. });
                 // ADR 0083 / BT-2879: a Meta-typed cascade target (`someVar ::
                 // SomeClass class`) is also class-side for block-param
@@ -1087,7 +1086,7 @@ impl TypeChecker {
                 // applies when the scrutinee has a stable narrowable key
                 // (`extract_variable_name`) — an arbitrary expression
                 // scrutinee has nothing to narrow.
-                let scrutinee_key = extract_variable_name(unwrap_parens(value));
+                let scrutinee_key = extract_variable_name(value.unwrap_parens());
                 let mut residual_scrutinee_ty = scrutinee_ty.clone();
 
                 let arm_types: Vec<InferredType> = arms
@@ -1696,7 +1695,7 @@ impl TypeChecker {
         // If receiver is a class reference, check class-side methods.
         // BT-2158: unwrap parens so `(HTTPRouter) foo:` dispatches class-side
         // — matches the block-param inference normalisation above.
-        if let Expression::ClassReference { name, package, .. } = unwrap_parens(receiver) {
+        if let Expression::ClassReference { name, package, .. } = receiver.unwrap_parens() {
             let class_name = &name.name;
 
             // ADR 0075: `Erlang <module>` — return ErlangModule<module_name> type
@@ -1839,7 +1838,7 @@ impl TypeChecker {
         {
             // In class methods, self sends should check class-side methods.
             // BT-2158: unwrap parens so `(self) foo:` dispatches class-side.
-            if env.in_class_method && Self::is_self_receiver(unwrap_parens(receiver)) {
+            if env.in_class_method && Self::is_self_receiver(receiver.unwrap_parens()) {
                 if !in_abstract_method {
                     self.check_argument_types(
                         class_name,
@@ -2228,7 +2227,7 @@ impl TypeChecker {
         if type_args.is_empty() || arguments.len() != 1 {
             return None;
         }
-        let index = match unwrap_parens(&arguments[0]) {
+        let index = match arguments[0].unwrap_parens() {
             Expression::Literal(Literal::Integer(n), _) => *n,
             _ => return None,
         };
@@ -2642,7 +2641,7 @@ impl TypeChecker {
     /// parentheses so `(HTTPRouter) foo:` and `(self) foo:` are treated
     /// identically to the un-parenthesised forms (BT-2158).
     fn is_class_side_receiver(expr: &Expression, env: &TypeEnv) -> bool {
-        let unwrapped = unwrap_parens(expr);
+        let unwrapped = expr.unwrap_parens();
         matches!(unwrapped, Expression::ClassReference { .. })
             || (env.in_class_method && Self::is_self_receiver(unwrapped))
     }
@@ -3022,7 +3021,7 @@ impl TypeChecker {
     /// shape (including `and:` sends whose receiver isn't a `notNil` test —
     /// those fall back to the generic block-context inference).
     fn detect_not_nil_and_narrowing(receiver: &Expression) -> Option<EnvKey> {
-        let receiver = unwrap_parens(receiver);
+        let receiver = receiver.unwrap_parens();
         let Expression::MessageSend {
             receiver: inner_recv,
             selector,
@@ -3919,8 +3918,8 @@ impl TypeChecker {
 
         // Unwrap parentheses so `on: (Error) do: ([:e | ...])` also gets the
         // contextual block-param typing.
-        let ex_class_inner = unwrap_parens(ex_class_arg);
-        let handler_inner = unwrap_parens(handler_arg);
+        let ex_class_inner = ex_class_arg.unwrap_parens();
+        let handler_inner = handler_arg.unwrap_parens();
 
         // Extract class name from ClassReference for block param typing
         let exception_class_name = if let Expression::ClassReference { name, .. } = ex_class_inner {
@@ -4012,7 +4011,7 @@ impl TypeChecker {
                     // `ifNil:ifNotNil:` / `ifNotNil:ifNil:` — a bare
                     // `infer_expr` would drop the `Block(..., R)` return type,
                     // degrading the whole send on statically-known receivers.
-                    let inner = unwrap_parens(arg);
+                    let inner = arg.unwrap_parens();
                     if let Expression::Block(block) = inner {
                         self.infer_block_with_typed_params(
                             block,
@@ -4047,7 +4046,7 @@ impl TypeChecker {
     ) -> InferredType {
         // Unwrap parens: `ifNotNil: ([:x | ...])` should narrow the same as
         // the unparenthesised form.
-        let inner = unwrap_parens(arg);
+        let inner = arg.unwrap_parens();
         let Expression::Block(block) = inner else {
             return self.infer_expr(arg, hierarchy, env, in_abstract_method);
         };
@@ -4127,7 +4126,7 @@ impl TypeChecker {
             // sub-expressions like `[[^1] value]` or `foo: (^bar)`) exits
             // the method before the expression value is observed — treat
             // the branch as Never so `union_of` skips it.
-            if let Expression::Block(block) = unwrap_parens(arg) {
+            if let Expression::Block(block) = arg.unwrap_parens() {
                 if block_has_any_return(block) {
                     return Some(InferredType::Never);
                 }
@@ -4204,7 +4203,7 @@ impl TypeChecker {
         if class_name.as_str() != "Block" {
             return None;
         }
-        let block_ret = if let Expression::Block(block) = unwrap_parens(arg) {
+        let block_ret = if let Expression::Block(block) = arg.unwrap_parens() {
             if block_has_any_return(block) {
                 InferredType::Never
             } else {
@@ -4321,7 +4320,7 @@ impl TypeChecker {
         // exit the method on every path. Some blocks that may-but-not-always
         // diverge get widened to `Never` here — an accepted imprecision this
         // shares with the mirror function, [`Self::if_nil_solo_union_ret_ty`].
-        let block_ret = if let Expression::Block(block) = unwrap_parens(arg) {
+        let block_ret = if let Expression::Block(block) = arg.unwrap_parens() {
             if block_has_any_return(block) {
                 InferredType::Never
             } else {
@@ -4416,7 +4415,7 @@ impl TypeChecker {
                         // `respondsTo: ifFalse: [...]` on `Boolean` lost `R`
                         // entirely and `if_true_false_solo_boolean_ret_ty`
                         // couldn't union it with the `Boolean` self-branch.
-                        let ty = if let Expression::Block(block) = unwrap_parens(arg) {
+                        let ty = if let Expression::Block(block) = arg.unwrap_parens() {
                             self.infer_block_with_typed_params(
                                 block,
                                 arg.span(),
@@ -4655,7 +4654,7 @@ impl TypeChecker {
                 return arguments
                     .iter()
                     .map(|arg| {
-                        if let Expression::Block(block) = unwrap_parens(arg) {
+                        if let Expression::Block(block) = arg.unwrap_parens() {
                             self.infer_block_with_typed_params(
                                 block,
                                 arg.span(),
@@ -4844,7 +4843,7 @@ impl TypeChecker {
                 // Unwrap parens so `foo: ([:x | ...])` gets the same
                 // Dynamic(DynamicReceiver) propagation as the unparenthesised
                 // `foo: [:x | ...]` form.
-                let inner = unwrap_parens(arg);
+                let inner = arg.unwrap_parens();
                 if let Expression::Block(block) = inner {
                     if propagate_dynamic {
                         let param_types: Vec<InferredType> = (0..block.parameters.len())

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -1873,15 +1873,8 @@ impl TypeChecker {
                 && !is_class_protocol_selector(&selector_name)
                 && !matches!(selector, MessageSelector::Binary(_))
             {
-                return self.infer_ffi_call(
-                    type_args,
-                    selector,
-                    &selector_name,
-                    arguments,
-                    &arg_types,
-                    span,
-                    hierarchy,
-                );
+                return self
+                    .infer_ffi_call(type_args, selector, arguments, &arg_types, span, hierarchy);
             }
 
             // BT-2254 (ADR 0075 amendment): literal-index tuple access.
@@ -2256,7 +2249,6 @@ impl TypeChecker {
         &mut self,
         receiver_type_args: &[InferredType],
         selector: &MessageSelector,
-        selector_name: &EcoString,
         arguments: &[Expression],
         arg_types: &[InferredType],
         span: Span,
@@ -2272,11 +2264,17 @@ impl TypeChecker {
             return InferredType::Dynamic(DynamicReason::DynamicReceiver); // Dynamic module name
         };
 
-        // Extract the canonical Erlang function name and arity from the selector.
-        // The canonical name is the first keyword without colons, matching the
-        // selector_to_function/1 logic in beamtalk_erlang_proxy. The spec reader
-        // normalizes stored names the same way, so a single lookup suffices.
-        let (function_name, arity) = Self::extract_ffi_function_info(selector_name, arguments);
+        // Extract the canonical Erlang function name and arity from the selector
+        // (BT-3089: delegates to the one canonical erlang_function_name/erlang_arity
+        // pair, see extract_ffi_function_info's doc comment). `None` for a binary
+        // selector — unreachable today since the BT-1880 guard at this method's
+        // call site already excludes `MessageSelector::Binary` before we get here,
+        // but falling back to `UntypedFfi` rather than panicking/asserting keeps
+        // that a soft invariant instead of a hard one.
+        let Some((function_name, arity)) = Self::extract_ffi_function_info(selector, arguments)
+        else {
+            return InferredType::Dynamic(DynamicReason::UntypedFfi);
+        };
 
         // Clone the signature to release the borrow on self before emitting diagnostics.
         let sig = self
@@ -2316,20 +2314,25 @@ impl TypeChecker {
     /// keyword ("seq") and the arity is the argument count.
     /// For unary selectors like `reverse`, the function name is the selector and
     /// arity is 0 (nullary Erlang call).
+    ///
+    /// Delegates to the canonical FFI-naming pair
+    /// [`erlang_function_name`](crate::semantic_analysis::validators::erlang_function_name) /
+    /// [`erlang_arity`](crate::semantic_analysis::validators::erlang_arity)
+    /// (BT-3089) rather than re-deriving "first keyword sans colon" with its
+    /// own `.split(':')` — that duplicate previously computed a name for
+    /// *binary* selectors too (e.g. `"+".split(':').next()` ⇒ `"+"`), which
+    /// disagreed with the canonical function (binary ⇒ `None`, no FFI-name
+    /// concept) and with `dispatch_codegen`'s `generate_direct_erlang_call`
+    /// (binary ⇒ falls through to normal dispatch, never emits a direct FFI
+    /// call). Returns `None` for a binary selector, matching both of those.
     fn extract_ffi_function_info(
-        selector_name: &EcoString,
+        selector: &MessageSelector,
         arguments: &[Expression],
-    ) -> (String, u8) {
-        // The selector_name for keyword messages is "reverse:" or "seq:to:"
-        // The Erlang function name is the first keyword without the colon
-        let function_name = selector_name
-            .split(':')
-            .next()
-            .unwrap_or(selector_name.as_str())
-            .to_string();
-
-        let arity = u8::try_from(arguments.len()).unwrap_or(u8::MAX);
-        (function_name, arity)
+    ) -> Option<(String, u8)> {
+        let function_name = crate::semantic_analysis::validators::erlang_function_name(selector)?;
+        let arity = crate::semantic_analysis::validators::erlang_arity(selector, arguments.len());
+        let arity = u8::try_from(arity).unwrap_or(u8::MAX);
+        Some((function_name, arity))
     }
 
     /// Checks argument types against declared parameter types in an FFI signature.
@@ -6650,6 +6653,47 @@ mod tests {
     fn split_type_params_nested() {
         let result = TypeChecker::split_type_params("GenResult(A, B), E");
         assert_eq!(result, vec!["GenResult(A, B)", "E"]);
+    }
+
+    // ---- extract_ffi_function_info (BT-3089) ----
+    //
+    // Pins the resolved binary-selector edge case: a binary selector has no
+    // FFI-proxy-call name (mirrors `erlang_function_name`/dispatch_codegen's
+    // `generate_direct_erlang_call`, both of which also decline to treat a
+    // binary send to `Erlang <module>` as a direct FFI call) — this used to
+    // disagree, deriving a name via `.split(':')` regardless of selector
+    // shape.
+
+    #[test]
+    fn extract_ffi_function_info_unary() {
+        let selector = MessageSelector::Unary("reverse".into());
+        assert_eq!(
+            TypeChecker::extract_ffi_function_info(&selector, &[]),
+            Some(("reverse".to_string(), 0))
+        );
+    }
+
+    #[test]
+    fn extract_ffi_function_info_keyword() {
+        let selector = MessageSelector::Keyword(vec![
+            KeywordPart::new("seq:", span()),
+            KeywordPart::new("to:", span()),
+        ]);
+        let args = [var("a"), var("b")];
+        assert_eq!(
+            TypeChecker::extract_ffi_function_info(&selector, &args),
+            Some(("seq".to_string(), 2))
+        );
+    }
+
+    #[test]
+    fn extract_ffi_function_info_binary_is_none() {
+        let selector = MessageSelector::Binary("+".into());
+        let args = [var("a")];
+        assert_eq!(
+            TypeChecker::extract_ffi_function_info(&selector, &args),
+            None
+        );
     }
 
     // ---- resolve_type_string (substitution) ----

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/extract.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/extract.rs
@@ -22,15 +22,6 @@
 use crate::ast::Expression;
 use crate::semantic_analysis::type_checker::EnvKey;
 
-/// Peel `Expression::Parenthesized` wrappers so callers can pattern-match on
-/// the inner expression directly.
-pub(crate) fn unwrap_parens(expr: &Expression) -> &Expression {
-    match expr {
-        Expression::Parenthesized { expression, .. } => unwrap_parens(expression),
-        other => other,
-    }
-}
-
 /// Extract a [`EnvKey`] naming the variable under a type test.
 ///
 /// Supports identifiers, parenthesized identifiers, and `self.<field>`

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/mod.rs
@@ -37,6 +37,6 @@ pub(crate) use rules::singleton_eq::detect_binary as detect_singleton_eq;
 ///
 /// Returns `None` when no rule matches.
 pub(crate) fn detect(receiver: &Expression) -> Option<NarrowingInfo> {
-    let receiver = extract::unwrap_parens(receiver);
+    let receiver = receiver.unwrap_parens();
     rules::RULES.iter().find_map(|rule| (rule.detect)(receiver))
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/singleton_eq.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/narrowing/rules/singleton_eq.rs
@@ -16,7 +16,7 @@ use ecow::EcoString;
 use crate::ast::{Expression, Literal, MessageSelector};
 use crate::semantic_analysis::type_checker::{DynamicReason, EnvKey, InferredType};
 
-use super::super::extract::{extract_variable_name, unwrap_parens};
+use super::super::extract::extract_variable_name;
 use super::super::info::{NarrowingInfo, SingletonEqInfo, SingletonName};
 use super::NarrowingRule;
 
@@ -92,7 +92,7 @@ pub(crate) fn detect_binary(
 /// Returns the symbol name of a `#foo` literal (without the leading `#`),
 /// unwrapping any nesting of parentheses; `None` for any other expression.
 fn symbol_literal(expr: &Expression) -> Option<&EcoString> {
-    match unwrap_parens(expr) {
+    match expr.unwrap_parens() {
         Expression::Literal(Literal::Symbol(name), _) => Some(name),
         _ => None,
     }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_and_blocks.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/dynamic_and_blocks.rs
@@ -522,19 +522,10 @@ fn block_params_typed_via_method_parameter_annotation() {
     );
 }
 
-#[test]
-fn split_union_respecting_parens_simple() {
-    let result = TypeChecker::split_union_respecting_parens("String | nil");
-    assert_eq!(result, vec!["String", "nil"]);
-}
-
-#[test]
-fn split_union_respecting_parens_inside_parametric() {
-    // Pipe inside parens should NOT cause a split
-    let result = TypeChecker::split_union_respecting_parens("Result(String | Integer, Error)");
-    assert_eq!(result, vec!["Result(String | Integer, Error)"]);
-}
-
+// `split_union_respecting_parens` is a thin wrapper over
+// `string_utils::split_top_level`, whose exhaustive nesting/edge-case
+// coverage lives at its definition site (BT-3089). This is a smoke test
+// that the wrapper is wired up correctly.
 #[test]
 fn split_union_respecting_parens_mixed() {
     // Top-level union with parametric member

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
@@ -775,30 +775,19 @@ fn resolve_type_keyword(name: &EcoString) -> EcoString {
 
 /// Split a stored-string type name into `(base, args_slice)`.
 ///
-/// Given `"Array(Integer)"` returns `("Array", Some("Integer"))`.
-/// Given `"Result(Integer, Error)"` returns `("Result", Some("Integer, Error"))`.
-/// Given `"Integer"` (no parentheses) returns `("Integer", None)`.
-/// Given `"Array(Integer)extra"` (not terminated by `)`) falls back to
-/// `("Array(Integer)extra", None)` — the caller should treat the string as an
-/// opaque class name.
-///
 /// Used by the string-form parsers (`resolve_type_param`,
 /// `parse_generic_type_string`, etc.) in
 /// place of manual `.find('(')` slicing. Centralising this keeps the
 /// parenthesis-parsing logic in one place and lets the
 /// `no .find('(')` grep check stay clean.
 ///
-/// **References:** BT-2025.
-#[must_use]
-pub(in crate::semantic_analysis) fn split_generic_base(type_name: &str) -> (&str, Option<&str>) {
-    match type_name.split_once('(') {
-        Some((base, rest)) if rest.ends_with(')') => {
-            let args = &rest[..rest.len() - 1];
-            (base, Some(args))
-        }
-        _ => (type_name, None),
-    }
-}
+/// Re-exported from [`string_utils`](crate::semantic_analysis::string_utils)
+/// — the shared implementation, below both `type_checker` and
+/// `class_hierarchy` (BT-3089) — so existing call sites that spell this as
+/// `type_resolver::split_generic_base` keep working unchanged.
+///
+/// **References:** BT-2025, BT-3089.
+pub(in crate::semantic_analysis) use crate::semantic_analysis::string_utils::split_generic_base;
 
 /// Extract the base class-name portion of a stored-string type name.
 ///
@@ -1967,34 +1956,10 @@ mod tests {
         assert_eq!(result, expected);
     }
 
-    // ---- split_generic_base / base_name_of_string ----
-
-    #[test]
-    fn split_generic_base_plain_name() {
-        assert_eq!(split_generic_base("Integer"), ("Integer", None));
-    }
-
-    #[test]
-    fn split_generic_base_single_arg() {
-        assert_eq!(
-            split_generic_base("Array(Integer)"),
-            ("Array", Some("Integer"))
-        );
-    }
-
-    #[test]
-    fn split_generic_base_multiple_args() {
-        assert_eq!(
-            split_generic_base("Result(Integer, Error)"),
-            ("Result", Some("Integer, Error"))
-        );
-    }
-
-    #[test]
-    fn split_generic_base_unterminated_treats_as_opaque() {
-        // No closing `)` — treat the whole string as an opaque class name.
-        assert_eq!(split_generic_base("Array(Integer"), ("Array(Integer", None));
-    }
+    // ---- base_name_of_string ----
+    //
+    // `split_generic_base` itself is tested once, at its definition site in
+    // `string_utils` (BT-3089) — no need to re-test it by proxy here.
 
     #[test]
     fn base_name_of_string_discards_args() {

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -3236,26 +3236,17 @@ impl TypeChecker {
     /// Used by [`check_protocol_conformance_in_expr`](super::protocol::TypeChecker::check_protocol_conformance_in_expr)
     /// so a parameter declared `:: P1 & P2` is checked for conformance to
     /// **both** protocol parts, per ADR 0068's protocol-composition use case.
+    ///
+    /// Thin wrapper over the shared nesting-aware scanner
+    /// (`string_utils::split_top_level`, BT-3089), layering on "no top-level
+    /// `&` found ⇒ `None`" — the one behavioural difference this consumer
+    /// actually needs (see doc comment above): callers use `None` to detect
+    /// "not an intersection annotation at all" and fall back to single-type
+    /// handling, which a bare 1-element `Vec` can't distinguish from "an
+    /// intersection of one part".
     pub(super) fn split_intersection_type_string(type_name: &str) -> Option<Vec<&str>> {
-        let mut depth: usize = 0;
-        let mut parts = Vec::new();
-        let mut start = 0usize;
-        for (i, byte) in type_name.bytes().enumerate() {
-            match byte {
-                b'(' => depth += 1,
-                b')' => depth = depth.saturating_sub(1),
-                b'&' if depth == 0 => {
-                    parts.push(type_name[start..i].trim());
-                    start = i + 1;
-                }
-                _ => {}
-            }
-        }
-        if parts.is_empty() {
-            return None;
-        }
-        parts.push(type_name[start..].trim());
-        Some(parts)
+        let parts = crate::semantic_analysis::string_utils::split_top_level(type_name, '&');
+        if parts.len() < 2 { None } else { Some(parts) }
     }
 
     /// Check type parameter bounds for a generic type application (ADR 0068 Phase 2d).

--- a/crates/beamtalk-core/src/semantic_analysis/validators/native_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/native_validators.rs
@@ -171,10 +171,7 @@ fn check_selector_reserved_word(
     span: crate::source_analysis::Span,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let fn_name = match selector {
-        MessageSelector::Unary(name) | MessageSelector::Binary(name) => name.as_str(),
-        MessageSelector::Keyword(parts) => parts[0].keyword.trim_end_matches(':'),
-    };
+    let fn_name = selector.leading_word();
     if ERLANG_RESERVED_WORDS.contains(&fn_name) {
         diagnostics.push(
             Diagnostic::error(


### PR DESCRIPTION
Part of epic BT-3078 (duplication audit). This is a grab-bag of small "same logic implemented N times" collapses in the compiler crates. Six of the seven listed items are landed here; item 6 (method-signature rendering) is deliberately deferred — see below.

## What's in this PR

**1. Nesting-aware type-string splitters (4 copies → 1).**
`split_type_params`, `split_union_respecting_parens`, `declared_type`'s local `split_top_level`, and `split_intersection_type_string` all reimplemented the same "split on separator, respecting paren nesting" scan; `split_generic_base` was independently duplicated in `type_resolver.rs` and `declared_type.rs`. Moved both into `semantic_analysis::string_utils` — a shared-kernel module already sitting below both `class_hierarchy` and `type_checker` — and pointed every former copy at it. `type_resolver::split_generic_base` is now a `pub use` re-export so its call sites didn't need to change.

Resolved the depth-underflow drift deliberately: the shared scanner clamps depth at zero via `saturating_sub` (a stray unmatched `)` recovers immediately) rather than `inference.rs`'s old plain `depth -= 1` (which could require an extra unmatched `(` to "recover" before later separators were treated as top-level again). Covered by a dedicated regression test. `split_intersection_type_string` keeps its distinct "no top-level `&` ⇒ `None`" semantics as a thin layer, since callers rely on that to distinguish "not an intersection" from "single-part intersection".

**2. Selector → string (3 near-identical impls → 1).**
`MessageSelector::to_erlang_atom()` and `block_context::selector_to_string()` were byte-for-byte identical to `MessageSelector::name()` — just returning `String` instead of `EcoString`. `to_erlang_atom`'s doc comment claimed to be "the domain service for selector mangling" but its body did no mangling at all (verified by inspection). Deleted both duplicates and their exactly-duplicated unit tests; repointed every call site (~35 in codegen, plus 2 in `analyser.rs`) at `.name()`. Documented on `name()` that it (not a separate mangling step) is the sole selector→atom-text authority.

**3. Atom escaping (3 rule sets → 1 funnel).**
`util::escape_atom_chars` (the BT-875 funnel behind `leaf::atom`) escaped only `'`/`\`; `erlang_types::ErlangAtom`'s `Display` additionally escaped `\n`/`\r`/`\t`; `beamtalk-cli`'s `test_stdlib::erlang_atom` did no escaping at all.

Resolved the `\n`/`\r`/`\t` question with evidence rather than picking a side: Beamtalk quoted-symbol literals (`#'foo bar'`) have **no backslash-escape syntax of their own** — confirmed in `lex_symbol_or_hash`, which accepts any literal character up to the closing `'`, including a raw newline typed directly in the source. That symbol text reaches `leaf::atom` unchanged via `Literal::Symbol => leaf::atom(...)`, so an unescaped control character can genuinely end up embedded in generated `.core` source today. Merged `\n`/`\r`/`\t` into the canonical `escape_atom_chars` (plus `\0`, mirroring the sibling `escape_erlang_string` table). `ErlangAtom::Display` now delegates to it instead of duplicating the table. `beamtalk-cli`'s `erlang_atom` — a real, if latent, bug — now routes through the same funnel via `beamtalk_core::codegen::core_erlang::escape_atom_chars`. `generate/native.rs`'s `needs_quoting` turned out to have moved/renamed to `unparse::needs_symbol_quoting`; confirmed it's a genuinely different concern (Beamtalk-source symbol-quoting, not Erlang-atom escaping) and left untouched.

**4. Paren-peeling (4 copies → 1).**
`structural_validators.rs`'s copy was already folded into `ffi_receiver.rs` by BT-3079 (verified — nothing left there). The remaining four — `ffi_receiver.rs::peel_parens`, `narrowing/extract.rs::unwrap_parens`, `CoreErlangGenerator::peel_parens`, `ffi_sites_query.rs::unwrap_parens` — were the identical "loop through `Expression::Parenthesized`" scan. Added `Expression::unwrap_parens(&self)` as an inherent method in `ast/expression.rs` (the bottom of the dependency graph) and repointed every call site, including 17 sites in `inference.rs` that imported `narrowing::extract::unwrap_parens` directly (not in the issue's original file list — found while chasing down `extract.rs`'s callers).

**5. Erlang FFI function-name derivation — binary-selector drift resolved.**
Two genuinely distinct families were tangled together here:
- *"`Erlang <module> <selector>`" FFI-proxy-call naming* — canonical is `structural_validators::erlang_function_name`/`erlang_arity`. `dispatch_codegen`'s duplicate was already behaviorally consistent (excludes `Binary`). `all_sends_query.rs`'s listed duplication turned out to already be resolved by BT-3079 (it only resolves *module* names, not function names). `inference.rs::infer_ffi_call` did **not** agree — its `extract_ffi_function_info` derived a name for binary selectors too (`"+".split(':').next()` ⇒ `"+"`), disagreeing with the canonical function. This was latent (a `BT-1880` guard upstream already filters out `Binary` before this runs) but structurally fragile — the duplicate's own logic silently diverged rather than being true by construction. Rewrote it to delegate to `erlang_function_name`/`erlang_arity` directly. Pinned with new unary/keyword/binary regression tests.
- *"`native: self delegate`" backing-function naming* (ADR 0101/BT-2720) — a different mechanism that legitimately **does** name binary operators (a user's own `+` method can delegate to a same-named native function). `value_type_codegen::native_delegate_fn_name` and `native_validators`'s reserved-word check reimplemented the identical rule. Neither module may depend on the other (`semantic_analysis` must not depend on `codegen`), so moved it down onto `MessageSelector::leading_word` — a new inherent method in `ast/expression.rs` — with a doc comment explicitly contrasting it against `erlang_function_name`'s binary exclusion, so the two families' diverging binary-selector behavior is documented as deliberate.

**7. Type-annotation rendering — parity now enforced by a test, not a comment.**
`TypeAnnotation::type_name`, `DeclaredType`'s `Display`, and `unparse::unparse_type_annotation_display` are three independent renderers for a real structural reason (different input types: spans+`Identifier`s vs. a span-free structural mirror vs. the `Document`-based pretty-printer) — not a safe mechanical merge. The `needs_parens_in_difference`/`needs_parens_in_intersection` predicates were already correctly *shared* where the types matched (`TypeAnnotation` ⟷ `unparse`); only `DeclaredType`, being a different type, had its own hand-synced mirror. An `assert_display_parity` fixture-test suite already existed comparing `DeclaredType::Display` against `type_name` across 11 representative shapes — extended it to also assert `unparse_type_annotation_display` matches. All 11 cases pass unchanged, confirming no live drift; now that stays true by construction per this repo's "no duplicate implementations without an enforcing test" rule.

## Deferred: item 6 (method-signature rendering)

Deliberately **not** attempted in this PR. On inspection this is larger and riskier than the other six:
- The 5 sites span two crates (`beamtalk-core`'s `unparse`, `hover_provider`, `signature_help_provider`; `beamtalk-cli`'s `doc/extractor`, `generate/stubs`) and at least one (`stubs.rs::format_signature`) formats a structurally different input type (`FunctionSignature`/`InferredType` from the native-type registry, not `MethodDefinition`/`TypeAnnotation`) — a true single renderer isn't a safe mechanical change without first unifying representations.
- The issue's own text acknowledges the 4 AST-based consumers *legitimately* want different detail levels — this needs an actual small design (a parameterized renderer or options struct), not a mechanical collapse, to avoid introducing LSP/doc/stub-generation output regressions.
- While scoping it, found a further wrinkle worth flagging for whoever picks this up: `hover_provider.rs::type_annotation_label` is effectively a **fourth** independent type-annotation-text renderer (distinct from item 7's three), so item 6's design should probably account for it too.

Given the risk/complexity and this repo's guidance to land a genuinely-complete subset over rushing everything, recommend a focused follow-up issue for item 6.

## Test plan

- [x] `cargo build --all-targets` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean (workspace-wide)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace` — no regressions. The only failures (`beamtalk-core`'s 19 `*_compiles_through_erlc`/`discover_otp_beam_files_*` tests, `beamtalk-cli`'s 8 tests needing a built `beamtalk_stdlib.app`) are pre-existing environment/toolchain gaps, confirmed identical on unmodified `main` in this sandbox before making any changes.
- [x] New regression tests added: `string_utils` splitter suite (incl. the unbalanced-paren case), `MessageSelector::leading_word`/`unwrap_parens` unit tests, `escape_atom_chars` control-character tests + `beamtalk-cli` `erlang_atom` tests, `extract_ffi_function_info` unary/keyword/binary tests, extended `assert_display_parity`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL7GE5XvKMame4UzYFb1dJ)_