### PR TITLE
BT-3058: Document module_name_safe/1's untrappable-kill caveat at call sites

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_package.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_package.erl
@@ -113,6 +113,15 @@ Returns the package name (binary) for a given class name.
 Extracts the package segment from the BEAM module name (`bt@{pkg}@{class}`)
 via `__beamtalk_meta/0` or from the `.app` class list metadata.
 Returns `nil` if the class is not found or has no package.
+
+Caveat: this calls `beamtalk_object_class:module_name_safe/1` rather than
+`module_name/1` because this function is reachable from inside an ADR 0109
+foreign-process block (directly, or via the unrestricted `Erlang <module>`
+FFI gateway), and an unsafe `gen_server:call` here would risk the deadlock
+shape BT-3052/BT-3054 fixed. That means the `noproc`/`timeout` catch clauses
+below cannot detect a class process killed via an untrappable `kill` signal
+before `terminate/2` ran — see `module_name_safe/1`'s doc for the full
+explanation.
 """.
 -spec package_name(atom()) -> binary() | nil.
 package_name(ClassName) when is_atom(ClassName) ->

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_runtime_api.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_runtime_api.erl
@@ -207,6 +207,14 @@ Remove a class from the system by name, with full cleanup.
 Returns the BEAM module atom of the removed class on success (so the caller
 can update its own tracking state), or {error, Reason} if the removal fails
 (class not found, stdlib class, has subclasses, etc.).
+
+Caveat: this is reachable from inside an ADR 0109 foreign-process block
+(directly, or via the unrestricted `Erlang <module>` FFI gateway), so the
+module lookup above uses `beamtalk_object_class:module_name_safe/1` rather
+than an unsafe `gen_server:call`-based precheck. That means it cannot detect
+a class process killed via an untrappable `kill` signal before `terminate/2`
+ran (it will resolve `ModuleName` for the dead pid rather than signalling
+death) — see `module_name_safe/1`'s doc for the full explanation.
 """.
 -spec remove_class_from_system(atom()) -> {ok, module()} | {error, #beamtalk_error{}}.
 remove_class_from_system(ClassName) ->
@@ -232,6 +240,15 @@ remove_class_from_system(ClassName) ->
 class_name(Pid) ->
     beamtalk_object_class:class_name(Pid).
 
+-doc """
+Get the BEAM module name for a class object's pid.
+
+Delegates to `beamtalk_object_class:module_name_safe/1` (BT-3054) and
+inherits its caveat verbatim: it may not raise `noproc`/`timeout` for a
+class process killed via an untrappable `kill` signal before `terminate/2`
+ran, because the ETS rows it reads survive that kind of death. See
+`module_name_safe/1`'s doc for the full explanation.
+""".
 -spec module_name(pid()) -> module().
 module_name(Pid) ->
     beamtalk_object_class:module_name_safe(Pid).

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_interface.erl
@@ -728,6 +728,14 @@ callers such as `SystemNavigation classesInPackage:` — which resolves *every*
 class in a package via `findClass:` — from crashing the whole query on a
 single transiently-unavailable class (nil results are filtered out by the
 caller, consistent with the "stale entries dropped silently" miss policy).
+
+Caveat: this is reachable from inside an ADR 0109 foreign-process block
+(directly, or via the unrestricted `Erlang <module>` FFI gateway), so it
+calls `module_name_safe/1` rather than an unsafe `gen_server:call`-based
+precheck. That means the `noproc`/`timeout` catches above cannot detect a
+class process killed via an untrappable `kill` signal before `terminate/2`
+ran — see `beamtalk_object_class:module_name_safe/1`'s doc for the full
+explanation.
 """.
 -spec class_object_for_pid(atom(), pid()) -> beamtalk_object() | 'nil'.
 class_object_for_pid(ClassName, Pid) ->

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_test_runner.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_test_runner.erl
@@ -649,6 +649,14 @@ Check whether a class's source file matches the given path.
 Looks up the class in the registry, reads its module's beamtalk_source
 attribute, and checks if the stored path ends with FilePath.
 Returns false if the class is not registered or has no source attribute.
+
+Caveat: this is reachable from inside an ADR 0109 foreign-process block
+(directly, or via the unrestricted `Erlang <module>` FFI gateway), so it
+resolves the module via `beamtalk_object_class:module_name_safe/1` rather
+than an unsafe `gen_server:call`-based precheck. That means the
+`noproc`/`timeout` catches below cannot detect a class process killed via an
+untrappable `kill` signal before `terminate/2` ran — see
+`module_name_safe/1`'s doc for the full explanation.
 """.
 -spec class_source_matches(atom(), binary()) -> boolean().
 class_source_matches(ClassName, FilePath) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_interface_primitives.erl
@@ -1242,6 +1242,15 @@ is_singleton_binding_name(Name) ->
 
 %% Tier 4: class registry → a class object tuple, mirroring REPL codegen for a
 %% capitalised name (`{beamtalk_object, '<Name> class', Module, ClassPid}`).
+%%
+%% Caveat: reachable from inside an ADR 0109 foreign-process block (directly,
+%% or via the unrestricted `Erlang <module>` FFI gateway), so the module is
+%% resolved via `beamtalk_runtime_api:module_name/1`, which delegates to
+%% `beamtalk_object_class:module_name_safe/1` rather than an unsafe
+%% `gen_server:call`-based precheck. That means the catch-all below cannot
+%% detect a class process killed via an untrappable `kill` signal before
+%% `terminate/2` ran — see `module_name_safe/1`'s doc for the full
+%% explanation.
 -spec lookup_class_object(atom()) -> {ok, tuple()} | error.
 lookup_class_object(Name) ->
     case beamtalk_runtime_api:whereis_class(Name) of


### PR DESCRIPTION
## Summary

`beamtalk_object_class:module_name_safe/1` resolves a class's module via two ETS reads instead of a `gen_server:call`, deliberately, to be deadlock-safe from inside an ADR 0109 foreign-process block. But if a class process is killed via an untrappable `kill` signal, `terminate/2` never runs, so the ETS rows survive and `module_name_safe/1` can resolve a plausible module for an already-dead pid instead of raising `noproc`/`timeout` the way callers might expect.

A prior reachability investigation traced every affected call site from inside ADR 0109 foreign-process blocks and concluded **every site is block-reachable** — directly, or via the unrestricted `Erlang <module>` FFI gateway, which allows calling any exported function from inside a block. That rules out adding a `gen_server:call`-based liveness precheck (e.g. `class_name/1`) anywhere ahead of `module_name_safe/1` — doing so would reintroduce the exact deadlock shape BT-3052/BT-3054 already fixed.

This PR is purely additive documentation: it adds the same untrappable-kill caveat already on `module_name_safe/1`'s own doc comment to each affected call site, matching that existing caveat style. **No behavior or logic changes.**

### Sites documented

1. `beamtalk_package:package_name/1` — reachable from inside a block; its `noproc`/`timeout` catch clauses cannot detect an untrappable-killed class.
2. `beamtalk_interface:class_object_for_pid/2` — same gap, reachable via the same block/FFI path.
3. `beamtalk_test_runner:class_source_matches/2` — same gap.
4. `beamtalk_workspace_interface_primitives:lookup_class_object/1` — same gap (delegates through `beamtalk_runtime_api:module_name/1`).
5. `beamtalk_runtime_api:remove_class_from_system/1` — a 5th site the investigation found beyond the original issue text; folded in here.

### Additionally: `beamtalk_runtime_api:module_name/1`

This function had **no doc comment at all** — just a bare `-spec`. It was repointed to call through to `module_name_safe/1`'s semantics under BT-3054 but kept its old name, silently inheriting the "may not raise for an untrappable-killed process" contract across all 15 of its call sites (mostly in `beamtalk_workspace`: `repl_eval.erl`, `repl_ops_load.erl`, `repl_ops_dev.erl`, `repl_ops_browse.erl`, `repl_compiler.erl`, `repl_ops_nav_symbols.erl`, `workspace_interface_primitives.erl`). Added a doc comment explaining what it does, that it delegates to `module_name_safe/1` and inherits its caveat, and pointing readers to `module_name_safe/1`'s doc for the full explanation. Not renamed; none of its call sites touched — documentation-only, scoped per the issue.

### What this PR deliberately does NOT do

- No `gen_server:call`/`class_name/1` precheck added anywhere (settled by the investigation — every site is block-reachable).
- `beamtalk_class_registry:live_class_entries/0`, `user_classes/0`, `beamtalk_test_runner:discover_methods_via_registry/1`, and `beamtalk_workspace_interface_primitives:startSupervisor/1` are untouched — these were already confirmed safe (they call an unsafe liveness check before `module_name_safe/1`).
- `beamtalk_runtime_api:module_name/1` is not renamed and its call sites are untouched.

## Test plan

- [x] `rebar3 fmt --check` (erlfmt) clean on touched files
- [x] `rebar3 eunit --app=beamtalk_runtime,beamtalk_workspace,beamtalk_compiler` — 5588 tests, 0 failures
- [x] `rebar3 eunit --dir=apps/beamtalk_stdlib/test` — 1807 tests, 0 failures
- [x] Full pre-push CI hook (clippy, dialyzer, rust/erlang build, spec validation, elixir/erlfmt checks) passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxoBbrDfCr9ZDkuuyNJBNd)_