### PR TITLE
BT-3099: Extract shared test-corpus-loading helper across peer apps

### DIFF
--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_port_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_port_tests.erl
@@ -8,8 +8,11 @@
 -include_lib("eunit/include/eunit.hrl").
 %% Helper to find the compiler binary
 compiler_binary() ->
-    %% Look in target/debug from project root
-    ProjectRoot = find_project_root(filename:absname("")),
+    %% Look in target/debug from project root. `beamtalk_test_corpus`
+    %% (BT-3099) walks up from the test CWD to the project root (the dir
+    %% holding `Cargo.toml`) — shared with the other EUnit suites that also
+    %% need project-root discovery.
+    ProjectRoot = beamtalk_test_corpus:project_root(),
     %% On Windows, executables have a .exe extension.
     ExeName =
         case os:type() of
@@ -20,14 +23,6 @@ compiler_binary() ->
     case filelib:is_regular(Path) of
         true -> Path;
         false -> error({compiler_not_found, Path})
-    end.
-
-find_project_root("/") ->
-    filename:absname("");
-find_project_root(Dir) ->
-    case filelib:is_regular(filename:join(Dir, "Cargo.toml")) of
-        true -> Dir;
-        false -> find_project_root(filename:dirname(Dir))
     end.
 
 %% Helper to open and close a port around a test

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_tests.erl
@@ -357,31 +357,17 @@ assert_command_recognized(Command) ->
     error({no_dispatch_table_entry_for_corpus_command, Command}).
 
 %% Load the shared compiler-port command-vocabulary conformance corpus
-%% (BT-3095) from the repo tree. Walks up from the test CWD to the project
-%% root (the dir holding `Cargo.toml`), mirroring
-%% `beamtalk_repl_ops_dev_tests:find_word_boundary_corpus_root/1`.
+%% (BT-3095) from the repo tree. `beamtalk_test_corpus` (BT-3099) walks up
+%% from the test CWD to the project root (the dir holding `Cargo.toml`),
+%% then reads the fixture both surfaces share. `beamtalk_test_support` is a
+%% test-only peer app (ADR 0022 — `beamtalk_compiler` has no dependency on
+%% `beamtalk_runtime`), never listed in `beamtalk_compiler.app.src`.
 load_command_vocabulary_corpus() ->
-    Root = find_command_vocabulary_corpus_root(filename:absname("")),
-    Path = filename:join([
-        Root,
+    beamtalk_test_corpus:load_json_fixture([
         "runtime",
         "apps",
         "beamtalk_compiler",
         "test",
         "fixtures",
         "compiler_port_command_vocabulary_corpus.json"
-    ]),
-    Bin =
-        case file:read_file(Path) of
-            {ok, B} -> B;
-            {error, Reason} -> error({corpus_file_unreadable, Path, Reason})
-        end,
-    json:decode(Bin).
-
-find_command_vocabulary_corpus_root("/") ->
-    error(project_root_not_found);
-find_command_vocabulary_corpus_root(Dir) ->
-    case filelib:is_regular(filename:join(Dir, "Cargo.toml")) of
-        true -> Dir;
-        false -> find_command_vocabulary_corpus_root(filename:dirname(Dir))
-    end.
+    ]).

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_dispatch_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_dispatch_tests.erl
@@ -183,33 +183,18 @@ class_method_fun_name_matches_shared_corpus_test() ->
     ).
 
 %% Load the shared class-method-fun-name conformance corpus from the repo
-%% tree. Walks up from the test CWD to the project root (the dir holding
-%% `Cargo.toml`), then reads the fixture both surfaces share.
+%% tree. `beamtalk_test_corpus` (BT-3099) walks up from the test CWD to the
+%% project root (the dir holding `Cargo.toml`), then reads the fixture both
+%% surfaces share.
 load_class_method_fun_name_corpus() ->
-    Root = find_class_method_fun_name_corpus_root(filename:absname("")),
-    Path = filename:join([
-        Root,
+    beamtalk_test_corpus:load_json_fixture([
         "runtime",
         "apps",
         "beamtalk_runtime",
         "test",
         "fixtures",
         "class_method_fun_name_corpus.json"
-    ]),
-    Bin =
-        case file:read_file(Path) of
-            {ok, B} -> B;
-            {error, Reason} -> error({corpus_file_unreadable, Path, Reason})
-        end,
-    json:decode(Bin).
-
-find_class_method_fun_name_corpus_root("/") ->
-    error(project_root_not_found);
-find_class_method_fun_name_corpus_root(Dir) ->
-    case filelib:is_regular(filename:join(Dir, "Cargo.toml")) of
-        true -> Dir;
-        false -> find_class_method_fun_name_corpus_root(filename:dirname(Dir))
-    end.
+    ]).
 
 is_test_execution_selector_test_() ->
     [

--- a/runtime/apps/beamtalk_test_support/src/beamtalk_test_corpus.erl
+++ b/runtime/apps/beamtalk_test_support/src/beamtalk_test_corpus.erl
@@ -1,0 +1,65 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_test_corpus).
+
+-moduledoc """
+Shared EUnit test helper: locate the project root and load a JSON
+conformance-corpus fixture from it (BT-3099).
+
+`beamtalk_compiler`, `beamtalk_runtime`, and `beamtalk_workspace` each have
+EUnit suites that pin an Erlang-side implementation to a JSON corpus shared
+with the Rust side (`crates/beamtalk-core`) — walking up from the test CWD to
+the directory holding the workspace `Cargo.toml`, then reading the fixture.
+That pattern was copied byte-for-byte across six test files before BT-3099
+extracted it here.
+
+**Why a standalone app, not a shared `test/` dir on one of the peer apps:**
+`beamtalk_compiler` is a peer of `beamtalk_runtime`, not a dependent (ADR
+0022 — "the compiler has no dependency on the runtime"). Putting this helper
+under `beamtalk_runtime/test/` would make `beamtalk_compiler`'s test suite
+reach into a peer app's test tree, quietly recreating the dependency ADR
+0022 rejected. `beamtalk_test_support` is a fourth, independent umbrella app
+(picked up automatically via `{project_app_dirs, ["apps/*"]}` in the
+top-level `rebar.config`) that only test suites use — none of
+`beamtalk_compiler.app.src` / `beamtalk_runtime.app.src` /
+`beamtalk_workspace.app.src` list it in `applications`, so it is never part
+of any production boot sequence or release.
+""".
+
+-export([project_root/0, load_json_fixture/1]).
+
+-doc """
+Walk up from the current working directory to the project root — the
+directory containing the workspace `Cargo.toml` — and return its absolute
+path. Raises `error({project_root_not_found})` if the filesystem root is
+reached first (should not happen when run from inside the repo).
+""".
+-spec project_root() -> file:filename().
+project_root() ->
+    find_project_root(filename:absname("")).
+
+find_project_root("/") ->
+    error(project_root_not_found);
+find_project_root(Dir) ->
+    case filelib:is_regular(filename:join(Dir, "Cargo.toml")) of
+        true -> Dir;
+        false -> find_project_root(filename:dirname(Dir))
+    end.
+
+-doc """
+Read and JSON-decode a conformance-corpus fixture addressed by
+`PathSegments`, a list of path components relative to the project root
+(e.g. `["runtime", "apps", "beamtalk_runtime", "test", "fixtures",
+"class_method_fun_name_corpus.json"]`). Raises
+`error({corpus_file_unreadable, Path, Reason})` if the file cannot be read.
+""".
+-spec load_json_fixture([file:filename_all()]) -> json:decode_value().
+load_json_fixture(PathSegments) when is_list(PathSegments) ->
+    Path = filename:join([project_root() | PathSegments]),
+    Bin =
+        case file:read_file(Path) of
+            {ok, B} -> B;
+            {error, Reason} -> error({corpus_file_unreadable, Path, Reason})
+        end,
+    json:decode(Bin).

--- a/runtime/apps/beamtalk_test_support/src/beamtalk_test_support.app.src
+++ b/runtime/apps/beamtalk_test_support/src/beamtalk_test_support.app.src
@@ -1,0 +1,10 @@
+{application, beamtalk_test_support, [
+    {description,
+        "Test-only helpers shared across beamtalk_compiler, beamtalk_runtime, and "
+        "beamtalk_workspace EUnit suites. Never a production dependency of any peer "
+        "app (ADR 0022) — see beamtalk_test_corpus."},
+    {vsn, {cmd, "escript ../../../scripts/version.escript"}},
+    {modules, []},
+    {registered, []},
+    {applications, [kernel, stdlib]}
+]}.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
@@ -903,33 +903,18 @@ with_star_selector_matches_shared_corpus_test() ->
     ).
 
 %% Load the shared with-star-selector conformance corpus from the repo tree.
-%% Walks up from the test CWD to the project root (the dir holding
-%% `Cargo.toml`), then reads the fixture both surfaces share.
+%% `beamtalk_test_corpus` (BT-3099) walks up from the test CWD to the
+%% project root (the dir holding `Cargo.toml`), then reads the fixture both
+%% surfaces share.
 load_with_star_selector_corpus() ->
-    Root = find_with_star_selector_corpus_root(filename:absname("")),
-    Path = filename:join([
-        Root,
+    beamtalk_test_corpus:load_json_fixture([
         "runtime",
         "apps",
         "beamtalk_workspace",
         "test",
         "fixtures",
         "with_star_selector_corpus.json"
-    ]),
-    Bin =
-        case file:read_file(Path) of
-            {ok, B} -> B;
-            {error, Reason} -> error({corpus_file_unreadable, Path, Reason})
-        end,
-    json:decode(Bin).
-
-find_with_star_selector_corpus_root("/") ->
-    error(project_root_not_found);
-find_with_star_selector_corpus_root(Dir) ->
-    case filelib:is_regular(filename:join(Dir, "Cargo.toml")) of
-        true -> Dir;
-        false -> find_with_star_selector_corpus_root(filename:dirname(Dir))
-    end.
+    ]).
 
 %% Pure helper — relevant_diagnostic_shape/3.
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_browse_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_browse_tests.erl
@@ -162,34 +162,19 @@ clause_selector_corpus_test() ->
         Cases
     ).
 
-%% Load the shared selector-conformance corpus from the repo tree. Walks up from
-%% the test CWD to the project root (the dir holding `Cargo.toml`), then reads
-%% the fixture both surfaces share.
+%% Load the shared selector-conformance corpus from the repo tree.
+%% `beamtalk_test_corpus` (BT-3099) walks up from the test CWD to the
+%% project root (the dir holding `Cargo.toml`), then reads the fixture both
+%% surfaces share.
 load_clause_corpus() ->
-    Root = find_project_root(filename:absname("")),
-    Path = filename:join([
-        Root,
+    beamtalk_test_corpus:load_json_fixture([
         "runtime",
         "apps",
         "beamtalk_workspace",
         "test",
         "fixtures",
         "handle_call_clause_corpus.json"
-    ]),
-    Bin =
-        case file:read_file(Path) of
-            {ok, B} -> B;
-            {error, Reason} -> error({corpus_file_unreadable, Path, Reason})
-        end,
-    json:decode(Bin).
-
-find_project_root("/") ->
-    error(project_root_not_found);
-find_project_root(Dir) ->
-    case filelib:is_regular(filename:join(Dir, "Cargo.toml")) of
-        true -> Dir;
-        false -> find_project_root(filename:dirname(Dir))
-    end.
+    ]).
 
 %% native_delegate is keyed off the facade's `dispatch_<selector>` exports — the
 %% compiler's own `is_self_delegate` decision (native_facade.rs), not a body-text

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_dev_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_dev_tests.erl
@@ -2016,34 +2016,19 @@ is_identifier_char_matches_shared_corpus_test() ->
         Cases
     ).
 
-%% Load the shared word-boundary conformance corpus from the repo tree. Walks
-%% up from the test CWD to the project root (the dir holding `Cargo.toml`),
-%% then reads the fixture both surfaces share.
+%% Load the shared word-boundary conformance corpus from the repo tree.
+%% `beamtalk_test_corpus` (BT-3099) walks up from the test CWD to the
+%% project root (the dir holding `Cargo.toml`), then reads the fixture both
+%% surfaces share.
 load_word_boundary_corpus() ->
-    Root = find_word_boundary_corpus_root(filename:absname("")),
-    Path = filename:join([
-        Root,
+    beamtalk_test_corpus:load_json_fixture([
         "runtime",
         "apps",
         "beamtalk_workspace",
         "test",
         "fixtures",
         "completion_word_boundary_corpus.json"
-    ]),
-    Bin =
-        case file:read_file(Path) of
-            {ok, B} -> B;
-            {error, Reason} -> error({corpus_file_unreadable, Path, Reason})
-        end,
-    json:decode(Bin).
-
-find_word_boundary_corpus_root("/") ->
-    error(project_root_not_found);
-find_word_boundary_corpus_root(Dir) ->
-    case filelib:is_regular(filename:join(Dir, "Cargo.toml")) of
-        true -> Dir;
-        false -> find_word_boundary_corpus_root(filename:dirname(Dir))
-    end.
+    ]).
 
 %%====================================================================
 %% builtin_keywords/0 — shared keyword-vocabulary conformance corpus (BT-3083)
@@ -2071,19 +2056,11 @@ builtin_keywords_covers_shared_vocabulary_corpus_test() ->
 
 %% Load the shared keyword-vocabulary conformance corpus from the repo tree.
 load_keyword_vocabulary_corpus() ->
-    Root = find_word_boundary_corpus_root(filename:absname("")),
-    Path = filename:join([
-        Root,
+    beamtalk_test_corpus:load_json_fixture([
         "runtime",
         "apps",
         "beamtalk_workspace",
         "test",
         "fixtures",
         "completion_keyword_vocabulary_corpus.json"
-    ]),
-    Bin =
-        case file:read_file(Path) of
-            {ok, B} -> B;
-            {error, Reason} -> error({corpus_file_unreadable, Path, Reason})
-        end,
-    json:decode(Bin).
+    ]).

--- a/runtime/rebar.config
+++ b/runtime/rebar.config
@@ -53,7 +53,8 @@
              %% that erlfmt cannot parse — exclude it.
              "apps/beamtalk_compiler/src/*.app.src",
              "apps/beamtalk_runtime/src/*.app.src",
-             "apps/beamtalk_workspace/src/*.app.src"]}
+             "apps/beamtalk_workspace/src/*.app.src",
+             "apps/beamtalk_test_support/src/*.app.src"]}
 ]}.
 
 %% Dialyzer configuration


### PR DESCRIPTION
## Summary

Six EUnit test files across `beamtalk_compiler`, `beamtalk_runtime`, and `beamtalk_workspace` copied the same "walk up from the test CWD to the project root (the dir holding `Cargo.toml`), then read a shared JSON conformance-corpus fixture" helper byte-for-byte (originally in `beamtalk_repl_ops_dev_tests.erl`). This PR extracts that into a single shared module.

### Sharing mechanism chosen: a standalone test-only umbrella app

`beamtalk_compiler` is a **peer** of `beamtalk_runtime`, not a dependent — ADR 0022 is explicit that "the compiler has no dependency on the runtime," and `beamtalk_compiler.app.src`'s `applications` list (`[kernel, stdlib, compiler]`) deliberately omits `beamtalk_runtime`. Putting the shared helper under `beamtalk_runtime/test/` (or any other single peer app's test tree) would make `beamtalk_compiler`'s test suite reach into a peer app's test code, quietly recreating the exact coupling ADR 0022 rejected — even though it's "just tests."

Instead, this PR adds a fourth, independent umbrella app: **`runtime/apps/beamtalk_test_support/`**, containing one module, `beamtalk_test_corpus`, exposing:
- `project_root/0` — walk up to the directory containing `Cargo.toml`
- `load_json_fixture/1` — read + JSON-decode a fixture, addressed by a list of path segments relative to the project root (parameterized per caller, not hardcoded to one corpus)

This app is picked up automatically by the existing `{project_app_dirs, ["apps/*"]}` in `runtime/rebar.config` (rebar3 compiles it as part of the umbrella build, confirmed via `rebar3 compile` and `rebar3 eunit --app=...`), but it is **never listed** in `beamtalk_compiler.app.src`, `beamtalk_runtime.app.src`, or `beamtalk_workspace.app.src`'s `applications` — so it's compiled for tests only and is never part of any production boot sequence or release, exactly like a rebar3 `test`-profile dependency but without needing per-app `rebar.config` files (this umbrella has none; everything is driven by the single top-level `runtime/rebar.config`).

This mirrors the equivalent Rust-side fix (`find_project_root` in `version.rs`/`publish.rs`, commit `4d7d51ad`) — same idea, Erlang side, adapted to the umbrella-app peer-boundary constraint.

### Migrated call sites
- `runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_dev_tests.erl` (2 corpora: word-boundary + keyword-vocabulary — the original copy)
- `runtime/apps/beamtalk_runtime/test/beamtalk_class_dispatch_tests.erl` (class-method-fun-name corpus)
- `runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl` (with-star-selector corpus)
- `runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_browse_tests.erl` (handle_call clause corpus)
- `runtime/apps/beamtalk_compiler/test/beamtalk_compiler_tests.erl` (command-vocabulary corpus)
- `runtime/apps/beamtalk_compiler/test/beamtalk_compiler_port_tests.erl` (root-finding only, for locating the compiler binary — no JSON corpus)

Out of scope (deliberately not touched): the *production* `find_project_root/0,1` copies in `beamtalk_exec_port.erl` (`beamtalk_stdlib`) and `beamtalk_compiler_port.erl` (`beamtalk_compiler`) — those are runtime code, not test helpers, and are a separate pre-existing duplication outside this ticket's scope.

## Test plan
- [x] `rebar3 eunit --cover=false --app=beamtalk_runtime,beamtalk_workspace,beamtalk_compiler` run before and after the migration (via `git stash`) — **identical results both times**: 5571 tests, 214 failures, 8 cancelled, and the failing-test-name sets are byte-identical (213 unique pre-existing failures — unrelated class-registry timing flakiness in this sandbox, confirmed present on `main` too). No corpus/fixture-loading test regressed or changed behavior.
- [x] `rebar3 fmt --check` passes (erlfmt, including the new `beamtalk_test_support.app.src`, added to the `erlfmt` file globs in `runtime/rebar.config`)
- [x] Full `just` pre-push lint/build/test hook (clippy, dialyzer, Erlang/Elixir/JS formatting, spec validation) passed on push


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoBbrDfCr9ZDkuuyNJBNd)_