### PR TITLE
Refactor: consolidate the analyse_with_* wrapper family into a builder on AnalysisContext (BT-3114)

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -692,7 +692,8 @@ pub struct CompileContext<'a> {
     pub strict_deps: bool,
     /// Native type registry for FFI call inference during build (ADR 0075).
     ///
-    /// When set, semantic analysis uses [`beamtalk_core::semantic_analysis::analyse_with_natives`]
+    /// When set, semantic analysis threads it through
+    /// [`beamtalk_core::semantic_analysis::AnalysisContext::with_native_type_registry`]
     /// so that `Erlang <module> <function>:` calls get return type inference and
     /// argument type checking in build output, not just the LSP.
     pub native_type_registry: Option<std::sync::Arc<NativeTypeRegistry>>,

--- a/crates/beamtalk-cli/src/commands/build_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/build_stdlib.rs
@@ -2154,32 +2154,26 @@ mod tests {
             current_package: Some("not_stdlib".into()),
             ..options.clone()
         };
-        let result =
-            beamtalk_core::semantic_analysis::analyse_with_natives_and_protocols_and_aliases(
-                &module_b,
-                &mismatched,
-                vec![],
-                vec![],
-                pre_loaded_aliases.clone(),
-                None,
-                &extensions,
-            );
+        let result = beamtalk_core::semantic_analysis::analyse_full(
+            &module_b,
+            beamtalk_core::semantic_analysis::AnalysisContext::default()
+                .with_options(&mismatched)
+                .with_pre_loaded_aliases(pre_loaded_aliases.clone())
+                .with_cross_file_extensions(&extensions),
+        );
         assert!(
             !result.alias_registry.has_alias("Direction"),
             "a mismatched current_package must drop the internal stdlib alias \
              at the seeding boundary"
         );
 
-        let result =
-            beamtalk_core::semantic_analysis::analyse_with_natives_and_protocols_and_aliases(
-                &module_b,
-                &options,
-                vec![],
-                vec![],
-                pre_loaded_aliases,
-                None,
-                &extensions,
-            );
+        let result = beamtalk_core::semantic_analysis::analyse_full(
+            &module_b,
+            beamtalk_core::semantic_analysis::AnalysisContext::default()
+                .with_options(&options)
+                .with_pre_loaded_aliases(pre_loaded_aliases)
+                .with_cross_file_extensions(&extensions),
+        );
         assert!(
             result.alias_registry.has_alias("Direction"),
             "the matching \"stdlib\" current_package must seed the internal alias"
@@ -2283,16 +2277,13 @@ mod tests {
         let (module_b, _diags) = beamtalk_core::source_analysis::parse(tokens_b);
         let extensions = beamtalk_core::compilation::extension_index::ExtensionIndex::default();
 
-        let result =
-            beamtalk_core::semantic_analysis::analyse_with_natives_and_protocols_and_aliases(
-                &module_b,
-                &options,
-                vec![],
-                protocol_infos,
-                vec![],
-                None,
-                &extensions,
-            );
+        let result = beamtalk_core::semantic_analysis::analyse_full(
+            &module_b,
+            beamtalk_core::semantic_analysis::AnalysisContext::default()
+                .with_options(&options)
+                .with_pre_loaded_protocols(protocol_infos)
+                .with_cross_file_extensions(&extensions),
+        );
         assert!(
             result.protocol_registry.has_protocol("ProtocolFixtureA"),
             "expected pre_loaded_protocols to seed the cross-file protocol into \
@@ -2302,16 +2293,12 @@ mod tests {
         // Negative control: WITHOUT pre_loaded_protocols (the pre-BT-3034
         // gap), the cross-file protocol never gets registered — proving the
         // assertion above exercises the fix rather than a tautology.
-        let result_unfixed =
-            beamtalk_core::semantic_analysis::analyse_with_natives_and_protocols_and_aliases(
-                &module_b,
-                &options,
-                vec![],
-                vec![],
-                vec![],
-                None,
-                &extensions,
-            );
+        let result_unfixed = beamtalk_core::semantic_analysis::analyse_full(
+            &module_b,
+            beamtalk_core::semantic_analysis::AnalysisContext::default()
+                .with_options(&options)
+                .with_cross_file_extensions(&extensions),
+        );
         assert!(
             !result_unfixed
                 .protocol_registry

--- a/crates/beamtalk-cli/src/commands/lint.rs
+++ b/crates/beamtalk-cli/src/commands/lint.rs
@@ -84,16 +84,14 @@ fn collect_diagnostics(
         current_package: current_package.map(str::to_string),
         ..Default::default()
     };
-    let analysis_result =
-        beamtalk_core::semantic_analysis::analyse_with_natives_and_protocols_and_aliases(
-            module,
-            &options,
-            cross_file_classes,
-            pre_loaded_protocols,
-            pre_loaded_aliases,
-            native_type_registry,
-            cross_file_extensions,
-        );
+    let analysis_ctx = beamtalk_core::semantic_analysis::AnalysisContext::default()
+        .with_options(&options)
+        .with_pre_loaded_classes(cross_file_classes)
+        .with_pre_loaded_protocols(pre_loaded_protocols)
+        .with_pre_loaded_aliases(pre_loaded_aliases)
+        .with_native_type_registry(native_type_registry)
+        .with_cross_file_extensions(cross_file_extensions);
+    let analysis_result = beamtalk_core::semantic_analysis::analyse_full(module, analysis_ctx);
     lint_diags.extend(
         analysis_result
             .diagnostics
@@ -1168,8 +1166,8 @@ mod tests {
         // stage (`merge_dependency_infos`/`ResolvedDependency.alias_infos`
         // carry every declaration, filtered or not) — the seeding-boundary
         // exclusion happens downstream, inside `AliasRegistry::add_pre_loaded`
-        // when `collect_diagnostics` calls `analyse_with_natives_and_protocols_and_aliases`
-        // below. That exclusion logic itself is already covered by
+        // when `collect_diagnostics` calls `analyse_full` below. That
+        // exclusion logic itself is already covered by
         // `add_pre_loaded_never_seeds_internal_alias_from_different_package`
         // in `alias_registry.rs` (BT-2898); what this test proves is that the
         // wiring correctly delivers `is_internal`/`package` all the way from
@@ -1188,9 +1186,8 @@ mod tests {
         );
 
         // Directly exercise the seeding step `collect_diagnostics` performs
-        // internally (`AliasRegistry::add_pre_loaded`, via
-        // `analyse_with_natives_and_protocols_and_aliases`), rather than
-        // trying to observe the exclusion through a lint diagnostic: a `::
+        // internally (`AliasRegistry::add_pre_loaded`, via `analyse_full`),
+        // rather than trying to observe the exclusion through a lint diagnostic: a `::
         // Secret` annotation on its own produces no diagnostic either way —
         // `check_unresolved_type_aliases` (structural_validators.rs) is
         // deliberately scoped to near-miss *typos* of already-registered

--- a/crates/beamtalk-cli/src/commands/type_coverage.rs
+++ b/crates/beamtalk-cli/src/commands/type_coverage.rs
@@ -78,11 +78,11 @@ pub fn run(
     for (file, _source, module) in &parsed_files {
         let cross_file_classes = ClassHierarchy::cross_file_class_infos(&all_class_infos, module);
 
-        let analysis_result = beamtalk_core::semantic_analysis::analyse_with_options_and_classes(
-            module,
-            &beamtalk_core::CompilerOptions::default(),
-            cross_file_classes,
-        );
+        let default_options = beamtalk_core::CompilerOptions::default();
+        let analysis_ctx = beamtalk_core::semantic_analysis::AnalysisContext::default()
+            .with_options(&default_options)
+            .with_pre_loaded_classes(cross_file_classes);
+        let analysis_result = beamtalk_core::semantic_analysis::analyse_full(module, analysis_ctx);
 
         let type_map = infer_types(
             module,

--- a/crates/beamtalk-core/src/lib.rs
+++ b/crates/beamtalk-core/src/lib.rs
@@ -84,9 +84,9 @@ pub struct CompilerOptions {
 
     /// The package name of the module being compiled (ADR 0071, BT-1700).
     ///
-    /// Used by `analyse_with_packages` to set the `package` field on
-    /// `ClassInfo` entries built from AST source. `None` for REPL sessions
-    /// and contexts where no package is active.
+    /// Threaded into semantic analysis via `AnalysisContext::with_options` to
+    /// set the `package` field on `ClassInfo` entries built from AST source.
+    /// `None` for REPL sessions and contexts where no package is active.
     pub current_package: Option<String>,
 
     /// How complete the cross-file knowledge injected into analysis is

--- a/crates/beamtalk-core/src/queries/diagnostic_provider.rs
+++ b/crates/beamtalk-core/src/queries/diagnostic_provider.rs
@@ -109,19 +109,18 @@ pub fn compute_project_diagnostics(
 ) -> Vec<Diagnostic> {
     let mut diagnostics = initial_diagnostics;
 
-    // Run semantic analysis with the richest available entry point.
+    // Run semantic analysis with the richest available context.
     // BT-2928: thread `pre_loaded_aliases` through so a cross-file/package
     // type alias resolves the same way a cross-file class reference already
     // does — see `AnalysisContext::pre_loaded_aliases`'s doc.
-    let analysis_result = crate::semantic_analysis::analyse_with_natives_and_protocols_and_aliases(
-        module,
-        &ctx.options,
-        ctx.cross_file_classes.clone(),
-        ctx.pre_loaded_protocols.clone(),
-        ctx.pre_loaded_aliases.clone(),
-        ctx.native_type_registry.clone(),
-        &ctx.cross_file_extensions,
-    );
+    let analysis_ctx = crate::semantic_analysis::AnalysisContext::default()
+        .with_options(&ctx.options)
+        .with_pre_loaded_classes(ctx.cross_file_classes.clone())
+        .with_pre_loaded_protocols(ctx.pre_loaded_protocols.clone())
+        .with_pre_loaded_aliases(ctx.pre_loaded_aliases.clone())
+        .with_native_type_registry(ctx.native_type_registry.clone())
+        .with_cross_file_extensions(&ctx.cross_file_extensions);
+    let analysis_result = crate::semantic_analysis::analyse_full(module, analysis_ctx);
     diagnostics.extend(analysis_result.diagnostics);
 
     // BT-1732: Enrich unresolved class warnings with dependency package hints.
@@ -232,7 +231,10 @@ pub fn compute_diagnostics_with_known_vars(
     let mut all_diagnostics = parse_diagnostics;
 
     // Run semantic analysis with known variables
-    let analysis_result = semantic_analysis::analyse_with_known_vars(module, known_vars);
+    let analysis_result = semantic_analysis::analyse_full(
+        module,
+        semantic_analysis::AnalysisContext::default().with_known_vars(known_vars),
+    );
     all_diagnostics.extend(analysis_result.diagnostics);
 
     apply_expect_directives(module, &mut all_diagnostics);
@@ -256,8 +258,10 @@ pub fn compute_diagnostics_with_native_types(
 
     if native_types.is_some() {
         let options = crate::CompilerOptions::default();
-        let analysis_result =
-            crate::semantic_analysis::analyse_with_natives(module, &options, vec![], native_types);
+        let ctx = crate::semantic_analysis::AnalysisContext::default()
+            .with_options(&options)
+            .with_native_type_registry(native_types);
+        let analysis_result = crate::semantic_analysis::analyse_full(module, ctx);
         all_diagnostics.extend(analysis_result.diagnostics);
     } else {
         let analysis_result = crate::semantic_analysis::analyse(module);
@@ -314,11 +318,10 @@ pub fn compute_diagnostics_with_known_vars_and_classes(
     pre_loaded_classes: Vec<crate::semantic_analysis::class_hierarchy::ClassInfo>,
     diagnostics_overrides: &crate::compilation::diagnostics_policy::DiagnosticsTable,
 ) -> Vec<Diagnostic> {
-    let analysis_result = crate::semantic_analysis::analyse_with_known_vars_and_classes(
-        module,
-        known_vars,
-        pre_loaded_classes,
-    );
+    let ctx = crate::semantic_analysis::AnalysisContext::default()
+        .with_known_vars(known_vars)
+        .with_pre_loaded_classes(pre_loaded_classes);
+    let analysis_result = crate::semantic_analysis::analyse_full(module, ctx);
     run_diagnostic_pipeline(
         module,
         parse_diagnostics,
@@ -345,12 +348,11 @@ pub fn compute_diagnostics_with_known_vars_classes_and_aliases(
     pre_loaded_aliases: Vec<crate::semantic_analysis::AliasInfo>,
     diagnostics_overrides: &crate::compilation::diagnostics_policy::DiagnosticsTable,
 ) -> Vec<Diagnostic> {
-    let analysis_result = crate::semantic_analysis::analyse_with_known_vars_classes_and_aliases(
-        module,
-        known_vars,
-        pre_loaded_classes,
-        pre_loaded_aliases,
-    );
+    let ctx = crate::semantic_analysis::AnalysisContext::default()
+        .with_known_vars(known_vars)
+        .with_pre_loaded_classes(pre_loaded_classes)
+        .with_pre_loaded_aliases(pre_loaded_aliases);
+    let analysis_result = crate::semantic_analysis::analyse_full(module, ctx);
     run_diagnostic_pipeline(
         module,
         parse_diagnostics,
@@ -379,12 +381,11 @@ pub fn compute_diagnostics_and_referenced_aliases(
     pre_loaded_aliases: Vec<crate::semantic_analysis::AliasInfo>,
     diagnostics_overrides: &crate::compilation::diagnostics_policy::DiagnosticsTable,
 ) -> (Vec<Diagnostic>, Vec<EcoString>) {
-    let analysis_result = crate::semantic_analysis::analyse_with_known_vars_classes_and_aliases(
-        module,
-        known_vars,
-        pre_loaded_classes,
-        pre_loaded_aliases,
-    );
+    let ctx = crate::semantic_analysis::AnalysisContext::default()
+        .with_known_vars(known_vars)
+        .with_pre_loaded_classes(pre_loaded_classes)
+        .with_pre_loaded_aliases(pre_loaded_aliases);
+    let analysis_result = crate::semantic_analysis::analyse_full(module, ctx);
     let referenced_aliases = analysis_result.referenced_aliases;
     let diagnostics = run_diagnostic_pipeline(
         module,

--- a/crates/beamtalk-core/src/semantic_analysis/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/mod.rs
@@ -222,14 +222,17 @@ pub enum MutationKind {
     Field { name: EcoString },
 }
 
-/// Bundles the knobs threaded through `analyse_full` (BT-2804).
+/// Bundles the knobs threaded through [`analyse_full`], the single semantic
+/// analysis entry point (BT-3114, consolidating BT-2804's wrapper family).
 ///
-/// Every public `analyse_*` entry point builds one of these and passes it to
-/// `analyse_full` instead of threading positional parameters through ~6
-/// wrappers. Each field's `Default` reproduces today's most conservative
-/// behaviour (empty cross-file knowledge, `ModuleOnly` scope, no package
-/// context) — so a new entry point that forgets to set a field degrades
-/// safely (quietly loses precision) rather than silently misbehaving.
+/// Call sites build a context with the builder methods below —
+/// `AnalysisContext::default().with_known_vars(...).with_natives(...)` — and
+/// pass it to `analyse_full` instead of calling one of a dozen
+/// progressively-richer `analyse_with_*` free functions. Each field's
+/// `Default` reproduces today's most conservative behaviour (empty
+/// cross-file knowledge, `ModuleOnly` scope, no package context) — so a
+/// context that leaves a field unset degrades safely (quietly loses
+/// precision) rather than silently misbehaving.
 #[derive(Debug, Default)]
 pub struct AnalysisContext<'a> {
     /// Pre-defined variables treated as already bound (REPL context).
@@ -281,6 +284,102 @@ pub struct AnalysisContext<'a> {
     pub has_package_dependencies: bool,
 }
 
+impl<'a> AnalysisContext<'a> {
+    /// Pre-defined variables treated as already bound (REPL context).
+    ///
+    /// Prevents "Undefined variable" errors for REPL session variables.
+    #[must_use]
+    pub fn with_known_vars(mut self, known_vars: &'a [&'a str]) -> Self {
+        self.known_vars = known_vars;
+        self
+    }
+
+    /// Applies the subset of [`crate::CompilerOptions`] that semantic
+    /// analysis cares about: `stdlib_mode`, `skip_module_expression_lint`,
+    /// `current_package`, `knowledge_scope`, `has_package_dependencies`.
+    #[must_use]
+    pub fn with_options(mut self, options: &'a crate::CompilerOptions) -> Self {
+        self.stdlib_mode = options.stdlib_mode;
+        self.skip_module_expression_lint = options.skip_module_expression_lint;
+        self.current_package = options.current_package.as_deref();
+        self.knowledge_scope = options.knowledge_scope;
+        self.has_package_dependencies = options.has_package_dependencies;
+        self
+    }
+
+    /// Cross-file class metadata injected into the class hierarchy before
+    /// type checking (BT-1523, ADR 0050 Phase 4).
+    #[must_use]
+    pub fn with_pre_loaded_classes(
+        mut self,
+        pre_loaded_classes: Vec<class_hierarchy::ClassInfo>,
+    ) -> Self {
+        self.pre_loaded_classes = pre_loaded_classes;
+        self
+    }
+
+    /// Protocol definitions extracted from other source files, e.g. `BUnit`
+    /// fixtures (BT-2006).
+    #[must_use]
+    pub fn with_pre_loaded_protocols(
+        mut self,
+        pre_loaded_protocols: Vec<protocol_registry::ProtocolInfo>,
+    ) -> Self {
+        self.pre_loaded_protocols = pre_loaded_protocols;
+        self
+    }
+
+    /// Type alias definitions extracted from other source files/packages, or
+    /// carried over from earlier turns of the same REPL session — see the
+    /// `pre_loaded_aliases` field's own doc for the full semantics.
+    #[must_use]
+    pub fn with_pre_loaded_aliases(
+        mut self,
+        pre_loaded_aliases: Vec<alias_registry::AliasInfo>,
+    ) -> Self {
+        self.pre_loaded_aliases = pre_loaded_aliases;
+        self
+    }
+
+    /// Known package names for package-qualifier validation (ADR 0070 Phase
+    /// 2). Unknown package qualifiers produce compile errors.
+    #[allow(clippy::implicit_hasher)] // concrete HashSet is simpler for callers
+    #[must_use]
+    pub fn with_known_packages(
+        mut self,
+        known_packages: std::collections::HashSet<String>,
+    ) -> Self {
+        self.known_packages = Some(known_packages);
+        self
+    }
+
+    /// Native type registry for FFI call inference (ADR 0075). When `Some`,
+    /// FFI calls (`Erlang <module> <function>:`) get return type inference
+    /// and keyword mismatch warnings from the registry.
+    #[must_use]
+    pub fn with_native_type_registry(
+        mut self,
+        native_type_registry: Option<std::sync::Arc<type_checker::NativeTypeRegistry>>,
+    ) -> Self {
+        self.native_type_registry = native_type_registry;
+        self
+    }
+
+    /// Project-wide standalone extension definitions (BT-2795, ADR 0066), so
+    /// a cross-file `ClassName >> selector` extension resolves instead of
+    /// producing a false `Dnu` hint. May safely include the current file's
+    /// own entries — the current module's extensions are registered first
+    /// and duplicates are skipped.
+    #[must_use]
+    pub fn with_cross_file_extensions(
+        mut self,
+        cross_file_extensions: &'a crate::compilation::extension_index::ExtensionIndex,
+    ) -> Self {
+        self.cross_file_extensions = Some(cross_file_extensions);
+        self
+    }
+}
+
 /// Perform semantic analysis on a module.
 ///
 /// This is the main entry point for semantic analysis. It orchestrates the
@@ -308,272 +407,37 @@ pub fn analyse(module: &Module) -> AnalysisResult {
     analyse_full(module, AnalysisContext::default())
 }
 
-/// Analyse a module with pre-defined variables (for REPL context).
-///
-/// Variables passed in `known_vars` are treated as already defined,
-/// preventing "Undefined variable" errors for REPL session variables.
-///
-/// **DDD Context:** Semantic Analysis
-///
-/// This function orchestrates the `NameResolver`, `TypeChecker`, and block analysis
-/// services. Pre-defining known variables is essential for REPL contexts where
-/// users build up state incrementally across multiple evaluations.
-pub fn analyse_with_known_vars(module: &Module, known_vars: &[&str]) -> AnalysisResult {
-    analyse_full(
-        module,
-        AnalysisContext {
-            known_vars,
-            ..Default::default()
-        },
-    )
-}
-
-/// Analyse a module with compiler options controlling stdlib-specific behaviour.
-///
-/// When `stdlib_mode` is true, built-in classes are permitted to subclass sealed
-/// classes (BT-791). This should only be set when compiling stdlib sources.
-pub fn analyse_with_options(module: &Module, options: &crate::CompilerOptions) -> AnalysisResult {
-    analyse_full(
-        module,
-        AnalysisContext {
-            stdlib_mode: options.stdlib_mode,
-            skip_module_expression_lint: options.skip_module_expression_lint,
-            current_package: options.current_package.as_deref(),
-            knowledge_scope: options.knowledge_scope,
-            has_package_dependencies: options.has_package_dependencies,
-            ..Default::default()
-        },
-    )
-}
-
-/// Analyse a module with compiler options and pre-loaded class entries.
-///
-/// BT-1523: Used by the build pipeline to inject cross-file class metadata
-/// from Pass 1 into Pass 2's semantic analysis, enabling proper method
-/// resolution across files.
-pub fn analyse_with_options_and_classes(
-    module: &Module,
-    options: &crate::CompilerOptions,
-    pre_loaded_classes: Vec<class_hierarchy::ClassInfo>,
-) -> AnalysisResult {
-    analyse_full(
-        module,
-        AnalysisContext {
-            stdlib_mode: options.stdlib_mode,
-            skip_module_expression_lint: options.skip_module_expression_lint,
-            pre_loaded_classes,
-            current_package: options.current_package.as_deref(),
-            knowledge_scope: options.knowledge_scope,
-            has_package_dependencies: options.has_package_dependencies,
-            ..Default::default()
-        },
-    )
-}
-
-/// Analyse a module with compiler options, pre-loaded classes, and native type registry.
-///
-/// ADR 0075: When `native_type_registry` is `Some`, FFI calls (`Erlang <module> <function>:`)
-/// get return type inference and keyword mismatch warnings from the registry.
-///
-/// This is the build-pipeline entry point for Phase 1 typed FFI.
-pub fn analyse_with_natives(
-    module: &Module,
-    options: &crate::CompilerOptions,
-    pre_loaded_classes: Vec<class_hierarchy::ClassInfo>,
-    native_type_registry: Option<std::sync::Arc<type_checker::NativeTypeRegistry>>,
-) -> AnalysisResult {
-    analyse_full(
-        module,
-        AnalysisContext {
-            stdlib_mode: options.stdlib_mode,
-            skip_module_expression_lint: options.skip_module_expression_lint,
-            pre_loaded_classes,
-            current_package: options.current_package.as_deref(),
-            native_type_registry,
-            knowledge_scope: options.knowledge_scope,
-            has_package_dependencies: options.has_package_dependencies,
-            ..Default::default()
-        },
-    )
-}
-
-/// Analyse a module with compiler options, pre-loaded classes, a native type
-/// registry, and project-wide cross-file extensions (BT-2795, ADR 0066).
-///
-/// `cross_file_extensions` carries standalone extension definitions
-/// (`ClassName >> selector => ...`) collected from the rest of the project,
-/// so a cross-file extension resolves instead of producing a false `Dnu`
-/// hint. It may safely include the current file's own entries — the current
-/// module's extensions are registered first and duplicates are skipped.
-pub fn analyse_with_natives_and_extensions(
-    module: &Module,
-    options: &crate::CompilerOptions,
-    pre_loaded_classes: Vec<class_hierarchy::ClassInfo>,
-    native_type_registry: Option<std::sync::Arc<type_checker::NativeTypeRegistry>>,
-    cross_file_extensions: &crate::compilation::extension_index::ExtensionIndex,
-) -> AnalysisResult {
-    analyse_full(
-        module,
-        AnalysisContext {
-            stdlib_mode: options.stdlib_mode,
-            skip_module_expression_lint: options.skip_module_expression_lint,
-            pre_loaded_classes,
-            current_package: options.current_package.as_deref(),
-            native_type_registry,
-            knowledge_scope: options.knowledge_scope,
-            cross_file_extensions: Some(cross_file_extensions),
-            has_package_dependencies: options.has_package_dependencies,
-            ..Default::default()
-        },
-    )
-}
-
-/// Analyse a module with compiler options, pre-loaded classes, pre-loaded
-/// protocols, and native type registry.
-///
-/// BT-2006: Mirrors `analyse_with_natives` but also accepts protocol
-/// definitions extracted from other source files (e.g. `BUnit` fixtures) so
-/// the unresolved-class validator and type checker recognise fixture-only
-/// protocol names when analysing a downstream module.
-pub fn analyse_with_natives_and_protocols(
-    module: &Module,
-    options: &crate::CompilerOptions,
-    pre_loaded_classes: Vec<class_hierarchy::ClassInfo>,
-    pre_loaded_protocols: Vec<protocol_registry::ProtocolInfo>,
-    native_type_registry: Option<std::sync::Arc<type_checker::NativeTypeRegistry>>,
-    cross_file_extensions: &crate::compilation::extension_index::ExtensionIndex,
-) -> AnalysisResult {
-    analyse_full(
-        module,
-        AnalysisContext {
-            stdlib_mode: options.stdlib_mode,
-            skip_module_expression_lint: options.skip_module_expression_lint,
-            pre_loaded_classes,
-            pre_loaded_protocols,
-            current_package: options.current_package.as_deref(),
-            native_type_registry,
-            knowledge_scope: options.knowledge_scope,
-            cross_file_extensions: Some(cross_file_extensions),
-            has_package_dependencies: options.has_package_dependencies,
-            ..Default::default()
-        },
-    )
-}
-
-/// Analyse a module with compiler options, pre-loaded classes, pre-loaded
-/// protocols, pre-loaded type aliases, and native type registry.
-///
-/// BT-2898: Mirrors `analyse_with_natives_and_protocols` but also accepts
-/// alias definitions extracted from other source files or packages (ADR 0108
-/// Phase 5) so the alias registry recognises fixture/dependency-only alias
-/// names when analysing a downstream module.
-#[allow(clippy::too_many_arguments)]
-pub fn analyse_with_natives_and_protocols_and_aliases(
-    module: &Module,
-    options: &crate::CompilerOptions,
-    pre_loaded_classes: Vec<class_hierarchy::ClassInfo>,
-    pre_loaded_protocols: Vec<protocol_registry::ProtocolInfo>,
-    pre_loaded_aliases: Vec<alias_registry::AliasInfo>,
-    native_type_registry: Option<std::sync::Arc<type_checker::NativeTypeRegistry>>,
-    cross_file_extensions: &crate::compilation::extension_index::ExtensionIndex,
-) -> AnalysisResult {
-    analyse_full(
-        module,
-        AnalysisContext {
-            stdlib_mode: options.stdlib_mode,
-            skip_module_expression_lint: options.skip_module_expression_lint,
-            pre_loaded_classes,
-            pre_loaded_protocols,
-            pre_loaded_aliases,
-            current_package: options.current_package.as_deref(),
-            native_type_registry,
-            knowledge_scope: options.knowledge_scope,
-            cross_file_extensions: Some(cross_file_extensions),
-            has_package_dependencies: options.has_package_dependencies,
-            ..Default::default()
-        },
-    )
-}
-
-/// Analyse a module with pre-defined variables and pre-loaded class entries
-/// from BEAM metadata (ADR 0050 Phase 4).
-///
-/// `pre_loaded_classes` are injected into the `ClassHierarchy` *before*
-/// `TypeChecking`, so user-defined REPL classes are visible to the `TypeChecker`.
-pub fn analyse_with_known_vars_and_classes(
-    module: &Module,
-    known_vars: &[&str],
-    pre_loaded_classes: Vec<class_hierarchy::ClassInfo>,
-) -> AnalysisResult {
-    analyse_full(
-        module,
-        AnalysisContext {
-            known_vars,
-            pre_loaded_classes,
-            ..Default::default()
-        },
-    )
-}
-
-/// Analyse a module with pre-defined variables, pre-loaded class entries,
-/// and pre-loaded type aliases from earlier REPL turns (ADR 0108 Phase 8,
-/// BT-2902).
-///
-/// Mirrors [`analyse_with_known_vars_and_classes`] — see its doc — with one
-/// addition: `pre_loaded_aliases` makes alias names declared in *earlier*
-/// turns of the same REPL session resolvable in the current turn's `::`
-/// annotations (`resolve_type_annotation`'s `subst → alias table → nominal
-/// class` order, ADR 0108 Semantics).
-pub fn analyse_with_known_vars_classes_and_aliases(
-    module: &Module,
-    known_vars: &[&str],
-    pre_loaded_classes: Vec<class_hierarchy::ClassInfo>,
-    pre_loaded_aliases: Vec<alias_registry::AliasInfo>,
-) -> AnalysisResult {
-    analyse_full(
-        module,
-        AnalysisContext {
-            known_vars,
-            pre_loaded_classes,
-            pre_loaded_aliases,
-            ..Default::default()
-        },
-    )
-}
-
-/// Analyse a module with known package dependencies (ADR 0070 Phase 2).
-///
-/// Package qualifiers in class references and extension targets are validated
-/// against the provided set of known package names. Unknown package qualifiers
-/// produce compile errors.
-#[allow(clippy::implicit_hasher)] // concrete HashSet is simpler for callers
-pub fn analyse_with_packages(
-    module: &Module,
-    options: &crate::CompilerOptions,
-    pre_loaded_classes: Vec<class_hierarchy::ClassInfo>,
-    known_packages: std::collections::HashSet<String>,
-) -> AnalysisResult {
-    analyse_full(
-        module,
-        AnalysisContext {
-            stdlib_mode: options.stdlib_mode,
-            skip_module_expression_lint: options.skip_module_expression_lint,
-            pre_loaded_classes,
-            known_packages: Some(known_packages),
-            current_package: options.current_package.as_deref(),
-            knowledge_scope: options.knowledge_scope,
-            has_package_dependencies: options.has_package_dependencies,
-            ..Default::default()
-        },
-    )
-}
-
-/// Internal: full analysis with all knobs, bundled into `ctx` (BT-2804).
+/// Perform semantic analysis on a module with a fully-populated
+/// [`AnalysisContext`] (BT-3114, the single entry point that replaces the
+/// former `analyse_with_*` wrapper family — REPL known-vars, compiler
+/// options, cross-file classes/protocols/aliases, native FFI types,
+/// cross-file extensions, and package-qualifier validation all thread
+/// through `ctx`, built via its `with_*` builder methods).
 ///
 /// ADR 0075: When `ctx.native_type_registry` is `Some`, FFI calls (`Erlang <module> <function>:`)
 /// get return type inference and keyword mismatch warnings from the registry.
+///
+/// # Panics
+///
+/// Never panics in practice: `ClassHierarchy::build_with_options` is
+/// documented infallible and its `Result` is unwrapped internally with an
+/// `.expect()` that exists only to surface a contract violation loudly
+/// rather than silently, should that documented invariant ever break.
+///
+/// # Examples
+///
+/// ```
+/// # use beamtalk_core::semantic_analysis::{analyse_full, AnalysisContext};
+/// # use beamtalk_core::ast::Module;
+/// # use beamtalk_core::source_analysis::Span;
+/// let module = Module::new(vec![], Span::default());
+/// let known_vars = ["x"];
+/// let ctx = AnalysisContext::default().with_known_vars(&known_vars);
+/// let result = analyse_full(&module, ctx);
+/// assert_eq!(result.diagnostics.len(), 0);
+/// ```
 #[allow(clippy::too_many_lines)] // orchestration function — one call per analysis phase
-fn analyse_full(module: &Module, ctx: AnalysisContext<'_>) -> AnalysisResult {
+pub fn analyse_full(module: &Module, ctx: AnalysisContext<'_>) -> AnalysisResult {
     let AnalysisContext {
         known_vars,
         stdlib_mode,

--- a/crates/beamtalk-core/src/semantic_analysis/property_tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/property_tests.rs
@@ -7,7 +7,7 @@
 //! arbitrary parsed AST, and that diagnostics have valid spans:
 //!
 //! 1. **`analyse` never panics** — any parsed module can be analysed
-//! 2. **`analyse_with_known_vars` never panics** — REPL context analysis is safe
+//! 2. **`analyse_full` with known vars never panics** — REPL context analysis is safe
 //! 3. **Semantic diagnostic spans within input** — all span bounds are valid
 //! 4. **Class hierarchy never panics** — building hierarchy from any AST is safe
 //! 5. **Type inference never panics** — type checking any parsed AST is safe
@@ -20,7 +20,7 @@ use proptest::prelude::*;
 
 use crate::source_analysis::{lex_with_eof, parse};
 
-use super::{ClassHierarchy, analyse, analyse_with_known_vars, infer_types};
+use super::{AnalysisContext, ClassHierarchy, analyse, analyse_full, infer_types};
 
 // ============================================================================
 // Generators
@@ -126,7 +126,7 @@ proptest! {
         let _result = analyse(&module);
     }
 
-    /// Property 2: `analyse_with_known_vars` never panics.
+    /// Property 2: `analyse_full` with known vars never panics.
     ///
     /// REPL-style analysis with pre-defined variables must be safe.
     #[test]
@@ -136,7 +136,7 @@ proptest! {
     ) {
         let (module, _) = parse_source(&input);
         let var_refs: Vec<&str> = vars.iter().map(String::as_str).collect();
-        let _result = analyse_with_known_vars(&module, &var_refs);
+        let _result = analyse_full(&module, AnalysisContext::default().with_known_vars(&var_refs));
     }
 
     /// Property 3: Semantic diagnostic spans are within input bounds.

--- a/crates/beamtalk-core/src/semantic_analysis/tests.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/tests.rs
@@ -1139,7 +1139,11 @@ fn test_analyse_with_known_vars_suppresses_undefined() {
     );
 
     // With 'x' in known vars - should NOT report undefined
-    let result_with = analyse_with_known_vars(&module, &["x"]);
+    let known_vars = ["x"];
+    let result_with = analyse_full(
+        &module,
+        AnalysisContext::default().with_known_vars(&known_vars),
+    );
     assert!(
         !result_with
             .diagnostics
@@ -1169,7 +1173,11 @@ fn test_analyse_with_known_vars_handles_reassignment() {
     let module = Module::new(vec![bare(expr)], test_span());
 
     // With 'x' known, the RHS reference should not report undefined
-    let result = analyse_with_known_vars(&module, &["x"]);
+    let known_vars = ["x"];
+    let result = analyse_full(
+        &module,
+        AnalysisContext::default().with_known_vars(&known_vars),
+    );
     assert!(
         !result
             .diagnostics
@@ -1348,7 +1356,11 @@ fn test_responds_to_with_symbol_no_diagnostic() {
     };
 
     let module = Module::new(vec![bare(expr)], test_span());
-    let result = analyse_with_known_vars(&module, &["counter"]);
+    let known_vars = ["counter"];
+    let result = analyse_full(
+        &module,
+        AnalysisContext::default().with_known_vars(&known_vars),
+    );
 
     // No symbol-related diagnostics
     assert!(
@@ -1382,7 +1394,11 @@ fn test_responds_to_with_identifier_no_error() {
     };
 
     let module = Module::new(vec![bare(expr)], test_span());
-    let result = analyse_with_known_vars(&module, &["counter", "sel"]);
+    let known_vars = ["counter", "sel"];
+    let result = analyse_full(
+        &module,
+        AnalysisContext::default().with_known_vars(&known_vars),
+    );
 
     let symbol_errors: Vec<_> = result
         .diagnostics
@@ -1459,7 +1475,11 @@ fn test_inst_var_at_with_integer_emits_error() {
     };
 
     let module = Module::new(vec![bare(expr)], test_span());
-    let result = analyse_with_known_vars(&module, &["obj"]);
+    let known_vars = ["obj"];
+    let result = analyse_full(
+        &module,
+        AnalysisContext::default().with_known_vars(&known_vars),
+    );
 
     let symbol_errors: Vec<_> = result
         .diagnostics
@@ -1498,7 +1518,11 @@ fn test_non_reflection_method_no_validation() {
     };
 
     let module = Module::new(vec![bare(expr)], test_span());
-    let result = analyse_with_known_vars(&module, &["obj"]);
+    let known_vars = ["obj"];
+    let result = analyse_full(
+        &module,
+        AnalysisContext::default().with_known_vars(&known_vars),
+    );
 
     assert!(
         !result
@@ -1540,7 +1564,11 @@ fn test_cascade_responds_to_with_identifier_no_error() {
     };
 
     let module = Module::new(vec![bare(cascade)], test_span());
-    let result = analyse_with_known_vars(&module, &["counter", "sel"]);
+    let known_vars = ["counter", "sel"];
+    let result = analyse_full(
+        &module,
+        AnalysisContext::default().with_known_vars(&known_vars),
+    );
 
     let symbol_errors: Vec<_> = result
         .diagnostics
@@ -3936,7 +3964,10 @@ fn analyse_with_known_vars_and_classes_injects_user_class_into_hierarchy() {
     let src = "42.";
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _parse_diags) = crate::source_analysis::parse(tokens);
-    let result = analyse_with_known_vars_and_classes(&module, &[], vec![pre_class]);
+    let result = analyse_full(
+        &module,
+        AnalysisContext::default().with_pre_loaded_classes(vec![pre_class]),
+    );
     assert!(
         result.class_hierarchy.has_class("UserClass"),
         "UserClass should be visible in the hierarchy after injection"
@@ -3948,8 +3979,11 @@ fn analyse_with_known_vars_and_classes_empty_is_equivalent_to_base() {
     let src = "1 + 2.";
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _parse_diags) = crate::source_analysis::parse(tokens);
-    let result_base = analyse_with_known_vars(&module, &[]);
-    let result_new = analyse_with_known_vars_and_classes(&module, &[], vec![]);
+    let result_base = analyse(&module);
+    let result_new = analyse_full(
+        &module,
+        AnalysisContext::default().with_pre_loaded_classes(vec![]),
+    );
     // Same number of diagnostics (both should be empty for valid source)
     assert_eq!(result_base.diagnostics.len(), result_new.diagnostics.len());
 }
@@ -4192,7 +4226,7 @@ fn extension_method_suppresses_dnu_in_analyse_pipeline() {
     ";
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _parse_diags) = crate::source_analysis::parse(tokens);
-    let result = analyse_with_known_vars(&module, &[]);
+    let result = analyse(&module);
     let dnu: Vec<_> = result
         .diagnostics
         .iter()
@@ -4214,7 +4248,7 @@ fn extension_method_return_type_flows_through_pipeline() {
     "#;
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _parse_diags) = crate::source_analysis::parse(tokens);
-    let result = analyse_with_known_vars(&module, &[]);
+    let result = analyse(&module);
     let dnu: Vec<_> = result
         .diagnostics
         .iter()
@@ -4236,7 +4270,7 @@ fn extension_method_unannotated_no_false_errors() {
     ";
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _parse_diags) = crate::source_analysis::parse(tokens);
-    let result = analyse_with_known_vars(&module, &[]);
+    let result = analyse(&module);
     let dnu: Vec<_> = result
         .diagnostics
         .iter()
@@ -4257,7 +4291,7 @@ fn missing_method_still_warns_with_extensions() {
     ";
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _parse_diags) = crate::source_analysis::parse(tokens);
-    let result = analyse_with_known_vars(&module, &[]);
+    let result = analyse(&module);
     let dnu: Vec<_> = result
         .diagnostics
         .iter()
@@ -4282,7 +4316,7 @@ fn extension_double_colon_return_type_flows_through_pipeline() {
     ";
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _parse_diags) = crate::source_analysis::parse(tokens);
-    let result = analyse_with_known_vars(&module, &[]);
+    let result = analyse(&module);
     let dnu: Vec<_> = result
         .diagnostics
         .iter()
@@ -4304,7 +4338,7 @@ fn class_side_extension_suppresses_dnu_in_pipeline() {
     "#;
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _parse_diags) = crate::source_analysis::parse(tokens);
-    let result = analyse_with_known_vars(&module, &[]);
+    let result = analyse(&module);
     let dnu: Vec<_> = result
         .diagnostics
         .iter()
@@ -4352,7 +4386,13 @@ fn workspace_binding_shadowing_class_emits_warning() {
     let (module, _parse_diags) = crate::source_analysis::parse(tokens);
 
     // Analyse with "Workspace" as both a known_var and a pre-loaded class.
-    let result = analyse_with_known_vars_and_classes(&module, &["Workspace"], vec![pre_class]);
+    let known_vars = ["Workspace"];
+    let result = analyse_full(
+        &module,
+        AnalysisContext::default()
+            .with_known_vars(&known_vars)
+            .with_pre_loaded_classes(vec![pre_class]),
+    );
 
     let shadow_warnings: Vec<_> = result
         .diagnostics
@@ -4408,7 +4448,13 @@ fn workspace_binding_not_in_hierarchy_no_shadow_warning() {
         superclass_type_args: vec![],
     };
 
-    let result = analyse_with_known_vars_and_classes(&module, &["myCustomVar"], vec![dummy_class]);
+    let known_vars = ["myCustomVar"];
+    let result = analyse_full(
+        &module,
+        AnalysisContext::default()
+            .with_known_vars(&known_vars)
+            .with_pre_loaded_classes(vec![dummy_class]),
+    );
 
     let shadow_warnings: Vec<_> = result
         .diagnostics
@@ -4477,14 +4523,17 @@ fn fixture_sourced_protocol_name_is_not_unresolved() {
     };
 
     let options = crate::CompilerOptions::default();
-    let result = analyse_with_natives_and_protocols(
-        &module,
-        &options,
-        vec![dummy_class],
-        vec![fixture_protocol],
-        None,
-        &crate::compilation::extension_index::ExtensionIndex::new(),
-    );
+    let result =
+        analyse_full(
+            &module,
+            AnalysisContext::default()
+                .with_options(&options)
+                .with_pre_loaded_classes(vec![dummy_class])
+                .with_pre_loaded_protocols(vec![fixture_protocol])
+                .with_cross_file_extensions(
+                    &crate::compilation::extension_index::ExtensionIndex::new(),
+                ),
+        );
 
     let unresolved: Vec<_> = result
         .diagnostics
@@ -4548,15 +4597,20 @@ fn pre_loaded_alias_is_seeded_and_current_module_wins() {
         current_package: Some("app".to_string()),
         ..Default::default()
     };
-    let result = analyse_with_natives_and_protocols_and_aliases(
-        &module,
-        &options,
-        vec![],
-        vec![],
-        vec![cross_file_alias, shadowed_alias, foreign_internal_alias],
-        None,
-        &crate::compilation::extension_index::ExtensionIndex::new(),
-    );
+    let result =
+        analyse_full(
+            &module,
+            AnalysisContext::default()
+                .with_options(&options)
+                .with_pre_loaded_aliases(vec![
+                    cross_file_alias,
+                    shadowed_alias,
+                    foreign_internal_alias,
+                ])
+                .with_cross_file_extensions(
+                    &crate::compilation::extension_index::ExtensionIndex::new(),
+                ),
+        );
 
     assert!(
         result
@@ -4613,15 +4667,16 @@ fn pre_loaded_internal_alias_from_same_package_is_still_seeded() {
         current_package: Some("json".to_string()),
         ..Default::default()
     };
-    let result = analyse_with_natives_and_protocols_and_aliases(
-        &module,
-        &options,
-        vec![],
-        vec![],
-        vec![same_package_internal_alias],
-        None,
-        &crate::compilation::extension_index::ExtensionIndex::new(),
-    );
+    let result =
+        analyse_full(
+            &module,
+            AnalysisContext::default()
+                .with_options(&options)
+                .with_pre_loaded_aliases(vec![same_package_internal_alias])
+                .with_cross_file_extensions(
+                    &crate::compilation::extension_index::ExtensionIndex::new(),
+                ),
+        );
 
     assert!(
         result.alias_registry.has_alias("ParserState"),
@@ -4679,15 +4734,16 @@ fn referenced_aliases_records_a_seeded_cross_package_alias_and_excludes_a_foreig
         current_package: Some("app".to_string()),
         ..Default::default()
     };
-    let result = analyse_with_natives_and_protocols_and_aliases(
-        &module,
-        &options,
-        vec![],
-        vec![],
-        vec![public_dependency_alias, foreign_internal_alias],
-        None,
-        &crate::compilation::extension_index::ExtensionIndex::new(),
-    );
+    let result =
+        analyse_full(
+            &module,
+            AnalysisContext::default()
+                .with_options(&options)
+                .with_pre_loaded_aliases(vec![public_dependency_alias, foreign_internal_alias])
+                .with_cross_file_extensions(
+                    &crate::compilation::extension_index::ExtensionIndex::new(),
+                ),
+        );
 
     // (a) The public dependency alias is seeded and, once referenced by
     // `TimeoutUser`'s parameter, recorded as a dependency edge — exactly
@@ -4748,7 +4804,7 @@ fn protocol_method_signature_records_referenced_aliases() {
 }
 
 // BT-2898: end-to-end wiring check — the E0402 alias-leak checks (Phase 8)
-// must fire through the full `analyse_with_options` pipeline, not just when
+// must fire through the full `analyse_full` pipeline, not just when
 // the validator functions are called directly in `visibility_validators.rs`.
 #[test]
 fn analyse_full_pipeline_reports_internal_alias_leaked_in_public_signature() {
@@ -4761,7 +4817,7 @@ fn analyse_full_pipeline_reports_internal_alias_leaked_in_public_signature() {
         current_package: Some("json".to_string()),
         ..Default::default()
     };
-    let result = analyse_with_options(&module, &options);
+    let result = analyse_full(&module, AnalysisContext::default().with_options(&options));
 
     assert!(
         result
@@ -4879,7 +4935,7 @@ fn analyse_with_options_stamps_project_complete_scope() {
         knowledge_scope: KnowledgeScope::ProjectComplete,
         ..Default::default()
     };
-    let result = analyse_with_options(&module, &options);
+    let result = analyse_full(&module, AnalysisContext::default().with_options(&options));
     assert_eq!(
         result.class_hierarchy.knowledge_scope(),
         KnowledgeScope::ProjectComplete,
@@ -4916,12 +4972,11 @@ fn cross_file_extension_resolves_instead_of_dnu_hint() {
 
     // With the index: the extension resolves, the hint disappears.
     let options = crate::CompilerOptions::default();
-    let result = analyse_with_natives_and_extensions(
+    let result = analyse_full(
         &module,
-        &options,
-        vec![],
-        None,
-        &cross_file_extensions,
+        AnalysisContext::default()
+            .with_options(&options)
+            .with_cross_file_extensions(&cross_file_extensions),
     );
     let dnu: Vec<_> = result
         .diagnostics
@@ -4949,12 +5004,11 @@ fn genuinely_unresolved_selector_still_hints_with_extensions_registered() {
     let tokens = crate::source_analysis::lex_with_eof(source);
     let (module, _) = crate::source_analysis::parse(tokens);
     let options = crate::CompilerOptions::default();
-    let result = analyse_with_natives_and_extensions(
+    let result = analyse_full(
         &module,
-        &options,
-        vec![],
-        None,
-        &cross_file_extensions,
+        AnalysisContext::default()
+            .with_options(&options)
+            .with_cross_file_extensions(&cross_file_extensions),
     );
     assert!(
         result
@@ -4980,7 +5034,7 @@ fn typo_hints_in_project_complete_dependency_free_package() {
         has_package_dependencies: false,
         ..Default::default()
     };
-    let result = analyse_with_options(&module, &options);
+    let result = analyse_full(&module, AnalysisContext::default().with_options(&options));
     assert!(
         result
             .diagnostics
@@ -5004,7 +5058,7 @@ fn dependency_package_suppresses_unresolved_selector_hints_pre_ws3() {
         has_package_dependencies: true,
         ..Default::default()
     };
-    let result = analyse_with_options(&module, &options);
+    let result = analyse_full(&module, AnalysisContext::default().with_options(&options));
     let dnu: Vec<_> = result
         .diagnostics
         .iter()

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/destructure_and_extension.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/destructure_and_extension.rs
@@ -401,10 +401,10 @@ Base subclass: Child
     };
 
     // Use the full analysis pipeline (same as the build command)
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
+    let result = crate::semantic_analysis::analyse_full(
         &module,
-        &crate::CompilerOptions::default(),
-        vec![base_info],
+        crate::semantic_analysis::AnalysisContext::default()
+            .with_pre_loaded_classes(vec![base_info]),
     );
     let dnu_warnings: Vec<_> = result
         .diagnostics

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/local_annotations.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/local_annotations.rs
@@ -260,11 +260,7 @@ Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     // Filter by DiagnosticCategory::Type so argument-type warnings
     // (formatted as "Argument ... expects ... got ...") are caught too,
     // not only assignment-style "Type mismatch" messages.
@@ -294,11 +290,7 @@ Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -331,11 +323,7 @@ Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_post_guard.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/narrowing_post_guard.rs
@@ -26,11 +26,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -61,11 +57,7 @@ typed Actor subclass: Engine
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -95,11 +87,7 @@ typed Actor subclass: Engine
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -129,11 +117,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     // The negative case must produce the specific argument-mismatch
     // diagnostic at the `process:` call site: `ms` should still be
     // `Integer | Nil` because the `ifTrue: [42]` block does not
@@ -193,11 +177,7 @@ typed Actor subclass: Engine
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -231,11 +211,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -267,11 +243,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     // Because the ifFalse: block reassigns `ms` to nil, we must still warn
     // on the `process:` call — otherwise we'd be unsound.
     //
@@ -329,11 +301,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -370,11 +338,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -407,11 +371,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -446,11 +406,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -481,11 +437,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -515,11 +467,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let mismatch_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -560,11 +508,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let mismatch_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -605,11 +549,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/never_divergence.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/never_divergence.rs
@@ -34,11 +34,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -68,11 +64,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -103,11 +95,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -137,11 +125,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     let type_warnings: Vec<_> = result
         .diagnostics
         .iter()
@@ -177,11 +161,7 @@ typed Object subclass: Caller
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     // The `ifTrue:` branch constructs a block that *would* diverge if run,
     // but the outer branch doesn't execute it — control falls through to
     // `Receiver process: ms` with `ms` still `Integer | Nil`, so the

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_display_provenance.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_display_provenance.rs
@@ -17,20 +17,16 @@
 //! `check_argument_types`) — see the tests below asserting a valid alias
 //! member is no longer flagged, and an invalid one still is.
 
-/// Parses `source` and runs the full `analyse_with_options_and_classes`
-/// pipeline (alias registration + `check_module_with_protocols_and_aliases`,
-/// exactly as a real compile would — see `type_alias_exhaustiveness.rs`'s
-/// identical helper), returning every diagnostic.
+/// Parses `source` and runs the full semantic-analysis pipeline (alias
+/// registration + `check_module_with_protocols_and_aliases`, exactly as a
+/// real compile would — see `type_alias_exhaustiveness.rs`'s identical
+/// helper), returning every diagnostic.
 fn analyse_diagnostics(source: &str) -> Vec<crate::source_analysis::Diagnostic> {
     let tokens = crate::source_analysis::lex_with_eof(source);
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     result.diagnostics
 }
 

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_exhaustiveness.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/tests/type_alias_exhaustiveness.rs
@@ -19,20 +19,16 @@ use super::common::*;
 
 use crate::source_analysis::Severity;
 
-/// Parses `source`, runs the full `analyse_with_options_and_classes`
-/// pipeline (so `type` declarations get registered into an `AliasRegistry`
-/// exactly as they would for a real compile — see `semantic_analysis::mod`'s
-/// `analyse_full`), and returns every diagnostic.
+/// Parses `source`, runs the full semantic-analysis pipeline (so `type`
+/// declarations get registered into an `AliasRegistry` exactly as they would
+/// for a real compile — see `semantic_analysis::mod`'s `analyse_full`), and
+/// returns every diagnostic.
 fn analyse_diagnostics(source: &str) -> Vec<crate::source_analysis::Diagnostic> {
     let tokens = crate::source_analysis::lex_with_eof(source);
     let (module, parse_diags) = crate::source_analysis::parse(tokens);
     assert!(parse_diags.is_empty(), "Parse failed: {parse_diags:?}");
 
-    let result = crate::semantic_analysis::analyse_with_options_and_classes(
-        &module,
-        &crate::CompilerOptions::default(),
-        vec![],
-    );
+    let result = crate::semantic_analysis::analyse(&module);
     result.diagnostics
 }
 

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -2342,12 +2342,11 @@ fn run_module_analysis(
         current_package: current_package.map(str::to_string),
         ..Default::default()
     };
-    let analysis_result = beamtalk_core::semantic_analysis::analyse_with_natives(
-        module,
-        &options,
-        cross_file_classes,
-        native_type_registry,
-    );
+    let analysis_ctx = beamtalk_core::semantic_analysis::AnalysisContext::default()
+        .with_options(&options)
+        .with_pre_loaded_classes(cross_file_classes)
+        .with_native_type_registry(native_type_registry);
+    let analysis_result = beamtalk_core::semantic_analysis::analyse_full(module, analysis_ctx);
     diags.extend(
         analysis_result
             .diagnostics

--- a/docs/internal/semantic-analysis.md
+++ b/docs/internal/semantic-analysis.md
@@ -29,7 +29,7 @@ Semantic analysis validates the AST after parsing, checking for errors that can'
 - **Module**: `crates/beamtalk-core/src/semantic_analysis/mod.rs`
   - `AnalysisResult` - Container for diagnostics, block metadata, and class hierarchy
   - `BlockInfo` - Block context, captures, and mutations
-  - `analyse()` / `analyse_with_known_vars()` - Public API (fully functional)
+  - `analyse()` / `analyse_full()` with `AnalysisContext` - Public API (fully functional)
   - Pattern binding extraction with duplicate detection
   - AST traversal for scope population and block analysis
   - **48 tests**
@@ -70,7 +70,7 @@ Semantic analysis validates the AST after parsing, checking for errors that can'
   - Stub for future gradual typing (Phase 3)
 
 - **Integration**: `crates/beamtalk-core/src/queries/diagnostic_provider.rs`
-  - `compute_diagnostics()` calls `analyse_with_known_vars()`
+  - `compute_diagnostics()` calls `analyse_full()` with an `AnalysisContext::default().with_known_vars(...)`
   - Merges parse + semantic diagnostics
   - REPL-aware variable handling
 


### PR DESCRIPTION
Linear issue: https://linear.app/beamtalk/issue/BT-3114/refactor-consolidate-the-analyse-with-wrapper-family-into-a-builder-on

## Summary

`crates/beamtalk-core/src/semantic_analysis/mod.rs` exposed ~10 progressively-richer `analyse_with_*` entry points that all funnelled into `analyse_full(module, AnalysisContext)`. Every new piece of context (aliases, packages, native specs) added another wrapper permutation. This PR shrinks that surface to a single entry point plus a zero-context convenience, per BT-3114.

- Made `AnalysisContext` constructible via builder methods: `with_known_vars`, `with_options`, `with_pre_loaded_classes`, `with_pre_loaded_protocols`, `with_pre_loaded_aliases`, `with_known_packages`, `with_native_type_registry`, `with_cross_file_extensions`.
- Made `analyse_full(module, ctx)` the single public entry point that takes a fully-populated context; `analyse(module)` remains as the zero-context convenience (unchanged).
- Deleted all 10 `analyse_with_*` wrappers (`analyse_with_known_vars`, `analyse_with_options`, `analyse_with_options_and_classes`, `analyse_with_natives`, `analyse_with_natives_and_extensions`, `analyse_with_natives_and_protocols`, `analyse_with_natives_and_protocols_and_aliases`, `analyse_with_known_vars_and_classes`, `analyse_with_known_vars_classes_and_aliases`, `analyse_with_packages` — the last had zero non-test callers per ADR 0071).
- Migrated every call site: CLI (`lint.rs`, `build_stdlib.rs`, `type_coverage.rs`, `beam_compiler.rs` doc), `queries/diagnostic_provider.rs`, `beamtalk-mcp/src/server.rs`, and all affected test files (`semantic_analysis/tests.rs`, `property_tests.rs`, `type_checker/tests/*.rs`).

## Behavior

No behavior change — every existing test passes unmodified (same assertions, same expected diagnostics): 5571 `beamtalk-core` tests, plus `beamtalk-cli`/`beamtalk-mcp`/`test-package-compiler` suites, MCP integration tests, REPL-protocol e2e tests, and the parity suite (REPL/MCP/CLI/LSP) all green. `check-corpus` and `check-surface-drift` both pass — no surface or corpus drift.

## What was NOT changed

- No changes to analysis phase ordering or `AnalysisResult` shape (follow-up issue BT-3123 threads `AnalysisResult` into codegen).
- No changes to which context each surface supplies (`ModuleOnly` vs `ProjectComplete` knowledge scope stays as-is, ADR 0100).


---
_Generated by [Claude Code](https://claude.ai/code/session_01ApDPx4Ar6fkgWSbYZWiTFi)_