### PR TITLE
BT-3096: walk_ancestors/3 max_depth_exceeded now carries the last-visited node

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
@@ -1196,14 +1196,12 @@ When the chain is exhausted (none or unregistered class), returns the fully
 folded accumulator built up through every ancestor visited.
 
 When the walk instead exhausts `?MAX_HIERARCHY_DEPTH` (a hierarchy cycle),
-returns the ORIGINAL `Acc` passed into this call — not the partial
-accumulator folded up through the ~`?MAX_HIERARCHY_DEPTH` ancestors visited
-before the guard tripped — and logs a `?LOG_WARNING`. This is a deliberate,
-narrower contract than the hand-rolled recursion this function replaced
-(which did return the partial fold): `walk_ancestors/3`'s `max_depth_exceeded`
-carries no payload, so every caller here falls back to a fixed default on
-this already-anomalous path rather than threading partial state back out.
-Only reachable via an actual hierarchy cycle or a legitimately
+returns the partial accumulator folded up through every ancestor actually
+visited before the guard tripped (BT-3096) — not the original `Acc` passed
+into this call — and logs a `?LOG_WARNING` naming the ancestor where the
+cycle was detected. This matches the hand-rolled recursion this function
+replaced, which also returned the partial fold on depth exhaustion. Only
+reachable via an actual hierarchy cycle or a legitimately
 `?MAX_HIERARCHY_DEPTH`-level-deep hierarchy.
 
 BT-3087: The walk itself (depth guard, cycle warning, advance-to-superclass)
@@ -1211,6 +1209,9 @@ is `beamtalk_hierarchy:walk_ancestors/3`; this function supplies only the
 per-ancestor registry lookup and threads Acc through the walk. Since
 `walk_ancestors/3` only threads a bare node id between steps (not a
 separate accumulator), Acc rides along inside the node as `{ClassName, Acc}`.
+BT-3096: this is also why `max_depth_exceeded` carries `LastNode` back to
+the caller — it's the only way to recover the partial `Acc` folded up to
+that point, since it rode along inside the node the whole time.
 """.
 -spec walk_hierarchy(atom() | none, fun((atom(), pid(), Acc) -> {cont, Acc} | {halt, Result}), Acc) ->
     Acc | Result.
@@ -1236,13 +1237,13 @@ walk_hierarchy(ClassName, Fun, Acc) ->
     case beamtalk_hierarchy:walk_ancestors({ClassName, Acc}, StepFun, ?MAX_HIERARCHY_DEPTH) of
         {found, {result, Result}} ->
             Result;
-        max_depth_exceeded ->
+        {max_depth_exceeded, {CycleClassName, PartialAcc}} ->
             ?LOG_WARNING(
-                "walk_hierarchy: max hierarchy depth ~p exceeded — possible cycle",
-                [?MAX_HIERARCHY_DEPTH],
+                "walk_hierarchy: max hierarchy depth ~p exceeded at ~p — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, CycleClassName],
                 #{domain => [beamtalk, runtime]}
             ),
-            Acc;
+            PartialAcc;
         not_found ->
             %% Unreachable: StepFun above always resolves to {found, _} — a
             %% `none` superclass or an unregistered ancestor is translated to

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl
@@ -936,10 +936,10 @@ find_class_method_in_chain(Selector, ClassName) ->
             {ok, AncestorName, AncestorModule};
         not_found ->
             not_found;
-        max_depth_exceeded ->
+        {max_depth_exceeded, CycleAncestor} ->
             ?LOG_WARNING(
-                "find_class_method_in_ancestors: max hierarchy depth ~p exceeded at ~p — possible cycle",
-                [?MAX_HIERARCHY_DEPTH, ClassName],
+                "find_class_method_in_ancestors: max hierarchy depth ~p exceeded at ~p (starting from ~p) — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, CycleAncestor, ClassName],
                 #{domain => [beamtalk, runtime]}
             ),
             not_found

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_dispatch.erl
@@ -257,10 +257,11 @@ lookup_in_class_chain(Selector, Args, Self, State, ClassName) ->
     case beamtalk_hierarchy:walk_ancestors(ClassName, StepFun, ?MAX_HIERARCHY_DEPTH) of
         {found, Result} ->
             Result;
-        max_depth_exceeded ->
+        {max_depth_exceeded, CycleClass} ->
             ?LOG_WARNING("Max hierarchy depth exceeded — possible cycle", #{
                 max_depth => ?MAX_HIERARCHY_DEPTH,
                 class => ClassName,
+                cycle_detected_at => CycleClass,
                 selector => Selector,
                 domain => [beamtalk, runtime]
             }),

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_hierarchy.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_hierarchy.erl
@@ -38,8 +38,26 @@ early (mirrors "no superclass").
 Callers that need caller-specific behaviour at the max-depth boundary (e.g.
 a structured `#beamtalk_error{}` naming the class that triggered it, or a
 contextual `?LOG_WARNING` naming the selector) inspect the
-`max_depth_exceeded` return and build their own error/log line; this module
-only owns the depth guard itself, not the logging.
+`{max_depth_exceeded, LastNode}` return and build their own error/log line;
+this module only owns the depth guard itself, not the logging.
+
+## Recovering state on `max_depth_exceeded` (BT-3096)
+
+`max_depth_exceeded` carries the node the walk was about to visit when the
+guard tripped — `LastNode` in `{max_depth_exceeded, LastNode}`. Two things
+fall out of that:
+
+- **Naming the actual cycle point.** A caller walking bare node ids (a class
+  name atom, a class-process pid) can name the concrete ancestor where the
+  cycle was detected in its log/error, instead of only the original
+  receiver the walk started from.
+- **Recovering partial fold state.** A caller that threads an accumulator
+  through the walk (since `StepFun` only receives/returns a single node,
+  such callers ride their accumulator along *inside* the node itself, e.g.
+  `{ClassName, Acc}` — see `beamtalk_behaviour_intrinsics:walk_hierarchy/3`'s
+  moduledoc) can pull `Acc` back out of `LastNode` and return the fold
+  built up through every ancestor actually visited, rather than discarding
+  it in favour of a fixed default.
 """.
 
 -export([walk_ancestors/3]).
@@ -47,7 +65,7 @@ only owns the depth guard itself, not the logging.
 -type node_id() :: term().
 -type step_result(Result) :: {found, Result} | {next, node_id() | none} | not_found.
 -type step_fun(Result) :: fun((node_id(), non_neg_integer()) -> step_result(Result)).
--type walk_result(Result) :: {found, Result} | not_found | max_depth_exceeded.
+-type walk_result(Result) :: {found, Result} | not_found | {max_depth_exceeded, node_id()}.
 
 -export_type([step_result/1, step_fun/1, walk_result/1]).
 
@@ -59,6 +77,12 @@ node until it reports `{found, Result}` or `not_found`, or the walk exceeds
 `StartNode` may be `none` (an empty chain — e.g. a class with no
 superclass), in which case the walk terminates immediately with `not_found`
 and `StepFun` is never invoked.
+
+On depth exhaustion, returns `{max_depth_exceeded, LastNode}` where
+`LastNode` is the node the walk was about to visit next (i.e. the node
+returned by the last successful `{next, NextNode}`) when the guard tripped
+— `StepFun` is never invoked on it. See the moduledoc for how callers use
+`LastNode` to name the cycle point or recover partial fold state.
 """.
 -spec walk_ancestors(node_id() | none, step_fun(Result), non_neg_integer()) ->
     walk_result(Result).
@@ -69,8 +93,8 @@ walk_ancestors(StartNode, StepFun, MaxDepth) ->
     walk_result(Result).
 walk_ancestors(none, _StepFun, _MaxDepth, _Depth) ->
     not_found;
-walk_ancestors(_Node, _StepFun, MaxDepth, Depth) when Depth > MaxDepth ->
-    max_depth_exceeded;
+walk_ancestors(Node, _StepFun, MaxDepth, Depth) when Depth > MaxDepth ->
+    {max_depth_exceeded, Node};
 walk_ancestors(Node, StepFun, MaxDepth, Depth) ->
     case StepFun(Node, Depth) of
         {found, Result} ->

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_hierarchy_docs.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_hierarchy_docs.erl
@@ -78,10 +78,11 @@ find_defining_class(ClassPid, Selector) ->
     case beamtalk_hierarchy:walk_ancestors(ClassPid, StepFun, ?MAX_HIERARCHY_DEPTH) of
         {found, DefiningClass} ->
             DefiningClass;
-        max_depth_exceeded ->
+        {max_depth_exceeded, CyclePid} ->
+            CycleClass = beamtalk_object_class:class_name(CyclePid),
             ?LOG_WARNING(
-                "find_defining_class: max hierarchy depth ~p exceeded at ~p for selector ~p — possible cycle",
-                [?MAX_HIERARCHY_DEPTH, ReceiverName, Selector],
+                "find_defining_class: max hierarchy depth ~p exceeded at ~p (starting from ~p) for selector ~p — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, CycleClass, ReceiverName, Selector],
                 #{domain => [beamtalk, runtime]}
             ),
             ReceiverName;
@@ -122,10 +123,11 @@ find_defining_class_method(ClassPid, Selector) ->
     case beamtalk_hierarchy:walk_ancestors(ClassPid, StepFun, ?MAX_HIERARCHY_DEPTH) of
         {found, DefiningClass} ->
             DefiningClass;
-        max_depth_exceeded ->
+        {max_depth_exceeded, CyclePid} ->
+            CycleClass = beamtalk_object_class:class_name(CyclePid),
             ?LOG_WARNING(
-                "find_defining_class_method: max hierarchy depth ~p exceeded at ~p for selector ~p — possible cycle",
-                [?MAX_HIERARCHY_DEPTH, ReceiverName, Selector],
+                "find_defining_class_method: max hierarchy depth ~p exceeded at ~p (starting from ~p) for selector ~p — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, CycleClass, ReceiverName, Selector],
                 #{domain => [beamtalk, runtime]}
             ),
             ReceiverName;
@@ -141,8 +143,10 @@ methods. Local methods shadow inherited ones (Smalltalk-style override):
 a selector redefined by a subclass is tagged with the subclass as its
 `DefiningClass`, never the ancestor it shadows.
 
-Returns `#{}` if the walk exhausts `?MAX_HIERARCHY_DEPTH` (a hierarchy
-cycle), logging a `?LOG_WARNING`.
+If the walk exhausts `?MAX_HIERARCHY_DEPTH` (a hierarchy cycle), returns the
+partial map folded up through the ancestors actually visited before the
+guard tripped (BT-3096) — not an empty map — and logs a `?LOG_WARNING`
+naming the ancestor where the cycle was detected.
 """.
 -spec collect_flattened_methods(atom(), pid()) -> map().
 collect_flattened_methods(ClassName, ClassPid) ->
@@ -170,13 +174,13 @@ collect_flattened_methods(ClassName, ClassPid) ->
     of
         {found, Result} ->
             Result;
-        max_depth_exceeded ->
+        {max_depth_exceeded, {CycleName, _CyclePid, PartialAcc}} ->
             ?LOG_WARNING(
-                "collect_flattened_methods: max hierarchy depth ~p exceeded at ~p — possible cycle",
-                [?MAX_HIERARCHY_DEPTH, ClassName],
+                "collect_flattened_methods: max hierarchy depth ~p exceeded at ~p (starting from ~p) — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, CycleName, ClassName],
                 #{domain => [beamtalk, runtime]}
             ),
-            #{};
+            PartialAcc;
         not_found ->
             %% Unreachable: see find_defining_class/2.
             erlang:error({unreachable, not_found, ClassName})

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_method_resolver.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_method_resolver.erl
@@ -114,10 +114,13 @@ resolve_with_hierarchy(ClassPid, Selector) ->
                     Method;
                 not_found ->
                     nil;
-                max_depth_exceeded ->
-                    ?LOG_WARNING(">> hierarchy walk exceeded ~p levels", [?MAX_HIERARCHY_DEPTH], #{
-                        domain => [beamtalk, runtime]
-                    }),
+                {max_depth_exceeded, CyclePid} ->
+                    CycleClass = beamtalk_object_class:class_name(CyclePid),
+                    ?LOG_WARNING(
+                        ">> hierarchy walk exceeded ~p levels at ~p",
+                        [?MAX_HIERARCHY_DEPTH, CycleClass],
+                        #{domain => [beamtalk, runtime]}
+                    ),
                     nil
             end;
         Method ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_behaviour_intrinsics_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_behaviour_intrinsics_tests.erl
@@ -2455,6 +2455,13 @@ stop_class_actors_with_registry_test_() ->
 %% A self-referential class (its own superclass) makes walk_hierarchy/3 loop;
 %% the ?MAX_HIERARCHY_DEPTH guard halts it and returns the accumulator. We drive
 %% it via classAllSuperclasses/1, which folds class objects up the chain.
+%%
+%% BT-3096: walk_ancestors/3's max_depth_exceeded now carries the last node
+%% visited (with its accumulator riding along inside it — see
+%% beamtalk_behaviour_intrinsics:walk_hierarchy/3's moduledoc), so
+%% walk_hierarchy/3 returns the PARTIAL fold built up before the guard
+%% tripped instead of discarding it in favour of the original (empty) `[]`
+%% accumulator. Assert the list is non-empty and bounded, not merely a list.
 walk_hierarchy_cycle_guard_test_() ->
     {setup, fun setup/0, fun teardown/1, fun(_) ->
         [
@@ -2473,9 +2480,23 @@ walk_hierarchy_cycle_guard_test_() ->
                     class = 'BTCycleSelf class', class_mod = test_class, pid = Pid
                 },
                 try
-                    %% Must terminate (depth guard) and return a bounded list.
+                    %% Must terminate (depth guard) and return a bounded,
+                    %% non-empty list: the partial fold collected from the
+                    %% (repeated, self-referencing) ancestor visited before
+                    %% the depth guard tripped, not the empty `[]` the walk
+                    %% started with.
                     Supers = beamtalk_behaviour_intrinsics:classAllSuperclasses(ClassObj),
-                    ?assert(is_list(Supers))
+                    ?assert(is_list(Supers)),
+                    ?assert(length(Supers) > 0),
+                    ?assert(length(Supers) =< ?MAX_HIERARCHY_DEPTH + 1),
+                    %% Every entry is the same self-referencing class, since
+                    %% the cycle never reaches a different ancestor.
+                    ?assert(
+                        lists:all(
+                            fun(#beamtalk_object{pid = SuperPid}) -> SuperPid =:= Pid end,
+                            Supers
+                        )
+                    )
                 after
                     try
                         gen_server:stop(Pid, normal, 5000)

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_docs.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_docs.erl
@@ -962,12 +962,10 @@ format_class_side_output(ClassName, Modifiers, OwnCM, InhCMGrouped, ProtoGrouped
 Walk the class hierarchy collecting class-side methods.
 Returns #{Selector => DefiningClass} — local methods shadow inherited ones.
 
-On depth exhaustion (`?MAX_HIERARCHY_DEPTH`, a hierarchy cycle) returns `#{}`
-— not the partial map folded up through the ancestors visited before the
-guard tripped — and logs a `?LOG_WARNING`. Deliberately narrower than
-returning partial results: `walk_ancestors/3`'s `max_depth_exceeded` carries
-no payload, so every caller falls back to a fixed default on this
-already-anomalous path.
+On depth exhaustion (`?MAX_HIERARCHY_DEPTH`, a hierarchy cycle) returns the
+partial map folded up through the ancestors actually visited before the
+guard tripped (BT-3096) — not `#{}` — and logs a `?LOG_WARNING` naming the
+ancestor where the cycle was detected.
 
 BT-3087: Built on `beamtalk_hierarchy:walk_ancestors/3` (the shared depth
 guard + cycle warning) rather than a hand-rolled recursion, matching the
@@ -1000,13 +998,13 @@ collect_flattened_class_methods(ClassName, ClassPid) ->
     of
         {found, Result} ->
             Result;
-        max_depth_exceeded ->
+        {max_depth_exceeded, {CycleName, _CyclePid, PartialAcc}} ->
             ?LOG_WARNING(
-                "collect_flattened_class_methods: max hierarchy depth ~p exceeded at ~p — possible cycle",
-                [?MAX_HIERARCHY_DEPTH, ClassName],
+                "collect_flattened_class_methods: max hierarchy depth ~p exceeded at ~p (starting from ~p) — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, CycleName, ClassName],
                 #{domain => [beamtalk, runtime]}
             ),
-            #{};
+            PartialAcc;
         not_found ->
             %% Unreachable: StepFun above always resolves to {found, _} — a
             %% `none` superclass or an unregistered ancestor is translated to

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
@@ -1855,12 +1855,10 @@ hierarchy walker (`beamtalk_behaviour_intrinsics:walk_hierarchy/3`,
 existing callers (always 0) but the walk itself always starts fresh at 0 —
 `walk_ancestors/3` owns depth-counting internally.
 
-On depth exhaustion (`?MAX_HIERARCHY_DEPTH`, a hierarchy cycle) returns `[]`
-— not the partial set of selectors collected from the ancestors visited
-before the guard tripped — and logs a `?LOG_WARNING`. Deliberately narrower
-than returning partial results: `walk_ancestors/3`'s `max_depth_exceeded`
-carries no payload, so every caller falls back to a fixed default on this
-already-anomalous path.
+On depth exhaustion (`?MAX_HIERARCHY_DEPTH`, a hierarchy cycle) returns the
+partial set of selectors collected from the ancestors actually visited
+before the guard tripped (BT-3096) — not `[]` — and logs a `?LOG_WARNING`
+naming the ancestor where the cycle was detected.
 """.
 -spec collect_methods_with_fun(atom(), non_neg_integer(), fun((pid()) -> [atom()])) -> [atom()].
 collect_methods_with_fun(ClassName, _Depth, Fun) ->
@@ -1901,13 +1899,13 @@ collect_methods_with_fun(ClassName, _Depth, Fun) ->
     case beamtalk_hierarchy:walk_ancestors({ClassName, #{}}, StepFun, ?MAX_HIERARCHY_DEPTH) of
         {found, ResultMap} ->
             maps:keys(ResultMap);
-        max_depth_exceeded ->
+        {max_depth_exceeded, {CycleClassName, PartialMap}} ->
             ?LOG_WARNING(
-                "collect_methods_with_fun: max hierarchy depth ~p exceeded at ~p — possible cycle",
-                [?MAX_HIERARCHY_DEPTH, ClassName],
+                "collect_methods_with_fun: max hierarchy depth ~p exceeded at ~p (starting from ~p) — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, CycleClassName, ClassName],
                 #{domain => [beamtalk, runtime]}
             ),
-            [];
+            maps:keys(PartialMap);
         not_found ->
             %% Unreachable: StepFun above always resolves to {found, _} — an
             %% unregistered class or a `none` superclass is translated to a


### PR DESCRIPTION
## Summary

`beamtalk_hierarchy:walk_ancestors/3`'s `max_depth_exceeded` return was a bare atom with no payload. Every caller that folds an accumulator through the walk (the accumulator rides along *inside* the node itself, e.g. `{ClassName, Acc}` — see `beamtalk_behaviour_intrinsics:walk_hierarchy/3`'s moduledoc) therefore fell back to a fixed default (`#{}`, `[]`, or the original `Acc`) on the cycle-guard path, discarding everything gathered before the guard tripped. Non-folding callers could only name the original receiver in their `?LOG_WARNING`, never the actual ancestor where the cycle was detected.

BT-3087 (merged) consolidated several hand-rolled hierarchy-walking recursions onto `walk_ancestors/3` and deliberately documented this narrower "cycle ⇒ fixed default" contract rather than fix it, to keep that PR's scope contained. This PR is the fix: `walk_ancestors/3` now returns `{max_depth_exceeded, LastNode}`, where `LastNode` is the node the walk was about to visit next when the guard tripped (`StepFun` is never invoked on it). Callers extract their partial `Acc` from inside `LastNode`, or use it to name the actual cycling ancestor in logs/errors.

## API change

```erlang
-type walk_result(Result) :: {found, Result} | not_found | {max_depth_exceeded, node_id()}.
```

(was `{found, Result} | not_found | max_depth_exceeded`)

## Call sites updated

**Non-folding callers** (no accumulator to recover — just improved cycle-point naming in the log/error):

- `beamtalk_dispatch:lookup_in_class_chain/5` — `?LOG_WARNING` now includes `cycle_detected_at => CycleClass` alongside the original receiver `class`.
- `beamtalk_class_dispatch:find_class_method_in_chain/2` — log message names the actual cycling ancestor, with the original `ClassName` kept as "starting from" context.
- `beamtalk_method_resolver:resolve_with_hierarchy/2` — resolves `LastNode` (a pid) to a class name via `beamtalk_object_class:class_name/1` and logs it.
- `beamtalk_hierarchy_docs:find_defining_class/2` and `find_defining_class_method/2` — same pid→class-name resolution; log now names both the cycling ancestor and the original receiver.

**Accumulator-folding callers** (extract partial `Acc` from `LastNode`, return it instead of a fixed default):

- `beamtalk_behaviour_intrinsics:walk_hierarchy/3` — node is `{ClassName, Acc}`; returns the partial `Acc` instead of the original accumulator passed in, matching the pre-BT-3087 hand-rolled recursion's behaviour.
- `beamtalk_hierarchy_docs:collect_flattened_methods/2` — node is `{ClassName, ClassPid, AccMap}`; returns the partial `AccMap` instead of `#{}`.
- `beamtalk_repl_docs:collect_flattened_class_methods/2` — same shape; returns the partial map instead of `#{}`.
- `beamtalk_repl_ops_dev:collect_methods_with_fun/3` — node is `{ClassName, AccMap}`; returns `maps:keys/1` of the partial map instead of `[]`.

Moduledocs/`-doc` comments on all of the above (several of which BT-3087 had just updated to precisely document the *old*, narrower "discards partial results" behaviour) are updated to describe the new, fixed contract.

## Test plan

- [x] `cd runtime && rebar3 compile` — clean
- [x] `cd runtime && rebar3 eunit --app=beamtalk_runtime,beamtalk_workspace` — 5297 tests, 0 failures (after a full `just build` to rebuild the stdlib/compiler-port fixtures the eunit run depends on)
- [x] `cd runtime && rebar3 fmt --check` — clean
- [x] `cd runtime && rebar3 dialyzer` — clean, no new warnings (the `walk_result/1` type change is reflected in every caller's pattern match)
- [x] Extended `beamtalk_behaviour_intrinsics_tests:walk_hierarchy_cycle_guard_test_` (the existing self-referential-class cycle fixture, driven via `classAllSuperclasses/1` → `walk_hierarchy/3`) to assert the result is a **bounded, non-empty** partial fold (length > 0, length ≤ `?MAX_HIERARCHY_DEPTH + 1`, every entry pointing at the cycling class) instead of merely `is_list/1`

---
_Generated by [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL7GE5XvKMame4UzYFb1dJ)_