### PR TITLE
BT-3100: Property-based tests for type-string fidelity across the Rust/Erlang compiler boundary

### DIFF
--- a/crates/beamtalk-compiler-port/Cargo.toml
+++ b/crates/beamtalk-compiler-port/Cargo.toml
@@ -38,6 +38,9 @@ tracing-subscriber = { workspace = true }
 [dev-dependencies]
 # why: property-based testing for compiler port robustness (ADR 0011 Phase 4)
 proptest = { workspace = true }
+# why: BT-3100 — reuse beamtalk-core's shared `arb_declared_type` property-test
+# generator (test_helpers::test_support) instead of duplicating it.
+beamtalk-core = { workspace = true, features = ["test"] }
 # why: isolated beamtalk.toml fixtures for load_diagnostics_overrides_from tests (BT-2839)
 tempfile = "3.14"
 # why: parse the shared compiler-port command-vocabulary conformance corpus (BT-3095)

--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -5403,62 +5403,24 @@ mod property_tests {
     /// the Erlang-side decode; that's `beamtalk_compiler_port.erl`'s job,
     /// exercised by the runtime `EUnit` suite, not this crate.
     ///
-    /// Generated strings reuse [`DeclaredType`]'s `Display` rendering
+    /// Generated strings reuse `DeclaredType`'s `Display` rendering
     /// (byte-identical to `TypeAnnotation::type_name()`, enforced by
     /// `declared_type.rs`'s own `assert_display_parity` tests) so the
     /// shapes this test carries across the wire — union, generic,
     /// singleton, `FalseOr`, difference, intersection, self-types — are
     /// the exact same canonical text a real compiled method signature
     /// would send, not an ad hoc string format.
+    ///
+    /// The generator itself (`arb_declared_type`) lives in beamtalk-core's
+    /// `test_helpers::test_support` (behind the `test` Cargo feature this
+    /// crate's dev-dependency enables) rather than being copied here, so
+    /// this test and `declared_type.rs`'s own fixed-point property tests
+    /// exercise the exact same shape space by construction — see this
+    /// repo's "No duplicate implementations" rule.
     #[cfg(test)]
     mod type_string_wire_fidelity {
         use super::*;
-        use beamtalk_core::semantic_analysis::class_hierarchy::DeclaredType;
-
-        /// Leaves: simple/singleton names plus every `Self`-family shape.
-        fn leaf() -> impl Strategy<Value = DeclaredType> {
-            prop_oneof![
-                "[A-Za-z][A-Za-z0-9]{0,4}".prop_map(DeclaredType::simple),
-                "[a-z][a-z0-9]{0,4}".prop_map(DeclaredType::singleton),
-                Just(DeclaredType::SelfType),
-                Just(DeclaredType::SelfClass),
-                "[A-Za-z][A-Za-z0-9]{0,4}".prop_map(|n| DeclaredType::ClassOf(n.into())),
-            ]
-        }
-
-        /// Arbitrary `DeclaredType`s covering every grouping shape named in
-        /// BT-3100's acceptance criteria (union/intersection/difference/
-        /// `FalseOr`/generic), mirrored from `declared_type.rs`'s own
-        /// property-test generator so both halves of the type-string
-        /// fidelity story (in-process round trip, wire round trip) exercise
-        /// the same shape space.
-        fn arb_declared_type() -> impl Strategy<Value = DeclaredType> {
-            leaf().prop_recursive(4, 32, 4, |inner| {
-                prop_oneof![
-                    prop::collection::vec(inner.clone(), 2..4).prop_map(DeclaredType::Union),
-                    (
-                        "[A-Za-z][A-Za-z0-9]{0,4}",
-                        prop::collection::vec(inner.clone(), 1..3),
-                    )
-                        .prop_map(|(base, params)| DeclaredType::generic(base, params)),
-                    inner
-                        .clone()
-                        .prop_map(|t| DeclaredType::FalseOr(Box::new(t))),
-                    (inner.clone(), inner.clone()).prop_map(|(base, excluded)| {
-                        DeclaredType::Difference {
-                            base: Box::new(base),
-                            excluded: Box::new(excluded),
-                        }
-                    }),
-                    (inner.clone(), inner.clone()).prop_map(|(left, right)| {
-                        DeclaredType::Intersection {
-                            left: Box::new(left),
-                            right: Box::new(right),
-                        }
-                    }),
-                ]
-            })
-        }
+        use beamtalk_core::test_helpers::test_support::arb_declared_type;
 
         fn arb_type_annotation_string() -> impl Strategy<Value = String> {
             arb_declared_type().prop_map(|dt| dt.to_string())

--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -5382,4 +5382,126 @@ mod property_tests {
              {response:?}"
         );
     }
+
+    // -------------------------------------------------------------------
+    // BT-3100: type-annotation string fidelity across the compiler-port
+    // wire protocol
+    // -------------------------------------------------------------------
+
+    /// Property-based tests pinning that a type-annotation *string* —
+    /// `method_signature_terms`'s `TypeAnnotation::type_name()` rendering,
+    /// carried in `return_type`/`param_types` response fields (see
+    /// `method_definition_ok_response`, ADR 0105 Phase 1 / BT-2777) —
+    /// crosses the compiler port's `{packet, 4}`-framed ETF wire unchanged.
+    ///
+    /// `Term::encode`/`Term::decode` (`eetf`) implement the same External
+    /// Term Format the BEAM's `term_to_binary`/`binary_to_term` speak, so
+    /// round-tripping a real response `Term` through them here exercises
+    /// the identical byte-level encoding the live Rust ⇄ Erlang port pipe
+    /// uses — there is no separate "real" wire representation this test
+    /// would be missing by not spawning a BEAM. What it *doesn't* cover is
+    /// the Erlang-side decode; that's `beamtalk_compiler_port.erl`'s job,
+    /// exercised by the runtime `EUnit` suite, not this crate.
+    ///
+    /// Generated strings reuse [`DeclaredType`]'s `Display` rendering
+    /// (byte-identical to `TypeAnnotation::type_name()`, enforced by
+    /// `declared_type.rs`'s own `assert_display_parity` tests) so the
+    /// shapes this test carries across the wire — union, generic,
+    /// singleton, `FalseOr`, difference, intersection, self-types — are
+    /// the exact same canonical text a real compiled method signature
+    /// would send, not an ad hoc string format.
+    #[cfg(test)]
+    mod type_string_wire_fidelity {
+        use super::*;
+        use beamtalk_core::semantic_analysis::class_hierarchy::DeclaredType;
+
+        /// Leaves: simple/singleton names plus every `Self`-family shape.
+        fn leaf() -> impl Strategy<Value = DeclaredType> {
+            prop_oneof![
+                "[A-Za-z][A-Za-z0-9]{0,4}".prop_map(DeclaredType::simple),
+                "[a-z][a-z0-9]{0,4}".prop_map(DeclaredType::singleton),
+                Just(DeclaredType::SelfType),
+                Just(DeclaredType::SelfClass),
+                "[A-Za-z][A-Za-z0-9]{0,4}".prop_map(|n| DeclaredType::ClassOf(n.into())),
+            ]
+        }
+
+        /// Arbitrary `DeclaredType`s covering every grouping shape named in
+        /// BT-3100's acceptance criteria (union/intersection/difference/
+        /// `FalseOr`/generic), mirrored from `declared_type.rs`'s own
+        /// property-test generator so both halves of the type-string
+        /// fidelity story (in-process round trip, wire round trip) exercise
+        /// the same shape space.
+        fn arb_declared_type() -> impl Strategy<Value = DeclaredType> {
+            leaf().prop_recursive(4, 32, 4, |inner| {
+                prop_oneof![
+                    prop::collection::vec(inner.clone(), 2..4).prop_map(DeclaredType::Union),
+                    (
+                        "[A-Za-z][A-Za-z0-9]{0,4}",
+                        prop::collection::vec(inner.clone(), 1..3),
+                    )
+                        .prop_map(|(base, params)| DeclaredType::generic(base, params)),
+                    inner
+                        .clone()
+                        .prop_map(|t| DeclaredType::FalseOr(Box::new(t))),
+                    (inner.clone(), inner.clone()).prop_map(|(base, excluded)| {
+                        DeclaredType::Difference {
+                            base: Box::new(base),
+                            excluded: Box::new(excluded),
+                        }
+                    }),
+                    (inner.clone(), inner.clone()).prop_map(|(left, right)| {
+                        DeclaredType::Intersection {
+                            left: Box::new(left),
+                            right: Box::new(right),
+                        }
+                    }),
+                ]
+            })
+        }
+
+        fn arb_type_annotation_string() -> impl Strategy<Value = String> {
+            arb_declared_type().prop_map(|dt| dt.to_string())
+        }
+
+        proptest! {
+            #![proptest_config(proptest_config())]
+
+            /// A `return_type`/`param_types` string embedded in a real
+            /// production response (`method_definition_ok_response`)
+            /// survives ETF encode → decode byte-for-byte: no truncation,
+            /// no re-encoding drift, regardless of how the type-annotation
+            /// text is shaped.
+            #[test]
+            fn type_annotation_string_survives_wire_roundtrip(type_str in arb_type_annotation_string()) {
+                let response = method_definition_ok_response(
+                    "Foo",
+                    "bar",
+                    false,
+                    "bar => self",
+                    &type_str,
+                    std::slice::from_ref(&type_str),
+                    &[],
+                );
+
+                let mut buf = Vec::new();
+                response.encode(&mut buf).expect("encoding a response Term must not fail");
+                let decoded = Term::decode(io::Cursor::new(buf))
+                    .expect("decoding a just-encoded response Term must not fail");
+
+                prop_assert_eq!(
+                    response_field_str(&decoded, "return_type"),
+                    Some(type_str.clone()),
+                    "return_type did not survive the ETF wire round trip for {:?}",
+                    type_str,
+                );
+                prop_assert_eq!(
+                    response_field_str_list(&decoded, "param_types"),
+                    Some(vec![type_str.clone()]),
+                    "param_types did not survive the ETF wire round trip for {:?}",
+                    type_str,
+                );
+            }
+        }
+    }
 }

--- a/crates/beamtalk-core/Cargo.toml
+++ b/crates/beamtalk-core/Cargo.toml
@@ -41,6 +41,12 @@ serde_json.workspace = true
 # (non-fatal by design), matching the tracing usage already established in
 # `beamtalk-cli`/`beamtalk-lsp`.
 tracing.workspace = true
+# why: BT-3100 — `test_support::arb_declared_type` (the shared proptest
+# generator for type-string fidelity tests) needs proptest in the normal
+# dependency graph, not just dev-dependencies, so it compiles for dependent
+# crates that opt in via the `test` feature below. Optional: stays out of
+# the default (production) build.
+proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
 insta.workspace = true
@@ -68,7 +74,7 @@ default = []
 ## Expose `test_helpers::test_support` for use in dependent crates' dev-dependencies.
 ## Add `beamtalk-core = { features = ["test"] }` to the dependent crate's
 ## `[dev-dependencies]` section to enable this.
-test = []
+test = ["dep:proptest"]
 ## Enable serde Serialize/Deserialize derives on ClassInfo and related types.
 ## Used by beamtalk-cli to persist Pass 1 metadata cache for incremental builds.
 serde = ["ecow/serde"]

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
@@ -814,3 +814,131 @@ mod tests {
         );
     }
 }
+
+/// Property-based tests for type-string fidelity (BT-3100): does a
+/// [`DeclaredType`] survive the round trip through its own textual form
+/// (`Display`) and back (`parse`)?
+///
+/// `DeclaredType::parse`'s grammar (see its doc comment) is strictly weaker
+/// than `Display`'s output range — it has no representation for `\`
+/// (difference), `&` (intersection), or `FalseOr`, so `parse` can't always
+/// invert `Display` on the first try. What it *can* do, and what these
+/// properties pin, is reach a stable fixed point: re-displaying what
+/// `parse` recovers, then re-parsing that, always lands on exactly the same
+/// structured value and text it started converging toward — the round trip
+/// never drifts, loses a branch, or panics, no matter how deeply
+/// union/intersection/difference/`FalseOr`/generic shapes are nested
+/// (BT-2760 grouping-paren shapes included).
+///
+/// One concrete non-idempotence this uncovered and pins deliberately: an
+/// intersection/difference whose right/excluded operand needs
+/// parenthesising (e.g. `A & (B | C)`) is misread by `parse` on the first
+/// pass as a single-argument `Generic` whose "base name" is the literal
+/// text `"A &"` — `split_generic_base` finds the first `(` in the whole
+/// string and doesn't know `&`/`\` aren't part of a class name. Displaying
+/// that `Generic` back out drops the space before the paren (`"A &(B | C)"`),
+/// but from there it's stable: reparsing that already-collapsed text
+/// reproduces the same `Generic` byte-for-byte forever after. Filed as a
+/// follow-up (not fixed here — out of scope per this issue's "Out of
+/// Scope" section, which restricts BT-3100 to adding the properties, not
+/// reworking `parse`'s grammar).
+#[cfg(test)]
+mod property_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// Leaves: simple/singleton names plus every `Self`-family shape
+    /// `parse` recognises structurally.
+    fn leaf() -> impl Strategy<Value = DeclaredType> {
+        prop_oneof![
+            "[A-Za-z][A-Za-z0-9]{0,4}".prop_map(DeclaredType::simple),
+            "[a-z][a-z0-9]{0,4}".prop_map(DeclaredType::singleton),
+            Just(DeclaredType::SelfType),
+            Just(DeclaredType::SelfClass),
+            "[A-Za-z][A-Za-z0-9]{0,4}".prop_map(|n| DeclaredType::ClassOf(n.into())),
+        ]
+    }
+
+    /// Arbitrary `DeclaredType`s, recursively built from every grouping
+    /// shape named in the acceptance criteria: union, generic, `FalseOr`,
+    /// difference, and intersection.
+    fn arb_declared_type() -> impl Strategy<Value = DeclaredType> {
+        leaf().prop_recursive(4, 32, 4, |inner| {
+            prop_oneof![
+                prop::collection::vec(inner.clone(), 2..4).prop_map(DeclaredType::Union),
+                (
+                    "[A-Za-z][A-Za-z0-9]{0,4}",
+                    prop::collection::vec(inner.clone(), 1..3),
+                )
+                    .prop_map(|(base, params)| DeclaredType::generic(base, params)),
+                inner
+                    .clone()
+                    .prop_map(|t| DeclaredType::FalseOr(Box::new(t))),
+                (inner.clone(), inner.clone()).prop_map(|(base, excluded)| {
+                    DeclaredType::Difference {
+                        base: Box::new(base),
+                        excluded: Box::new(excluded),
+                    }
+                }),
+                (inner.clone(), inner.clone()).prop_map(|(left, right)| {
+                    DeclaredType::Intersection {
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    }
+                }),
+            ]
+        })
+    }
+
+    fn proptest_config() -> ProptestConfig {
+        crate::test_helpers::test_support::proptest_config_default()
+    }
+
+    proptest! {
+        #![proptest_config(proptest_config())]
+
+        /// `parse ∘ Display` never panics on any generated shape, including
+        /// the ones (`\`, `&`, `FalseOr`) the parser can't fully represent.
+        #[test]
+        fn parse_display_never_panics(dt in arb_declared_type()) {
+            let text = dt.to_string();
+            let _ = DeclaredType::parse(&text);
+        }
+
+        /// `parse ∘ Display` reaches a canonical fixed point within one
+        /// extra round trip: parsing the text `dt` displays, then
+        /// re-displaying and re-parsing *that*, always lands on the same
+        /// structured value and text — it never keeps drifting.
+        #[test]
+        fn parse_display_reaches_fixed_point(dt in arb_declared_type()) {
+            let text1 = dt.to_string();
+            let recovered1 = DeclaredType::parse(&text1);
+            let text2 = recovered1.to_string();
+            let recovered2 = DeclaredType::parse(&text2);
+            let text3 = recovered2.to_string();
+
+            prop_assert_eq!(
+                &recovered1, &recovered2,
+                "parse(Display(x)) did not stabilise for {:?}: \
+                 first pass = {:?} ({:?}), second pass = {:?} ({:?})",
+                dt, recovered1, text2, recovered2, text3,
+            );
+            prop_assert_eq!(
+                &text2, &text3,
+                "Display text kept drifting for {:?}: {:?} -> {:?}",
+                dt, text2, text3,
+            );
+        }
+
+        /// Once at the fixed point, `parse ∘ Display` is a true identity —
+        /// applying it again changes nothing further.
+        #[test]
+        fn parse_display_idempotent_from_fixed_point(dt in arb_declared_type()) {
+            let stable = DeclaredType::parse(&DeclaredType::parse(&dt.to_string()).to_string());
+            let text = stable.to_string();
+            let reparsed = DeclaredType::parse(&text);
+            prop_assert_eq!(&reparsed, &stable);
+            prop_assert_eq!(reparsed.to_string(), text);
+        }
+    }
+}

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/declared_type.rs
@@ -845,50 +845,8 @@ mod tests {
 #[cfg(test)]
 mod property_tests {
     use super::*;
+    use crate::test_helpers::test_support::arb_declared_type;
     use proptest::prelude::*;
-
-    /// Leaves: simple/singleton names plus every `Self`-family shape
-    /// `parse` recognises structurally.
-    fn leaf() -> impl Strategy<Value = DeclaredType> {
-        prop_oneof![
-            "[A-Za-z][A-Za-z0-9]{0,4}".prop_map(DeclaredType::simple),
-            "[a-z][a-z0-9]{0,4}".prop_map(DeclaredType::singleton),
-            Just(DeclaredType::SelfType),
-            Just(DeclaredType::SelfClass),
-            "[A-Za-z][A-Za-z0-9]{0,4}".prop_map(|n| DeclaredType::ClassOf(n.into())),
-        ]
-    }
-
-    /// Arbitrary `DeclaredType`s, recursively built from every grouping
-    /// shape named in the acceptance criteria: union, generic, `FalseOr`,
-    /// difference, and intersection.
-    fn arb_declared_type() -> impl Strategy<Value = DeclaredType> {
-        leaf().prop_recursive(4, 32, 4, |inner| {
-            prop_oneof![
-                prop::collection::vec(inner.clone(), 2..4).prop_map(DeclaredType::Union),
-                (
-                    "[A-Za-z][A-Za-z0-9]{0,4}",
-                    prop::collection::vec(inner.clone(), 1..3),
-                )
-                    .prop_map(|(base, params)| DeclaredType::generic(base, params)),
-                inner
-                    .clone()
-                    .prop_map(|t| DeclaredType::FalseOr(Box::new(t))),
-                (inner.clone(), inner.clone()).prop_map(|(base, excluded)| {
-                    DeclaredType::Difference {
-                        base: Box::new(base),
-                        excluded: Box::new(excluded),
-                    }
-                }),
-                (inner.clone(), inner.clone()).prop_map(|(left, right)| {
-                    DeclaredType::Intersection {
-                        left: Box::new(left),
-                        right: Box::new(right),
-                    }
-                }),
-            ]
-        })
-    }
 
     fn proptest_config() -> ProptestConfig {
         crate::test_helpers::test_support::proptest_config_default()

--- a/crates/beamtalk-core/src/test_helpers.rs
+++ b/crates/beamtalk-core/src/test_helpers.rs
@@ -79,6 +79,7 @@ pub mod test_support {
         ClassDefinition, ClassModifiers, Expression, ExpressionStatement, Identifier,
         MessageSelector, MethodDefinition, Module,
     };
+    use crate::semantic_analysis::class_hierarchy::DeclaredType;
     use crate::source_analysis::{Severity, Span, lex_with_eof, parse};
 
     /// Parses a Beamtalk source string and returns the [`Module`] AST.
@@ -188,6 +189,55 @@ pub mod test_support {
     #[must_use]
     pub fn bare(expr: Expression) -> ExpressionStatement {
         ExpressionStatement::bare(expr)
+    }
+
+    /// Arbitrary [`DeclaredType`] values, recursively covering every
+    /// grouping shape BT-3100's type-string fidelity properties exercise:
+    /// union, generic, `FalseOr`/optional, difference, intersection, and
+    /// the `Self`-family leaves (`Self`, `Self class`, `<Name> class`).
+    ///
+    /// Shared by `declared_type.rs`'s own `parse`/`Display` fixed-point
+    /// property tests and `beamtalk-compiler-port`'s wire-fidelity property
+    /// test (ETF encode/decode round trip) — both boundaries need the exact
+    /// same generated shape space, so it lives here once rather than being
+    /// copied into both crates (this repo's "No duplicate implementations"
+    /// rule).
+    pub fn arb_declared_type() -> impl proptest::strategy::Strategy<Value = DeclaredType> {
+        use proptest::prelude::*;
+
+        let leaf = prop_oneof![
+            "[A-Za-z][A-Za-z0-9]{0,4}".prop_map(DeclaredType::simple),
+            "[a-z][a-z0-9]{0,4}".prop_map(DeclaredType::singleton),
+            Just(DeclaredType::SelfType),
+            Just(DeclaredType::SelfClass),
+            "[A-Za-z][A-Za-z0-9]{0,4}".prop_map(|n| DeclaredType::ClassOf(n.into())),
+        ];
+
+        leaf.prop_recursive(4, 32, 4, |inner| {
+            prop_oneof![
+                prop::collection::vec(inner.clone(), 2..4).prop_map(DeclaredType::Union),
+                (
+                    "[A-Za-z][A-Za-z0-9]{0,4}",
+                    prop::collection::vec(inner.clone(), 1..3),
+                )
+                    .prop_map(|(base, params)| DeclaredType::generic(base, params)),
+                inner
+                    .clone()
+                    .prop_map(|t| DeclaredType::FalseOr(Box::new(t))),
+                (inner.clone(), inner.clone()).prop_map(|(base, excluded)| {
+                    DeclaredType::Difference {
+                        base: Box::new(base),
+                        excluded: Box::new(excluded),
+                    }
+                }),
+                (inner.clone(), inner.clone()).prop_map(|(left, right)| {
+                    DeclaredType::Intersection {
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    }
+                }),
+            ]
+        })
     }
 
     /// Returns the standard proptest configuration used across beamtalk-core property tests.


### PR DESCRIPTION
## Summary

Adds the property-based type-string fidelity tests requested in [BT-3100](https://linear.app/beamtalk/issue/BT-3100), covering the two boundaries the issue names:

- **`crates/beamtalk-core/.../class_hierarchy/declared_type.rs`** — a new `property_tests` module generates arbitrary `DeclaredType` values across every grouping shape the issue calls out (union, generic, `FalseOr`/optional, difference, intersection, plus the `Self`-family leaves), and asserts `parse ∘ Display` never panics and converges to a canonical fixed point (parsing the displayed text, then re-displaying and re-parsing *that*, always lands on the same structured value and text — per the acceptance criteria's "idempotent, or at minimum round-trips to a canonical fixed point").

  This also surfaced (and pins, rather than silently papers over) a genuine pre-existing quirk: when an intersection/difference's right/excluded operand needs parenthesising (e.g. `A & (B | C)`), `DeclaredType::parse` misreads it on the first pass as a single-argument `Generic` whose "base name" is the literal text `"A &"` (`split_generic_base` finds the first `(` in the whole string without knowing `&`/`\` aren't part of a class name), dropping the space before the paren. It's stable from the second parse onward, so the fixed-point property still holds — documented in the test module's doc comment. Filed [BT-3102](https://linear.app/beamtalk/issue/BT-3102) to track a grammar fix, since fixing it is out of scope for this issue.

- **`crates/beamtalk-compiler-port/src/main.rs`** (existing `property_tests` module) — a new `type_string_wire_fidelity` submodule asserts that a type-annotation string embedded in a real production response (`method_definition_ok_response`, the `return_type`/`param_types` fields ADR 0105 Phase 1 introduced) survives ETF encode → decode across the compiler-port wire byte-for-byte (no truncation, no re-encoding drift), using `eetf`'s `Term::encode`/`Term::decode` — the same External Term Format the BEAM's `term_to_binary`/`binary_to_term` speak. The generator reuses the same `DeclaredType`-shape strategy so both halves of the fidelity story exercise the same shape space.

Both new property test modules run under plain `cargo test` / `just test` — no special invocation needed.

## Test plan

- [x] `cargo test -p beamtalk-core semantic_analysis::class_hierarchy::declared_type::property_tests` — 3 new proptests pass
- [x] `cargo test -p beamtalk-compiler-port property_tests::type_string_wire_fidelity` — new proptest passes
- [x] `cargo clippy -p beamtalk-core -p beamtalk-compiler-port --tests --all-features -- -D warnings` — clean
- [x] `just test` — full Rust + stdlib + BUnit + runtime suite, all passing
- [x] Pre-push lint hook (Rust/Erlang/JS/Elixir formatting, Dialyzer, spec validation) — all passing

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Djke7fneGuG9thi29qC1ns