### PR TITLE
core_lint: surface compile:forms failures as readable diagnostics (BT-3115)

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -1215,6 +1215,59 @@ end
         result.expect("compile_batch should succeed when escript is available");
     }
 
+    /// BT-3115: a deliberately-malformed Core Erlang module — `foo/1`
+    /// references `State`, which is never a parameter or let-bound — must
+    /// fail with a readable `core_lint` message naming the unbound
+    /// variable, actually reaching this process's stderr (and therefore
+    /// this error message), not a raw term dump or a silently-dropped
+    /// stdout line (`compile.escript`'s `worker_loop/2` used to rely on
+    /// `report_errors`, which prints via the compiling process's default
+    /// group leader — verified empirically to land on stdout, invisible to
+    /// `read_compilation_output`'s protocol-marker-only parser). Exercises
+    /// the same acceptance criterion the Port-backend `EUnit` tests
+    /// (`beamtalk_build_worker_tests`/`beamtalk_compiler_server_tests`
+    /// `compile_core_erlang_unbound_var_test`) cover for the other backend —
+    /// together they demonstrate the two backends stay in parity.
+    #[test]
+    fn test_compile_batch_escript_core_lint_unbound_var() {
+        if check_escript_available().is_err() {
+            println!("Skipping test - escript not installed");
+            return;
+        }
+
+        let temp = TempDir::new().unwrap();
+        let output_dir = Utf8PathBuf::from_path_buf(temp.path().join("build")).unwrap();
+        fs::create_dir_all(&output_dir).unwrap();
+        let compiler = BeamCompiler::new(output_dir);
+
+        let core_content = r"module 'bt_cli_unbound_var' ['foo'/1]
+  attributes []
+  'foo'/1 = fun (X) ->
+    let Y = call 'erlang':'+' (X, State)
+    in Y
+end
+";
+
+        let core_file = Utf8PathBuf::from_path_buf(temp.path().join("bad.core")).unwrap();
+        fs::write(&core_file, core_content).unwrap();
+
+        let result = compiler.compile_batch_escript(&[core_file]);
+        let err = result.expect_err("malformed Core Erlang must fail to compile");
+        let message = format!("{err}");
+        assert!(
+            message.contains("unbound variable"),
+            "expected a readable core_lint message, got: {message}"
+        );
+        assert!(
+            message.contains("'State'"),
+            "expected the offending variable name in the message, got: {message}"
+        );
+        assert!(
+            !message.contains("{unbound_var,"),
+            "expected readable prose, not a raw term dump: {message}"
+        );
+    }
+
     // Tests for is_valid_module_name
     #[test]
     fn test_is_valid_module_name_valid() {

--- a/crates/beamtalk-cli/templates/compile.escript
+++ b/crates/beamtalk-cli/templates/compile.escript
@@ -111,14 +111,36 @@ start_compiler_workers(OutDir) ->
 
 worker_loop(Parent, OutDir) ->
     %% Compile options for Core Erlang
+    %%
+    %% BT-3115: previously used `report_errors'/`report_warnings', which
+    %% print via `io:fwrite' to the compiling process's *default group
+    %% leader* — verified empirically (`erl -eval 'compile:file(...)' 1>out
+    %% 2>err`) that this lands on stdout, not stderr. The Rust CLI's stdout
+    %% parser (`read_compilation_output') only recognises the
+    %% `beamtalk-compile-*' protocol markers and silently drops every other
+    %% line, so compiler diagnostics were being lost outright, not just
+    %% poorly formatted. `return_errors'/`return_warnings' get the
+    %% structured terms back instead; `worker_loop' below formats them via
+    %% the same OTP `sys_messages' function `report_errors' would have used
+    %% internally, and prints explicitly to `standard_error' — where the
+    %% Rust side's stderr-reading thread actually looks.
+    %%
+    %% `clint' is passed explicitly for documentation purposes but is a
+    %% no-op — `core_lint' already runs unconditionally as part of the
+    %% `from_core' pipeline `compile:file/2' selects (independent of
+    %% `clint'/`clint0'/`no_lint', which only gate lint re-runs on the
+    %% source-compilation branch this escript never takes; see the Port
+    %% backend's `beamtalk_compile_diagnostics' moduledoc for the full
+    %% explanation).
     Options = [
         from_core,           % Compile from Core Erlang
-        report_errors,       % Print errors
-        report_warnings,     % Print warnings
+        return_errors,       % BT-3115: structured errors, formatted below
+        return_warnings,     % BT-3115: structured warnings, formatted below
         debug_info,          % Include debug info for hot code reload
+        clint,               % BT-3115: explicit core_lint pass (no-op, see above)
         {outdir, OutDir}     % Output directory
     ],
-    
+
     erlang:send(Parent, {work_please, self()}),
     receive
         {module, CoreFile} ->
@@ -128,11 +150,41 @@ worker_loop(Parent, OutDir) ->
                     inject_docs_chunk(CoreFile, ModuleName, OutDir),
                     erlang:send(Parent, {compiled, ModuleName}),
                     worker_loop(Parent, OutDir);
+                {ok, ModuleName, Warnings} ->
+                    print_messages(Warnings, "Warning: "),
+                    inject_docs_chunk(CoreFile, ModuleName, OutDir),
+                    erlang:send(Parent, {compiled, ModuleName}),
+                    worker_loop(Parent, OutDir);
+                {error, Errors, Warnings} ->
+                    print_messages(Warnings, "Warning: "),
+                    print_messages(Errors, ""),
+                    erlang:send(Parent, failed),
+                    worker_loop(Parent, OutDir);
                 error ->
                     erlang:send(Parent, failed),
                     worker_loop(Parent, OutDir)
             end
     end.
+
+%% BT-3115: format compile:file/2's structured error/warning list — each
+%% entry `{File, [{Loc, Mod, ErrDesc}]}' — via OTP's own
+%% `sys_messages:format_messages/4' (the exact function `report_errors'/
+%% `report_warnings' use internally, so the rendered text is unchanged from
+%% before) and print each line to `standard_error' explicitly, instead of
+%% letting `compile:file/2' print it to the default group leader (stdout —
+%% see `worker_loop/2's doc for why that loses the message entirely).
+print_messages([], _Prefix) ->
+    ok;
+print_messages(Messages, Prefix) ->
+    lists:foreach(
+        fun({File, Infos}) ->
+            lists:foreach(
+                fun({_Loc, Text}) -> io:put_chars(standard_error, Text) end,
+                sys_messages:format_messages(File, Prefix, Infos, [])
+            )
+        end,
+        Messages
+    ).
 
 %% BT-499: Inject EEP-48 doc chunk into compiled .beam file.
 %%

--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -111,6 +111,40 @@ dbg!(&expr);
 // Rebuild and check output
 ```
 
+### core_lint (BT-3115)
+
+Every scoping bug in the list above — unbound `StateX`, missing `State`/`Self`,
+wrong arities — is a Core Erlang well-formedness violation that OTP's
+`core_lint` pass catches during `beamtalk build`, with a message naming the
+offending variable and function/arity directly:
+
+```
+build/failing.core: unbound variable 'State' in myMethod/2
+```
+
+`core_lint` runs **unconditionally** as part of `compile:forms`/`compile:file`'s
+`from_core` pipeline (every Beamtalk compile path takes this route) —
+independent of the `clint`/`clint0`/`no_lint` options, which only affect lint
+re-runs when compiling from Erlang *source*, a path Beamtalk never takes. So
+this check was always on; what changed in BT-3115 was making the failure
+readable everywhere it can surface:
+
+- **Port backend** (`beamtalk_build_worker`/`beamtalk_compiler_server`, the
+  default): formats `compile:forms`' raw error term via
+  `beamtalk_compile_diagnostics:format_errors/1`, which calls the same
+  `sys_messages:format_messages/4` OTP itself uses internally.
+- **Escript backend** (`BEAMTALK_COMPILER=escript`, `compile.escript`):
+  formats the same way and prints to this process's actual stderr — a prior
+  version relied on `compile:file`'s `report_errors`/`report_warnings`
+  options, which print via the compiling process's default group leader;
+  that lands on **stdout**, not stderr, so the Rust CLI's stdout parser
+  (which only recognises the `beamtalk-compile-*` protocol markers) silently
+  dropped the message rather than showing it.
+
+If you see a bare `internal error` or a build failure with no readable cause,
+run with `BEAMTALK_COMPILER=escript` and compare — the two backends are
+expected to produce the same wording for the same malformed input.
+
 ## Runtime/REPL Debugging
 
 ```bash

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_build_worker.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_build_worker.erl
@@ -229,8 +229,8 @@ compile_core_file(CoreFile, OutDir) ->
                     io:put_chars(
                         standard_error,
                         io_lib:format(
-                            "Error compiling ~s: ~p~n",
-                            [CoreFile, Reason]
+                            "Error compiling ~s: ~ts~n",
+                            [CoreFile, describe_compile_error(Reason)]
                         )
                     ),
                     error
@@ -292,6 +292,15 @@ compile_core_erlang(CoreErlangBin) when is_binary(CoreErlangBin) ->
 
 %% Internal: shared `compile:forms/2' arm used by both wire shapes.
 %% Includes `debug_info' (this is the build path).
+%%
+%% BT-3115: `clint' is passed explicitly for documentation purposes, but is
+%% a no-op today — `core_lint' already runs unconditionally on the
+%% `from_core' pipeline this call takes (see `beamtalk_compile_diagnostics'
+%% moduledoc for the full explanation of why `clint'/`clint0' only matter on
+%% the `verified_core' branch, which compiling from Core Erlang never
+%% reaches). `strong_validation'/`basic_validation' were evaluated and are
+%% NOT applicable here: both skip code generation entirely, which this build
+%% path requires (it must produce a `.beam' binary, not just diagnostics).
 compile_core_forms(CoreModule) ->
     case
         compile:forms(
@@ -301,7 +310,8 @@ compile_core_forms(CoreModule) ->
                 binary,
                 return_errors,
                 report_warnings,
-                debug_info
+                debug_info,
+                clint
             ]
         )
     of
@@ -310,5 +320,20 @@ compile_core_forms(CoreModule) ->
         {ok, ModuleName, Binary, _Warnings} ->
             {ok, ModuleName, Binary};
         {error, Errors, _Warnings} ->
-            {error, {core_compile_error, Errors}}
+            {error,
+                {core_compile_error, #{
+                    message => beamtalk_compile_diagnostics:format_errors(Errors),
+                    raw => Errors
+                }}}
     end.
+
+%% Render a `compile_core_erlang/1' error `Reason' for stderr. The
+%% `core_compile_error' shape (compile:forms failures — by definition an
+%% internal-compiler-error at this pipeline stage, BT-3115) gets the
+%% human-readable `sys_messages'-formatted text carrying the offending
+%% variable/function name; every other shape (scan/parse errors, which are
+%% already compact) falls back to a plain term dump.
+describe_compile_error({core_compile_error, #{message := Message}}) ->
+    Message;
+describe_compile_error(Reason) ->
+    unicode:characters_to_binary(io_lib:format("~p", [Reason])).

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compile_diagnostics.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compile_diagnostics.erl
@@ -1,0 +1,70 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_compile_diagnostics).
+
+-moduledoc """
+Formats `compile:forms/2' error terms produced while compiling
+Beamtalk-generated Core Erlang to BEAM bytecode (BT-3115).
+
+Every error `compile:forms/2' can return at this pipeline stage is an
+internal-compiler-error by definition: the input is compiler-generated
+Core Erlang, not user source, so a well-formedness failure here — most
+commonly `core_lint''s `unbound_var'/`duplicate_var' (see
+`docs/development/debugging.md' § Codegen Debugging) — means codegen
+produced invalid output, not that the user wrote bad Beamtalk.
+
+`core_lint' already runs *unconditionally* as part of OTP's `from_core'
+compile pipeline: `compile:forms(Forms, [from_core | Opts])' always
+includes `core_lint_module' in `core_passes(non_verified_core)'
+(`compiler-*/src/compile.erl'), completely independent of the
+`clint'/`clint0'/`no_lint' options — those only gate lint re-runs on the
+`verified_core' branch taken when compiling from Erlang *source*, which
+this from-Core-Erlang pipeline never does. So detection was never the
+gap here; readability was. `compile:forms' with `return_errors' hands
+back a raw `[{File,[{Loc,Mod,ErrDesc}]}]' term with no formatting,
+unlike `compile:file'/`compile:forms' with `report_errors', which prints
+through `sys_messages:format_messages/4' — the exact same OTP-internal
+function this module calls, so the text this module produces is
+byte-for-byte what `report_errors' would have printed (verified: both
+render as `"<file>: unbound variable 'State' in foo/1"' for the same
+input).
+
+Used by both `beamtalk_build_worker' and `beamtalk_compiler_server' (the
+in-memory Port backend, ADR 0022 Phase 3) so the two never drift. The
+escript fallback backend (`compile.escript') cannot depend on this
+module — escripts run standalone with no project code path, only OTP's
+own applications — so it carries its own small `print_messages/2' that
+calls the same `sys_messages:format_messages/4' directly; see that
+function's doc for why `report_errors'/`report_warnings' (the more
+obvious option) turned out to be actively wrong here, not just an
+unshared duplicate of this formatting: they print through the compiling
+process's default group leader, which lands on stdout, not stderr — the
+Rust CLI's stdout parser only recognises the `beamtalk-compile-*'
+protocol markers and silently drops every other line, so the message was
+being lost outright rather than merely unformatted.
+""".
+
+-export([format_errors/1]).
+
+-doc """
+Turn a `compile:forms/2' `{error, Errors, Warnings}' error list into a
+single human-readable binary, one line per underlying error, each
+carrying whatever identifying detail the originating lint pass reports
+(e.g. the unbound variable's name and the enclosing function/arity for
+`core_lint').
+""".
+-spec format_errors([{file:filename() | string() | binary(), [tuple()]}]) -> binary().
+format_errors(Errors) when is_list(Errors) ->
+    Lines = [
+        Text
+     || {File, ErrorInfos} <- Errors,
+        {_Loc, Text} <- sys_messages:format_messages(to_filename(File), "", ErrorInfos, [])
+    ],
+    unicode:characters_to_binary(Lines).
+
+%% sys_messages:format_messages/4 expects a string() file identifier;
+%% compile:forms/2's error tuples may carry it as a binary depending on
+%% how the module name/filename was set upstream.
+to_filename(File) when is_binary(File) -> unicode:characters_to_list(File);
+to_filename(File) -> File.

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -658,7 +658,7 @@ compile_core_erlang({cerl, Etf}) when is_binary(Etf) ->
     %% failure mode.
     try binary_to_term(Etf, [safe]) of
         CoreModule ->
-            compile_core_forms(CoreModule, [from_core, binary, return_errors])
+            compile_core_forms(CoreModule, [from_core, binary, return_errors, clint])
     catch
         error:badarg ->
             {error, {cerl_decode_error, unsafe_atoms_or_malformed_etf}}
@@ -670,7 +670,7 @@ compile_core_erlang(CoreErlangBin) when is_binary(CoreErlangBin) ->
             case core_parse:parse(Tokens) of
                 {ok, CoreModule} ->
                     compile_core_forms(
-                        CoreModule, [from_core, binary, return_errors]
+                        CoreModule, [from_core, binary, return_errors, clint]
                     );
                 {error, ParseError} ->
                     {error, {core_parse_error, ParseError}}
@@ -680,6 +680,13 @@ compile_core_erlang(CoreErlangBin) when is_binary(CoreErlangBin) ->
     end.
 
 %% Internal: shared `compile:forms/2' arm used by both wire shapes.
+%%
+%% BT-3115: `clint' is passed explicitly by both callers above for
+%% documentation purposes, but is a no-op today — see
+%% `beamtalk_compile_diagnostics' moduledoc for why `core_lint' already runs
+%% unconditionally on this `from_core' pipeline regardless of `clint'.
+%% `strong_validation'/`basic_validation' were evaluated and are NOT
+%% applicable: both skip code generation, which this path requires.
 compile_core_forms(CoreModule, Options) ->
     case compile:forms(CoreModule, Options) of
         {ok, ModuleName, Binary} ->
@@ -687,7 +694,11 @@ compile_core_forms(CoreModule, Options) ->
         {ok, ModuleName, Binary, _Warnings} ->
             {ok, ModuleName, Binary};
         {error, Errors, _Warnings} ->
-            {error, {core_compile_error, Errors}}
+            {error,
+                {core_compile_error, #{
+                    message => beamtalk_compile_diagnostics:format_errors(Errors),
+                    raw => Errors
+                }}}
     end.
 
 %%% gen_server callbacks

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_build_worker_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_build_worker_tests.erl
@@ -83,6 +83,24 @@ compile_core_erlang_compile_error_test() ->
     Result = beamtalk_build_worker:compile_core_erlang(CoreErlang),
     ?assertMatch({error, {core_compile_error, _}}, Result).
 
+%% BT-3115: Core Erlang that scans, parses, and passes compile:forms'
+%% earlier passes, but fails core_lint — 'State' is referenced in 'foo'/1
+%% without ever being bound. Demonstrates the failure is caught (core_lint
+%% already runs unconditionally on the from_core pipeline — see
+%% beamtalk_compile_diagnostics' moduledoc) *and* reported with the
+%% offending variable name, not a raw `~p` term dump.
+compile_core_erlang_unbound_var_test() ->
+    CoreErlang = unbound_var_core_erlang_source(),
+    Result = beamtalk_build_worker:compile_core_erlang(CoreErlang),
+    ?assertMatch({error, {core_compile_error, #{message := _, raw := _}}}, Result),
+    {error, {core_compile_error, #{message := Message}}} = Result,
+    ?assert(is_binary(Message)),
+    %% Readable prose, not the raw {unbound_var, 'State', {foo, 1}} term.
+    ?assertEqual(nomatch, binary:match(Message, <<"{unbound_var,">>)),
+    ?assertNotEqual(nomatch, binary:match(Message, <<"unbound variable">>)),
+    ?assertNotEqual(nomatch, binary:match(Message, <<"'State'">>)),
+    ?assertNotEqual(nomatch, binary:match(Message, <<"foo/1">>)).
+
 %% {cerl, Etf} path: cerl module that exports foo/0 but only defines bar/0.
 %% Covers the same compile_core_forms error arm via the ETF wire.
 compile_core_erlang_cerl_compile_error_test() ->
@@ -264,6 +282,20 @@ valid_core_erlang_source() ->
         "module 'test_build_worker_mod' ['hello'/0]\n"
         "  attributes []\n"
         "  'hello'/0 = fun () -> 'world'\n"
+        "end\n"
+    >>.
+
+%% BT-3115: Core Erlang whose 'foo'/1 references an unbound variable
+%% ('State' is never a parameter or let-bound) — a genuine core_lint
+%% unbound_var failure, the historical codegen failure mode this issue
+%% targets (docs/development/debugging.md § Codegen Debugging).
+unbound_var_core_erlang_source() ->
+    <<
+        "module 'bt_bw_unbound_var' ['foo'/1]\n"
+        "  attributes []\n"
+        "  'foo'/1 = fun (X) ->\n"
+        "    let Y = call 'erlang':'+' (X, State)\n"
+        "    in Y\n"
         "end\n"
     >>.
 

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compile_diagnostics_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compile_diagnostics_tests.erl
@@ -1,0 +1,45 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_compile_diagnostics_tests).
+
+-moduledoc """
+Tests for beamtalk_compile_diagnostics (BT-3115).
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% A synthetic core_lint unbound_var error, in the exact shape
+%% compile:forms/2 returns from its {error, Errors, Warnings} tuple.
+format_errors_unbound_var_test() ->
+    Errors = [{"my_module", [{none, core_lint, {unbound_var, 'State', {foo, 1}}}]}],
+    Formatted = beamtalk_compile_diagnostics:format_errors(Errors),
+    ?assert(is_binary(Formatted)),
+    ?assertEqual(nomatch, binary:match(Formatted, <<"{unbound_var,">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"unbound variable">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"'State'">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"foo/1">>)),
+    ?assertEqual(<<"my_module: unbound variable 'State' in foo/1\n">>, Formatted).
+
+%% Multiple errors across files/lines all render, one line each.
+format_errors_multiple_test() ->
+    Errors = [
+        {"mod_a", [{none, core_lint, {duplicate_var, 'I', {bar, 2}}}]},
+        {"mod_b", [{none, core_lint, {unbound_var, 'X', {baz, 0}}}]}
+    ],
+    Formatted = beamtalk_compile_diagnostics:format_errors(Errors),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"duplicate variable 'I' in bar/2">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"unbound variable 'X' in baz/0">>)).
+
+%% A binary file identifier (as some compile:forms/2 callers may produce)
+%% is accepted the same as a string one.
+format_errors_binary_file_test() ->
+    Errors = [{<<"my_module">>, [{none, core_lint, {unbound_var, 'Y', {qux, 3}}}]}],
+    Formatted = beamtalk_compile_diagnostics:format_errors(Errors),
+    ?assertNotEqual(
+        nomatch, binary:match(Formatted, <<"my_module: unbound variable 'Y' in qux/3">>)
+    ).
+
+%% Empty error list renders to an empty binary.
+format_errors_empty_test() ->
+    ?assertEqual(<<>>, beamtalk_compile_diagnostics:format_errors([])).

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
@@ -43,6 +43,24 @@ compile_core_erlang_empty_test() ->
     Result = beamtalk_compiler_server:compile_core_erlang(<<>>),
     ?assertMatch({error, _}, Result).
 
+%% BT-3115: 'State' is referenced in 'foo'/1 without ever being bound — a
+%% genuine core_lint unbound_var failure. core_lint already runs
+%% unconditionally on the from_core pipeline this call takes (see
+%% beamtalk_compile_diagnostics' moduledoc); this test demonstrates the
+%% failure surfaces as readable prose naming the offending variable, not a
+%% raw `~p` term dump — and that the Port backend (this module) matches the
+%% escript backend's report_errors-driven wording (both go through OTP's
+%% sys_messages formatter).
+compile_core_erlang_unbound_var_test() ->
+    Result = beamtalk_compiler_server:compile_core_erlang(unbound_var_core_erlang()),
+    ?assertMatch({error, {core_compile_error, #{message := _, raw := _}}}, Result),
+    {error, {core_compile_error, #{message := Message}}} = Result,
+    ?assert(is_binary(Message)),
+    ?assertEqual(nomatch, binary:match(Message, <<"{unbound_var,">>)),
+    ?assertNotEqual(nomatch, binary:match(Message, <<"unbound variable">>)),
+    ?assertNotEqual(nomatch, binary:match(Message, <<"'State'">>)),
+    ?assertNotEqual(nomatch, binary:match(Message, <<"foo/1">>)).
+
 %%% ---------------------------------------------------------------
 %%% handle_compile_response/1 — internal response handler
 %%% ---------------------------------------------------------------
@@ -586,5 +604,17 @@ valid_core_erlang() ->
         "module 'test_server_mod' ['hello'/0]\n"
         "  attributes []\n"
         "  'hello'/0 = fun () -> 'world'\n"
+        "end\n"
+    >>.
+
+%% BT-3115: 'foo'/1 references 'State', which is never a parameter or
+%% let-bound — a genuine core_lint unbound_var failure.
+unbound_var_core_erlang() ->
+    <<
+        "module 'bt_server_unbound_var' ['foo'/1]\n"
+        "  attributes []\n"
+        "  'foo'/1 = fun (X) ->\n"
+        "    let Y = call 'erlang':'+' (X, State)\n"
+        "    in Y\n"
         "end\n"
     >>.


### PR DESCRIPTION
## Summary

Resolves [BT-3115](https://linear.app/beamtalk/issue/BT-3115/run-core-lint-on-all-generated-core-erlang-in-devci-compile-paths).

**Finding (documented per the ticket's first task):** `core_lint` already runs **unconditionally** on every Beamtalk compile path today. `compile:forms`/`compile:file` with `from_core` always includes `core_lint_module` in `core_passes(non_verified_core)` (OTP `compiler-9.0.6/src/compile.erl`), completely independent of the `clint`/`clint0`/`no_lint` options — those only gate lint re-runs on the `verified_core` branch taken when compiling from Erlang *source*, a path Beamtalk never takes. Verified empirically against the pinned OTP 28.5. So detection was never the gap this ticket needed to close — **readability** was, and in one case (the escript backend), the diagnostic was being **lost outright**, not just poorly formatted:

- **Port backend** (`beamtalk_build_worker`/`beamtalk_compiler_server`): used `return_errors`, which hands back a raw `[{File,[{Loc,Mod,ErrDesc}]}]` term — errors were surfaced as a raw `~p` dump instead of readable prose naming the offending variable.
- **Escript backend** (`compile.escript`): used `report_errors`/`report_warnings`, which print via `io:fwrite` to the compiling process's *default group leader* — verified empirically (`erl -eval 'compile:file(...)' 1>out 2>err`) that this lands on **stdout**, not stderr. The Rust CLI's stdout parser (`read_compilation_output`) only recognizes the `beamtalk-compile-*` protocol markers and silently discards every other line, so the diagnostic never reached the user at all.

**Gating decision:** always-on, since it already is — core_lint is one pass over already-generated forms and cannot meaningfully be disabled on the `from_core` path without `no_lint` (never passed anywhere in this codebase). No env var or `just ci` wiring was needed.

## Changes

- Added `beamtalk_compile_diagnostics:format_errors/1` (new, `runtime/apps/beamtalk_compiler/src/`), shared by `beamtalk_build_worker` and `beamtalk_compiler_server` (the Port backend). Formats `compile:forms`' raw error terms via OTP's own `sys_messages:format_messages/4` — the exact function `report_errors` uses internally — so the wording is byte-for-byte identical to what OTP would have printed.
- Fixed `compile.escript`: switched from `report_errors`/`report_warnings` to `return_errors`/`return_warnings`, formatting via the same `sys_messages` function and printing explicitly to `standard_error` (where the Rust CLI's stderr-reading thread actually looks).
- Passed `clint` explicitly at all three call sites, documented as a no-op today (see above) but kept for defensiveness/documentation. Evaluated `strong_validation`/`basic_validation` — not applicable, since both skip code generation, which every one of these paths needs.
- No changes to codegen — detection-only, per the ticket's "What NOT to change."

## Test plan

- [x] New EUnit tests (`beamtalk_build_worker_tests`, `beamtalk_compiler_server_tests`, new `beamtalk_compile_diagnostics_tests`) compile a deliberately-malformed Core Erlang module (`foo/1` references an unbound `State`) and assert the failure surfaces with the variable name in readable prose, not a raw `{unbound_var, ...}` term.
- [x] New Rust test (`beam_compiler::tests::test_compile_batch_escript_core_lint_unbound_var`) exercises the same fixture through the escript backend directly, demonstrating both backends produce the same readable wording (surface parity).
- [x] `just test`, `just test-stdlib`, `just test-bunit`, `just test-repl-protocol` all green with linting on (linting was always on; these confirm no regression).
- [x] `just ci-changed` — full local lint/build/test/corpus/surface-drift pass.
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `rebar3 dialyzer` (0 warnings), erlfmt — all clean.
- [x] Pre-push hook (equivalent to CI) passed in full on `git push`.

## Follow-up

Filed [BT-3126](https://linear.app/beamtalk/issue/BT-3126) for a related-but-out-of-scope finding: the Port backend's `beamtalk_build_worker.erl` still uses `report_warnings` (the same stdout-swallowing pattern fixed here for errors), so successful-but-warning-producing compiles on that backend still lose their warnings. Fixing it requires changing `compile_core_erlang/1`'s public return arity, a larger change than this ticket's "detection-only" scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qnn9bSqtt93xwdMnNMK9TT)_