### PR TITLE
Thread AnalysisResult into codegen; delete the re-derivation (BT-3123)

### DIFF
--- a/crates/beamtalk-cli/src/beam_compiler.rs
+++ b/crates/beamtalk-cli/src/beam_compiler.rs
@@ -723,6 +723,7 @@ pub fn write_core_erlang_with_bindings(
     hierarchy: &ClassHierarchyContext,
     source: Option<(&str, Option<&str>)>,
     native_type_registry: Option<std::sync::Arc<NativeTypeRegistry>>,
+    analysis: Option<beamtalk_core::semantic_analysis::AnalysisResult>,
 ) -> Result<()> {
     validate_module_name(module_name)?;
 
@@ -730,33 +731,39 @@ pub fn write_core_erlang_with_bindings(
         Some((text, path)) => (Some(text), path),
         None => (None, None),
     };
-    let core_erlang = beamtalk_core::erlang::generate_module(
-        module,
-        beamtalk_core::erlang::CodegenOptions::new(module_name)
-            .with_bindings(bindings.clone())
-            .with_source_opt(source_text)
-            .with_workspace_mode(options.workspace_mode)
-            .with_stdlib_mode(options.stdlib_mode)
-            .with_class_module_index(hierarchy.class_module_index.clone())
-            .with_class_superclass_index(hierarchy.class_superclass_index.clone())
-            .with_source_path_opt(source_path)
-            .with_class_hierarchy(hierarchy.pre_loaded_classes.clone())
-            // BT-2932: thread cross-module type aliases through to codegen so
-            // an alias-typed annotation referencing a `type Name = ...` from
-            // another module in the same compilation unit resolves to a
-            // `user_type` reference in generated `-spec`/`-type` attributes
-            // instead of falling through to `any()` — mirrors
-            // `pre_loaded_classes` immediately above.
-            .with_pre_loaded_aliases(hierarchy.pre_loaded_aliases.clone())
-            .with_native_type_registry(native_type_registry)
-            // ADR 0098 Phase 3: bake the producing-toolchain identity into __beamtalk_meta.
-            .with_provenance(
-                env!("BEAMTALK_VERSION"),
-                crate::commands::build_stamp::current_otp_version(),
-            ),
-    )
-    .into_diagnostic()
-    .wrap_err("Failed to generate Core Erlang")?;
+    let mut codegen_options = beamtalk_core::erlang::CodegenOptions::new(module_name)
+        .with_bindings(bindings.clone())
+        .with_source_opt(source_text)
+        .with_workspace_mode(options.workspace_mode)
+        .with_stdlib_mode(options.stdlib_mode)
+        .with_class_module_index(hierarchy.class_module_index.clone())
+        .with_class_superclass_index(hierarchy.class_superclass_index.clone())
+        .with_source_path_opt(source_path)
+        .with_class_hierarchy(hierarchy.pre_loaded_classes.clone())
+        // BT-2932: thread cross-module type aliases through to codegen so
+        // an alias-typed annotation referencing a `type Name = ...` from
+        // another module in the same compilation unit resolves to a
+        // `user_type` reference in generated `-spec`/`-type` attributes
+        // instead of falling through to `any()` — mirrors
+        // `pre_loaded_classes` immediately above.
+        .with_pre_loaded_aliases(hierarchy.pre_loaded_aliases.clone())
+        .with_native_type_registry(native_type_registry)
+        // ADR 0098 Phase 3: bake the producing-toolchain identity into __beamtalk_meta.
+        .with_provenance(
+            env!("BEAMTALK_VERSION"),
+            crate::commands::build_stamp::current_otp_version(),
+        );
+    // BT-3123: thread the driver's already-computed semantic analysis (class
+    // hierarchy, semantic facts, inferred method return types) into codegen
+    // when the caller ran `analyse_full` itself (via
+    // `compute_project_diagnostics_with_analysis`) — avoids codegen re-deriving
+    // all three from scratch, including a second full type-checking pass.
+    if let Some(analysis) = analysis {
+        codegen_options = codegen_options.with_analysis(analysis);
+    }
+    let core_erlang = beamtalk_core::erlang::generate_module(module, codegen_options)
+        .into_diagnostic()
+        .wrap_err("Failed to generate Core Erlang")?;
 
     write_core_erlang_bytes(&core_erlang, output_path)
 }
@@ -874,11 +881,17 @@ pub(crate) fn compile_source_with_bindings(
         // call, so severity can never drift between the two surfaces.
         diagnostics_overrides: ctx.diagnostics_overrides.clone(),
     };
-    diagnostics = beamtalk_core::queries::diagnostic_provider::compute_project_diagnostics(
-        &module,
-        diagnostics,
-        &diag_ctx,
-    );
+    // BT-3123: capture the `AnalysisResult` this pipeline's `analyse_full`
+    // call already produced, so it can be handed to codegen below instead of
+    // codegen re-deriving the class hierarchy, semantic facts, and inferred
+    // method return types from scratch (a second full type-checking pass).
+    let (new_diagnostics, analysis_result) =
+        beamtalk_core::queries::diagnostic_provider::compute_project_diagnostics_with_analysis(
+            &module,
+            diagnostics,
+            &diag_ctx,
+        );
+    diagnostics = new_diagnostics;
 
     // Check for errors (and optionally treat warnings/hints as errors).
     // Deprecation-category warnings (BT-1529) and structural validation warnings
@@ -996,6 +1009,14 @@ pub(crate) fn compile_source_with_bindings(
         &codegen_hierarchy,
         Some((&source, embed_source_path)),
         ctx.native_type_registry.clone(),
+        // BT-3123: hand off the `AnalysisResult` this function's own
+        // `compute_project_diagnostics_with_analysis` call above already
+        // computed — `cross_file_classes` (this analysis's
+        // `AnalysisContext::pre_loaded_classes`) is exactly `codegen_hierarchy`'s
+        // `pre_loaded_classes` above, so codegen's `add_from_beam_meta` call
+        // is a guaranteed no-op and this handoff always skips the second
+        // type-checking pass for this driver.
+        Some(analysis_result),
     )
     .wrap_err_with(|| format!("Failed to generate Core Erlang for '{source_path}'"))?;
 

--- a/crates/beamtalk-compiler-port/src/main.rs
+++ b/crates/beamtalk-compiler-port/src/main.rs
@@ -1179,9 +1179,17 @@ fn load_native_type_registry_from(
 
 /// Parse a Beamtalk expression source and run full diagnostics with primitive validation.
 ///
-/// Returns `Ok((module, warnings, referenced_aliases))` on success, or
+/// Returns `Ok((module, warnings, analysis))` on success, or
 /// `Err(response_term)` containing a formatted `diagnostic_error_response`
-/// that the caller should return directly.
+/// that the caller should return directly. `analysis` is the full
+/// [`AnalysisResult`](beamtalk_core::semantic_analysis::AnalysisResult) this
+/// function's own semantic-analysis pass produced (BT-3123) — callers that go
+/// on to run codegen for the same module thread it into
+/// `CodegenOptions::with_analysis` instead of letting codegen re-derive the
+/// class hierarchy, semantic facts, and inferred method return types from
+/// scratch. `analysis.referenced_aliases` is the alias-dependency set
+/// (ADR 0108 hot-reload re-check trigger, BT-2899) callers used to receive
+/// as this tuple's third element directly.
 ///
 /// `pre_loaded_aliases` (ADR 0108 Phase 8, BT-2902) carries type aliases
 /// declared in earlier turns of the same REPL session, re-parsed standalone
@@ -1189,11 +1197,11 @@ fn load_native_type_registry_from(
 /// aliases need their own re-parse path rather than `pre_class_hierarchy`'s
 /// recover-from-live-BEAM-state mechanism.
 ///
-/// BT-2952: uses `compute_diagnostics_and_referenced_aliases` (the same
-/// analysis as `compute_diagnostics_with_known_vars_classes_and_aliases`,
-/// additionally returning `AnalysisResult::referenced_aliases`) so the
-/// REPL-inline `compile_expression` path computes the same alias-dependency
-/// set `handle_compile`'s file-compile path already did — previously this
+/// BT-2952: uses `compute_diagnostics_and_analysis` (the same analysis as
+/// `compute_diagnostics_with_known_vars_classes_and_aliases`, additionally
+/// returning the full `AnalysisResult`) so the REPL-inline
+/// `compile_expression` path computes the same alias-dependency set
+/// `handle_compile`'s file-compile path already did — previously this
 /// function discarded it, so `handle_inline_class_definition` never got a
 /// real set to thread through and `handle_inline_protocol_definition` was
 /// called with a hardcoded `&[]` (BT-2917's known limitation).
@@ -1206,7 +1214,7 @@ fn parse_and_check_expression(
     (
         beamtalk_core::ast::Module,
         Vec<String>,
-        Vec<ecow::EcoString>,
+        beamtalk_core::semantic_analysis::AnalysisResult,
     ),
     Term,
 > {
@@ -1214,8 +1222,8 @@ fn parse_and_check_expression(
     let (module, parse_diagnostics) = beamtalk_core::source_analysis::parse(tokens);
 
     let known_var_refs: Vec<&str> = known_vars.iter().map(String::as_str).collect();
-    let (mut all_diagnostics, referenced_aliases) =
-        beamtalk_core::queries::diagnostic_provider::compute_diagnostics_and_referenced_aliases(
+    let (mut all_diagnostics, analysis) =
+        beamtalk_core::queries::diagnostic_provider::compute_diagnostics_and_analysis(
             &module,
             parse_diagnostics,
             &known_var_refs,
@@ -1238,10 +1246,11 @@ fn parse_and_check_expression(
         return Err(diagnostic_error_response(&error_diags, source));
     }
 
-    Ok((module, warnings, referenced_aliases))
+    Ok((module, warnings, analysis))
 }
 
 /// Handle a single `compile_expression` request.
+#[allow(clippy::too_many_lines)]
 fn handle_compile_expression(request: &Map) -> Term {
     // Extract required fields
     let Some(source) = map_get(request, "source").and_then(term_to_string) else {
@@ -1268,7 +1277,7 @@ fn handle_compile_expression(request: &Map) -> Term {
     let pre_class_hierarchy = extract_class_hierarchy(request);
     let pre_loaded_aliases = extract_known_type_aliases(request);
 
-    let (module, warnings, referenced_aliases) = match parse_and_check_expression(
+    let (module, warnings, analysis) = match parse_and_check_expression(
         &source,
         &known_vars,
         pre_class_hierarchy.clone(),
@@ -1284,6 +1293,20 @@ fn handle_compile_expression(request: &Map) -> Term {
 
     // BT-571: If the parsed module contains class definitions, use compile path
     if !module.classes.is_empty() {
+        let referenced_aliases = analysis.referenced_aliases.clone();
+        // BT-3123: `handle_inline_class_definition` merges any standalone
+        // `module.method_definitions` into their target class *after* this
+        // point — a method the type checker saw as a standalone extension
+        // during `analysis` above. `infer_method_return_types`/writeback key
+        // return types by `(ClassName, Selector, IsClassMethod)` regardless
+        // of whether the method AST lives standalone or inside
+        // `class.methods`, so the map itself stays valid across the merge —
+        // but only thread `analysis` through when there's no merge about to
+        // happen at all, so this call site never has to reason about it:
+        // codegen's own no-analysis-supplied fallback (still correct, just
+        // not the fast path) covers the rarer "class def + inline standalone
+        // method in the same eval" REPL pattern.
+        let analysis = module.method_definitions.is_empty().then_some(analysis);
         return handle_inline_class_definition(
             module,
             &source,
@@ -1295,6 +1318,7 @@ fn handle_compile_expression(request: &Map) -> Term {
             pre_loaded_aliases,
             module_name_override.as_deref(),
             &referenced_aliases,
+            analysis,
         );
     }
 
@@ -1338,6 +1362,7 @@ fn handle_compile_expression(request: &Map) -> Term {
         // (BT-2917 shipped the protocol-side wiring but left this call site
         // passing a hardcoded `&[]`, since the Rust side didn't compute a
         // real set yet).
+        let referenced_aliases = analysis.referenced_aliases.clone();
         return handle_inline_protocol_definition(
             &module,
             &source,
@@ -1349,6 +1374,7 @@ fn handle_compile_expression(request: &Map) -> Term {
             module_name_override.as_deref(),
             false, // REPL expressions are never stdlib
             &referenced_aliases,
+            Some(analysis),
         );
     }
 
@@ -1407,10 +1433,12 @@ fn handle_compile_expression_trace(request: &Map) -> Term {
     let pre_loaded_aliases = extract_known_type_aliases(request);
 
     // Trace mode never defines classes/protocols/aliases (rejected below), so
-    // the `referenced_aliases` this also now computes (BT-2952) has no
-    // consumer here — trace-mode expressions can't reference an alias in a
-    // position that needs xref registration.
-    let (module, warnings, _referenced_aliases) = match parse_and_check_expression(
+    // neither the `referenced_aliases` nor the rest of the `AnalysisResult`
+    // this also now computes (BT-2952 / BT-3123) has a consumer here —
+    // trace-mode expressions never reach a `generate_module` call that could
+    // use it, and can't reference an alias in a position that needs xref
+    // registration either.
+    let (module, warnings, _analysis) = match parse_and_check_expression(
         &source,
         &known_vars,
         pre_class_hierarchy,
@@ -1490,10 +1518,18 @@ fn derive_class_module_name(
 /// are used consistently across all load paths.
 /// BT-2952: Accepts `referenced_aliases` — the caller's already-computed
 /// alias-dependency set (`parse_and_check_expression`'s
-/// `compute_diagnostics_and_referenced_aliases` result), threaded into the
+/// `compute_diagnostics_and_analysis` result), threaded into the
 /// response so the Erlang side can register the same `beamtalk_alias_xref`
 /// dependency edges a file-defining compile gets. Mirrors
 /// `handle_inline_protocol_definition`'s identical parameter.
+/// BT-3123: Accepts `analysis` — the caller's already-computed
+/// [`AnalysisResult`](beamtalk_core::semantic_analysis::AnalysisResult),
+/// threaded into codegen via `CodegenOptions::with_analysis` so it doesn't
+/// re-derive the class hierarchy, semantic facts, and inferred method return
+/// types from scratch. `None` when the caller has no analysis to hand off
+/// (or, per `handle_compile_expression`'s call site, when a standalone
+/// method merge between `analysis` and codegen would make it stale) —
+/// codegen falls back to computing its own, exactly as before BT-3123.
 #[allow(clippy::too_many_arguments)]
 fn handle_inline_class_definition(
     module: beamtalk_core::ast::Module,
@@ -1506,6 +1542,7 @@ fn handle_inline_class_definition(
     pre_loaded_aliases: Vec<beamtalk_core::semantic_analysis::AliasInfo>,
     module_name_override: Option<&str>,
     referenced_aliases: &[ecow::EcoString],
+    analysis: Option<beamtalk_core::semantic_analysis::AnalysisResult>,
 ) -> Term {
     let mut module = module;
     let mut warnings = warnings.to_vec();
@@ -1565,16 +1602,17 @@ fn handle_inline_class_definition(
         }
     };
 
-    match beamtalk_core::erlang::generate_module(
-        &module,
-        beamtalk_core::erlang::CodegenOptions::new(&class_module_name)
-            .with_workspace_mode(true)
-            .with_source(source)
-            .with_class_superclass_index(class_superclass_index.clone())
-            .with_class_module_index(class_module_index)
-            .with_class_hierarchy(pre_class_hierarchy)
-            .with_pre_loaded_aliases(pre_loaded_aliases),
-    ) {
+    let mut codegen_options = beamtalk_core::erlang::CodegenOptions::new(&class_module_name)
+        .with_workspace_mode(true)
+        .with_source(source)
+        .with_class_superclass_index(class_superclass_index.clone())
+        .with_class_module_index(class_module_index)
+        .with_class_hierarchy(pre_class_hierarchy)
+        .with_pre_loaded_aliases(pre_loaded_aliases);
+    if let Some(analysis) = analysis {
+        codegen_options = codegen_options.with_analysis(analysis);
+    }
+    match beamtalk_core::erlang::generate_module(&module, codegen_options) {
         Ok(code) => class_definition_ok_response(
             &code,
             &class_module_name,
@@ -1606,6 +1644,11 @@ fn handle_inline_class_definition(
 /// `handle_compile_method`) — so a protocol method signature referencing a
 /// cross-module alias resolves to a `user_type` reference in the generated
 /// `-type` attributes instead of silently dropping the alias (empty registry).
+/// BT-3123: Accepts `analysis` — mirrors `handle_inline_class_definition`'s
+/// identical parameter; both callers pass their own already-computed
+/// [`AnalysisResult`](beamtalk_core::semantic_analysis::AnalysisResult)
+/// unconditionally since, unlike the class path, nothing mutates `module`
+/// between computing it and this call.
 #[allow(clippy::too_many_arguments)]
 fn handle_inline_protocol_definition(
     module: &beamtalk_core::ast::Module,
@@ -1618,6 +1661,7 @@ fn handle_inline_protocol_definition(
     module_name_override: Option<&str>,
     stdlib_mode: bool,
     referenced_aliases: &[ecow::EcoString],
+    analysis: Option<beamtalk_core::semantic_analysis::AnalysisResult>,
 ) -> Term {
     let first_protocol_name = &module.protocols[0].name.name;
     let protocol_module_name =
@@ -1629,16 +1673,17 @@ fn handle_inline_protocol_definition(
         .map(|p| p.name.name.to_string())
         .collect();
 
-    match beamtalk_core::erlang::generate_module(
-        module,
-        beamtalk_core::erlang::CodegenOptions::new(&protocol_module_name)
-            .with_workspace_mode(true)
-            .with_source(source)
-            .with_class_superclass_index(class_superclass_index.clone())
-            .with_class_module_index(class_module_index)
-            .with_class_hierarchy(pre_class_hierarchy)
-            .with_pre_loaded_aliases(pre_loaded_aliases),
-    ) {
+    let mut codegen_options = beamtalk_core::erlang::CodegenOptions::new(&protocol_module_name)
+        .with_workspace_mode(true)
+        .with_source(source)
+        .with_class_superclass_index(class_superclass_index.clone())
+        .with_class_module_index(class_module_index)
+        .with_class_hierarchy(pre_class_hierarchy)
+        .with_pre_loaded_aliases(pre_loaded_aliases);
+    if let Some(analysis) = analysis {
+        codegen_options = codegen_options.with_analysis(analysis);
+    }
+    match beamtalk_core::erlang::generate_module(module, codegen_options) {
         Ok(code) => protocol_definition_ok_response(
             &code,
             &protocol_module_name,
@@ -1724,8 +1769,13 @@ fn handle_compile(request: &Map) -> Term {
     // `beamtalk_alias_xref`'s alias-name → dependent-class index at class
     // install time (see `diagnostics_ok_response`/this handler's response
     // builder for where the field is attached).
-    let (mut all_diagnostics, referenced_aliases) =
-        beamtalk_core::queries::diagnostic_provider::compute_diagnostics_and_referenced_aliases(
+    // BT-3123: `compute_diagnostics_and_analysis` additionally returns the
+    // full `AnalysisResult`, threaded into codegen below via
+    // `CodegenOptions::with_analysis` so it doesn't re-derive the class
+    // hierarchy, semantic facts, and inferred method return types from
+    // scratch.
+    let (mut all_diagnostics, analysis) =
+        beamtalk_core::queries::diagnostic_provider::compute_diagnostics_and_analysis(
             &module,
             parse_diagnostics,
             &[],
@@ -1733,6 +1783,7 @@ fn handle_compile(request: &Map) -> Term {
             pre_loaded_aliases.clone(),
             diagnostics_overrides(),
         );
+    let referenced_aliases = analysis.referenced_aliases.clone();
 
     // Run @primitive validation
     let options = beamtalk_core::CompilerOptions {
@@ -1765,7 +1816,11 @@ fn handle_compile(request: &Map) -> Term {
         return diagnostic_error_response(&error_diags, &source);
     }
 
-    // BT-571: Merge standalone method definitions into their target classes
+    // BT-571: Merge standalone method definitions into their target classes.
+    // BT-3123: captured *before* the merge so the class-codegen call below
+    // knows whether `analysis` (computed pre-merge) is still trustworthy —
+    // see `handle_compile_expression`'s identical `analysis` gating for why.
+    let had_standalone_method_definitions = !module.method_definitions.is_empty();
     let mut module = module;
     if !module.method_definitions.is_empty() {
         let method_defs = std::mem::take(&mut module.method_definitions);
@@ -1851,6 +1906,7 @@ fn handle_compile(request: &Map) -> Term {
             module_name_override.as_deref(),
             stdlib_mode,
             &referenced_aliases,
+            Some(analysis),
         );
     }
 
@@ -1866,17 +1922,21 @@ fn handle_compile(request: &Map) -> Term {
 
     // Generate Core Erlang
     let warning_msgs: Vec<String> = warnings.iter().map(|w| w.message.clone()).collect();
-    match beamtalk_core::erlang::generate_module(
-        &module,
-        beamtalk_core::erlang::CodegenOptions::new(&module_name)
-            .with_workspace_mode(workspace_mode)
-            .with_source(&source)
-            .with_class_module_index(class_module_index)
-            .with_class_superclass_index(class_superclass_index)
-            .with_class_hierarchy(pre_class_hierarchy)
-            .with_pre_loaded_aliases(pre_loaded_aliases)
-            .with_source_path_opt(source_path.as_deref()),
-    ) {
+    let mut codegen_options = beamtalk_core::erlang::CodegenOptions::new(&module_name)
+        .with_workspace_mode(workspace_mode)
+        .with_source(&source)
+        .with_class_module_index(class_module_index)
+        .with_class_superclass_index(class_superclass_index)
+        .with_class_hierarchy(pre_class_hierarchy)
+        .with_pre_loaded_aliases(pre_loaded_aliases)
+        .with_source_path_opt(source_path.as_deref());
+    // BT-3123: only trust `analysis` (computed pre-merge) when nothing was
+    // merged into `module` afterward — see `had_standalone_method_definitions`'s
+    // doc above.
+    if !had_standalone_method_definitions {
+        codegen_options = codegen_options.with_analysis(analysis);
+    }
+    match beamtalk_core::erlang::generate_module(&module, codegen_options) {
         Ok(code) => compile_ok_response(
             &code,
             &module_name,
@@ -2045,8 +2105,12 @@ fn handle_compile_method(request: &Map) -> Term {
     //    relative to the patched method (so the method editor shows a snippet-local
     //    line) while rarer class-context errors keep their merged-source line — all
     //    accurate and in-range (BT-2563 #2).
-    let (mut all_diagnostics, referenced_aliases) =
-        beamtalk_core::queries::diagnostic_provider::compute_diagnostics_and_referenced_aliases(
+    // BT-3123: `compute_diagnostics_and_analysis` additionally returns the
+    // full `AnalysisResult` for the already-merged `merged_module` — no
+    // further mutation happens before the codegen call below, so it's always
+    // safe to thread through via `CodegenOptions::with_analysis`.
+    let (mut all_diagnostics, analysis) =
+        beamtalk_core::queries::diagnostic_provider::compute_diagnostics_and_analysis(
             &merged_module,
             merged_parse_diags,
             &[],
@@ -2054,6 +2118,7 @@ fn handle_compile_method(request: &Map) -> Term {
             pre_loaded_aliases.clone(),
             diagnostics_overrides(),
         );
+    let referenced_aliases = analysis.referenced_aliases.clone();
     let options = beamtalk_core::CompilerOptions {
         stdlib_mode,
         allow_primitives: false,
@@ -2099,17 +2164,18 @@ fn handle_compile_method(request: &Map) -> Term {
         .collect();
     let warning_msgs: Vec<String> = warnings.iter().map(|w| w.message.clone()).collect();
 
-    match beamtalk_core::erlang::generate_module(
-        &merged_module,
-        beamtalk_core::erlang::CodegenOptions::new(&module_name)
-            .with_workspace_mode(workspace_mode)
-            .with_source(&merged_class_source)
-            .with_class_module_index(class_module_index)
-            .with_class_superclass_index(class_superclass_index)
-            .with_class_hierarchy(pre_class_hierarchy)
-            .with_pre_loaded_aliases(pre_loaded_aliases)
-            .with_source_path_opt(source_path.as_deref()),
-    ) {
+    let codegen_options = beamtalk_core::erlang::CodegenOptions::new(&module_name)
+        .with_workspace_mode(workspace_mode)
+        .with_source(&merged_class_source)
+        .with_class_module_index(class_module_index)
+        .with_class_superclass_index(class_superclass_index)
+        .with_class_hierarchy(pre_class_hierarchy)
+        .with_pre_loaded_aliases(pre_loaded_aliases)
+        .with_source_path_opt(source_path.as_deref())
+        // BT-3123: `analysis` was computed on `merged_module` with no
+        // mutation since — always safe to hand off.
+        .with_analysis(analysis);
+    match beamtalk_core::erlang::generate_module(&merged_module, codegen_options) {
         Ok(code) => compile_method_ok_response(
             &code,
             &module_name,

--- a/crates/beamtalk-core/benches/compiler_pipeline.rs
+++ b/crates/beamtalk-core/benches/compiler_pipeline.rs
@@ -181,6 +181,11 @@ fn bench_codegen(c: &mut Criterion) {
     group.finish();
 }
 
+/// BT-3123: threads `analyse`'s `AnalysisResult` into codegen via
+/// `CodegenOptions::with_analysis` — the fixed pipeline every real driver
+/// (CLI build, compiler-port) now uses, so this benchmark measures the
+/// analyse+codegen path new code actually takes, not the doubled-up
+/// analyse-then-codegen-re-derives-its-own-view path the fix eliminated.
 fn bench_end_to_end(c: &mut Criterion) {
     let mut group = c.benchmark_group("end_to_end");
 
@@ -194,8 +199,10 @@ fn bench_end_to_end(c: &mut Criterion) {
                 b.iter(|| {
                     let tokens = lex_with_eof(src);
                     let (module, _diags) = parse(tokens);
-                    let _analysis = analyse(&module);
-                    let opts = CodegenOptions::new(input.module_name).with_source(src);
+                    let analysis = analyse(&module);
+                    let opts = CodegenOptions::new(input.module_name)
+                        .with_source(src)
+                        .with_analysis(analysis);
                     black_box(generate_module(&module, opts).expect("compile must succeed"))
                 });
             },
@@ -232,8 +239,10 @@ fn bench_project(c: &mut Criterion) {
             for (module_name, source) in &sources {
                 let tokens = lex_with_eof(source);
                 let (module, _) = parse(tokens);
-                let _analysis = analyse(&module);
-                let opts = CodegenOptions::new(module_name).with_source(source);
+                let analysis = analyse(&module);
+                let opts = CodegenOptions::new(module_name)
+                    .with_source(source)
+                    .with_analysis(analysis);
                 black_box(generate_module(&module, opts).unwrap());
             }
         });
@@ -270,8 +279,10 @@ fn bench_project_otp(c: &mut Criterion) {
             for (module_name, source) in &sources {
                 let tokens = lex_with_eof(source);
                 let (module, _) = parse(tokens);
-                let _analysis = analyse(&module);
-                let opts = CodegenOptions::new(module_name).with_source(source);
+                let analysis = analyse(&module);
+                let opts = CodegenOptions::new(module_name)
+                    .with_source(source)
+                    .with_analysis(analysis);
                 black_box(generate_module(&module, opts).unwrap());
             }
         });

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -371,6 +371,9 @@ pub struct CodegenOptions {
     /// generated `-spec`/`-type` attributes instead of falling through to
     /// `any()`.
     pre_loaded_aliases: Vec<crate::semantic_analysis::alias_registry::AliasInfo>,
+    /// BT-3123: pre-computed analysis outputs from the driver's own
+    /// `analyse_full` call. See [`Self::with_analysis`].
+    analysis: Option<crate::semantic_analysis::AnalysisResult>,
 }
 
 impl CodegenOptions {
@@ -391,6 +394,7 @@ impl CodegenOptions {
             otp_release: None,
             native_type_registry: None,
             pre_loaded_aliases: Vec::new(),
+            analysis: None,
         }
     }
 
@@ -521,6 +525,23 @@ impl CodegenOptions {
         self.pre_loaded_aliases = aliases;
         self
     }
+
+    /// BT-3123: threads a driver's already-computed [`AnalysisResult`](crate::semantic_analysis::AnalysisResult)
+    /// into codegen, so `generate_module`/`generate_module_with_warnings` consume
+    /// the same class hierarchy, semantic facts, and inferred method return types
+    /// the driver's own `analyse_full` call already produced for diagnostics,
+    /// instead of re-deriving all three from scratch (see ADR 0006, BT-1288, BT-1005).
+    ///
+    /// `None` (the default) preserves the previous self-sufficient behaviour —
+    /// codegen computes its own analysis internally. Callers that already run
+    /// `analyse_full` before codegen (e.g. the CLI build pipeline via
+    /// `compile_source_with_bindings`) should always supply it here to avoid
+    /// running the type checker twice per compiled module.
+    #[must_use]
+    pub fn with_analysis(mut self, analysis: crate::semantic_analysis::AnalysisResult) -> Self {
+        self.analysis = Some(analysis);
+        self
+    }
 }
 
 /// Generates Core Erlang code from a Beamtalk module.
@@ -609,34 +630,70 @@ pub fn generate_module_with_warnings(
         generator.codegen_diagnostics_enabled = enabled;
     }
 
-    // BT-1288: Compute semantic facts before codegen begins.
-    let semantic_facts = crate::semantic_analysis::compute_semantic_facts(module);
-    generator.semantic_facts = semantic_facts;
+    // BT-3123: Consume the driver's already-computed analysis when supplied
+    // (`CodegenOptions::with_analysis`) instead of re-deriving semantic facts,
+    // the class hierarchy, and inferred method return types from scratch —
+    // eliminating a second full type-checking pass per compiled module. `None`
+    // preserves the previous self-sufficient behaviour for callers that don't
+    // run analysis separately (unit tests, ad-hoc codegen).
+    let (mut hierarchy, precomputed_method_return_types) = if let Some(analysis) = options.analysis
+    {
+        generator.semantic_facts = analysis.semantic_facts;
+        (analysis.class_hierarchy, Some(analysis.method_return_types))
+    } else {
+        // BT-1288: Compute semantic facts before codegen begins.
+        generator.semantic_facts = crate::semantic_analysis::compute_semantic_facts(module);
 
-    // Build hierarchy once for the entire generation (ADR 0006)
-    let (hierarchy_result, _) =
-        crate::semantic_analysis::class_hierarchy::ClassHierarchy::build(module);
-    let mut hierarchy =
-        hierarchy_result.map_err(|e| CodeGenError::Internal(format!("hierarchy: {e:?}")))?;
+        // Build hierarchy once for the entire generation (ADR 0006)
+        let (hierarchy_result, _) =
+            crate::semantic_analysis::class_hierarchy::ClassHierarchy::build(module);
+        let hierarchy =
+            hierarchy_result.map_err(|e| CodeGenError::Internal(format!("hierarchy: {e:?}")))?;
+        (hierarchy, None)
+    };
 
     // ADR 0050 Phase 4: inject richer user-class entries from BEAM metadata first,
     // so that add_external_superclasses (which uses contains_key before inserting)
-    // does not overwrite BEAM data with partial stubs.
-    hierarchy.add_from_beam_meta(options.pre_class_hierarchy);
+    // does not overwrite BEAM data with partial stubs. Both calls are no-ops for
+    // classes the handed-off analysis hierarchy already carries (BT-1523/BT-894
+    // insert only into vacant entries) — the common case, since a driver that
+    // hands off analysis typically fed the same cross-file class metadata to
+    // `AnalysisContext::with_pre_loaded_classes`. `class_superclass_index`
+    // (BT-894) is codegen-only and has no `AnalysisContext` counterpart, so it
+    // can still add genuinely new stub entries analysis never saw; both calls
+    // report whether they did so `method_return_types` below knows whether the
+    // handed-off inference is still trustworthy.
+    let added_beam_meta = hierarchy.add_from_beam_meta(options.pre_class_hierarchy);
 
     // BT-894: Backfill missing cross-file superclass stubs (only for classes not
     // already present from build() or BEAM metadata).
-    hierarchy.add_external_superclasses(&options.class_superclass_index);
+    let added_superclasses = hierarchy.add_external_superclasses(&options.class_superclass_index);
+
+    // BT-3123: Use the driver's precomputed method-return-type inferences
+    // unless this generation's own cross-file enrichment (above) added stub
+    // classes analysis's own hierarchy didn't have — in that rare case, the
+    // handed-off map may be missing entries a class only visible through those
+    // stubs would need, so fall back to a full `infer_method_return_types`
+    // pass exactly as the no-analysis-supplied path always has. The common
+    // case (nothing added, or no analysis supplied at all) never re-runs
+    // inference the driver already did.
+    let method_return_types = match precomputed_method_return_types {
+        Some(map) if !added_beam_meta && !added_superclasses => map,
+        _ => crate::semantic_analysis::type_checker::infer_method_return_types(
+            module,
+            &hierarchy,
+            options.native_type_registry.as_deref(),
+        ),
+    };
 
     // BT-1005: Writeback inferred return types into the AST before codegen so
     // that unannotated methods appear in the emitted `method_return_types` map.
     // BT-1218: Also writeback supervisor_kind for Supervisor/DynamicSupervisor subclasses.
     // We clone to avoid mutating the caller's Module.
     let mut module_with_writeback = module.clone();
-    crate::semantic_analysis::apply_return_type_writeback(
+    crate::semantic_analysis::apply_return_type_writeback_from_map(
         &mut module_with_writeback,
-        &hierarchy,
-        options.native_type_registry.as_deref(),
+        &method_return_types,
     );
     crate::semantic_analysis::apply_supervisor_kind_writeback(
         &mut module_with_writeback,

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/analysis_handoff.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/analysis_handoff.rs
@@ -119,3 +119,104 @@ fn without_analysis_codegen_computes_its_own() {
          (via infer_method_return_types) for the return-type writeback"
     );
 }
+
+/// A minimal `ClassInfo` stub, mirroring the private helpers of the same
+/// name used throughout `semantic_analysis` tests (e.g.
+/// `receiver_knowledge::tests::base_class_info`).
+fn base_class_info(
+    name: &str,
+    superclass: &str,
+) -> crate::semantic_analysis::class_hierarchy::ClassInfo {
+    crate::semantic_analysis::class_hierarchy::ClassInfo {
+        surface_incomplete: false,
+        name: name.into(),
+        superclass: Some(superclass.into()),
+        is_sealed: false,
+        is_abstract: false,
+        is_typed: false,
+        is_internal: false,
+        package: None,
+        is_value: false,
+        is_native: false,
+        handle_scope: None,
+        state: vec![],
+        state_types: std::collections::HashMap::new(),
+        state_has_default: std::collections::HashMap::new(),
+        methods: vec![],
+        class_methods: vec![],
+        class_variables: vec![],
+        type_params: vec![],
+        type_param_bounds: vec![],
+        superclass_type_args: vec![],
+    }
+}
+
+/// Real multi-file package drivers (`compile_source_with_bindings`,
+/// compiler-port's `handle_compile`) feed the *same* cross-file class list to
+/// both `AnalysisContext::with_pre_loaded_classes` (for `analyse_full`) and
+/// `CodegenOptions::with_class_hierarchy`/`with_class_superclass_index` (for
+/// codegen) — see `write_core_erlang_with_bindings`'s BT-3123 comment. This
+/// guards against a regression where that overlap stops being a no-op: if
+/// `add_from_beam_meta`/`add_external_superclasses` ever "see" a class that
+/// wasn't already in the handed-off hierarchy for realistic same-driver
+/// inputs, codegen's safety net (correctly!) falls back to recomputing
+/// `method_return_types` — which would silently defeat the fix for every
+/// real multi-file package build, while every other test here only exercises
+/// the empty-cross-file-metadata (REPL/single-file) case.
+#[test]
+fn with_analysis_skips_re_derivation_with_overlapping_cross_file_metadata() {
+    let module = parse_fixture(
+        "Object subclass: Bar\n  useFoo: f => f.\n\nBar subclass: Baz\n  hi => \"hi\".\n",
+    );
+
+    // Mirrors a package build's Pass 1 output: full ClassInfo for a
+    // same-package sibling file's class, AND a name-only superclass index
+    // entry for the very same class (BT-894's codegen-only field, populated
+    // from the same Pass 1 walk as the full ClassInfo list in every real
+    // driver).
+    let foo_info = base_class_info("Foo", "Object");
+    let mut superclass_index = std::collections::HashMap::new();
+    superclass_index.insert("Foo".to_string(), "Object".to_string());
+
+    let build_before = BUILD_CALL_COUNT.with(std::cell::Cell::get);
+    let check_before = CHECK_MODULE_CALL_COUNT.with(std::cell::Cell::get);
+
+    let analysis = analyse_full(
+        &module,
+        AnalysisContext::default().with_pre_loaded_classes(vec![foo_info.clone()]),
+    );
+    assert_eq!(
+        BUILD_CALL_COUNT.with(std::cell::Cell::get) - build_before,
+        1
+    );
+    assert_eq!(
+        CHECK_MODULE_CALL_COUNT.with(std::cell::Cell::get) - check_before,
+        1
+    );
+
+    let code = crate::codegen::core_erlang::generate_module(
+        &module,
+        crate::codegen::core_erlang::CodegenOptions::new("bar")
+            .with_class_hierarchy(vec![foo_info])
+            .with_class_superclass_index(superclass_index)
+            .with_analysis(analysis),
+    )
+    .expect("codegen should succeed");
+    assert!(code.contains("useFoo"));
+
+    // The overlap must be recognised as a no-op: codegen must not fall back
+    // to rebuilding the hierarchy or re-running the type checker just
+    // because `pre_class_hierarchy`/`class_superclass_index` were non-empty.
+    assert_eq!(
+        BUILD_CALL_COUNT.with(std::cell::Cell::get) - build_before,
+        1,
+        "codegen must not rebuild the hierarchy when the pre-loaded class/superclass \
+         data it's given is already reflected in the handed-off analysis"
+    );
+    assert_eq!(
+        CHECK_MODULE_CALL_COUNT.with(std::cell::Cell::get) - check_before,
+        1,
+        "codegen must not re-run the type checker when the pre-loaded class/superclass \
+         data it's given is already reflected in the handed-off analysis"
+    );
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/analysis_handoff.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/analysis_handoff.rs
@@ -1,0 +1,121 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! BT-3123: verifies that threading a driver's `AnalysisResult` into codegen
+//! via `CodegenOptions::with_analysis` skips codegen's own re-derivation of
+//! the class hierarchy, semantic facts, and inferred method return types —
+//! the duplicate work this issue eliminates.
+//!
+//! Uses `#[cfg(test)]`-only thread-local call counters on the three costly
+//! functions (`ClassHierarchy::build_with_options`, `compute_semantic_facts`,
+//! `TypeChecker::check_module`) rather than a shared global counter, since
+//! plenty of *other* tests call these functions too and may run concurrently
+//! on other threads — only the delta this test's own thread accumulates is
+//! meaningful. See `CHECK_MODULE_CALL_COUNT`'s doc for the full rationale.
+
+use crate::semantic_analysis::class_hierarchy::BUILD_CALL_COUNT;
+use crate::semantic_analysis::facts::COMPUTE_SEMANTIC_FACTS_CALL_COUNT;
+use crate::semantic_analysis::type_checker::CHECK_MODULE_CALL_COUNT;
+use crate::semantic_analysis::{AnalysisContext, analyse_full};
+
+fn parse_fixture(src: &str) -> crate::ast::Module {
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, diagnostics) = crate::source_analysis::parse(tokens);
+    let errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.severity == crate::source_analysis::Severity::Error)
+        .collect();
+    assert!(errors.is_empty(), "fixture failed to parse: {errors:?}");
+    module
+}
+
+/// A driver that runs `analyse_full` and threads the result into codegen via
+/// `with_analysis` performs each of the three costly passes exactly once —
+/// codegen makes zero *additional* calls of its own.
+#[test]
+fn with_analysis_skips_codegen_re_derivation() {
+    let module = parse_fixture("Object subclass: Greeter\n  greet => \"hello\".\n");
+
+    let build_before = BUILD_CALL_COUNT.with(std::cell::Cell::get);
+    let facts_before = COMPUTE_SEMANTIC_FACTS_CALL_COUNT.with(std::cell::Cell::get);
+    let check_before = CHECK_MODULE_CALL_COUNT.with(std::cell::Cell::get);
+
+    let analysis = analyse_full(&module, AnalysisContext::default());
+    assert_eq!(
+        BUILD_CALL_COUNT.with(std::cell::Cell::get) - build_before,
+        1,
+        "analyse_full should build the class hierarchy exactly once"
+    );
+    assert_eq!(
+        COMPUTE_SEMANTIC_FACTS_CALL_COUNT.with(std::cell::Cell::get) - facts_before,
+        1,
+        "analyse_full should compute semantic facts exactly once"
+    );
+    assert_eq!(
+        CHECK_MODULE_CALL_COUNT.with(std::cell::Cell::get) - check_before,
+        1,
+        "analyse_full should run the type checker exactly once"
+    );
+
+    let code = crate::codegen::core_erlang::generate_module(
+        &module,
+        crate::codegen::core_erlang::CodegenOptions::new("greeter").with_analysis(analysis),
+    )
+    .expect("codegen should succeed");
+    assert!(code.contains("greet"));
+
+    // BT-3123: codegen must not have made ANY additional calls to the three
+    // costly functions — it consumed the driver's already-computed analysis
+    // instead of re-deriving it from scratch.
+    assert_eq!(
+        BUILD_CALL_COUNT.with(std::cell::Cell::get) - build_before,
+        1,
+        "codegen must not re-build the class hierarchy when analysis is supplied"
+    );
+    assert_eq!(
+        COMPUTE_SEMANTIC_FACTS_CALL_COUNT.with(std::cell::Cell::get) - facts_before,
+        1,
+        "codegen must not recompute semantic facts when analysis is supplied"
+    );
+    assert_eq!(
+        CHECK_MODULE_CALL_COUNT.with(std::cell::Cell::get) - check_before,
+        1,
+        "codegen must not re-run the type checker when analysis is supplied"
+    );
+}
+
+/// Baseline: without `with_analysis`, codegen computes its own — confirming
+/// the counters actually detect a re-derivation (i.e. the assertions above
+/// aren't vacuously true because codegen never calls these functions at all).
+#[test]
+fn without_analysis_codegen_computes_its_own() {
+    let module = parse_fixture("Object subclass: Greeter\n  greet => \"hello\".\n");
+
+    let build_before = BUILD_CALL_COUNT.with(std::cell::Cell::get);
+    let facts_before = COMPUTE_SEMANTIC_FACTS_CALL_COUNT.with(std::cell::Cell::get);
+    let check_before = CHECK_MODULE_CALL_COUNT.with(std::cell::Cell::get);
+
+    let code = crate::codegen::core_erlang::generate_module(
+        &module,
+        crate::codegen::core_erlang::CodegenOptions::new("greeter"),
+    )
+    .expect("codegen should succeed");
+    assert!(code.contains("greet"));
+
+    assert_eq!(
+        BUILD_CALL_COUNT.with(std::cell::Cell::get) - build_before,
+        1,
+        "codegen without an analysis handoff should build its own hierarchy"
+    );
+    assert_eq!(
+        COMPUTE_SEMANTIC_FACTS_CALL_COUNT.with(std::cell::Cell::get) - facts_before,
+        1,
+        "codegen without an analysis handoff should compute its own semantic facts"
+    );
+    assert_eq!(
+        CHECK_MODULE_CALL_COUNT.with(std::cell::Cell::get) - check_before,
+        1,
+        "codegen without an analysis handoff should run its own type-checking pass \
+         (via infer_method_return_types) for the return-type writeback"
+    );
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/mod.rs
@@ -89,6 +89,7 @@ pub(crate) fn make_value_subclass_point() -> Module {
     }
 }
 
+mod analysis_handoff;
 mod control_flow;
 mod dispatch;
 mod expressions;

--- a/crates/beamtalk-core/src/queries/diagnostic_provider.rs
+++ b/crates/beamtalk-core/src/queries/diagnostic_provider.rs
@@ -107,6 +107,25 @@ pub fn compute_project_diagnostics(
     initial_diagnostics: Vec<Diagnostic>,
     ctx: &ProjectDiagnosticContext<'_>,
 ) -> Vec<Diagnostic> {
+    compute_project_diagnostics_with_analysis(module, initial_diagnostics, ctx).0
+}
+
+/// [`compute_project_diagnostics`], additionally returning the
+/// [`AnalysisResult`](crate::semantic_analysis::AnalysisResult) the pipeline's
+/// `analyse_full` call produced (BT-3123).
+///
+/// Callers that go on to run codegen for the same module (e.g. the CLI build
+/// pipeline) should use this variant and thread the returned `AnalysisResult`
+/// into `CodegenOptions::with_analysis`, instead of letting codegen re-derive
+/// the class hierarchy, semantic facts, and inferred method return types from
+/// scratch. Callers that only need diagnostics (e.g. the LSP) can keep using
+/// [`compute_project_diagnostics`].
+#[must_use]
+pub fn compute_project_diagnostics_with_analysis(
+    module: &Module,
+    initial_diagnostics: Vec<Diagnostic>,
+    ctx: &ProjectDiagnosticContext<'_>,
+) -> (Vec<Diagnostic>, semantic_analysis::AnalysisResult) {
     let mut diagnostics = initial_diagnostics;
 
     // Run semantic analysis with the richest available context.
@@ -120,8 +139,12 @@ pub fn compute_project_diagnostics(
         .with_pre_loaded_aliases(ctx.pre_loaded_aliases.clone())
         .with_native_type_registry(ctx.native_type_registry.clone())
         .with_cross_file_extensions(&ctx.cross_file_extensions);
-    let analysis_result = crate::semantic_analysis::analyse_full(module, analysis_ctx);
-    diagnostics.extend(analysis_result.diagnostics);
+    let mut analysis_result = crate::semantic_analysis::analyse_full(module, analysis_ctx);
+    // BT-3123: diagnostics are consumed below (and by every downstream pass
+    // in this pipeline); take them out of `analysis_result` so the rest of
+    // `AnalysisResult` (hierarchy, semantic facts, inferred return types,
+    // alias registry) can be handed to codegen without cloning it.
+    diagnostics.extend(std::mem::take(&mut analysis_result.diagnostics));
 
     // BT-1732: Enrich unresolved class warnings with dependency package hints.
     if let Some(registry) = ctx.dep_registry {
@@ -184,7 +207,7 @@ pub fn compute_project_diagnostics(
         &ctx.diagnostics_overrides,
     );
 
-    diagnostics
+    (diagnostics, analysis_result)
 }
 
 /// Computes diagnostics for a module.
@@ -381,19 +404,54 @@ pub fn compute_diagnostics_and_referenced_aliases(
     pre_loaded_aliases: Vec<crate::semantic_analysis::AliasInfo>,
     diagnostics_overrides: &crate::compilation::diagnostics_policy::DiagnosticsTable,
 ) -> (Vec<Diagnostic>, Vec<EcoString>) {
+    let (diagnostics, analysis_result) = compute_diagnostics_and_analysis(
+        module,
+        parse_diagnostics,
+        known_vars,
+        pre_loaded_classes,
+        pre_loaded_aliases,
+        diagnostics_overrides,
+    );
+    (diagnostics, analysis_result.referenced_aliases)
+}
+
+/// [`compute_diagnostics_and_referenced_aliases`], additionally returning the
+/// full [`AnalysisResult`](semantic_analysis::AnalysisResult) (BT-3123) —
+/// class hierarchy, semantic facts, and inferred method return types,
+/// alongside `referenced_aliases` (still reachable as a field on the result).
+///
+/// Used by compiler-port handlers that go on to run codegen for the same
+/// module (`compile`, `compile_method`, and `compile_expression`'s
+/// class/protocol-defining paths) so codegen can consume this analysis via
+/// `CodegenOptions::with_analysis` instead of re-deriving the class
+/// hierarchy, semantic facts, and inferred method return types from scratch.
+/// Callers that only need diagnostics/`referenced_aliases` should keep using
+/// [`compute_diagnostics_and_referenced_aliases`].
+#[must_use]
+pub fn compute_diagnostics_and_analysis(
+    module: &crate::ast::Module,
+    parse_diagnostics: Vec<Diagnostic>,
+    known_vars: &[&str],
+    pre_loaded_classes: Vec<crate::semantic_analysis::class_hierarchy::ClassInfo>,
+    pre_loaded_aliases: Vec<crate::semantic_analysis::AliasInfo>,
+    diagnostics_overrides: &crate::compilation::diagnostics_policy::DiagnosticsTable,
+) -> (Vec<Diagnostic>, semantic_analysis::AnalysisResult) {
     let ctx = crate::semantic_analysis::AnalysisContext::default()
         .with_known_vars(known_vars)
         .with_pre_loaded_classes(pre_loaded_classes)
         .with_pre_loaded_aliases(pre_loaded_aliases);
-    let analysis_result = crate::semantic_analysis::analyse_full(module, ctx);
-    let referenced_aliases = analysis_result.referenced_aliases;
+    let mut analysis_result = crate::semantic_analysis::analyse_full(module, ctx);
+    // BT-3123: diagnostics are consumed by `run_diagnostic_pipeline` below;
+    // take them out so the rest of `analysis_result` can be returned for
+    // codegen without cloning it.
+    let analysis_diagnostics = std::mem::take(&mut analysis_result.diagnostics);
     let diagnostics = run_diagnostic_pipeline(
         module,
         parse_diagnostics,
-        analysis_result.diagnostics,
+        analysis_diagnostics,
         diagnostics_overrides,
     );
-    (diagnostics, referenced_aliases)
+    (diagnostics, analysis_result)
 }
 
 /// Applies `@expect` directives to suppress matching diagnostics.

--- a/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/class_hierarchy/mod.rs
@@ -29,6 +29,22 @@ pub use class_info::{ClassInfo, MethodInfo, SuperclassTypeArg, format_default_va
 pub use declared_type::DeclaredType;
 /// Per-class selector index: maps class name → (selector → method vec position).
 type SelectorIndexMap = HashMap<EcoString, HashMap<EcoString, usize>>;
+
+#[cfg(test)]
+thread_local! {
+    /// BT-3123 test-only instrumentation: counts calls to
+    /// [`ClassHierarchy::build_with_options`] (which [`ClassHierarchy::build`]
+    /// delegates to) — the from-scratch hierarchy construction pass. Used by a
+    /// codegen test to verify that a driver threading an `AnalysisResult` into
+    /// codegen via `CodegenOptions::with_analysis` doesn't trigger a second
+    /// build. `#[cfg(test)]` only — compiled out of release builds entirely.
+    ///
+    /// Thread-local, not a shared global counter — see
+    /// `type_checker::CHECK_MODULE_CALL_COUNT`'s doc for why a global counter's
+    /// absolute value would be meaningless under `cargo test`'s concurrency.
+    pub(crate) static BUILD_CALL_COUNT: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
 /// Static class hierarchy built during semantic analysis.
 ///
 /// Provides compile-time knowledge of the full class hierarchy,
@@ -133,6 +149,10 @@ impl ClassHierarchy {
         module: &Module,
         stdlib_mode: bool,
     ) -> (Result<Self, SemanticError>, Vec<Diagnostic>) {
+        // BT-3123 test-only instrumentation — see `BUILD_CALL_COUNT`'s doc.
+        #[cfg(test)]
+        BUILD_CALL_COUNT.with(|c| c.set(c.get() + 1));
+
         let mut hierarchy = Self::with_builtins();
         let diagnostics = hierarchy.add_module_classes(module, stdlib_mode);
         hierarchy.rebuild_all_indexes();
@@ -359,7 +379,15 @@ impl ClassHierarchy {
     ///
     /// BT-1528: After all entries are inserted, walks the ancestor chain for
     /// each new class to resolve `is_value` correctly for indirect subclasses.
-    pub fn add_external_superclasses(&mut self, index: &std::collections::HashMap<String, String>) {
+    ///
+    /// BT-3123: Returns whether any stub was actually inserted — `false` means
+    /// every class in `index` was already present, so a caller holding a
+    /// hierarchy-derived cache (e.g. codegen's handed-off `method_return_types`)
+    /// can trust it's still valid without recomputing.
+    pub fn add_external_superclasses(
+        &mut self,
+        index: &std::collections::HashMap<String, String>,
+    ) -> bool {
         // BT-1545: Track which classes are newly inserted so the is_value
         // fixup loop only walks them and their descendants, not everything.
         let mut newly_inserted: HashSet<EcoString> = HashSet::new();
@@ -400,7 +428,7 @@ impl ClassHierarchy {
             }
         }
         if newly_inserted.is_empty() {
-            return;
+            return false;
         }
         // BT-1528: Fix is_value for indirect Value subclasses now that all
         // entries are in the hierarchy and superclass_chain can walk them.
@@ -436,6 +464,7 @@ impl ClassHierarchy {
                 }
             }
         }
+        true
     }
     /// Populate the hierarchy with user-class entries pre-deserialized from
     /// `__beamtalk_meta/0` maps (ADR 0050 Phase 4).
@@ -443,7 +472,10 @@ impl ClassHierarchy {
     /// Skips builtins (stdlib has richer data) and classes already present
     /// in the hierarchy (AST-derived entries from `build()` are authoritative
     /// over cached BEAM metadata, which may be stale during redefinition).
-    pub fn add_from_beam_meta(&mut self, classes: Vec<ClassInfo>) {
+    ///
+    /// BT-3123: Returns whether any entry was actually inserted — see
+    /// [`Self::add_external_superclasses`]'s doc for why callers care.
+    pub fn add_from_beam_meta(&mut self, classes: Vec<ClassInfo>) -> bool {
         let mut changed = false;
         for info in classes {
             if !Self::is_builtin_class(&info.name) {
@@ -458,6 +490,7 @@ impl ClassHierarchy {
         if changed {
             self.rebuild_all_indexes();
         }
+        changed
     }
     /// Set the `package` field on all non-builtin classes that don't already
     /// have a package assigned (ADR 0071, BT-1700).

--- a/crates/beamtalk-core/src/semantic_analysis/facts.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/facts.rs
@@ -226,6 +226,21 @@ fn block_has_nlr(block: &Block) -> bool {
         .any(|s| expr_has_block_nlr(&s.expression, true))
 }
 
+#[cfg(test)]
+thread_local! {
+    /// BT-3123 test-only instrumentation: counts calls to
+    /// [`compute_semantic_facts`]. Used by a codegen test to verify that a driver
+    /// threading an `AnalysisResult` into codegen via `CodegenOptions::with_analysis`
+    /// doesn't trigger a second pass. `#[cfg(test)]` only — compiled out of
+    /// release builds entirely.
+    ///
+    /// Thread-local, not a shared global counter — see
+    /// `type_checker::CHECK_MODULE_CALL_COUNT`'s doc for why a global counter's
+    /// absolute value would be meaningless under `cargo test`'s concurrency.
+    pub(crate) static COMPUTE_SEMANTIC_FACTS_CALL_COUNT: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
 /// Compute semantic facts for all nodes in a module.
 ///
 /// Performs a single top-level pass over the AST:
@@ -233,6 +248,10 @@ fn block_has_nlr(block: &Block) -> bool {
 /// - Populates `dispatch_kinds` for every [`Expression::MessageSend`] node.
 /// - Populates `methods_with_block_nlr` for methods whose body contains `^` inside a block.
 pub fn compute_semantic_facts(module: &Module) -> SemanticFacts {
+    // BT-3123 test-only instrumentation — see `COMPUTE_SEMANTIC_FACTS_CALL_COUNT`'s doc.
+    #[cfg(test)]
+    COMPUTE_SEMANTIC_FACTS_CALL_COUNT.with(|c| c.set(c.get() + 1));
+
     let mut facts = SemanticFacts::default();
 
     // Process module-level expressions

--- a/crates/beamtalk-core/src/semantic_analysis/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/mod.rs
@@ -63,7 +63,9 @@ pub use name_resolver::NameResolver;
 pub use pattern_bindings::{extract_match_arm_bindings, extract_pattern_bindings};
 pub use protocol_registry::{ProtocolInfo, ProtocolRegistry};
 pub use receiver_knowledge::{KnowledgeScope, ReceiverKnowledge, classify_receiver};
-pub use return_type_writeback::apply_return_type_writeback;
+pub use return_type_writeback::{
+    apply_return_type_writeback, apply_return_type_writeback_from_map,
+};
 pub use scope::BindingKind;
 pub use supervisor_kind_writeback::apply_supervisor_kind_writeback;
 pub use type_checker::{
@@ -84,7 +86,16 @@ pub fn check_stdlib_name_shadowing(
 }
 
 /// Result of semantic analysis.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// BT-3123: Also carries [`SemanticFacts`] and inferred method return types
+/// (`method_return_types`) alongside the class hierarchy, protocol registry,
+/// and alias registry already here — the full set of analysis outputs codegen
+/// needs. This lets a driver that already ran [`analyse_full`] for
+/// diagnostics hand the *same* `AnalysisResult` to codegen (via
+/// `CodegenOptions::with_analysis`) instead of codegen re-deriving its own
+/// view (a fresh `ClassHierarchy::build`, a fresh `compute_semantic_facts`,
+/// and a full re-run of `infer_method_return_types` — see BT-3123).
+#[derive(Debug, Clone)]
 pub struct AnalysisResult {
     /// Diagnostics (errors and warnings) from analysis.
     pub diagnostics: Vec<Diagnostic>,
@@ -100,6 +111,22 @@ pub struct AnalysisResult {
 
     /// Type alias registry (ADR 0108 Phase 2, BT-2895).
     pub alias_registry: AliasRegistry,
+
+    /// Pre-codegen semantic facts (BT-1288) computed in the same pass as the
+    /// rest of analysis (BT-3123) — block mutation/capture profiles, dispatch
+    /// classification, and non-local-return spans. Consumed by codegen via
+    /// `CodegenOptions::with_analysis` instead of a second
+    /// `compute_semantic_facts` call.
+    pub semantic_facts: facts::SemanticFacts,
+
+    /// Inferred return types for unannotated methods (BT-1005), keyed by
+    /// `(ClassName, Selector, IsClassMethod)`. Populated from the same
+    /// [`TypeChecker`] pass that builds `type_map` during Phase 2 below —
+    /// previously discarded here and re-derived by codegen's return-type
+    /// writeback pass via a second, full `infer_method_return_types` call
+    /// (BT-3123). `Dynamic` results are omitted (absence = dynamic), matching
+    /// [`type_checker::infer_method_return_types`]'s own contract.
+    pub method_return_types: HashMap<type_checker::MethodReturnKey, InferredType>,
 
     /// Every alias name transitively referenced by an annotation resolved
     /// during this compile (ADR 0108 hot-reload re-check trigger, BT-2899).
@@ -140,6 +167,8 @@ impl AnalysisResult {
             class_hierarchy: ClassHierarchy::with_builtins(),
             protocol_registry: ProtocolRegistry::new(),
             alias_registry: AliasRegistry::new(),
+            semantic_facts: facts::SemanticFacts::default(),
+            method_return_types: HashMap::new(),
             referenced_aliases: Vec::new(),
         }
     }
@@ -455,6 +484,14 @@ pub fn analyse_full(module: &Module, ctx: AnalysisContext<'_>) -> AnalysisResult
 
     let mut result = AnalysisResult::new();
 
+    // BT-1288 / BT-3123: Compute pre-codegen semantic facts in the same pass
+    // as the rest of analysis, on the same (pre-writeback) module AST that
+    // codegen's own `compute_semantic_facts(module)` call used to re-derive.
+    // A pure AST walk with no hierarchy/type dependency, so it can run
+    // anywhere in this function; done first for symmetry with the writeback
+    // trio's ordering in codegen.
+    result.semantic_facts = facts::compute_semantic_facts(module);
+
     // Phase 0: Build Class Hierarchy (ADR 0006 Phase 1a)
     let (hierarchy_result, hierarchy_diags) =
         ClassHierarchy::build_with_options(module, stdlib_mode);
@@ -658,6 +695,10 @@ pub fn analyse_full(module: &Module, ctx: AnalysisContext<'_>) -> AnalysisResult
         type_checker.take_referenced_aliases().into_iter().collect();
     referenced_aliases.sort();
     result.referenced_aliases = referenced_aliases;
+    // BT-3123: capture the method-return-type inferences this same
+    // `TypeChecker` pass already computed, so codegen's return-type
+    // writeback pass can consume them instead of re-running inference.
+    result.method_return_types = type_checker.take_method_return_types();
     let type_map = type_checker.take_type_map();
 
     // BT-2140: Lint redundant local-variable type annotations using the

--- a/crates/beamtalk-core/src/semantic_analysis/return_type_writeback.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/return_type_writeback.rs
@@ -25,10 +25,11 @@
 use crate::ast::{Identifier, Module, TypeAnnotation};
 use crate::semantic_analysis::class_hierarchy::ClassHierarchy;
 use crate::semantic_analysis::type_checker::{
-    InferredType, NativeTypeRegistry, infer_method_return_types,
+    InferredType, MethodReturnKey, NativeTypeRegistry, infer_method_return_types,
 };
 use crate::source_analysis::Span;
 use ecow::EcoString;
+use std::collections::HashMap;
 
 /// Build a `TypeAnnotation` from an `InferredType` for AST writeback.
 ///
@@ -89,7 +90,21 @@ pub fn apply_return_type_writeback(
     native_type_registry: Option<&NativeTypeRegistry>,
 ) {
     let inferred = infer_method_return_types(module, hierarchy, native_type_registry);
+    apply_return_type_writeback_from_map(module, &inferred);
+}
 
+/// [`apply_return_type_writeback`], given an already-computed inferred-return-types
+/// map instead of running [`infer_method_return_types`] itself.
+///
+/// BT-3123: used by codegen when a driver hands off an [`AnalysisResult`](crate::semantic_analysis::AnalysisResult)
+/// whose `method_return_types` field was populated by the same [`TypeChecker`](crate::semantic_analysis::type_checker::TypeChecker)
+/// pass that already ran for diagnostics — avoids a second, full type-checking
+/// pass over the module purely to re-derive the same map.
+#[allow(clippy::implicit_hasher)] // concrete HashMap (matches AnalysisResult::method_return_types) is simpler for callers
+pub fn apply_return_type_writeback_from_map(
+    module: &mut Module,
+    inferred: &HashMap<MethodReturnKey, InferredType>,
+) {
     for class in &mut module.classes {
         for method in &mut class.methods {
             if method.return_type.is_some() {

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/inference.rs
@@ -121,6 +121,10 @@ impl TypeChecker {
     /// `method_return_types` map when the hierarchy has no explicit annotation.
     #[allow(clippy::too_many_lines)] // struct patterns expanded by BT-1569 refactor
     pub fn check_module(&mut self, module: &Module, hierarchy: &ClassHierarchy) {
+        // BT-3123 test-only instrumentation — see `CHECK_MODULE_CALL_COUNT`'s doc.
+        #[cfg(test)]
+        super::CHECK_MODULE_CALL_COUNT.with(|c| c.set(c.get() + 1));
+
         let mut env = TypeEnv::new();
 
         // Check method bodies inside class definitions first, so that inferred

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/mod.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/mod.rs
@@ -27,6 +27,28 @@ use ecow::EcoString;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+#[cfg(test)]
+thread_local! {
+    /// BT-3123 test-only instrumentation: counts calls to
+    /// [`TypeChecker::check_module`] — the actual full type-checking pass (the
+    /// costly operation the issue's "runs twice per file" complaint is about).
+    /// Used by a codegen test to verify that a driver threading an
+    /// `AnalysisResult` into codegen via `CodegenOptions::with_analysis` doesn't
+    /// trigger a second pass. `#[cfg(test)]` only — compiled out of release
+    /// builds entirely, so it has no runtime cost or behavioural effect outside
+    /// `cargo test`.
+    ///
+    /// Thread-local (not a shared global counter): `cargo test` runs many tests
+    /// concurrently across threads, and plenty of *other* tests call
+    /// `check_module` too — a global counter's absolute value is meaningless
+    /// under that concurrency. A thread-local counter isolates each test's own
+    /// before/after delta from unrelated tests running on other threads, since a
+    /// single `#[test]` function body always runs start-to-finish on one thread
+    /// with no other test scheduled onto it in between.
+    pub(crate) static CHECK_MODULE_CALL_COUNT: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
 mod env_key;
 mod inference;
 mod narrowing;


### PR DESCRIPTION
## Summary

`generate_module_with_warnings` ignored the `AnalysisResult` the driver already computed for diagnostics and re-derived its own view: a fresh `ClassHierarchy::build(module)`, a fresh `compute_semantic_facts(&module)`, and (via the writeback trio) a full re-run of `infer_method_return_types` — a second, full type-checking pass per compiled module, with no guarantee analysis and codegen agreed on class kinds, hierarchy, or inferred types.

- `AnalysisResult` now also carries `semantic_facts` and `method_return_types`, populated by `analyse_full`'s *existing* passes (no new computation added to analysis itself).
- `CodegenOptions::with_analysis(AnalysisResult)` threads it into codegen. `generate_module`/`generate_module_with_warnings` consume it directly instead of rebuilding the hierarchy/facts/types. `None` (the default) preserves today's self-sufficient behaviour for callers that don't run analysis separately (unit tests, ad-hoc codegen, REPL trace mode).
- Cross-file enrichment (`add_from_beam_meta`/`add_external_superclasses`) still runs on top of the handed-off hierarchy — both now report whether they actually inserted anything. If they did (i.e. the driver's codegen-only inputs carried a class the driver's own analysis pass never saw), codegen transparently falls back to a fresh `infer_method_return_types` call instead of trusting a possibly-stale map. Verified this doesn't spuriously trigger for the realistic same-driver overlap case (see Testing).
- `apply_return_type_writeback` split into a map-based `apply_return_type_writeback_from_map` so codegen can consume a precomputed map without re-running inference.
- `compute_project_diagnostics_with_analysis` (beamtalk-core) and `compute_diagnostics_and_analysis` (compiler-port) return the `AnalysisResult` alongside diagnostics for drivers that go on to run codegen.
- Wired drivers: the CLI build/stdlib path (`compile_source_with_bindings` → `write_core_erlang_with_bindings`, used by both `beamtalk build` and `build_stdlib`), and the compiler-port's `compile`/`compile_method`/`compile_expression` handlers. Threading is skipped only where a standalone-method merge happens *between* computing analysis and calling codegen, which would make the handed-off map stale — codegen's normal fallback (still correct) covers that rarer case.

## What was NOT changed

- What analysis computes, or what codegen emits for the paths already exercised by `test-package-compiler`'s snapshots (none of those call `with_analysis`, so they exercise the unchanged fallback path).
- Layering: codegen already depended on `semantic_analysis` types; nothing new upward.

## Testing

- All **398** `test-package-compiler` codegen snapshots byte-identical.
- New test module `codegen::core_erlang::tests::analysis_handoff` — thread-local call counters (test-only, compiled out of release builds) on `ClassHierarchy::build_with_options`, `compute_semantic_facts`, and `TypeChecker::check_module`, proving:
  1. A driver that threads `AnalysisResult` into codegen makes **zero additional calls** to any of the three (`with_analysis_skips_codegen_re_derivation`).
  2. Without threading, codegen still computes its own (baseline, so the assertions above aren't vacuous) (`without_analysis_codegen_computes_its_own`).
  3. **Added during review (Pass 3 adversarial):** the realistic multi-file package scenario — where a driver feeds the *same* cross-file class list to both `AnalysisContext` and `CodegenOptions` — is correctly recognised as a no-op and doesn't spuriously trigger the safety-net fallback (`with_analysis_skips_re_derivation_with_overlapping_cross_file_metadata`). This was a real risk caught during review: without it, the fix would have silently not applied to any real multi-file package build.
- `just test`: Rust (5574 tests), stdlib (231/231), BUnit (3213/3215, 0 failed), runtime (5594 + 1807, 0 failures) — all green.
- `just ci-changed`: build, lint, corpus check, surface-drift check — all green.

### `compiler_pipeline` bench (release, `end_to_end` group, this machine — before → after)

| Input | Before | After | Δ |
|---|---|---|---|
| minimal | 1.838 ms | 1.428 ms | ~22% faster |
| typical | 2.561 ms | 2.180 ms | ~15% faster |
| large | 7.221 ms | 6.418 ms | ~11% faster |

(`bench_end_to_end`/`bench_project`/`bench_project_otp` updated to call `.with_analysis(...)`, matching the fixed driver pattern — otherwise they'd keep measuring the unfixed double-computation path regardless of the production fix.)

## Review

Went through all 3 passes of `/review-code` (diff review, system/cross-component review, adversarial review). The adversarial pass caught a genuine correctness-adjacent risk (see "Added during review" above) which is now covered by a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApDPx4Ar6fkgWSbYZWiTFi

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApDPx4Ar6fkgWSbYZWiTFi)_