### PR TITLE
fix: clean up per-invocation BEAMTALK_CACHE_DIR test-cache dirs (BT-3077)

### DIFF
--- a/crates/beamtalk-cli/src/commands/workspace/node_state.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/node_state.rs
@@ -165,44 +165,9 @@ pub fn tcp_health_probe(host: &str, port: u16, cookie: &str) -> Result<HealthPro
 
 /// Check whether a process is alive by PID.
 ///
-/// On Unix: uses `kill(pid, 0)` — signal 0 tests process existence without sending a signal.
-/// On Windows: uses `OpenProcess` + `GetExitCodeProcess` to check for `STILL_ACTIVE`.
-pub(super) fn is_process_alive(pid: u32) -> bool {
-    #[cfg(unix)]
-    {
-        let Ok(pid_i) = i32::try_from(pid) else {
-            return false;
-        };
-        // SAFETY: kill(2) with signal 0 is a standard existence check.
-        let ret = unsafe { libc::kill(pid_i, 0) };
-        if ret == 0 {
-            return true;
-        }
-        // EPERM means the process exists but we lack permission to signal it —
-        // it is still alive.
-        std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
-    }
-
-    #[cfg(windows)]
-    {
-        use windows_sys::Win32::Foundation::{CloseHandle, FALSE, STILL_ACTIVE};
-        use windows_sys::Win32::System::Threading::{
-            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
-        };
-
-        // SAFETY: Windows API call with documented parameters.
-        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid) };
-        if handle.is_null() {
-            return false;
-        }
-        let mut exit_code: u32 = 0;
-        // SAFETY: handle is valid, exit_code is a local variable.
-        let ok = unsafe { GetExitCodeProcess(handle, &raw mut exit_code) };
-        // SAFETY: handle is valid, obtained from OpenProcess above.
-        unsafe { CloseHandle(handle) };
-        ok != FALSE && exit_code == STILL_ACTIVE as u32
-    }
-}
+/// Shared with `tests/cli_common` (BT-3077's stale test-cache-dir sweep),
+/// so this lives in the lib-level `pid_liveness` module rather than here.
+pub(super) use beamtalk_cli::pid_liveness::is_process_alive;
 
 #[cfg(test)]
 mod tests {

--- a/crates/beamtalk-cli/src/lib.rs
+++ b/crates/beamtalk-cli/src/lib.rs
@@ -12,10 +12,13 @@
 //!   resolution shared with `beamtalk-mcp` (BT-2823)
 //! - [`native_type_specs`] — Erlang FFI type-spec extraction shared with
 //!   `beamtalk-mcp` (BT-2858)
+//! - [`pid_liveness`] — cross-platform "is this PID alive?" check, shared
+//!   with `tests/cli_common` (BT-3077)
 
 pub mod build_layout;
 pub mod dependency_classes;
 pub mod erlc;
 pub mod manifest;
 pub mod native_type_specs;
+pub mod pid_liveness;
 pub mod repl_startup;

--- a/crates/beamtalk-cli/src/pid_liveness.rs
+++ b/crates/beamtalk-cli/src/pid_liveness.rs
@@ -1,0 +1,50 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cross-platform process-liveness check.
+//!
+//! Shared leaf module: used by `commands::workspace::node_state` (detached
+//! BEAM node liveness polling) and by `tests/cli_common` (BT-3077's stale
+//! test-cache-dir sweep) so neither has to duplicate the OS-specific PID
+//! check.
+
+/// Check whether a process is alive by PID.
+///
+/// On Unix: uses `kill(pid, 0)` — signal 0 tests process existence without sending a signal.
+/// On Windows: uses `OpenProcess` + `GetExitCodeProcess` to check for `STILL_ACTIVE`.
+pub fn is_process_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        let Ok(pid_i) = i32::try_from(pid) else {
+            return false;
+        };
+        // SAFETY: kill(2) with signal 0 is a standard existence check.
+        let ret = unsafe { libc::kill(pid_i, 0) };
+        if ret == 0 {
+            return true;
+        }
+        // EPERM means the process exists but we lack permission to signal it —
+        // it is still alive.
+        std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+    }
+
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Foundation::{CloseHandle, FALSE, STILL_ACTIVE};
+        use windows_sys::Win32::System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+
+        // SAFETY: Windows API call with documented parameters.
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid) };
+        if handle.is_null() {
+            return false;
+        }
+        let mut exit_code: u32 = 0;
+        // SAFETY: handle is valid, exit_code is a local variable.
+        let ok = unsafe { GetExitCodeProcess(handle, &raw mut exit_code) };
+        // SAFETY: handle is valid, obtained from OpenProcess above.
+        unsafe { CloseHandle(handle) };
+        ok != FALSE && exit_code == STILL_ACTIVE as u32
+    }
+}

--- a/crates/beamtalk-cli/tests/cli_common/mod.rs
+++ b/crates/beamtalk-cli/tests/cli_common/mod.rs
@@ -9,10 +9,11 @@
 //! it returns, so tests are safe to run in parallel.
 
 use assert_cmd::Command;
+use beamtalk_cli::pid_liveness::is_process_alive;
+use std::cell::RefCell;
 use std::path::{Path, PathBuf};
+use std::sync::Once;
 use std::sync::OnceLock;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 use tempfile::TempDir;
 
 /// Resolve the workspace root (repo root) from `CARGO_MANIFEST_DIR`.
@@ -68,10 +69,21 @@ pub fn beamtalk() -> Command {
         // matching. Long-lived developer machines accumulate this state;
         // ephemeral CI runners mostly don't, which is why this surfaced as
         // a "deterministic on this Windows box" failure rather than a CI
-        // one. Each invocation gets its own never-reused directory so no
-        // test run can read a poisoned cache written by an earlier one, or
-        // poison the cache for a later one.
-        .env("BEAMTALK_CACHE_DIR", isolated_cache_dir())
+        // one. BT-3077: every `beamtalk()` call made from a given test
+        // *thread* shares that thread's isolated directory (see
+        // `thread_cache_dir`) rather than littering a fresh one per call.
+        // libtest runs each `#[test]` on its own worker thread and never
+        // runs two tests concurrently on the same thread, so calls sharing
+        // a directory are always sequential — this can't reintroduce the
+        // cross-test races/poisoning a fully process-wide shared directory
+        // would (verified: that was tried and did reproduce spurious
+        // failures under `--test-threads` > 1). The directory is a
+        // `TempDir` guard, so it's deleted automatically when its owning
+        // thread exits (libtest joins every worker thread before the test
+        // binary exits), and a startup sweep mops up any directory a prior
+        // *process* left behind (e.g. Ctrl-C/timeout kill skipped the
+        // thread-local `Drop`).
+        .env("BEAMTALK_CACHE_DIR", thread_cache_dir())
         // Disable colored output so assertions on text content are stable.
         .env("NO_COLOR", "1")
         // Quiet tracing — some tests assert on stderr content.
@@ -79,22 +91,83 @@ pub fn beamtalk() -> Command {
     cmd
 }
 
-/// Returns a fresh, never-reused directory path under the system temp dir
-/// for `BEAMTALK_CACHE_DIR` isolation (BT-3066). The directory is not
-/// created here — `beamtalk_core::ffi_type_specs`'s cache readers treat a
-/// missing directory as an empty cache, and writers create it lazily on
-/// first write — so a plain unique path is sufficient.
-fn isolated_cache_dir() -> PathBuf {
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or_default();
-    std::env::temp_dir().join(format!(
-        "beamtalk-cli-test-cache-{}-{n}-{nanos}",
-        std::process::id()
-    ))
+/// Prefix shared by every `BEAMTALK_CACHE_DIR` this helper ever creates, so
+/// [`sweep_stale_cache_dirs`] can recognise its own litter under the OS
+/// temp dir (and the encoded PID within it) without touching unrelated
+/// entries.
+const CACHE_DIR_PREFIX: &str = "beamtalk-cli-test-cache-";
+
+thread_local! {
+    /// This test thread's `BEAMTALK_CACHE_DIR` (BT-3066), created lazily on
+    /// first use and reused by every `beamtalk()` call made from this
+    /// thread (BT-3077) instead of littering a fresh directory per call.
+    /// Dropping the `TempDir` deletes it — which happens when this worker
+    /// thread exits, i.e. after libtest has run every test scheduled on it
+    /// and joins the thread, well after any subprocess using the directory
+    /// has finished.
+    static CACHE_DIR: RefCell<Option<TempDir>> = const { RefCell::new(None) };
+}
+
+/// Returns this test thread's `BEAMTALK_CACHE_DIR` isolation directory
+/// (BT-3066/BT-3077), creating it on first call from this thread.
+///
+/// Threads (not the whole process) are the sharing unit because libtest
+/// runs each `#[test]` on its own worker thread and never runs two tests
+/// concurrently on the same thread — so every `beamtalk()` call sharing a
+/// directory is guaranteed sequential, which is what keeps this from
+/// reintroducing the cross-test cache-poisoning race BT-3066 fixed. A
+/// process-wide shared directory does not have that guarantee (many test
+/// threads run truly concurrently) and was confirmed to reproduce spurious
+/// `beamtalk lint`/`build` FFI-check failures under parallel test
+/// execution.
+fn thread_cache_dir() -> PathBuf {
+    sweep_stale_cache_dirs_once();
+    CACHE_DIR.with(|cell| {
+        cell.borrow_mut()
+            .get_or_insert_with(|| {
+                tempfile::Builder::new()
+                    .prefix(&format!("{CACHE_DIR_PREFIX}{}-", std::process::id()))
+                    .tempdir()
+                    .expect("create BEAMTALK_CACHE_DIR tempdir")
+            })
+            .path()
+            .to_path_buf()
+    })
+}
+
+/// Best-effort removal, once per test *process*, of `BEAMTALK_CACHE_DIR`
+/// directories left behind by earlier processes that never got to run their
+/// [`CACHE_DIR`] thread-local destructors — e.g. a `cargo test` run killed
+/// by Ctrl-C or a CI timeout mid-suite. Normal completion doesn't need this:
+/// every directory is already cleaned up by `TempDir::drop` as its owning
+/// thread exits.
+fn sweep_stale_cache_dirs_once() {
+    static SWEPT: Once = Once::new();
+    SWEPT.call_once(|| {
+        let Ok(entries) = std::fs::read_dir(std::env::temp_dir()) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            let Some(rest) = name.strip_prefix(CACHE_DIR_PREFIX) else {
+                continue;
+            };
+            // rest is "{pid}-{random}"; only the pid field matters here.
+            let Some(pid_str) = rest.split('-').next() else {
+                continue;
+            };
+            let Ok(pid) = pid_str.parse::<u32>() else {
+                continue;
+            };
+            if pid == std::process::id() || is_process_alive(pid) {
+                continue;
+            }
+            // Best-effort: the owning process may have raced back to life
+            // with a reused PID between the check above and this removal.
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    });
 }
 
 /// Locate the workspace `runtime/` directory.

--- a/crates/beamtalk-cli/tests/cli_common/mod.rs
+++ b/crates/beamtalk-cli/tests/cli_common/mod.rs
@@ -10,7 +10,7 @@
 
 use assert_cmd::Command;
 use beamtalk_cli::pid_liveness::is_process_alive;
-use std::cell::RefCell;
+use std::cell::OnceCell;
 use std::path::{Path, PathBuf};
 use std::sync::Once;
 use std::sync::OnceLock;
@@ -105,7 +105,7 @@ thread_local! {
     /// thread exits, i.e. after libtest has run every test scheduled on it
     /// and joins the thread, well after any subprocess using the directory
     /// has finished.
-    static CACHE_DIR: RefCell<Option<TempDir>> = const { RefCell::new(None) };
+    static CACHE_DIR: OnceCell<TempDir> = const { OnceCell::new() };
 }
 
 /// Returns this test thread's `BEAMTALK_CACHE_DIR` isolation directory
@@ -123,15 +123,14 @@ thread_local! {
 fn thread_cache_dir() -> PathBuf {
     sweep_stale_cache_dirs_once();
     CACHE_DIR.with(|cell| {
-        cell.borrow_mut()
-            .get_or_insert_with(|| {
-                tempfile::Builder::new()
-                    .prefix(&format!("{CACHE_DIR_PREFIX}{}-", std::process::id()))
-                    .tempdir()
-                    .expect("create BEAMTALK_CACHE_DIR tempdir")
-            })
-            .path()
-            .to_path_buf()
+        cell.get_or_init(|| {
+            tempfile::Builder::new()
+                .prefix(&format!("{CACHE_DIR_PREFIX}{}-", std::process::id()))
+                .tempdir()
+                .expect("create BEAMTALK_CACHE_DIR tempdir")
+        })
+        .path()
+        .to_path_buf()
     })
 }
 


### PR DESCRIPTION
## Summary

- `crates/beamtalk-cli/tests/cli_common/mod.rs`'s `beamtalk()` test helper (BT-3066) gave every subprocess invocation its own never-reused `BEAMTALK_CACHE_DIR` under the OS temp dir, and nothing ever deleted them — a `TempDir` guard would be dropped (deleting the directory) before the subprocess it's passed to even runs. Each call permanently littered a `beamtalk-cli-test-cache-*` directory.
- `beamtalk()` now reuses one `BEAMTALK_CACHE_DIR` per test **thread**, held in a `thread_local!` `TempDir`. Its `Drop` deletes the directory automatically when the owning libtest worker thread exits (libtest joins every worker thread before the test binary process exits, so this always fires on normal completion).
- Threads (not the whole process) are the sharing unit: libtest never runs two `#[test]`s concurrently on the same thread, so every `beamtalk()` call sharing a directory is guaranteed sequential. A process-wide shared directory was tried first per the linked PR discussion's suggestion, but reproduced spurious `cli_lint`/`cli_build` FFI type-spec check failures under parallel test execution (`--test-threads` > 1) — concurrent subprocesses racing on the same shared OTP type-spec cache, the same class of bug BT-3066 fixed. Per-thread reuse avoids that while still eliminating the per-call litter.
- A one-time startup sweep (`sweep_stale_cache_dirs_once`) removes any leftover `beamtalk-cli-test-cache-*` directory whose encoded PID no longer belongs to a live process, covering the case where a prior `cargo test` process was killed (Ctrl-C, CI timeout) before its thread-local destructors could run.
- Extracted the cross-platform `is_process_alive` PID-liveness check (used by the sweep) out of `commands::workspace::node_state` into a new `pub` lib module, `pid_liveness`, so it's a shared leaf module reachable from both the `beamtalk` binary and `tests/cli_common` instead of duplicating the OS-specific check.

Follow-up from a Claude review Suggestion on #3271 (BT-3066), tracked as [BT-3077](https://linear.app/beamtalk/issue/BT-3077).

## Test plan

- [x] `just build`
- [x] `just test` (Rust, stdlib, BUnit, runtime — all green)
- [x] `just ci-changed` (lint/clippy/fmt/dialyzer/build/test/parity — all green)
- [x] Verified no `beamtalk-cli-test-cache-*` directories are left in the OS temp dir after a normal `cargo test -p beamtalk-cli --test cli` run (previously every run left one per `beamtalk()` call)
- [x] Verified the stale-directory sweep removes a simulated leftover directory owned by a dead PID while leaving one owned by a live PID untouched
- [x] Re-ran `cargo test -p beamtalk-cli --test cli` repeatedly with default parallelism; only the two pre-existing, unrelated environment-flaky tests (`cli_doctor::doctor_passes_against_real_workspace_runtime`, `cli_test::test_passes_for_passing_suite`) fail, matching the pre-change baseline exactly

---
_Generated by [Claude Code](https://claude.ai/code/session_0131CQ4UAn5hH28fhXohLhgG)_