### PR TITLE
BT-3095: Shared conformance corpus for compiler-port command vocabulary

### DIFF
--- a/crates/beamtalk-compiler-port/Cargo.toml
+++ b/crates/beamtalk-compiler-port/Cargo.toml
@@ -40,6 +40,8 @@ tracing-subscriber = { workspace = true }
 proptest = { workspace = true }
 # why: isolated beamtalk.toml fixtures for load_diagnostics_overrides_from tests (BT-2839)
 tempfile = "3.14"
+# why: parse the shared compiler-port command-vocabulary conformance corpus (BT-3095)
+serde_json = { workspace = true }
 
 [build-dependencies]
 beamtalk-build.workspace = true

--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -2571,6 +2571,25 @@ fn handle_request(request_term: &Term) -> Term {
         _ => return error_response(&["Missing or invalid 'command' field".to_string()]),
     };
 
+    // BT-3095: this match arm's string literals are the Rust half of the
+    // compiler-port wire vocabulary; `beamtalk_compiler.erl` (fanning out
+    // through `beamtalk_compiler_server`/`beamtalk_compiler_port`) is the
+    // Erlang half, sending each `command => <atom>` from separate call
+    // sites. The two lists cannot literally share code (different
+    // languages/processes either side of the OTP port), so a command
+    // added to one side and not the other is a silent drift whose only
+    // symptom is a runtime "Unknown command" error wherever it's invoked
+    // (BT-3078 drift audit; BT-3091 flagged this pair for evaluation).
+    // A shared corpus fixture
+    // (`runtime/apps/beamtalk_compiler/test/fixtures/compiler_port_command_vocabulary_corpus.json`)
+    // pins both sides to the same 16-command list end-to-end: the Rust test
+    // below dispatches each corpus command through `handle_request` and
+    // checks it isn't the catch-all arm, while
+    // `beamtalk_compiler_tests:command_vocabulary_corpus_is_recognized_test/0`
+    // drives the real compiled binary through `beamtalk_compiler`'s public
+    // API (one command per corpus entry) and asserts each one dispatches
+    // successfully — so a command missing on either side fails a build-time
+    // test instead of surfacing only at runtime.
     match command {
         "compile_expression" => handle_compile_expression(map),
         "compile_expression_trace" => handle_compile_expression_trace(map),
@@ -2699,6 +2718,59 @@ fn directive_for_verbosity(v: u8) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// BT-3095 conformance: every command in the shared wire-vocabulary
+    /// corpus must be recognized by `handle_request`'s dispatch — i.e. it
+    /// must not fall through to the catch-all `"Unknown command: ..."` arm.
+    /// The corpus is the single source of truth both implementations are
+    /// pinned to; the Erlang side asserts the identical list drives real
+    /// dispatch on the compiled binary in
+    /// `beamtalk_compiler_tests:command_vocabulary_corpus_is_recognized_test/0`.
+    /// See `handle_request`'s doc comment for the full rationale.
+    #[test]
+    fn handle_request_recognizes_shared_command_vocabulary_corpus() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("crates/")
+            .parent()
+            .expect("repo root")
+            .join(
+                "runtime/apps/beamtalk_compiler/test/fixtures/compiler_port_command_vocabulary_corpus.json",
+            );
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read corpus {}: {e}", path.display()));
+        let corpus: Vec<String> = serde_json::from_str(&raw).expect("corpus is a JSON array");
+        assert!(!corpus.is_empty(), "corpus must have cases");
+
+        for command in &corpus {
+            // Deliberately send no fields beyond `command` — a recognized
+            // command may still fail (e.g. "Missing or invalid 'source'
+            // field"), but that failure is distinct from the dispatcher's
+            // catch-all message, which is the unique fingerprint of an
+            // unrecognized command atom.
+            let request = Term::from(Map::from([(atom("command"), atom(command.as_str()))]));
+            let response = handle_request(&request);
+            let Term::Map(ref m) = response else {
+                panic!("command {command:?}: expected a map response, got {response:?}");
+            };
+            let unknown_message = format!("Unknown command: {command}");
+            if let Some(Term::List(diagnostics)) = map_get(m, "diagnostics") {
+                for diag in &diagnostics.elements {
+                    let Term::Map(diag_map) = diag else {
+                        continue;
+                    };
+                    if let Some(msg) = map_get(diag_map, "message").and_then(term_to_string) {
+                        assert_ne!(
+                            msg, unknown_message,
+                            "corpus command {command:?} is not recognized by handle_request's \
+                             dispatch — add a match arm (or remove it from the corpus if it was \
+                             deliberately retired)"
+                        );
+                    }
+                }
+            }
+        }
+    }
 
     /// BT-907: Inline class definition with cross-file superclass index must compile
     /// as a value type, not an Actor, when the parent's chain resolves to Object.

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_tests.erl
@@ -54,7 +54,9 @@ compiler_test_() ->
         {"compiler app module callbacks", fun compiler_app_callbacks/0},
         {"resolve_method_span instance method", fun resolve_method_span_instance/0},
         {"resolve_method_span class method", fun resolve_method_span_class/0},
-        {"resolve_method_span selector not found", fun resolve_method_span_not_found/0}
+        {"resolve_method_span selector not found", fun resolve_method_span_not_found/0},
+        {"command vocabulary corpus is recognized (BT-3095)",
+            fun command_vocabulary_corpus_is_recognized/0}
     ]}.
 
 %%% Tests
@@ -258,3 +260,128 @@ resolve_method_span_not_found() ->
     Result =
         beamtalk_compiler:resolve_method_span(Source, <<"SpanCounter">>, <<"nope">>, instance),
     ?assertMatch({error, selector_not_found, _}, Result).
+
+%%% ---------------------------------------------------------------
+%%% Command-vocabulary conformance corpus (BT-3095)
+%%% ---------------------------------------------------------------
+
+%% BT-3095 conformance: every command in the shared wire-vocabulary corpus
+%% must dispatch successfully through `beamtalk_compiler`'s public API,
+%% against the REAL compiled `beamtalk-compiler-port` binary (via
+%% `beamtalk_compiler_server`'s port, opened by this file's `setup/0`). The
+%% corpus is the single source of truth both implementations are pinned to;
+%% the Rust side asserts the identical list against `handle_request`'s
+%% dispatch in `tests::handle_request_recognizes_shared_command_vocabulary_corpus`
+%% (`crates/beamtalk-compiler-port/src/main.rs`) — see that function's doc
+%% comment, and `handle_request`'s, for the full rationale. A command
+%% missing from either side therefore fails a build-time test instead of
+%% surfacing only as a runtime "Unknown command" error wherever it's
+%% invoked.
+command_vocabulary_corpus_is_recognized() ->
+    Corpus = load_command_vocabulary_corpus(),
+    ?assert(length(Corpus) > 0),
+    lists:foreach(fun assert_command_recognized/1, Corpus).
+
+%% Exercise one corpus command through a minimal-but-successful call to
+%% `beamtalk_compiler`'s public API. Each clause asserts an unambiguous
+%% success shape — not just "didn't error" — so an "Unknown command"
+%% mismatch can't hide behind a legitimate not-found/empty result.
+%% `resolve_completion_type` needs an *exact* expected value rather than
+%% just `{ok, _}`: its Erlang API collapses every failure shape (a
+%% legitimate not-found result *and* an unrecognized command) into the same
+%% `{error, type_unknown}`, so only a guaranteed-resolvable expression proves
+%% the command actually dispatched.
+assert_command_recognized(<<"compile_expression">>) ->
+    ?assertMatch(
+        {ok, _, _}, beamtalk_compiler:compile_expression(<<"1 + 2">>, <<"bt3095_ce">>, [])
+    );
+assert_command_recognized(<<"compile_expression_trace">>) ->
+    ?assertMatch(
+        {ok, _, _},
+        beamtalk_compiler:compile_expression_trace(<<"1 + 2">>, <<"bt3095_cet">>, [])
+    );
+assert_command_recognized(<<"compile">>) ->
+    Source = <<"Object subclass: Bt3095CompileTarget\n  value => 42">>,
+    ?assertMatch({ok, _}, beamtalk_compiler:compile(Source, #{}));
+assert_command_recognized(<<"compile_method">>) ->
+    ClassSource = <<"Object subclass: Bt3095MethodTarget\n  greet => 42">>,
+    MethodSource = <<"greet => 43">>,
+    ?assertMatch({ok, _}, beamtalk_compiler:compile_method(ClassSource, MethodSource, #{}));
+assert_command_recognized(<<"diagnostics">>) ->
+    ?assertMatch({ok, _}, beamtalk_compiler:diagnostics(<<"1 + 2">>));
+assert_command_recognized(<<"version">>) ->
+    ?assertMatch({ok, _}, beamtalk_compiler:version());
+assert_command_recognized(<<"resolve_completion_type">>) ->
+    %% "42" resolves deterministically to 'Integer' — see
+    %% `completion_provider::tests::resolve_expression_type_integer_literal`.
+    ?assertEqual({ok, 'Integer'}, beamtalk_compiler:resolve_completion_type(<<"42">>));
+assert_command_recognized(<<"find_senders_in_source">>) ->
+    ?assertMatch({ok, _}, beamtalk_compiler:find_senders_in_source(<<"x printNl">>, printNl));
+assert_command_recognized(<<"find_all_sends_in_source">>) ->
+    ?assertMatch({ok, _}, beamtalk_compiler:find_all_sends_in_source(<<"x printNl">>));
+assert_command_recognized(<<"find_references_to_in_source">>) ->
+    ?assertMatch(
+        {ok, _},
+        beamtalk_compiler:find_references_to_in_source(<<"x := MyClass new">>, 'MyClass')
+    );
+assert_command_recognized(<<"find_field_readers_in_source">>) ->
+    ?assertMatch(
+        {ok, _}, beamtalk_compiler:find_field_readers_in_source(<<"^ self.value">>, value)
+    );
+assert_command_recognized(<<"find_field_writers_in_source">>) ->
+    ?assertMatch(
+        {ok, _},
+        beamtalk_compiler:find_field_writers_in_source(<<"self.value := 42">>, <<"value">>)
+    );
+assert_command_recognized(<<"find_ffi_sites_in_source">>) ->
+    ?assertMatch(
+        {ok, _},
+        beamtalk_compiler:find_ffi_sites_in_source(
+            <<"(Erlang lists) reverse: x">>, lists, reverse, any
+        )
+    );
+assert_command_recognized(<<"find_announce_sites_in_source">>) ->
+    ?assertMatch({ok, _}, beamtalk_compiler:find_announce_sites_in_source(<<"x printNl">>));
+assert_command_recognized(<<"resolve_method_span">>) ->
+    ?assertMatch(
+        {ok, _, _},
+        beamtalk_compiler:resolve_method_span(
+            span_fixture(), <<"SpanCounter">>, <<"increment">>, instance
+        )
+    );
+assert_command_recognized(<<"reindent_method_source">>) ->
+    ?assertMatch({ok, _}, beamtalk_compiler:reindent_method_source(<<"greet => 42">>, <<"  ">>));
+assert_command_recognized(Command) ->
+    %% A corpus entry with no dispatch clause is a test-authoring gap, not a
+    %% vocabulary mismatch — fail loudly rather than silently skipping it.
+    error({no_dispatch_table_entry_for_corpus_command, Command}).
+
+%% Load the shared compiler-port command-vocabulary conformance corpus
+%% (BT-3095) from the repo tree. Walks up from the test CWD to the project
+%% root (the dir holding `Cargo.toml`), mirroring
+%% `beamtalk_repl_ops_dev_tests:find_word_boundary_corpus_root/1`.
+load_command_vocabulary_corpus() ->
+    Root = find_command_vocabulary_corpus_root(filename:absname("")),
+    Path = filename:join([
+        Root,
+        "runtime",
+        "apps",
+        "beamtalk_compiler",
+        "test",
+        "fixtures",
+        "compiler_port_command_vocabulary_corpus.json"
+    ]),
+    Bin =
+        case file:read_file(Path) of
+            {ok, B} -> B;
+            {error, Reason} -> error({corpus_file_unreadable, Path, Reason})
+        end,
+    json:decode(Bin).
+
+find_command_vocabulary_corpus_root("/") ->
+    error(project_root_not_found);
+find_command_vocabulary_corpus_root(Dir) ->
+    case filelib:is_regular(filename:join(Dir, "Cargo.toml")) of
+        true -> Dir;
+        false -> find_command_vocabulary_corpus_root(filename:dirname(Dir))
+    end.

--- a/runtime/apps/beamtalk_compiler/test/fixtures/compiler_port_command_vocabulary_corpus.json
+++ b/runtime/apps/beamtalk_compiler/test/fixtures/compiler_port_command_vocabulary_corpus.json
@@ -1,0 +1,18 @@
+[
+  "compile_expression",
+  "compile_expression_trace",
+  "compile",
+  "compile_method",
+  "diagnostics",
+  "version",
+  "resolve_completion_type",
+  "find_senders_in_source",
+  "find_all_sends_in_source",
+  "find_references_to_in_source",
+  "find_field_readers_in_source",
+  "find_field_writers_in_source",
+  "find_ffi_sites_in_source",
+  "find_announce_sites_in_source",
+  "resolve_method_span",
+  "reindent_method_source"
+]


### PR DESCRIPTION
## Summary

BT-3091's drift audit asked whether the compiler-port command vocabulary — `handle_request`'s match arms in `crates/beamtalk-compiler-port/src/main.rs` vs. the `command => <atom>` call sites spread across `beamtalk_compiler.erl` / `beamtalk_compiler_server.erl` / `beamtalk_compiler_port.erl` — needs a conformance test. This PR is that evaluation for BT-3095.

**Decision: yes, a fixture is warranted.** Reasoning:

- Manually enumerating both sides (grep for every `"..."  =>` arm in `handle_request` and every `command => <atom>` call site in the Erlang modules) confirms both currently agree on the same **16 commands** — so there's no drift *today*, but nothing enforced that.
- This is a real cross-language wire boundary (separate OTP port process, different languages either side) — exactly the case `docs/development/architecture-principles.md` § Duplication & the Shared-Leaf-Module Pattern calls out as "keep/enforce," alongside the existing BT-3080/3081/3085/3090 Rust↔Erlang conformance fixtures.
- The blast radius of a mismatch is a runtime `"Unknown command: ..."` `#beamtalk_error{}` wherever the missing command is invoked (LSP feature, REPL op, etc.) — not silently wrong output, but also not caught until someone exercises that exact code path in production. A build-time gate is cheap relative to that.
- Automatic extraction from source text would be fragile (regex over Rust match arms / Erlang call sites), so this fixture is **behavioral**, following the repo's established pattern (`completion_word_boundary_corpus.json`, `completion_keyword_vocabulary_corpus.json`): a shared JSON corpus of command names, asserted independently by a Rust test and an Erlang EUnit test, each exercising real dispatch rather than parsing source.

## Changes

- `runtime/apps/beamtalk_compiler/test/fixtures/compiler_port_command_vocabulary_corpus.json` — the 16-command corpus (single source of truth).
- **Rust** (`crates/beamtalk-compiler-port/src/main.rs`): `handle_request_recognizes_shared_command_vocabulary_corpus` dispatches each corpus command through `handle_request` with a minimal request and asserts the response isn't the catch-all `"Unknown command: ..."` arm. Added a doc comment on `handle_request` itself explaining the wire-vocabulary boundary and pointing at both tests.
- **Erlang** (`runtime/apps/beamtalk_compiler/test/beamtalk_compiler_tests.erl`): `command_vocabulary_corpus_is_recognized` drives the **real compiled `beamtalk-compiler-port` binary** through `beamtalk_compiler`'s public API — one minimal-but-deterministically-successful call per corpus command — so a command missing from Rust's dispatch fails an actual end-to-end round trip, not just a static check.
- `crates/beamtalk-compiler-port/Cargo.toml`: added `serde_json` as a dev-dependency (workspace-pinned) to parse the JSON corpus in the Rust test, mirroring how the existing corpus tests do it elsewhere in the codebase.

I verified both tests actually catch drift: temporarily removed the `reindent_method_source` match arm from `handle_request`, confirmed both the Rust test and the Erlang test (against the rebuilt binary) failed with a clear message, then restored it and confirmed both pass again.

## Test plan

- [x] `cargo build -p beamtalk-compiler-port --quiet`
- [x] `cargo test -p beamtalk-compiler-port --bin beamtalk-compiler-port` — 71 passed, including the new corpus test
- [x] `cargo clippy -p beamtalk-compiler-port --all-targets --quiet -- -D warnings` — clean
- [x] `cargo fmt -p beamtalk-compiler-port -- --check` — clean
- [x] `cd runtime && rebar3 compile` — clean
- [x] `cd runtime && rebar3 eunit --app=beamtalk_compiler` — 288 passed, including the new corpus test
- [x] `cd runtime && rebar3 fmt --check` — clean
- [x] `cd runtime && rebar3 dialyzer` — exit 0, no warnings
- [x] Synthetic-mismatch check: removing a Rust match arm makes both new tests fail with a clear message; restoring it makes them pass again
- [x] Full pre-push CI hook (clippy, dialyzer, spec validation, fmt across all languages) passed on `git push`

---
_Generated by [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YL7GE5XvKMame4UzYFb1dJ)_