### PR TITLE
Restore write-back for partially-Dynamic inferred returns; document SelfType provenance (BT-3101)

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
@@ -191,14 +191,23 @@ impl DeclaredType {
     /// [`ClassHierarchy::apply_inferred_return_types`](super::ClassHierarchy::apply_inferred_return_types)
     /// (only `Known` and `Never` are ever written back today):
     /// - [`InferredType::Known`] → [`DeclaredType::Simple`] (no type args) or
-    ///   [`DeclaredType::Generic`] (with type args, recursively converted;
-    ///   `None` if any argument is unconvertible).
+    ///   [`DeclaredType::Generic`] (with type args, converted via
+    ///   [`Self::from_inferred_nested`]; `None` if any argument is
+    ///   unconvertible).
     /// - [`InferredType::Never`] → `Simple("Never")`.
-    /// - [`InferredType::Union`] → `Union` of converted members, `None` if
-    ///   any member is unconvertible.
+    /// - [`InferredType::Union`] → `Union` of converted members (also via
+    ///   `from_inferred_nested`), `None` if any member is unconvertible.
     /// - Everything else (`Dynamic`, `Meta`, `Negation`, `Intersection`) →
     ///   `None` — these don't have a single canonical declared-type spelling
-    ///   the writeback path should commit to.
+    ///   the writeback path should commit to. Note the top-level/nested
+    ///   asymmetry for `Dynamic`: a bare `Dynamic` return is *not* written
+    ///   back (same as the pre-BT-3076 `Known | Never` filter), but a
+    ///   `Dynamic` nested inside a `Known`/`Union` converts to
+    ///   `Simple("Dynamic")` so partially-inferred generics like
+    ///   `List(Dynamic)` still write back — matching the old
+    ///   `display_name()` string path, which rendered exactly
+    ///   `"List(Dynamic)"` (BT-3101). Lossy cases that remain: a nested
+    ///   `Meta`/`Negation`/`Intersection` still aborts the whole conversion.
     #[must_use]
     pub fn from_inferred(ty: &InferredType) -> Option<DeclaredType> {
         match ty {
@@ -214,7 +223,7 @@ impl DeclaredType {
             } => {
                 let parameters = type_args
                     .iter()
-                    .map(DeclaredType::from_inferred)
+                    .map(DeclaredType::from_inferred_nested)
                     .collect::<Option<Vec<_>>>()?;
                 Some(DeclaredType::Generic {
                     base: class_name.clone(),
@@ -225,11 +234,24 @@ impl DeclaredType {
             InferredType::Union { members, .. } => {
                 let converted = members
                     .iter()
-                    .map(DeclaredType::from_inferred)
+                    .map(DeclaredType::from_inferred_nested)
                     .collect::<Option<Vec<_>>>()?;
                 Some(DeclaredType::Union(converted))
             }
             _ => None,
+        }
+    }
+
+    /// [`Self::from_inferred`] for *nested* positions (generic type args,
+    /// union members), where `Dynamic` additionally converts to
+    /// `Simple("Dynamic")` — the resolver normalises that name back to
+    /// `Dynamic`, so the round-trip is faithful. Kept out of `from_inferred`
+    /// itself so a bare top-level `Dynamic` return type still skips
+    /// writeback entirely (see its doc, BT-3101).
+    fn from_inferred_nested(ty: &InferredType) -> Option<DeclaredType> {
+        match ty {
+            InferredType::Dynamic(_) => Some(DeclaredType::Simple("Dynamic".into())),
+            other => DeclaredType::from_inferred(other),
         }
     }
 
@@ -812,5 +834,77 @@ mod tests {
             }),
             None
         );
+    }
+
+    #[test]
+    fn from_inferred_nested_dynamic_arg_writes_back_as_dynamic_name() {
+        // BT-3101: `List(Dynamic)` must still write back — the pre-BT-3076
+        // string path always produced `"List(Dynamic)"`; skipping the whole
+        // conversion was a precision regression. The nested `Dynamic`
+        // becomes `Simple("Dynamic")`, which the resolver normalises back
+        // to the real `Dynamic` variant (BT-2865).
+        use crate::semantic_analysis::type_checker::{DynamicReason, TypeProvenance};
+        let ty = InferredType::Known {
+            class_name: "List".into(),
+            type_args: vec![InferredType::Dynamic(DynamicReason::Unknown)],
+            provenance: TypeProvenance::Inferred(span()),
+        };
+        assert_eq!(
+            DeclaredType::from_inferred(&ty),
+            Some(DeclaredType::Generic {
+                base: "List".into(),
+                parameters: vec![DeclaredType::Simple("Dynamic".into())],
+            })
+        );
+    }
+
+    #[test]
+    fn from_inferred_deeply_nested_dynamic_arg() {
+        use crate::semantic_analysis::type_checker::{DynamicReason, TypeProvenance};
+        let inner = InferredType::Known {
+            class_name: "List".into(),
+            type_args: vec![InferredType::Dynamic(DynamicReason::Unknown)],
+            provenance: TypeProvenance::Inferred(span()),
+        };
+        let ty = InferredType::Known {
+            class_name: "Result".into(),
+            type_args: vec![inner, InferredType::known("Error")],
+            provenance: TypeProvenance::Inferred(span()),
+        };
+        assert_eq!(
+            DeclaredType::from_inferred(&ty).map(|dt| dt.to_string()),
+            Some("Result(List(Dynamic), Error)".to_string())
+        );
+    }
+
+    #[test]
+    fn from_inferred_union_with_dynamic_member() {
+        use crate::semantic_analysis::type_checker::{DynamicReason, TypeProvenance};
+        let ty = InferredType::Union {
+            members: vec![
+                InferredType::known("Integer"),
+                InferredType::Dynamic(DynamicReason::Unknown),
+            ],
+            provenance: TypeProvenance::Inferred(span()),
+        };
+        let result = DeclaredType::from_inferred(&ty).expect("expected Some");
+        assert_eq!(result.to_string(), "Integer | Dynamic");
+    }
+
+    #[test]
+    fn from_inferred_nested_meta_still_aborts() {
+        // The nested-`Dynamic` carve-out (BT-3101) is deliberately narrow:
+        // a nested `Meta` still has no declared-type spelling the writeback
+        // should commit to, so the whole conversion aborts as before.
+        use crate::semantic_analysis::type_checker::TypeProvenance;
+        let ty = InferredType::Known {
+            class_name: "List".into(),
+            type_args: vec![InferredType::Meta {
+                class_name: "Foo".into(),
+                provenance: TypeProvenance::Inferred(span()),
+            }],
+            provenance: TypeProvenance::Inferred(span()),
+        };
+        assert_eq!(DeclaredType::from_inferred(&ty), None);
     }
 }

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/type_resolver.rs
@@ -602,6 +602,18 @@ fn resolve_declared_type_inner(
             // doc), so this fallback only matters for the nested case.
             // Without a threaded binding, falls back to `Dynamic` — the
             // pre-BT-3076 behaviour for every caller that never threads one.
+            //
+            // Provenance: unlike the `SelfClass` arm above (which constructs
+            // a fresh `Meta` and stamps `declared_type_provenance(ctx)`),
+            // this arm returns the bound receiver type *verbatim*, keeping
+            // whatever provenance the caller's receiver carried (typically
+            // `Inferred`). That's deliberate: the substituted `Self` IS the
+            // receiver's type, not a type this annotation constructed, and
+            // re-stamping it `Substituted` would erase where it came from —
+            // e.g. flow-sensitive narrowing keyed on inferred provenance.
+            // Pinned by `substitute_self_in_union_uses_full_receiver_type`
+            // (inference.rs), which asserts the receiver's exact
+            // `InferredType` (provenance included) survives substitution.
             if let Some(self_ty) = subst.get("Self") {
                 return self_ty.clone();
             }


### PR DESCRIPTION
Fixes [BT-3101](https://linear.app/beamtalk/issue/BT-3101) — the two follow-ups surfaced by the review of #3273 (BT-3076 stages 3–4).

## What changed

**1. Write-back precision restored for partially-Dynamic inferred generics.**

`DeclaredType::from_inferred` returned `None` for a `Known`/`Union` with any nested type arg that wasn't `Known`/`Never`/`Union` — so an inferred `List(Dynamic)` return skipped `MethodInfo::return_type` write-back entirely, where the pre-BT-3076 `display_name()` string path always wrote `"List(Dynamic)"`. A new `from_inferred_nested` helper converts a `Dynamic` in *nested* position (generic type args, union members) to `Simple("Dynamic")`, which the resolver already normalises back to the real `Dynamic` variant (BT-2865), so the round-trip is faithful.

The carve-out is deliberately narrow, preserving the old top-level filter:
- a bare top-level `Dynamic` return still skips write-back (matching the pre-BT-3076 `Known | Never` filter);
- a nested `Meta`/`Negation`/`Intersection` still aborts the whole conversion;
- the doc comment now states the lossy cases accurately instead of implying the conversion is behavior-preserving.

**2. `SelfType` provenance pass-through documented.**

`resolve_declared_type_inner`'s `SelfType` arm returns the bound receiver type verbatim (keeping its provenance, typically `Inferred`), while the sibling `SelfClass` arm constructs a fresh `Meta` and stamps `declared_type_provenance(ctx)`. The asymmetry is deliberate — the substituted `Self` *is* the receiver's type, and re-stamping would erase where it came from — and is pinned by the existing `substitute_self_in_union_uses_full_receiver_type` test. The arm now carries a comment explaining this so a future provenance-sensitive consumer doesn't "fix" it.

## Testing

- New tests: `from_inferred_nested_dynamic_arg_writes_back_as_dynamic_name` (`List(Dynamic)`), `from_inferred_deeply_nested_dynamic_arg` (`Result(List(Dynamic), Error)`), `from_inferred_union_with_dynamic_member` (`Integer | Dynamic`), and `from_inferred_nested_meta_still_aborts` (pins the narrow scope).
- Full `just ci` green locally (one known-flaky `ReactiveSubprocessTest` subprocess-timeout failure on the first run, unrelated to this change; the suite passes clean on re-run: 3215 BUnit tests, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFGGuJFsUTKV1VropLbqck

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFGGuJFsUTKV1VropLbqck)_