### PR TITLE
docs: add ADR 0111 - mid-level lowered IR + verifier for state threading (BT-3122)

### DIFF
--- a/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
+++ b/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
@@ -1,7 +1,7 @@
 # ADR 0111: Mid-Level Lowered IR + Verifier for State Threading, Control Flow, and Non-Local Return
 
 ## Status
-Proposed (2026-08-09)
+Accepted (2026-08-10)
 
 ## Context
 

--- a/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
+++ b/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
@@ -1,11 +1,7 @@
 # ADR 0111: Mid-Level Lowered IR + Verifier for State Threading, Control Flow, and Non-Local Return
 
 ## Status
-Proposed (2026-08-09; revised same day after `/review-adr` adversarial pass —
-the revision corrected the verifier's claimed relationship to ADR 0110's bug,
-brought the `Bind`-emission sites into scope, added frame identity to the IR
-design, and replaced the snapshot-parity gate with an expanded-corpus gate.
-See §Verifier honesty and §Phase A0.)
+Proposed (2026-08-09)
 
 ## Context
 
@@ -70,8 +66,7 @@ numbers:
 | "~16 scattered `debug_assert!`s" | **6 in the named in-scope files** (29 repo-wide in `codegen/core_erlang/`, but 23 are arity/argument-count checks in `intrinsics.rs`/`erlang_types.rs` — expression/primitive codegen, explicitly out of scope per BT-3122's own "that's not where the failures are") | Full 6: `while_loops.rs:317`, `while_loops.rs:454`, `control_flow/mod.rs:2522`, `control_flow/mod.rs:2651` (all four assert an *optimized threading mode implies no `StateAcc` unpack code* — the same invariant, independently asserted at four call sites instead of centralized once); `gen_server/methods.rs:1258`, `gen_server/methods.rs:1450` (both assert that `classify_body_expr`'s upfront classification and `threaded_expr.rs`'s downstream recognizer *agree* on whether a construct routes through the Actor threaded emitter) |
 | "`CoreErlangGenerator` ~90 fields" | **36 fields** on `CoreErlangGenerator` (`mod.rs:1288-1481`), ≈39 including its two state-carrying sub-structs (`VariableContext`, `StateThreading`) | Still large enough to be the "coordinates everything" bottleneck the issue describes — just not 90 |
 
-Two honesty notes on the `debug_assert!` situation, both from the
-adversarial review pass:
+Two honesty notes on the `debug_assert!` situation:
 
 - **The six assertions are not the last line of defense.** In release
   builds, a violation of any of the six degrades into malformed Core
@@ -148,7 +143,7 @@ positional index with no relation to mutation-version threading at all.)
   running a separate verification pass over it. There is no existing
   verifier-pattern precedent in this codebase; this ADR introduces one.
 - **The codegen snapshot corpus is currently too thin to gate this
-  migration** — measured during review: of the 318 snapshots under
+  migration** — measured: of the 318 snapshots under
   `test-package-compiler/tests/snapshots/`, exactly **1** contains a
   `letrec` loop, **1** contains `$bt_nlr`, **1** contains `ClassVars1`,
   **1** contains `class_vars_shadow`, and **4** contain `StateAcc`. A
@@ -161,12 +156,11 @@ positional index with no relation to mutation-version threading at all.)
 
 ### Constraints
 
-- **Narrow scope, as specified by BT-3122 — with one correction.** The
+- **Narrow scope, as specified by BT-3122 — with one addition.** The
   lowered form covers the control-flow + state-threading core: the
   `control_flow/` cluster, `threaded_expr.rs`, the state-versioning subset
   of `gen_server/methods.rs` (measured at roughly 1900–2400 of its 5805
-  lines), **and — a scope correction found in review — the
-  version-`Bind`-emitting slices of `expressions.rs` and
+  lines), **and the version-`Bind`-emitting slices of `expressions.rs` and
   `dispatch_codegen.rs`**: `generate_field_assignment`
   (`expressions.rs:552` calls `next_class_var()`; the analogous field
   paths drive `next_self_var()`/`next_state_var()`) and
@@ -346,10 +340,9 @@ refusal to compile valid code.
 
 ### Verifier honesty — what this catches and what it cannot
 
-This section exists because the first draft of this ADR overclaimed, and
-the adversarial review caught it (verified against
-`wrap_body_with_nlr_catch`, `mod.rs:2480-2549`, and `NlrCatchVars`,
-`mod.rs:880-890`):
+These limits are structural, not incidental — they follow directly from how
+the generator emits NLR scaffolding (`wrap_body_with_nlr_catch`,
+`mod.rs:2480-2549`, and `NlrCatchVars`, `mod.rs:880-890`):
 
 - **The verifier checks what the lowering pass said, not what it meant.**
   The lowering pass and the emitter share their source of truth
@@ -452,12 +445,11 @@ corpus, Phase A3, at the end of each migration phase.)
 
 ### Option B: Verifier without IR
 
-Two forms, split per the adversarial review because they have opposite verdicts:
+Two forms, split because they have opposite verdicts:
 
 **B1 — re-derive post-hoc (from Document/text or generator state after the
-fact).** Rejected for the reason the first draft gave, which survives
-review: the needed structure (version provenance, frame identity, mode
-membership) doesn't exist post-emission and re-deriving it means
+fact).** Rejected: the needed structure (version provenance, frame
+identity, mode membership) doesn't exist post-emission and re-deriving it means
 re-implementing `classify_body_expr`/`ThreadingPlan` a second time — the
 §6 duplication anti-pattern.
 
@@ -470,11 +462,11 @@ gets the mode/unpack and classifier/emitter checks always-on at a fraction
 of the cost.
 
 - 🧑‍💻 **Newcomer**: "No new pipeline stage to learn — the codegen I read is still the codegen that runs."
-- ⚙️ **BEAM veteran**: "This is the 90/10 point. The checks that survive the honesty analysis are exactly the ones this gets."
+- ⚙️ **BEAM veteran**: "This is the 90/10 point. The checks that are actually sound (§Verifier honesty) are exactly the ones this gets."
 - 🏭 **Operator**: "No migration freeze on 11K LOC of actively-developed files."
-- 🎨 **Language designer (sharpest form)**: "After the honesty corrections, the verifier's *checks* don't require the IR — they require the *decisions*, which already exist as data. The IR's remaining unique contribution is single-sourcing (one node, one emitter) and the counter unification. Is that worth the migration?"
+- 🎨 **Language designer (sharpest form)**: "On §Verifier honesty's own accounting, the verifier's *checks* don't require the IR — they require the *decisions*, which already exist as data. The IR's remaining unique contribution is single-sourcing (one node, one emitter) and the counter unification. Is that worth the migration?"
 
-**Why A still wins, on the corrected claims — narrowly.** B2 checks that
+**Why A still wins — narrowly.** B2 checks that
 two independently-computed decisions agree; A removes the second
 computation. B2's recorder must itself be maintained at every decision
 site (a site that forgets to record is invisible to the validator — the
@@ -494,8 +486,7 @@ transfers to B2 directly.
 - 🏭 **Operator**: "Zero cost, zero risk, zero freeze."
 - 🎨 **Language designer**: "One shipped bug in the codebase's lifetime for this class; is any of this proportionate?"
 
-**Why A wins despite this steelman.** The corrected version of the
-argument, since the first draft overstated it: the six assertions *do*
+**Why A wins despite this steelman.** The six assertions *do*
 have a release-mode backstop (`core_lint`), but it fires far from the
 cause with an Erlang-level message about generated code, and it covers
 only the failures that happen to produce malformed output — a
@@ -522,7 +513,7 @@ to any black-box oracle. This ADR's Phase A runs in parallel with
 BT-3112's early children, and the A0 gate provides the explicit
 reconsideration point if the harness's early results change the calculus.
 What this ADR does *not* claim is that the verifier substitutes for the
-harness — the first draft's error, corrected in §Verifier honesty.
+harness (§Verifier honesty).
 
 ### Tension Points
 
@@ -555,19 +546,20 @@ snapshot corpus. That outcome is explicitly acceptable and pre-planned,
 not a failure mode.
 
 ### 2. Status quo
-See Steelman Option C. **Rejected** — on the corrected argument (no
+See Steelman Option C. **Rejected** (no
 protection for the silent-wrong class; poor diagnosis for the loud class;
 `self_version` hole and shadow-write forgettability unaddressed).
 
 ### 3. Unify the three version counters only
-**Absorbed rather than rejected.** This is now precisely Phase A2, and it
-is independently justified — the review established it must be done as
-*naming-only* unification with per-prefix discipline preserved and pinned
-by tests, plus the typestate hardening of Alternative 5. What the full ADR
-adds beyond it is the single-sourcing of classifier/emitter decisions and
-the shadow-write contract check; the first draft's claim that the six
-`debug_assert!`s were "the actual mechanism behind ADR 0110's bug class"
-was wrong (none of the six is on 0110's path) and is withdrawn.
+**Absorbed rather than rejected.** This is precisely Phase A2, and it is
+independently justified — done as *naming-only* unification with
+per-prefix discipline preserved and pinned by tests, plus the typestate
+hardening of Alternative 5. What the full ADR adds beyond it is the
+single-sourcing of classifier/emitter decisions and the shadow-write
+contract check. (Note the six `debug_assert!`s are *not* an argument
+against this alternative: none of the six is on ADR 0110's path — they
+guard the mode/unpack and classifier/emitter invariants, which counter
+unification alone indeed does not address.)
 
 ### 4. Full-pipeline typed Core Erlang IR
 **Rejected** — per ADR 0018's still-valid reasoning and BT-3122's explicit
@@ -619,7 +611,7 @@ substitute.
 
 ### Negative
 - **New internal API surface** for contributors to the in-scope files.
-- **A real test-migration cost the first draft omitted:** ~1,484 `#[test]`s
+- **A real test-migration cost:** ~1,484 `#[test]`s
   and 231 `to_pretty_string()` assertion sites live under `codegen/`
   (`tests/control_flow.rs` alone is 2,591 lines; `list_ops/tests.rs`
   2,660). Functions returning `ThreadedIr` instead of `Document` would
@@ -704,10 +696,9 @@ building a to-be-deleted re-derivation). Deletes the four unpack
 `debug_assert!`s.
 
 ### Phase C — `list_ops/` (L)
-Migrate the foldl list-op family — re-scoped **L** (the first draft's
-"mechanical follow-on, no new invariant classes" was wrong). New invariant
-classes Phase B never exercises, each needing IR modeling and verifier
-coverage: (1) the flat `{FoldAcc, Var1..VarN}` positional-unpack
+Migrate the foldl list-op family — sized **L**, not a mechanical
+follow-on to Phase B: it introduces invariant classes Phase B never
+exercises, each needing IR modeling and verifier coverage: (1) the flat `{FoldAcc, Var1..VarN}` positional-unpack
 accumulator discipline (distinct from parameter threading); (2)
 `select_tuple_acc`'s ValueType-context exclusion (`control_flow/mod.rs:448-466`);
 (3) the recursive inter-construct `list_op_needs_stateacc_fallback`
@@ -720,8 +711,8 @@ point. May split fold-shaped vs. early-exit-shaped in `/plan-adr`.
 Migrate the state-versioning slice of `gen_server/methods.rs`
 (`BodyExprKind`, `generate_body_exprs_with_reply`, tier-2 helpers), the
 `ClassVars` threading path **including its `Bind`-emission sites in
-`expressions.rs:552` and `dispatch_codegen.rs:463`** (the scope correction
-— these are the producers of everything the verifier checks),
+`expressions.rs:552` and `dispatch_codegen.rs:463`** (these are the
+producers of everything the verifier checks),
 `conditionals.rs`, `exception_handling.rs`, and `threaded_expr.rs`'s
 boundary adapter. Lands `ShadowWriteMissing` plus the **cross-boundary
 conformance fixture** pinning codegen's shadow-write emission against
@@ -749,8 +740,8 @@ extended.
 
 ### Verification
 - **Expanded snapshot corpus (A3) byte-parity** after every phase — the
-  real gate, replacing the first draft's reliance on a corpus measured at
-  1–4 relevant cases per phase.
+  real gate; the pre-expansion corpus covers the in-scope constructs in
+  only 1–4 of 318 snapshots and cannot serve as one.
 - **Ordered diagnostic-stream equality** (`BEAMTALK_CODEGEN_DIAGNOSTICS`
   output as a sequence, not a set) after every phase.
 - **Verifier green** on all `stdlib/test/*.bt` +
@@ -806,7 +797,7 @@ extended.
   - `control_flow/` (13 files, 16,329 LOC), `threaded_expr.rs` (416),
     `gen_server/methods.rs` (5805; ≈1900–2400 in scope) — in scope
   - `expressions.rs:552`, `dispatch_codegen.rs:463` — the
-    version-`Bind`/shadow-write emission sites (scope correction)
+    version-`Bind`/shadow-write emission sites (in scope)
   - `mod.rs` — `NlrBoundary` (:902), `NlrCatchVars` (:880),
     `wrap_body_with_nlr_catch` (:2480), `with_branch_context` (:2064),
     counters (:1132, :1211, :2088, :2104)

--- a/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
+++ b/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
@@ -1,0 +1,746 @@
+# ADR 0111: Mid-Level Lowered IR + Verifier for State Threading, Control Flow, and Non-Local Return
+
+## Status
+Proposed (2026-08-09)
+
+## Context
+
+### Problem statement
+
+The 2026-08 compiler pipeline architecture review (reflected in this issue and
+its siblings [BT-3111](https://linear.app/beamtalk/issue/BT-3111) and
+[BT-3112](https://linear.app/beamtalk/issue/BT-3112); there is no standalone
+document for the review itself — it exists only as the shared rationale cited
+by these three issues) identified the AST→Core-Erlang-text gap as Beamtalk's
+main divergence from state-of-the-art compiler shape. All of the semantically
+hard lowering — actor/instance state threading (`State`/`State1`/`State2`
+versioning), class-variable threading (`ClassVars`/`ClassVars1`/…),
+value-type field threading (`Self`/`Self1`/…), non-local-return (NLR)
+lowering, and the `{Value, StateAcc}` calling convention (ADR 0041) —
+happens **interleaved with `Document` construction** (the ADR 0089
+pretty-printer tree), coordinated through a handful of scattered
+`debug_assert!`s that compile out of release builds and a set of
+independently-implemented decisions that must agree with each other by
+convention, not by construction.
+
+This is not a hypothetical risk. [ADR 0110](0110-class-var-shadow-write-through-for-nlr-relay.md)
+is a real, shipped bug in exactly this class: a class method that mutated a
+class variable and then handed a block to another method lost the mutation
+when the block's `^` escaped through library code, while still returning the
+*correct value*. The generated Core Erlang was well-formed the entire time —
+every variable bound, every arity correct — so `core_lint` (which runs
+unconditionally on every compile; see below) passed it without complaint.
+The bug was purely semantic: the wrong-but-validly-typed `ClassVars` value
+flowed to the reply. That is precisely the class of bug a structural linter
+cannot see and a lowered IR + verifier is designed to catch mechanically,
+before the code ships, not after a user reports silently-wrong behavior.
+
+### Current state, as measured
+
+BT-3122 estimated the in-scope surface as "the `control_flow/` cluster
+(4.4K LOC), `threaded_expr.rs`, and the state-versioning parts of
+`gen_server/methods.rs` (5.8K LOC)," guarded by "~16 scattered
+`debug_assert!`s" inside a "~90-field `CoreErlangGenerator`." Direct
+measurement during this ADR's research corrects all three figures — the
+underlying problem is the same, but the ADR should proceed from accurate
+numbers:
+
+| Claimed | Measured | Detail |
+|---|---|---|
+| `control_flow/` cluster: 4.4K LOC | **16,329 LOC total** (≈11,264 excluding inline/separate test modules) across 13 files | 4.4K matches `control_flow/mod.rs` alone (4454 lines); the cluster also includes `conditionals.rs` (1127), `counted_loops.rs` (617), `dict_ops.rs` (641), `exception_handling.rs` (1272), `while_loops.rs` (1248), and `list_ops/` (6 files, ≈4310 lines led by `transform_ops.rs` at 2074 and `search_ops.rs` at 917) |
+| `threaded_expr.rs`: implied to carry significant complexity | **416 LOC** | Confirmed small — it is a boundary *adapter* (`ThreadingBoundary::{ValueType, ClassMethod, Actor}`, `ThreadedExpr`), not where the bulk of state-threading logic lives. That logic (the `ThreadingPlan`/`StateAccFallbackReason` mode selection) is in `control_flow/mod.rs` |
+| "~16 scattered `debug_assert!`s" | **6 in the named in-scope files** (29 repo-wide in `codegen/core_erlang/`, but 23 are arity/argument-count checks in `intrinsics.rs`/`erlang_types.rs` — expression/primitive codegen, explicitly out of scope per BT-3122's own "that's not where the failures are") | Full 6: `while_loops.rs:317`, `while_loops.rs:454`, `control_flow/mod.rs:2522`, `control_flow/mod.rs:2651` (all four assert an *optimized threading mode implies no `StateAcc` unpack code* — the same invariant, independently asserted at four call sites instead of centralized once); `gen_server/methods.rs:1258`, `gen_server/methods.rs:1450` (both assert that `classify_body_expr`'s upfront classification and `threaded_expr.rs`'s downstream recognizer *agree* on whether a construct routes through the Actor threaded emitter) |
+| "`CoreErlangGenerator` ~90 fields" | **36 fields** on `CoreErlangGenerator` (`mod.rs:1288-1481`), ≈39 including its two state-carrying sub-structs (`VariableContext`, `StateThreading`) | Still large enough to be the "coordinates everything" bottleneck the issue describes — just not 90 |
+
+None of these corrections weaken the case for this ADR; if anything the
+`debug_assert!` finding sharpens it: **every one of the six in-scope
+assertions is a "two independently-computed decisions must agree" check**,
+not an arity or bounds check. That is exactly the shape of invariant a
+verifier over a shared IR replaces with a structural guarantee instead of a
+runtime spot-check that six people (or six future PRs) have to remember to
+keep synchronized.
+
+### The duplication this ADR's IR would also close
+
+Research for this ADR surfaced a second, previously undocumented instance of
+the CLAUDE.md/`architecture-principles.md` §6 duplication anti-pattern
+("layer X can't depend on layer Y" leading to independent reimplementation
+instead of a shared leaf module — see
+[`docs/development/architecture-principles.md`](../development/architecture-principles.md)
+§6): **three structurally identical, independently implemented
+monotonic-version-counter services**, all producing `Prefix`, `Prefix1`,
+`Prefix2`, … names via the same `util::versioned_var(prefix, version)`
+helper, but tracked as three separate fields with three separate
+save/restore disciplines:
+
+| Counter | Type | Where | Produces |
+|---|---|---|---|
+| Actor/instance state | `StateThreading` struct (`state_codegen.rs:42`) | `CoreErlangGenerator.state_threading` field | `State`, `State1`, `State2`, … (renamed to `StateAcc*` inside loop bodies) |
+| Class variables | `usize` field + `next_class_var()` (`mod.rs:1132`, `mod.rs:2088`) | `ClassContext.class_var_version` | `ClassVars`, `ClassVars1`, … (ADR 0110's mechanism) |
+| Value-type fields | `usize` field + `next_self_var()` (`mod.rs:1211`, `mod.rs:2095`) | `ValueTypeContext.self_version` | `Self`, `Self1`, … |
+
+`with_branch_context` (`mod.rs:2064-2080`, BT-1449/BT-1550) already has to
+save, reset, and restore `state_version` *and* `class_var_version` together
+whenever codegen enters a branch — but not `self_version`, because that
+coupling is maintained by a developer remembering to update the function,
+not by a shared type. (A fourth, unrelated "State" name,
+`_BuilderStateN` in `gen_server/methods.rs:2514`'s `build_builder_state_doc`,
+is a per-class positional index with no relation to mutation-version
+threading at all — worth flagging so a future IR design doesn't conflate
+it with the other three.) This ADR's lowered IR gives these three counters
+one shared representation (a `VersionedVar` type — see Decision) instead of
+three parallel structs that must be kept in sync by convention.
+
+### What already exists and does *not* need to change
+
+- **`core_lint`** (BT-3115) already runs unconditionally as part of every
+  `compile:forms(Forms, [from_core | Opts])` call — independent of the
+  `clint`/`no_lint` options, which only gate a different code path
+  (compiling from Erlang *source*, which Beamtalk never does). It reliably
+  catches unbound-variable and duplicate-variable well-formedness bugs
+  (`docs/development/debugging.md` §"core_lint (BT-3115)"). It cannot and
+  structurally will not catch semantic bugs like ADR 0110's — the generated
+  code was well-formed. This ADR's verifier operates one layer earlier, on
+  Beamtalk's own lowering decisions, and is explicitly a complement to
+  `core_lint`, not a replacement.
+- **`core_erlang_validity_tests.rs`** (part of BT-3112's epic) is a
+  proptest suite over a fixed 20-element `FRAGMENTS` array checking three
+  purely textual properties on rendered Core Erlang: balanced delimiters,
+  module-name match, and absence of `Debug`/`Display`-format artifacts
+  (the BT-875 class ADR 0089 closed). None of the three inspect
+  state-threading correctness, NLR semantics, or variable-binding
+  provenance — they cannot, because by the time text is rendered the
+  structure this ADR's verifier needs (which version bound which, which
+  mutation is reachable from which relay) no longer exists as data.
+- **`document/` (ADR 0089)** is the closest existing precedent for
+  "typed structure with its own discipline," but it solves a different
+  class of bug by a different method: it makes the BT-875 string-escape
+  vector *unrepresentable* (no `Document::String` variant exists to
+  misuse), rather than building a checkable structure and running a
+  separate verification pass over it. A grep for `Verifier`/`verify_ir`/
+  `fn verify(` across `crates/beamtalk-core/src` returns nothing — there is
+  no existing verifier-pattern precedent in this codebase. This ADR
+  introduces one.
+
+### Constraints
+
+- **Narrow scope, as specified by BT-3122.** The lowered form covers only
+  the control-flow + state-threading core: the `control_flow/` cluster
+  (`conditionals.rs`, `counted_loops.rs`, `dict_ops.rs`,
+  `exception_handling.rs`, `while_loops.rs`, `list_ops/`), `threaded_expr.rs`,
+  and the state-versioning subset of `gen_server/methods.rs` (measured at
+  roughly 1900–2400 of its 5805 lines — `BodyExprKind` classification,
+  `generate_body_exprs_with_reply`, the tier-2/mutation-threading helpers,
+  and the class-method `ClassVars` threading path; the remaining ~60% of
+  the file is class/module registration scaffolding and ADR 0068 runtime
+  reflection metadata that is not in scope). Expression and primitive
+  codegen (`expressions.rs`, `intrinsics.rs`, `dispatch_codegen.rs`,
+  `value_type_codegen.rs`, …) stays AST-directed.
+- **Explicit non-goals** (BT-3122): no full-pipeline IR covering all of
+  Core Erlang codegen — this was already considered and rejected once, as
+  "Typed Core Erlang IR," in [ADR 0018](0018-document-tree-codegen.md)
+  §Alternatives Considered #3, for being "over-engineered for our needs —
+  we don't transform or optimize the IR, we just emit it." That reasoning
+  still holds for the 90% of codegen this ADR does not touch. No cerl-wire
+  change — [ADR 0088](0088-direct-cerl-emission.md) (Rust↔BEAM transport
+  format) stays closed/withdrawn; this ADR's IR is entirely internal to
+  `beamtalk-core` and never reaches the Port. No behavior change — every
+  phase must produce byte-identical `Document`/`.core` output on the
+  existing codegen snapshot suite, the same discipline ADR 0089's Phase B
+  used.
+- **The `Document`/text printer is unchanged.** The typed-leaf API (ADR
+  0089) remains the only path from a lowered leaf to Core Erlang text. This
+  ADR's IR sits *between* the AST and `Document` construction, not
+  alongside or in place of it.
+- **Coordinate with BT-3111/BT-3125, don't block on them.** BT-3125
+  (currently In Progress) is moving the `apply_return_type_writeback`/
+  `apply_supervisor_kind_writeback`/`apply_class_kind_writeback` trio out of
+  codegen's discretion and into a driver-level `lower_module_for_codegen(&mut
+  module, &analysis)` preparation step, explicitly leaving a note in its own
+  issue: *"if the BT-3122 ADR is accepted, this preparation step is where it
+  slots in — keep the seam clean."* This ADR's lowering entry point is
+  designed to consume that prepared AST + threaded `AnalysisResult` once
+  BT-3125 lands, rather than re-deriving semantic facts locally (the same
+  anti-pattern BT-3111 is closing project-wide). Until BT-3125 ships, this
+  ADR's Phase A/B work (IR types, verifier, migrating `while_loops.rs`/
+  `counted_loops.rs`) does not depend on it — only the final wiring point
+  (Phase E) does.
+
+## Decision
+
+**Introduce a small, narrowly-scoped lowered IR — `ThreadedIr` — covering
+state-version bindings, threading-mode selection, and NLR relay
+boundaries, plus a verifier that checks it before it reaches `Document`
+construction.** Everything else in codegen (expressions, primitives,
+dispatch) stays AST-directed and unaffected.
+
+### Pipeline shape
+
+```
+Beamtalk AST
+    │  (post BT-3125: lower_module_for_codegen(&mut module, &analysis))
+    ▼
+AST, prepared with threaded AnalysisResult / SemanticFacts
+    │  (this ADR: lower_control_flow — control_flow/, threaded_expr.rs,
+    │   and the state-versioning slice of gen_server/methods.rs only)
+    ▼
+ThreadedIr                      ◄── verify(&ThreadedIr) -> Vec<VerifyError>
+    │  (unchanged: typed-leaf Document construction, ADR 0089)
+    ▼
+Document
+    │  (unchanged: Wadler-Lindig pretty-printer, ADR 0018)
+    ▼
+Core Erlang text ──► core_lint (unconditional, OTP) ──► BEAM
+```
+
+Expression/primitive codegen continues to call directly into `Document`
+construction as it does today; it never touches `ThreadedIr`. The lowered
+form exists only for the constructs that already require multi-step
+state-threading decisions — loops, conditionals with mutation, list-ops,
+actor/class-method/value-type field mutation, and NLR relay.
+
+### The IR
+
+```rust
+/// One of the three (formerly independent) monotonic version counters,
+/// unified into a single representation. Replaces StateThreading's
+/// ad-hoc `State{N}`, ClassContext::class_var_version's `ClassVars{N}`,
+/// and ValueTypeContext::self_version's `Self{N}`.
+struct VersionedVar {
+    prefix: VersionPrefix,   // State | ClassVars | Self
+    version: usize,
+}
+
+enum ThreadingMode { DirectParams, TupleAcc, Hybrid, StateAcc(StateAccFallbackReason) }
+
+enum ThreadedStmt {
+    /// A mutation: binds a fresh version from a prior one.
+    /// `op` is Put { key, value } | Merge { .. } | Identity — never raw text.
+    Bind { target: VersionedVar, source: VersionedVar, op: BindOp },
+
+    /// A loop or mutation-carrying conditional, with its selected mode
+    /// already resolved (by the existing ThreadingPlan logic, moved to
+    /// run once during lowering instead of being re-derived at emission).
+    Threaded { mode: ThreadingMode, body: Vec<ThreadedStmt>, produces: Vec<VersionedVar> },
+
+    /// A non-local-return boundary — the throw/catch scaffolding's meaning,
+    /// not its Document rendering. `carries` names the version that must be
+    /// reachable from every mutation made before this point in the same frame.
+    NlrRelay { boundary: NlrBoundary, token: TokenId, carries: VersionedVar },
+
+    Return(ValueRef, VersionedVar),
+}
+```
+
+`NlrBoundary` (`ActorReply | ClassMethod { has_class_vars: bool } | ValueType`)
+is not new — it is the existing enum from `mod.rs:902-911`, reused as-is;
+this ADR gives it a home in the IR instead of only existing implicitly in
+the try/catch-emission code path.
+
+### The verifier
+
+```rust
+enum VerifyError {
+    /// Catches the unbound-`StateX` bug class — mechanically, before core_lint,
+    /// with a Beamtalk-source-attributable diagnostic instead of a raw
+    /// "unbound variable 'State3' in myMethod/2" from erlc.
+    UnboundVersion { var: VersionedVar, at: Span },
+
+    /// Every VersionedVar must be produced by exactly one Bind and consumed
+    /// by exactly its immediate successor — catches reuse/skip bugs in the
+    /// hand-written version-counter bookkeeping (the class of bug the three
+    /// duplicated counters above are structurally prone to).
+    NonLinearVersion { var: VersionedVar, producers: usize, consumers: usize },
+
+    /// Replaces the four "unpack should emit no code" debug_asserts:
+    /// an optimized ThreadingMode (DirectParams/TupleAcc/Hybrid) is
+    /// structurally forbidden from containing an unpack Bind.
+    ThreadingModeUnpackMismatch { mode: ThreadingMode, at: Span },
+
+    /// The ADR-0110 bug class, generalized: a mutation made before an
+    /// NlrRelay whose `carries` version does not descend from it.
+    /// This is the check that would have caught ADR 0110's bug in CI,
+    /// months before the production symptom, instead of after it shipped.
+    MutationLostAcrossRelay { mutated: VersionedVar, boundary: NlrBoundary, at: Span },
+}
+
+fn verify(ir: &[ThreadedStmt]) -> Vec<VerifyError>;
+```
+
+The verifier runs unconditionally in every build profile (unlike
+`debug_assert!`, which compiles out of `--release`) and in CI over every
+compiled `stdlib/test/*.bt` and `stdlib/bootstrap-test/*.btscript` fixture,
+the same way `core_lint` already runs unconditionally today. A verifier
+failure is a compiler-internal bug (the lowering pass produced malformed
+IR), reported the same way a panic in codegen is reported today — it is
+not a new class of user-facing diagnostic and does not change what valid
+Beamtalk programs compile to.
+
+### Worked example: the bug class this closes
+
+Recall [ADR 0110](0110-class-var-shadow-write-through-for-nlr-relay.md)'s
+motivating case:
+
+```beamtalk
+Value subclass: CollectionDriver
+  classState: runs = 0
+
+  class countedRun: aBlock over: aList -> Nil =>
+    self.runs := self.runs + 1
+    aList do: [:x | aBlock value: x]
+    nil
+```
+
+A block escaping via `^` from inside `aList do: [...]` relays a foreign
+NLR whose carried state is the *wrong* frame's state — the mutation to
+`self.runs` is lost. Lowered to `ThreadedIr`, the method body looks
+schematically like:
+
+```
+Bind { target: ClassVars1, source: ClassVars0, op: Put(runs, ...) }
+NlrRelay { boundary: ClassMethod { has_class_vars: true }, token: T0, carries: ClassVars0 }
+                                                                    ^^^^^^^^^ wrong — should be ClassVars1
+```
+
+`verify()` reports `MutationLostAcrossRelay { mutated: ClassVars1, boundary:
+ClassMethod{..}, at: <line> }` — the exact shape of ADR 0110's bug, caught
+mechanically at compile-time-of-the-compiler (i.e., against the compiler's
+own test fixtures in CI) instead of via a user-filed production report.
+ADR 0110's shipped fix (the process-dictionary shadow write-through) is
+unaffected by this ADR — it is a runtime fix for a class of relay this IR
+happens to make mechanically checkable *in the codegen layer*, catching
+future variants of the same bug class before they reach runtime, not a
+replacement for the runtime mechanism itself.
+
+### Observable behavior — unchanged
+
+Per the non-goals constraint, no Beamtalk program's compiled output or
+REPL behavior changes:
+
+```
+st> CollectionDriver runCount
+0
+st> CollectionProbe escapeAfterCountedRun: #(1, 2, 3)
+2
+st> CollectionDriver runCount
+1
+```
+(identical to ADR 0110's example — verified byte-for-byte via the existing
+codegen snapshot suite at the end of each migration phase, the same
+discipline ADR 0089 Phase B used.)
+
+## Prior Art
+
+| System | Approach | What we adopt / reject |
+|---|---|---|
+| **rustc: HIR → THIR → MIR** | Each IR is progressively simplified and single-purpose; MIR specifically exists to run flow-sensitive checks (the borrow checker) via a general dataflow framework (`rustc_mir_dataflow`), not to represent the whole language. [Source](https://github.com/rust-lang/rustc-dev-guide/blob/main/src/mir/index.md) | **Adopted:** the "small, single-purpose, narrowly-scoped IR whose job is to make one class of check possible" shape. rustc's precedent directly supports scoping this ADR to control-flow/state-threading only rather than building one IR that models everything, which is what makes the "no full-pipeline IR" non-goal defensible rather than merely expedient. |
+| **Swift SIL ownership verifier** | A static verifier over an SSA-form IR checks ownership-model invariants (no use-after-free, no leaks) at compile time, explicitly framed as catching bugs in *SILGen and optimization passes* — i.e. compiler bugs, not user bugs. [Source](https://forums.swift.org/t/proposal-sil-ownership-model-verifier/4665) | **Adopted:** the framing that this verifier's job is to catch *codegen's own* bugs (drift between `classify_body_expr` and `threaded_expr.rs`, a lowering pass that loses a mutation across a relay), the same role SIL's verifier plays for SILGen — not a new class of end-user diagnostic. |
+| **Cranelift's `verifier` module** | Cranelift IR (CLIF) ships an explicit, standard verifier pass checked in CI and (optionally) at each compilation, confirming CLIF invariants before lowering to machine code. | **Adopted:** "the verifier is a standard, expected part of a codegen backend that lowers through an internal IR," not a novel or heavyweight addition — reinforces this is ordinary compiler engineering for a project at Beamtalk's current maturity, not premature infrastructure. |
+| **MLIR dialects + per-op `Verifier`** | MLIR's core insight is that a compiler doesn't need one universal IR — narrow, purpose-built "dialects" coexist, each with its own verification trait, and only the parts of a program that need a dialect's semantics are lowered into it. | **Adopted as the closest structural analogy:** `ThreadedIr` is, in MLIR's vocabulary, a small dialect for exactly the control-flow/state-threading subset of the program, verified on its own terms, coexisting with AST-directed codegen for everything else — rather than a monolithic IR the whole pipeline must funnel through. |
+| **Erlang/OTP's `core_lint`** | Runs unconditionally as part of every `compile:forms([from_core \| Opts])` call, checking Core Erlang well-formedness (unbound/duplicate variables) — external to Beamtalk, downstream of code generation, syntactic only. | **Kept, complemented, not replaced.** `core_lint` is a real safety net for the well-formedness class of bug and stays exactly as-is (BT-3115). This ADR's verifier operates one layer earlier (Beamtalk's own lowering decisions) and catches the semantic class `core_lint` cannot see by construction — ADR 0110's bug was `core_lint`-clean. |
+| **Gleam's codegen** | Gleam has no actor/mutable-state threading requirement analogous to Beamtalk's (no built-in process/gen_server state model compiled through tail-recursive loops with version-counted map threading) — its `Document`-tree codegen (the direct ancestor of ADR 0018's) doesn't face this problem at all. | **Not directly transferable.** Unlike ADR 0089, where Gleam was strong comparative prior art for leaf-typing, Gleam's absence of this exact problem means it offers no guidance on the IR/verifier question — noted for completeness, not as a design input. |
+| **Pharo/Squeak Smalltalk** | Class-variable/instance-variable mutation is a direct memory write; a non-local return unwinds the real call stack via `BlockContext`, and there's no "commit" step for a mutation to survive — precisely the point ADR 0110 made about why this bug class is BEAM-specific, not Smalltalk-general. | **Confirms the constraint, not the solution.** Beamtalk inherits Smalltalk's mutable-variable *semantics* while compiling to an immutable substrate, so it must reconstruct "the assignment already happened" via functional threading — this ADR's IR/verifier targets exactly the reconstruction machinery that choice requires and that Smalltalk itself never needed. |
+
+## User Impact
+
+| Persona | Impact |
+|---|---|
+| **Newcomer** | None. No language syntax, semantics, or REPL output changes — every compiled Beamtalk program produces byte-identical output before and after. |
+| **Smalltalk developer** | None directly; indirectly, this closes future variants of the ADR-0110 bug class (silently-lost mutations across `^`) before they ship, reinforcing the existing invariant that `^` is ordinary control flow, not a special case that can silently drop side effects. |
+| **Erlang/BEAM developer** | None to generated `.beam` artifacts. The verifier's error shapes (`UnboundVersion`, `MutationLostAcrossRelay`, …) will look familiar to anyone who has read a `core_lint` "unbound variable" message — same spirit, one layer earlier, with Beamtalk-source-line attribution instead of a raw Core Erlang variable name. |
+| **Production operator** | None. No runtime change; the verifier runs at compile time, in CI, against the compiler's own test fixtures — it is not part of the shipped runtime or the `beamtalk build` fast path beyond the (small, one-time-per-compile) cost of walking the lowered IR for the control-flow/state-threading subset of the module being compiled. |
+| **Tooling developer (LSP, debugger)** | Mildly positive, longer-term. A structured `ThreadedIr` with span information is a better foundation for future BT-aware diagnostics or a codegen-decision inspector (e.g. "why did this loop fall back to StateAcc?") than re-deriving that information from `BEAMTALK_CODEGEN_DIAGNOSTICS=1` log lines, though no such tooling is proposed as part of this ADR. |
+| **Compiler contributor** | The main audience. Adding a new stateful control-flow construct becomes "add a `ThreadedStmt` case + a verifier check" instead of "add Document-emission code and hope the four other `ThreadingPlan` call sites, the `BodyExprKind` classifier, and the `threaded_expr.rs` recognizer all still agree." The three duplicated version-counter services collapse into one `VersionedVar` type. Net positive with a real adjustment cost: this is new internal API surface (~S-to-M sized per migrated subsystem) that must be learned, on top of the existing `Document`/typed-leaf combinator surface (ADR 0089), which is unchanged. |
+
+## Steelman Analysis
+
+### Option A: Narrow lowered IR + verifier, phase-gated by subsystem (Recommended)
+
+- 🧑‍💻 **Newcomer-to-compiler-internals contributor**: "When I add a new stateful loop variant, the compiler tells me at CI time — with a Beamtalk-source-line-attributed error — if I got the state threading wrong, instead of me discovering it three weeks later as a silently-wrong runtime value like ADR 0110's bug."
+- 🎩 **Smalltalk purist**: "This is the same principle ADR 0110 already established for class vars — `^` must be ordinary control flow that never silently drops side effects — generalized from 'documented and runtime-patched for one case' to 'mechanically checked for the whole state-threading surface, before it ships.'"
+- ⚙️ **BEAM veteran**: "`core_lint` already proved the value of an unconditional structural check baked into the pipeline. This is the same idea one layer up — narrowly scoped, doesn't touch the wire, doesn't touch `Document`, doesn't touch the 90% of codegen that doesn't need it."
+- 🏭 **Operator**: "Zero runtime change, zero wire change. All risk is contained to compile-time internals, verified phase-by-phase against the existing byte-identical-snapshot discipline that already proved itself in ADR 0089's flag-day migration."
+- 🎨 **Language/compiler designer**: "This is the textbook 'narrow, purpose-built IR + verifier' shape (rustc's MIR, Swift's SIL, MLIR's dialects) applied at exactly the size Beamtalk's current problem calls for — not the 58K-LOC full-pipeline rewrite ADR 0088 correctly rejected, and not zero, which leaves six independently-drifting invariants as the only defense against a real, previously-shipped bug class."
+
+### Option B: Verifier without IR — strengthen the current generator with a post-hoc validator only
+
+- 🧑‍💻 **Newcomer contributor**: "I don't have to learn a new IR type at all — the validator runs over what's already there."
+- 🎩 **Smalltalk purist**: "Minimal new machinery is more in the spirit of pragmatic, incremental Smalltalk-style development than committing to a new typed layer up front."
+- ⚙️ **BEAM veteran**: "`core_erlang_validity_tests.rs` already proved a post-hoc property-test validator has *some* value (BT-875 format-artifact detection) at very low cost. Why not extend that same style of check instead of adding a new internal representation?"
+- 🏭 **Operator**: "Lowest-risk option on the table. No new pipeline stage, no new pass ordering to get wrong, ships incrementally with no coordination against BT-3125's `AnalysisResult` threading."
+- 🎨 **Language designer (the sharpest form of this argument)**: "A verifier's value comes from what it checks, not from where the data it checks lives. If we can re-derive 'is this version linear, does this mutation survive this relay' by walking the *existing* generator state or rendered `Document` tree, we get the same safety without committing to a new IR that has to be kept in sync with codegen forever."
+
+**Why A wins despite this steelman.** The sharpest form of B's argument
+("value comes from the check, not the representation") is correct in the
+abstract but fails on this codebase's specific problem: the information
+`MutationLostAcrossRelay` needs (which version a relay's `carries` field
+descends from) **does not exist** once code is lowered to `Document`/text —
+it has to be *re-derived*, which means re-implementing the same
+classification logic `classify_body_expr` and `ThreadingPlan` already
+compute, a fourth time, in the validator. That is exactly the
+`architecture-principles.md` §6 duplication anti-pattern this ADR's own
+Context section documents happening three times already (`StateThreading`/
+`class_var_version`/`self_version`). A validator that re-derives semantic
+structure post-hoc is not lower-risk than an IR that carries that structure
+through explicitly — it is the same risk, hidden one layer deeper, plus a
+second implementation to keep in sync with the first. Building the small
+IR is not overhead layered on top of the fix; constructing the IR *is* the
+mechanism by which the classifier's and emitter's decisions stop being two
+independently-maintained things that must agree.
+
+### Option C: Status quo — `debug_assert!`s + `core_lint` + code review
+
+- 🧑‍💻 **Newcomer contributor**: "The state-threading code has worked for many releases. Six `debug_assert!`s plus attentive code review caught real bugs before (they're how ADR 0110's bug class was eventually found and fixed)."
+- 🎩 **Smalltalk purist**: "Smalltalk favors iterative refinement over up-front structure. Add checks where bugs are actually found, not speculatively."
+- ⚙️ **BEAM veteran**: "`debug_assert!` is idiomatic Rust for this; every Rust codebase has invariants it doesn't formally verify. This isn't unusual."
+- 🏭 **Operator**: "Zero migration cost, zero risk, ships nothing new."
+- 🎨 **Language designer**: "The `control_flow/` cluster is 16K LOC and has shipped correct code for most of its history. The base rate of this specific bug class (mutation-lost-across-relay) is one documented occurrence (ADR 0110) in the codebase's lifetime — is a whole new IR proportionate to a rate-one bug?"
+
+**Why A wins despite this steelman.** The rate-one framing undercounts the
+risk: ADR 0110's bug was found because it was *reachable* through a common,
+recommended pattern (`docs/beamtalk-language-features.md` itself
+recommends the collection-driven-block shape that triggered it) — not
+because it's rare in principle, but because most code doesn't happen to
+combine class-var mutation with a block that escapes through library code.
+`debug_assert!`s compile out of release builds entirely (the issue's
+original framing is correct on this point even where its LOC/count
+estimates were off), so they provide **zero** protection in the actual
+shipped compiler binary — only in `cargo test`/dev builds. And the six that
+do exist are concentrated on exactly one narrow slice (threading-mode/unpack
+agreement, classifier/emitter agreement) — they provide no coverage at all
+for the NLR-relay-loses-a-mutation class that ADR 0110 actually was. Status
+quo is not "we have a check and choose not to add another" — it is "we have
+no check for the bug class that has already shipped once."
+
+### Option D: Full-pipeline typed Core Erlang IR (revisiting ADR 0018's rejected alternative)
+
+Referenced for completeness, not re-litigated — this is explicitly excluded
+as a non-goal by BT-3122. [ADR 0018](0018-document-tree-codegen.md)
+§Alternatives Considered #3 already rejected "Typed Core Erlang IR" covering
+all of codegen, for being "significantly more work... over-engineered for
+our needs — we don't transform or optimize the IR, we just emit it," while
+explicitly leaving the door open: *"A typed IR may become valuable later
+(for optimization passes, multiple backends), but it's premature now."*
+That reasoning holds unchanged for the ~90% of codegen (expressions,
+primitives, dispatch) this ADR does not touch — those code paths don't
+exhibit the multi-step, must-stay-synchronized decision structure that
+makes control-flow/state-threading specifically worth lowering.
+
+### Tension Points
+
+- **Scope discipline is the whole argument.** BEAM veterans and operators
+  broadly favor A over C once the ADR-0110 gap is made concrete, but would
+  reject a version of A that crept toward D's full-pipeline scope — the
+  ADR's phase-gating (below) exists specifically to keep each phase's
+  migration cost visible and stoppable, learning directly from the ADR
+  0088 lesson (a large, ungated migration that had to be withdrawn after
+  Phase 0 measurement).
+- **B vs A is a real disagreement about where duplication risk lives**, not
+  a strawman — see the "why A wins" analysis above. If a future maintainer
+  finds `ThreadedIr` drifting out of sync with the AST-directed codegen it
+  sits next to (an IR that itself becomes stale relative to what it's
+  supposed to represent), that is the risk B's steelman correctly
+  identifies; this ADR's answer is that IR construction happens as an
+  explicit lowering step immediately before verification and Document
+  construction — there is no window where it can silently go stale,
+  unlike a validator re-deriving structure after the fact.
+- **Newcomers vs. compiler-internals contributors.** End users and
+  newcomers see zero impact either way (User Impact table) — the entire
+  cost/benefit of this decision is scoped to the small population of
+  contributors touching `control_flow/`/`gen_server/methods.rs`, which
+  argues for keeping the new API surface as small as BT-3122's scope
+  allows rather than over-generalizing it.
+
+## Alternatives Considered
+
+### 1. Verifier without IR (post-hoc validator over current generator/Document state)
+
+See Steelman Analysis. **Rejected**: the semantic structure the verifier
+needs (version provenance, mode/unpack agreement, mutation reachability
+across a relay) does not survive to `Document`/text — recovering it
+post-hoc means re-implementing `classify_body_expr`/`ThreadingPlan`'s logic
+a second time, the exact duplication this ADR's own IR unification is
+meant to close. Not a lower-risk option; the same risk one layer deeper,
+plus a second implementation to maintain.
+
+### 2. Status quo — `debug_assert!`s + `core_lint` + code review
+
+See Steelman Analysis. **Rejected**: `debug_assert!`s provide zero
+protection in release builds (confirmed: none of the six in-scope
+assertions run outside dev/test profiles), and none of the six cover the
+NLR-relay-loses-a-mutation class that ADR 0110 already shipped once.
+`core_lint` structurally cannot see this class of bug — the code it
+checked in ADR 0110's case was well-formed.
+
+### 3. Unify the three version counters only, no IR/verifier
+
+A narrower fix: collapse `StateThreading`/`class_var_version`/
+`self_version` into one `VersionedVar`-producing service (closing the
+`architecture-principles.md` §6 duplication directly) without building a
+lowered IR or verifier around it.
+
+**Rejected as insufficient on its own** (though this ADR's `VersionedVar`
+design absorbs it as a side effect): it removes the "three independently
+implemented counters" duplication smell but does nothing for the six
+`debug_assert!`-guarded "these two independently-computed decisions must
+agree" invariants, which are the actual mechanism behind ADR 0110's bug
+class. A shared counter type does not, by itself, check that a mutation
+survives an NLR relay or that a threading mode and its unpack logic agree
+— those checks require walking a structure that records the relationship
+between binds and relays, which is what the IR is for. Worth doing either
+way; this ADR folds it in rather than treating it as a separate, smaller
+project, since the IR's `VersionedVar` type is the natural home for the
+unification.
+
+### 4. Full-pipeline typed Core Erlang IR
+
+See Steelman Analysis Option D. **Rejected**: already rejected once (ADR
+0018), for reasons that still hold for the 90% of codegen this ADR
+deliberately excludes; explicitly a non-goal per BT-3122.
+
+## Consequences
+
+### Positive
+- **Closes a real, previously-shipped bug class mechanically.** The
+  `MutationLostAcrossRelay` check generalizes ADR 0110's fix from "one
+  documented and runtime-patched case" to "checked at compile time for the
+  entire control-flow/state-threading surface," before a future variant
+  reaches production.
+- **The six `debug_assert!`s become structural, always-on checks** instead
+  of dev-build-only spot checks that silently vanish in release — the
+  underlying invariants (threading-mode/unpack agreement,
+  classifier/emitter agreement) are enforced by construction rather than
+  by four/two independently-maintained runtime assertions.
+- **Closes a real, previously undocumented duplication instance**
+  (`StateThreading`/`class_var_version`/`self_version`) per
+  `architecture-principles.md` §6, without a separate migration project.
+- **`Document`, the typed-leaf API (ADR 0089), and the Wadler-Lindig
+  printer (ADR 0018) are entirely unchanged** — this ADR adds a stage
+  before them, not a replacement for anything already working.
+- **No wire change, no runtime change, no behavior change** — every phase
+  is gated on byte-identical `Document`/`.core` output, verified the same
+  way ADR 0089's flag-day migration was.
+- **Scoped and phase-gated**, learning directly from the ADR 0088 lesson:
+  each phase has an independent exit criterion (byte-identical snapshots +
+  verifier green + the corresponding `debug_assert!`s deleted), rather than
+  one large, hard-to-review migration.
+
+### Negative
+- **New internal API surface to learn.** Contributors touching
+  `control_flow/`/`gen_server/methods.rs`'s state-versioning slice must
+  learn `ThreadedIr`/`ThreadedStmt`/`VersionedVar` in addition to the
+  existing `Document`/typed-leaf combinator surface. Scoped narrowly
+  (BT-3122's explicit non-goals) to limit this to the ~30% of codegen that
+  actually exhibits the multi-step-decision problem.
+- **Migration is multi-phase and multi-PR**, each touching working, tested
+  code (`while_loops.rs`, `counted_loops.rs`, `list_ops/`'s six files,
+  the actor/class-method threading slice of `gen_server/methods.rs`).
+  Mitigated the same way ADR 0089 Phase B was: byte-identical snapshot
+  parity as the hard gate on every phase, plus the full behavioral suite
+  (`just test-stdlib`/`test-bunit`/`test-repl-protocol`).
+- **The verifier can produce false confidence if its checks are
+  incomplete.** `MutationLostAcrossRelay` as specified catches the
+  ADR-0110 shape (a mutation whose version doesn't reach a relay's
+  `carries` field); it does not claim to catch every possible semantic bug
+  in state threading — only the class this ADR's research identified as
+  currently unchecked. Extending its checks as new bug classes are found
+  is expected, ongoing work, not a one-time deliverable.
+- **Coordination risk with BT-3111/BT-3125.** This ADR's lowering entry
+  point is designed to consume BT-3125's `lower_module_for_codegen`
+  output once that epic lands (per the Constraints section), but BT-3125
+  is independently in progress; if its design changes materially before
+  landing, this ADR's Phase E wiring point may need to be revisited. Phases
+  A–D do not depend on BT-3125 and are not blocked by this risk.
+
+### Neutral
+- **`NlrBoundary` is reused, not redesigned.** The existing enum
+  (`ActorReply | ClassMethod{..} | ValueType`, `mod.rs:902-911`) and its
+  builder `nlr_arm_result()` become inputs to `ThreadedStmt::NlrRelay`
+  rather than being restructured.
+- **`ThreadingPlan`'s mode-selection logic (`select_direct_params`/
+  `select_tuple_acc`/`select_hybrid_params`, `BodyEffects` prescan,
+  `StateAccFallbackReason`) is reused as-is** — it already computes the
+  right answer; this ADR changes *when* that answer becomes durable data
+  (as an IR node) rather than being immediately consumed by Document
+  emission, and *what* checks run against it afterward.
+- **`BEAMTALK_CODEGEN_DIAGNOSTICS=1`'s existing diagnostic categories**
+  (`docs/development/debugging.md` §"Codegen Diagnostics") are unaffected;
+  they report the same decisions, now sourced from `ThreadedIr` instead of
+  inline generator state, with no change to their wording or gating env
+  vars.
+
+## Implementation
+
+Phase-gated by subsystem, per BT-3122's requirement to avoid the ADR 0088
+lesson (an unbounded, all-at-once migration). Each phase's exit criteria are
+the same: byte-identical `Document`/`.core` output on the existing codegen
+snapshot suite, verifier green on 100% of `stdlib/test/*.bt` and
+`stdlib/bootstrap-test/*.btscript` fixtures, full behavioral suite
+(`just test-stdlib`/`test-bunit`/`test-repl-protocol`) green, and the
+`debug_assert!`s superseded by that phase's verifier checks *deleted from
+source* (the forcing function that a phase is actually done, not merely
+running in parallel with the old mechanism — the same discipline ADR 0089
+used for `Document::String`/`Document::Eco`). The `/plan-adr` output
+decomposes these into implementation issues; this section names the
+commitment level.
+
+### Phase A — IR types + verifier skeleton (S)
+Define `VersionedVar`, `ThreadedStmt`, `VerifyError`, and `verify()` in a
+new `crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs`. Unify
+`StateThreading`/`class_var_version`/`self_version` behind `VersionedVar`.
+No codegen call site constructs `ThreadedIr` yet — this phase ships with
+unit tests only (verifier logic against hand-built IR fixtures), zero
+behavioral risk since nothing consumes it.
+
+### Phase B — `while_loops.rs` + `counted_loops.rs` (M)
+Migrate the `ThreadingPlan`-driven direct-params/tuple-acc/hybrid/StateAcc
+modes for `whileTrue:`/`whileFalse:`/`to:do:`/`to:by:do:`/`timesRepeat:` to
+construct `ThreadedIr` before Document emission. The four
+"unpack should emit no code" `debug_assert!`s
+(`while_loops.rs:317,454`, `control_flow/mod.rs:2522,2651`) are replaced by
+`ThreadingModeUnpackMismatch` and deleted from source.
+
+### Phase C — `list_ops/` (M)
+Migrate `do:`/`collect:`/`select:`/`reject:`/`inject:into:`/`detect:`/
+`anySatisfy:`/`allSatisfy:`/`flatMap:`/`takeWhile:`/`dropWhile:`/
+`partition:`/`groupBy:`/`sort:` (the six `list_ops/` files, led by
+`transform_ops.rs` at 2074 lines and `search_ops.rs` at 917) to the same IR.
+Largest phase by LOC; no new invariant classes beyond Phase B's, so scoped
+as a mechanical follow-on rather than combined with B to keep each PR
+independently reviewable.
+
+### Phase D — Actor/class-method state threading + NLR relay (L)
+Migrate the state-versioning slice of `gen_server/methods.rs`
+(`BodyExprKind` classification, `generate_body_exprs_with_reply`,
+`classify_body_expr`, the tier-2/mutation-threading helpers), the
+class-method `ClassVars` threading path (including ADR 0110's shadow-write
+mechanism, unaffected at runtime but now covered by
+`MutationLostAcrossRelay` at compile time), `conditionals.rs`'s
+mutation-inlining, and `exception_handling.rs`'s try/catch-with-mutation
+lowering. The two "must route through the Actor threaded emitter"
+`debug_assert!`s (`methods.rs:1258,1450`) are replaced by
+`UnboundVersion`/structural IR-construction guarantees and deleted — this
+is the phase that actually removes the classifier/emitter duplication,
+not merely checks for it. Largest and highest-risk phase; may itself split
+into sub-PRs (actor state, then class-method state, then NLR relay) during
+`/plan-adr` decomposition.
+
+### Phase E — Wire to BT-3125's prepared-AST boundary (S, coordinate)
+Once BT-3125 lands `lower_module_for_codegen(&mut module, &analysis)`, move
+this ADR's lowering entry point to consume the threaded `AnalysisResult`/
+`SemanticFacts` there, per the Constraints section, instead of any
+interim local re-derivation used in Phases A–D. If BT-3125 has not yet
+landed when Phases A–D are implemented, they read `AnalysisResult` the same
+way current codegen does (via whatever re-derivation exists at that time)
+— Phase E's job is exclusively to delete that interim path once the
+shared boundary exists, not to block Phases A–D on BT-3125's timeline.
+
+### Affected Components
+- **New**: `crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs` —
+  `VersionedVar`, `ThreadedStmt`, `VerifyError`, `verify()`.
+- **Modified**: `control_flow/mod.rs`, `control_flow/while_loops.rs`,
+  `control_flow/counted_loops.rs`, `control_flow/list_ops/*.rs`,
+  `control_flow/conditionals.rs`, `control_flow/exception_handling.rs`,
+  `threaded_expr.rs` — construct `ThreadedIr` instead of emitting
+  `Document` directly for state-threading constructs; the four/two
+  `debug_assert!`s removed as their phases land.
+- **Modified**: `gen_server/methods.rs` — the state-versioning slice only
+  (Phase D); class/module registration scaffolding and ADR 0068 reflection
+  metadata (the other ~60% of the file) unaffected.
+- **Modified**: `mod.rs` — `StateThreading`/`class_var_version`/
+  `self_version` fields collapse behind `VersionedVar`; `NlrBoundary`
+  reused as-is inside `ThreadedStmt::NlrRelay`.
+- **Unchanged**: `document/` (ADR 0089 typed-leaf API and printer),
+  `dispatch_codegen.rs`, `expressions.rs`, `intrinsics.rs`,
+  `value_type_codegen.rs` (expression/primitive codegen — AST-directed,
+  out of scope), all Erlang-side runtime and wire format.
+
+### Verification
+- **Snapshot parity**: existing codegen snapshot suite (the same one ADR
+  0089 Phase B verified byte-for-byte) must be unchanged after every phase.
+- **Verifier coverage**: `just` target (name TBD in `/plan-adr`, e.g.
+  `just verify-threaded-ir`) runs `verify()` over every compiled
+  `stdlib/test/*.bt`/`stdlib/bootstrap-test/*.btscript` fixture in CI,
+  reporting zero `VerifyError`s as a hard gate per phase.
+  `core_erlang_validity_tests.rs`'s existing three text-shape properties
+  are unaffected and continue running independently.
+- **Behavioral suite**: `just test-stdlib`, `just test-bunit`,
+  `just test-repl-protocol` green after every phase — the standard
+  behavior-preservation bar this codebase already uses for codegen
+  refactors (ADR 0089, ADR 0110).
+- **Regression test for the motivating case**: ADR 0110's
+  `CollectionDriver`/`CollectionProbe` repro (or an equivalent minimal
+  case) added as a verifier unit test asserting `MutationLostAcrossRelay`
+  fires on the *unfixed* shape and is silent on the *fixed* shape, so a
+  future regression in either the runtime shadow-write mechanism or a new
+  lowering path is caught by two independent layers (runtime behavior test
+  + compile-time verifier).
+
+## References
+
+- Related issues:
+  - [BT-3122](https://linear.app/beamtalk/issue/BT-3122) — this ADR
+  - [BT-3111](https://linear.app/beamtalk/issue/BT-3111) — Epic:
+    Analysis→codegen handoff (single semantic source of truth);
+    coordination point for Phase E
+  - [BT-3125](https://linear.app/beamtalk/issue/BT-3125) — Writeback
+    passes consume threaded analysis; the `lower_module_for_codegen`
+    preparation step this ADR's lowering entry point slots into
+  - [BT-3112](https://linear.app/beamtalk/issue/BT-3112) — Epic:
+    Generated-code correctness (core_lint, semantic fuzzing, real
+    fixtures) — sibling correctness-net work; this ADR's verifier is a
+    complementary, compile-time-internal layer, distinct from that epic's
+    fuzzing/property-testing children
+  - [BT-3035](https://linear.app/beamtalk/issue/BT-3035) — Epic that
+    shipped ADR 0110's runtime fix; this ADR's `MutationLostAcrossRelay`
+    check generalizes detection of that bug class to compile time
+  - BT-3115 — `core_lint` readability fix (referenced in
+    `docs/development/debugging.md`)
+- Related ADRs:
+  - [ADR 0018](0018-document-tree-codegen.md) — the `Document` tree this
+    ADR's IR sits *before*; §Alternatives Considered #3 previously
+    rejected a full-pipeline typed IR for reasons this ADR's narrower
+    scope deliberately avoids re-triggering
+  - [ADR 0041](0041-universal-state-threading-block-protocol.md) — the
+    `{Value, StateAcc}` calling convention and 4-tuple NLR throw
+    convention this ADR's `ThreadedStmt`/`NlrRelay` formalize as data
+  - [ADR 0042](0042-immutable-value-objects-actor-mutable-state.md) —
+    actor mutable state vs. value-type immutability, the semantic split
+    `ThreadingBoundary`/`NlrBoundary` encode
+  - [ADR 0088](0088-direct-cerl-emission.md) — cerl-as-wire-format
+    proposal; stays closed/withdrawn; orthogonal to this ADR (wire
+    transport vs. internal lowering stage)
+  - [ADR 0089](0089-typed-document-leaves.md) — the typed-leaf `Document`
+    API this ADR's printer stage is unchanged; also this codebase's most
+    directly comparable prior large-scale phase-gated codegen migration
+    (byte-identical-snapshot discipline adopted here)
+  - [ADR 0109](0109-block-scoped-class-methods-run-blocks-in-the-caller.md)
+    — block-runs-where-invoked semantics underlying the NLR relay problem
+  - [ADR 0110](0110-class-var-shadow-write-through-for-nlr-relay.md) — the
+    shipped bug and runtime fix this ADR's verifier generalizes detection
+    of to compile time; not superseded or affected at runtime
+- Documentation:
+  - `docs/development/debugging.md` §"Codegen Diagnostics", §"core_lint
+    (BT-3115)"
+  - `docs/development/architecture-principles.md` §6 "Duplication & the
+    Shared-Leaf-Module Pattern" — the pattern this ADR's `VersionedVar`
+    unification follows
+- Code:
+  - `crates/beamtalk-core/src/codegen/core_erlang/control_flow/` (13
+    files, 16,329 LOC) — in scope
+  - `crates/beamtalk-core/src/codegen/core_erlang/threaded_expr.rs` (416
+    LOC) — in scope
+  - `crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs`
+    (5805 LOC; ≈1900–2400 lines state-versioning-specific) — in scope
+    (state-versioning slice only)
+  - `crates/beamtalk-core/src/codegen/core_erlang/mod.rs` — `NlrBoundary`,
+    `nlr_arm_result`, `ClassContext`, `ValueTypeContext`,
+    `with_branch_context`
+  - `crates/beamtalk-core/src/codegen/core_erlang/state_codegen.rs` —
+    `StateThreading`
+  - `crates/beamtalk-core/src/codegen/core_erlang/util.rs` —
+    `versioned_var`
+  - `crates/beamtalk-core/src/codegen/core_erlang_validity_tests.rs` —
+    existing text-shape property suite, unaffected
+  - `runtime/apps/beamtalk_compiler/src/beamtalk_compile_diagnostics.erl`
+    — `core_lint` integration

--- a/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
+++ b/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
@@ -620,7 +620,7 @@ substitute.
 ### Negative
 - **New internal API surface** for contributors to the in-scope files.
 - **A real test-migration cost the first draft omitted:** ~1,484 `#[test]`s
-  and ~298 `to_pretty_string()` assertion sites live under `codegen/`
+  and 231 `to_pretty_string()` assertion sites live under `codegen/`
   (`tests/control_flow.rs` alone is 2,591 lines; `list_ops/tests.rs`
   2,660). Functions returning `ThreadedIr` instead of `Document` would
   break every test asserting on their output. **Mitigation, committed in

--- a/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
+++ b/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
@@ -77,7 +77,7 @@ save/restore disciplines:
 |---|---|---|---|
 | Actor/instance state | `StateThreading` struct (`state_codegen.rs:42`) | `CoreErlangGenerator.state_threading` field | `State`, `State1`, `State2`, … (renamed to `StateAcc*` inside loop bodies) |
 | Class variables | `usize` field + `next_class_var()` (`mod.rs:1132`, `mod.rs:2088`) | `ClassContext.class_var_version` | `ClassVars`, `ClassVars1`, … (ADR 0110's mechanism) |
-| Value-type fields | `usize` field + `next_self_var()` (`mod.rs:1211`, `mod.rs:2095`) | `ValueTypeContext.self_version` | `Self`, `Self1`, … |
+| Value-type fields | `usize` field + `next_self_var()` (`mod.rs:1211`, `mod.rs:2104`) | `ValueTypeContext.self_version` | `Self`, `Self1`, … |
 
 `with_branch_context` (`mod.rs:2064-2080`, BT-1449/BT-1550) already has to
 save, reset, and restore `state_version` *and* `class_var_version` together

--- a/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
+++ b/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
@@ -1,7 +1,11 @@
 # ADR 0111: Mid-Level Lowered IR + Verifier for State Threading, Control Flow, and Non-Local Return
 
 ## Status
-Proposed (2026-08-09)
+Proposed (2026-08-09; revised same day after `/review-adr` adversarial pass —
+the revision corrected the verifier's claimed relationship to ADR 0110's bug,
+brought the `Bind`-emission sites into scope, added frame identity to the IR
+design, and replaced the snapshot-parity gate with an expanded-corpus gate.
+See §Verifier honesty and §Phase A0.)
 
 ## Context
 
@@ -19,21 +23,35 @@ value-type field threading (`Self`/`Self1`/…), non-local-return (NLR)
 lowering, and the `{Value, StateAcc}` calling convention (ADR 0041) —
 happens **interleaved with `Document` construction** (the ADR 0089
 pretty-printer tree), coordinated through a handful of scattered
-`debug_assert!`s that compile out of release builds and a set of
-independently-implemented decisions that must agree with each other by
-convention, not by construction.
+`debug_assert!`s and a set of independently-implemented decisions that must
+agree with each other by convention, not by construction.
 
-This is not a hypothetical risk. [ADR 0110](0110-class-var-shadow-write-through-for-nlr-relay.md)
-is a real, shipped bug in exactly this class: a class method that mutated a
-class variable and then handed a block to another method lost the mutation
-when the block's `^` escaped through library code, while still returning the
-*correct value*. The generated Core Erlang was well-formed the entire time —
-every variable bound, every arity correct — so `core_lint` (which runs
+[ADR 0110](0110-class-var-shadow-write-through-for-nlr-relay.md) is a real,
+shipped bug in the adjacent class: a class method that mutated a class
+variable and then handed a block to another method lost the mutation when the
+block's `^` escaped through library code, while still returning the *correct
+value*. The generated Core Erlang was well-formed the entire time — every
+variable bound, every arity correct — so `core_lint` (which runs
 unconditionally on every compile; see below) passed it without complaint.
-The bug was purely semantic: the wrong-but-validly-typed `ClassVars` value
-flowed to the reply. That is precisely the class of bug a structural linter
-cannot see and a lowered IR + verifier is designed to catch mechanically,
-before the code ships, not after a user reports silently-wrong behavior.
+
+**What this ADR honestly claims about that bug — and what it does not.**
+A verifier catches violations of invariants someone has already stated; it
+does not discover unknown-unknowns. ADR 0110's bug was an unknown-unknown:
+before it was found, no lowering pass would have encoded the requirement
+"every class-var mutation must be recoverable at every relay exit," because
+that requirement was exactly the missing knowledge. The mechanism that hunts
+that kind of bug is BT-3112's planned metamorphic/differential harness
+(semantics-preserving transforms must preserve results — ADR 0110's
+signature, "the returned value is correct; only the mutation is lost," is
+the canonical metamorphic-oracle target). What this ADR's verifier does for
+the 0110 class is narrower and still valuable: **now that the invariant is
+known**, the IR models the shadow-write emission explicitly, and the
+verifier enforces it at every existing and future mutation site — pinning
+ADR 0110's fix against regression and extending it mechanically to code
+paths its authors never saw (a new control-flow construct, a new mutation
+emission site) instead of relying on each future author to remember the
+rule. The two mechanisms are complementary and this ADR sequences itself
+accordingly (see §Coordination).
 
 ### Current state, as measured
 
@@ -52,13 +70,22 @@ numbers:
 | "~16 scattered `debug_assert!`s" | **6 in the named in-scope files** (29 repo-wide in `codegen/core_erlang/`, but 23 are arity/argument-count checks in `intrinsics.rs`/`erlang_types.rs` — expression/primitive codegen, explicitly out of scope per BT-3122's own "that's not where the failures are") | Full 6: `while_loops.rs:317`, `while_loops.rs:454`, `control_flow/mod.rs:2522`, `control_flow/mod.rs:2651` (all four assert an *optimized threading mode implies no `StateAcc` unpack code* — the same invariant, independently asserted at four call sites instead of centralized once); `gen_server/methods.rs:1258`, `gen_server/methods.rs:1450` (both assert that `classify_body_expr`'s upfront classification and `threaded_expr.rs`'s downstream recognizer *agree* on whether a construct routes through the Actor threaded emitter) |
 | "`CoreErlangGenerator` ~90 fields" | **36 fields** on `CoreErlangGenerator` (`mod.rs:1288-1481`), ≈39 including its two state-carrying sub-structs (`VariableContext`, `StateThreading`) | Still large enough to be the "coordinates everything" bottleneck the issue describes — just not 90 |
 
-None of these corrections weaken the case for this ADR; if anything the
-`debug_assert!` finding sharpens it: **every one of the six in-scope
-assertions is a "two independently-computed decisions must agree" check**,
-not an arity or bounds check. That is exactly the shape of invariant a
-verifier over a shared IR replaces with a structural guarantee instead of a
-runtime spot-check that six people (or six future PRs) have to remember to
-keep synchronized.
+Two honesty notes on the `debug_assert!` situation, both from the
+adversarial review pass:
+
+- **The six assertions are not the last line of defense.** In release
+  builds, a violation of any of the six degrades into malformed Core
+  Erlang — an unbound `StateAcc` reference (the four unpack asserts) or an
+  assignment target/reply that was never emitted (the two routing asserts)
+  — which `core_lint` catches unconditionally at compile time. The honest
+  statement is *"these six invariants have a structural backstop that
+  produces a bad, Erlang-level error message far from the real cause, not
+  no backstop"* — the verifier's contribution for these six is diagnosis
+  quality and centralization, not net-new detection.
+- **Every one of the six is a "two independently-computed decisions must
+  agree" check** (threading-mode vs. unpack logic; classifier vs.
+  emitter). That is the shape of invariant an IR removes by construction
+  — one IR node has one emitter — rather than merely checks.
 
 ### The duplication this ADR's IR would also close
 
@@ -70,26 +97,30 @@ instead of a shared leaf module — see
 §6): **three structurally identical, independently implemented
 monotonic-version-counter services**, all producing `Prefix`, `Prefix1`,
 `Prefix2`, … names via the same `util::versioned_var(prefix, version)`
-helper, but tracked as three separate fields with three separate
-save/restore disciplines:
+helper, but tracked as three separate fields with three separate — and
+deliberately *different* — save/restore disciplines:
 
-| Counter | Type | Where | Produces |
-|---|---|---|---|
-| Actor/instance state | `StateThreading` struct (`state_codegen.rs:42`) | `CoreErlangGenerator.state_threading` field | `State`, `State1`, `State2`, … (renamed to `StateAcc*` inside loop bodies) |
-| Class variables | `usize` field + `next_class_var()` (`mod.rs:1132`, `mod.rs:2088`) | `ClassContext.class_var_version` | `ClassVars`, `ClassVars1`, … (ADR 0110's mechanism) |
-| Value-type fields | `usize` field + `next_self_var()` (`mod.rs:1211`, `mod.rs:2104`) | `ValueTypeContext.self_version` | `Self`, `Self1`, … |
+| Counter | Type | Where | Produces | Branch discipline (`with_branch_context`, `mod.rs:2064-2080`) |
+|---|---|---|---|---|
+| Actor/instance state | `StateThreading` struct (`state_codegen.rs:42`) | `CoreErlangGenerator.state_threading` field | `State`, `State1`, … — **rendered as `StateAcc{N}` inside non-hybrid loop bodies** (`mod.rs:1994-2028`) | reset to 0 on branch entry, restored on exit |
+| Class variables | `usize` field + `next_class_var()` (`mod.rs:1132`, `mod.rs:2088`) | `ClassContext.class_var_version` | `ClassVars`, `ClassVars1`, … (ADR 0110's mechanism) | restored but **not** reset (BT-1550); `class_var_mutated` deliberately sticky, never restored |
+| Value-type fields | `usize` field + `next_self_var()` (`mod.rs:1211`, `mod.rs:2104`) | `ValueTypeContext.self_version` | `Self`, `Self1`, … | **neither saved nor restored** — the live landmine |
 
-`with_branch_context` (`mod.rs:2064-2080`, BT-1449/BT-1550) already has to
-save, reset, and restore `state_version` *and* `class_var_version` together
-whenever codegen enters a branch — but not `self_version`, because that
-coupling is maintained by a developer remembering to update the function,
-not by a shared type. (A fourth, unrelated "State" name,
-`_BuilderStateN` in `gen_server/methods.rs:2514`'s `build_builder_state_doc`,
-is a per-class positional index with no relation to mutation-version
-threading at all — worth flagging so a future IR design doesn't conflate
-it with the other three.) This ADR's lowered IR gives these three counters
-one shared representation (a `VersionedVar` type — see Decision) instead of
-three parallel structs that must be kept in sync by convention.
+These asymmetries are load-bearing (BT-1449/BT-1550), which means
+**unifying the representation is not the same as unifying the discipline**:
+a naive "one counter type for all three" would change generated variable
+names and break byte-parity. The `VersionedVar` design below therefore
+unifies *naming and identity only*; per-prefix scope discipline remains an
+explicit, per-prefix policy, preserved exactly and pinned by tests (see
+Phase A2). Note also that the `State` counter's prefix is a *render-time*
+function of generator context (`in_loop_body`/`in_hybrid_loop` select
+`StateAcc*` vs `State*` naming for the same counter), and `"StateAcc"`
+additionally serves as an unversioned lambda *parameter* name in foldl
+list-ops (`basic_ops.rs:84`, `dict_ops.rs:90`, …) — two distinct roles one
+string currently covers, which the IR must model as distinct nodes.
+(A fourth, unrelated "State" name, `_BuilderStateN` in
+`gen_server/methods.rs:2514`'s `build_builder_state_doc`, is a per-class
+positional index with no relation to mutation-version threading at all.)
 
 ### What already exists and does *not* need to change
 
@@ -98,91 +129,105 @@ three parallel structs that must be kept in sync by convention.
   `clint`/`no_lint` options, which only gate a different code path
   (compiling from Erlang *source*, which Beamtalk never does). It reliably
   catches unbound-variable and duplicate-variable well-formedness bugs
-  (`docs/development/debugging.md` §"core_lint (BT-3115)"). It cannot and
-  structurally will not catch semantic bugs like ADR 0110's — the generated
-  code was well-formed. This ADR's verifier operates one layer earlier, on
-  Beamtalk's own lowering decisions, and is explicitly a complement to
-  `core_lint`, not a replacement.
+  (`docs/development/debugging.md` §"core_lint (BT-3115)"). It cannot
+  catch semantic bugs like ADR 0110's — the generated code was well-formed.
+  This ADR's verifier operates one layer earlier, on Beamtalk's own
+  lowering decisions, and is a complement to `core_lint`, not a
+  replacement.
 - **`core_erlang_validity_tests.rs`** (part of BT-3112's epic) is a
   proptest suite over a fixed 20-element `FRAGMENTS` array checking three
   purely textual properties on rendered Core Erlang: balanced delimiters,
   module-name match, and absence of `Debug`/`Display`-format artifacts
   (the BT-875 class ADR 0089 closed). None of the three inspect
   state-threading correctness, NLR semantics, or variable-binding
-  provenance — they cannot, because by the time text is rendered the
-  structure this ADR's verifier needs (which version bound which, which
-  mutation is reachable from which relay) no longer exists as data.
+  provenance.
 - **`document/` (ADR 0089)** is the closest existing precedent for
   "typed structure with its own discipline," but it solves a different
   class of bug by a different method: it makes the BT-875 string-escape
-  vector *unrepresentable* (no `Document::String` variant exists to
-  misuse), rather than building a checkable structure and running a
-  separate verification pass over it. A grep for `Verifier`/`verify_ir`/
-  `fn verify(` across `crates/beamtalk-core/src` returns nothing — there is
-  no existing verifier-pattern precedent in this codebase. This ADR
-  introduces one.
+  vector *unrepresentable*, rather than building a checkable structure and
+  running a separate verification pass over it. There is no existing
+  verifier-pattern precedent in this codebase; this ADR introduces one.
+- **The codegen snapshot corpus is currently too thin to gate this
+  migration** — measured during review: of the 318 snapshots under
+  `test-package-compiler/tests/snapshots/`, exactly **1** contains a
+  `letrec` loop, **1** contains `$bt_nlr`, **1** contains `ClassVars1`,
+  **1** contains `class_vars_shadow`, and **4** contain `StateAcc`. A
+  "byte-identical snapshots" gate over that corpus is near-vacuous for
+  precisely the constructs this ADR migrates. Expanding the corpus is
+  therefore a *prerequisite deliverable* of this ADR (Phase A3), not an
+  assumed pre-existing safety net. (ADR 0089's byte-parity discipline,
+  which this ADR follows in spirit, was likewise not a standing harness —
+  its `.beam`-parity check was an ad-hoc `cmp -l` during its flag-day PR.)
 
 ### Constraints
 
-- **Narrow scope, as specified by BT-3122.** The lowered form covers only
-  the control-flow + state-threading core: the `control_flow/` cluster
-  (`conditionals.rs`, `counted_loops.rs`, `dict_ops.rs`,
-  `exception_handling.rs`, `while_loops.rs`, `list_ops/`), `threaded_expr.rs`,
-  and the state-versioning subset of `gen_server/methods.rs` (measured at
-  roughly 1900–2400 of its 5805 lines — `BodyExprKind` classification,
-  `generate_body_exprs_with_reply`, the tier-2/mutation-threading helpers,
-  and the class-method `ClassVars` threading path; the remaining ~60% of
-  the file is class/module registration scaffolding and ADR 0068 runtime
-  reflection metadata that is not in scope). Expression and primitive
-  codegen (`expressions.rs`, `intrinsics.rs`, `dispatch_codegen.rs`,
-  `value_type_codegen.rs`, …) stays AST-directed.
+- **Narrow scope, as specified by BT-3122 — with one correction.** The
+  lowered form covers the control-flow + state-threading core: the
+  `control_flow/` cluster, `threaded_expr.rs`, the state-versioning subset
+  of `gen_server/methods.rs` (measured at roughly 1900–2400 of its 5805
+  lines), **and — a scope correction found in review — the
+  version-`Bind`-emitting slices of `expressions.rs` and
+  `dispatch_codegen.rs`**: `generate_field_assignment`
+  (`expressions.rs:552` calls `next_class_var()`; the analogous field
+  paths drive `next_self_var()`/`next_state_var()`) and
+  `dispatch_codegen.rs:463`. These two sites are the *sole producers* of
+  the version bindings the verifier checks; an IR that cannot see its own
+  `Bind` producers cannot verify them. The rest of those two files
+  (expression and dispatch codegen generally) stays AST-directed and out
+  of scope, as do `intrinsics.rs` and `value_type_codegen.rs`.
 - **Explicit non-goals** (BT-3122): no full-pipeline IR covering all of
-  Core Erlang codegen — this was already considered and rejected once, as
-  "Typed Core Erlang IR," in [ADR 0018](0018-document-tree-codegen.md)
-  §Alternatives Considered #3, for being "over-engineered for our needs —
-  we don't transform or optimize the IR, we just emit it." That reasoning
-  still holds for the 90% of codegen this ADR does not touch. No cerl-wire
-  change — [ADR 0088](0088-direct-cerl-emission.md) (Rust↔BEAM transport
-  format) stays closed/withdrawn; this ADR's IR is entirely internal to
-  `beamtalk-core` and never reaches the Port. No behavior change — every
-  phase must produce byte-identical `Document`/`.core` output on the
-  existing codegen snapshot suite, the same discipline ADR 0089's Phase B
-  used.
+  Core Erlang codegen — already considered and rejected once, as "Typed
+  Core Erlang IR," in [ADR 0018](0018-document-tree-codegen.md)
+  §Alternatives Considered #3 ("over-engineered for our needs — we don't
+  transform or optimize the IR, we just emit it"); that reasoning still
+  holds for the codegen this ADR does not touch. No cerl-wire change —
+  [ADR 0088](0088-direct-cerl-emission.md) stays closed/withdrawn; this
+  ADR's IR is entirely internal to `beamtalk-core` and never reaches the
+  Port. No behavior change — every phase must produce byte-identical
+  output over the *expanded* snapshot corpus (Phase A3) plus an ordered
+  diagnostic-stream equality check (the `BEAMTALK_CODEGEN_DIAGNOSTICS`
+  pipeline's `Vec<Diagnostic>` order and multiplicity are observable and
+  moving `ThreadingPlan` selection into lowering changes when diagnostics
+  fire — parity must be asserted, not assumed).
 - **The `Document`/text printer is unchanged.** The typed-leaf API (ADR
-  0089) remains the only path from a lowered leaf to Core Erlang text. This
-  ADR's IR sits *between* the AST and `Document` construction, not
-  alongside or in place of it.
-- **Coordinate with BT-3111/BT-3125, don't block on them.** BT-3125
-  (currently In Progress) is moving the `apply_return_type_writeback`/
-  `apply_supervisor_kind_writeback`/`apply_class_kind_writeback` trio out of
-  codegen's discretion and into a driver-level `lower_module_for_codegen(&mut
-  module, &analysis)` preparation step, explicitly leaving a note in its own
-  issue: *"if the BT-3122 ADR is accepted, this preparation step is where it
-  slots in — keep the seam clean."* This ADR's lowering entry point is
-  designed to consume that prepared AST + threaded `AnalysisResult` once
-  BT-3125 lands, rather than re-deriving semantic facts locally (the same
-  anti-pattern BT-3111 is closing project-wide). Until BT-3125 ships, this
-  ADR's Phase A/B work (IR types, verifier, migrating `while_loops.rs`/
-  `counted_loops.rs`) does not depend on it — only the final wiring point
-  (Phase E) does.
+  0089) remains the only path from a lowered leaf to Core Erlang text.
+- **Coordination with BT-3111/BT-3125.** BT-3125 (In Progress, PR open at
+  the time of writing) is moving the writeback trio out of codegen's
+  discretion into a driver-level `lower_module_for_codegen(&mut module,
+  &analysis)` preparation step, explicitly noting *"if the BT-3122 ADR is
+  accepted, this preparation step is where it slots in."* Because BT-3125
+  is landing imminently and on the same snapshot gate, **it is a soft
+  prerequisite for this ADR's Phase B onward** — building an interim
+  analysis re-derivation path only to delete it later would reproduce the
+  exact anti-pattern BT-3111 is closing. Phase A (types, verifier,
+  snapshot expansion, measurement) has no dependency on BT-3125 and can
+  proceed in parallel.
+- **Coordination with BT-3112.** The metamorphic/differential harness in
+  that epic is the unknown-unknown hunter for this bug space; this ADR's
+  verifier is the known-invariant enforcer. They are complementary, and
+  the Phase A0 measurement gate below gives an explicit decision point to
+  descope this ADR toward its cheaper fallback (Alternative 1b) if the
+  harness lands first and changes the value calculus.
 
 ## Decision
 
 **Introduce a small, narrowly-scoped lowered IR — `ThreadedIr` — covering
-state-version bindings, threading-mode selection, and NLR relay
-boundaries, plus a verifier that checks it before it reaches `Document`
-construction.** Everything else in codegen (expressions, primitives,
-dispatch) stays AST-directed and unaffected.
+state-version bindings (with frame identity), threading-mode selection,
+shadow-write emission, and NLR relay boundaries, plus a verifier that
+checks it before `Document` construction.** Everything else in codegen
+stays AST-directed and unaffected. The decision is gated: Phase A0
+measures IR-construction/verification cost on a fixed fixture set against
+a pre-declared threshold before any migration phase begins (the ADR 0088
+lesson, applied to ourselves).
 
 ### Pipeline shape
 
 ```
 Beamtalk AST
-    │  (post BT-3125: lower_module_for_codegen(&mut module, &analysis))
+    │  (BT-3125: lower_module_for_codegen(&mut module, &analysis))
     ▼
 AST, prepared with threaded AnalysisResult / SemanticFacts
-    │  (this ADR: lower_control_flow — control_flow/, threaded_expr.rs,
-    │   and the state-versioning slice of gen_server/methods.rs only)
+    │  (this ADR: lower_control_flow — the in-scope slices only)
     ▼
 ThreadedIr                      ◄── verify(&ThreadedIr) -> Vec<VerifyError>
     │  (unchanged: typed-leaf Document construction, ADR 0089)
@@ -193,129 +238,173 @@ Document
 Core Erlang text ──► core_lint (unconditional, OTP) ──► BEAM
 ```
 
-Expression/primitive codegen continues to call directly into `Document`
-construction as it does today; it never touches `ThreadedIr`. The lowered
-form exists only for the constructs that already require multi-step
-state-threading decisions — loops, conditionals with mutation, list-ops,
-actor/class-method/value-type field mutation, and NLR relay.
-
 ### The IR
 
 ```rust
-/// One of the three (formerly independent) monotonic version counters,
-/// unified into a single representation. Replaces StateThreading's
-/// ad-hoc `State{N}`, ClassContext::class_var_version's `ClassVars{N}`,
-/// and ValueTypeContext::self_version's `Self{N}`.
+/// Frame identity — allocated at each method entry, with_branch_context
+/// entry, builder-fun entry. Version linearity is PER FRAME: the existing
+/// counters are deliberately not SSA (with_branch_context resets
+/// state_version to 0 per branch arm, so sibling arms legitimately both
+/// produce State1 in disjoint scopes). Without frame identity, a linearity
+/// check false-positives on every branching method — this field is a
+/// design requirement, not a nicety.
+struct FrameId(u32);
+
+/// One of the three (formerly independent) version counters, unified in
+/// NAMING AND IDENTITY ONLY. Per-prefix scope discipline (state:
+/// reset+restore per branch; class_vars: restore-only, mutated-flag
+/// sticky; self: currently neither — see Phase A2) remains explicit
+/// per-prefix policy, preserved exactly.
 struct VersionedVar {
-    prefix: VersionPrefix,   // State | ClassVars | Self
+    prefix: VersionPrefix,   // State | ClassVars | SelfVt
     version: usize,
+    frame: FrameId,
 }
+/// NOTE: the State counter renders as `StateAcc{N}` inside non-hybrid
+/// loop bodies — prefix rendering is a function of (counter, loop
+/// context), decided at Document-construction time, not stored in the IR.
+/// The unversioned `StateAcc` lambda *parameter* of foldl list-ops is a
+/// separate node (AccParam), not a VersionedVar.
 
 enum ThreadingMode { DirectParams, TupleAcc, Hybrid, StateAcc(StateAccFallbackReason) }
 
 enum ThreadedStmt {
-    /// A mutation: binds a fresh version from a prior one.
-    /// `op` is Put { key, value } | Merge { .. } | Identity — never raw text.
-    Bind { target: VersionedVar, source: VersionedVar, op: BindOp },
+    /// A mutation: binds a fresh version from a prior one in the same
+    /// frame. `shadow_write: bool` records whether this Bind also emits
+    /// the ADR 0110 process-dictionary shadow write — modeling the side
+    /// channel explicitly is what makes the ShadowWriteMissing check
+    /// (below) possible.
+    Bind { target: VersionedVar, source: VersionedVar, op: BindOp, shadow_write: bool },
 
-    /// A loop or mutation-carrying conditional, with its selected mode
-    /// already resolved (by the existing ThreadingPlan logic, moved to
-    /// run once during lowering instead of being re-derived at emission).
-    Threaded { mode: ThreadingMode, body: Vec<ThreadedStmt>, produces: Vec<VersionedVar> },
+    /// A loop or mutation-carrying conditional, with its mode already
+    /// resolved (by the existing ThreadingPlan logic, run once during
+    /// lowering instead of re-derived at emission).
+    Threaded { mode: ThreadingMode, frame: FrameId, body: Vec<ThreadedStmt>, produces: Vec<VersionedVar> },
 
-    /// A non-local-return boundary — the throw/catch scaffolding's meaning,
-    /// not its Document rendering. `carries` names the version that must be
-    /// reachable from every mutation made before this point in the same frame.
-    NlrRelay { boundary: NlrBoundary, token: TokenId, carries: VersionedVar },
+    /// An NLR boundary. Faithful to what codegen actually emits
+    /// (mod.rs:2480-2549): the token-MATCHING catch arm binds its state
+    /// from the thrown 4-tuple's pattern variable (NlrCatchVars.state_var
+    /// — a fresh pattern binding, not a versioned var), and the
+    /// token-non-matching (foreign) arm carries nothing and re-raises.
+    /// The IR does NOT pretend the relay "carries" a VersionedVar.
+    NlrCatch { boundary: NlrBoundary, token: TokenId, frame: FrameId },
 
     Return(ValueRef, VersionedVar),
 }
 ```
 
 `NlrBoundary` (`ActorReply | ClassMethod { has_class_vars: bool } | ValueType`)
-is not new — it is the existing enum from `mod.rs:902-911`, reused as-is;
-this ADR gives it a home in the IR instead of only existing implicitly in
-the try/catch-emission code path.
+is the existing enum from `mod.rs:902-911`, reused as-is.
 
 ### The verifier
 
 ```rust
 enum VerifyError {
-    /// Catches the unbound-`StateX` bug class — mechanically, before core_lint,
-    /// with a Beamtalk-source-attributable diagnostic instead of a raw
-    /// "unbound variable 'State3' in myMethod/2" from erlc.
+    /// A versioned var referenced with no producing Bind in its frame (or
+    /// a parent frame per the explicit frame-flow rule). Catches the
+    /// unbound-StateX class one layer earlier than core_lint, with a
+    /// Beamtalk-source-attributable message instead of erlc's raw
+    /// "unbound variable 'State3' in myMethod/2". Diagnosis-quality
+    /// improvement over an existing backstop, not net-new detection.
     UnboundVersion { var: VersionedVar, at: Span },
 
-    /// Every VersionedVar must be produced by exactly one Bind and consumed
-    /// by exactly its immediate successor — catches reuse/skip bugs in the
-    /// hand-written version-counter bookkeeping (the class of bug the three
-    /// duplicated counters above are structurally prone to).
+    /// Per-frame linearity: within one FrameId, each version produced by
+    /// exactly one Bind, consumed as the source of at most one successor.
+    /// Frame-scoped by design — see FrameId above.
     NonLinearVersion { var: VersionedVar, producers: usize, consumers: usize },
 
-    /// Replaces the four "unpack should emit no code" debug_asserts:
-    /// an optimized ThreadingMode (DirectParams/TupleAcc/Hybrid) is
-    /// structurally forbidden from containing an unpack Bind.
+    /// Replaces the four "unpack should emit no code" debug_asserts as a
+    /// structural property: an optimized ThreadingMode node cannot
+    /// contain an unpack Bind. (In release today this failure degrades to
+    /// a core_lint unbound-variable error; the gain is a correct,
+    /// centralized, source-attributed diagnosis.)
     ThreadingModeUnpackMismatch { mode: ThreadingMode, at: Span },
 
-    /// The ADR-0110 bug class, generalized: a mutation made before an
-    /// NlrRelay whose `carries` version does not descend from it.
-    /// This is the check that would have caught ADR 0110's bug in CI,
-    /// months before the production symptom, instead of after it shipped.
-    MutationLostAcrossRelay { mutated: VersionedVar, boundary: NlrBoundary, at: Span },
+    /// The ADR 0110 CONTRACT check — regression-pinning, not
+    /// counterfactual detection (see "Verifier honesty" below). Now that
+    /// ADR 0110 established the invariant, it is checkable structurally:
+    /// a class-var Bind at frame depth 0 (method top frame) inside a
+    /// method whose body can relay a foreign NLR (has_class_vars: true
+    /// boundary present) MUST have shadow_write: true. Fires if a future
+    /// emission path forgets the shadow write ADR 0110's fix depends on,
+    /// or if a new mutation site is added without it.
+    ShadowWriteMissing { mutated: VersionedVar, at: Span },
 }
 
 fn verify(ir: &[ThreadedStmt]) -> Vec<VerifyError>;
 ```
 
-The verifier runs unconditionally in every build profile (unlike
-`debug_assert!`, which compiles out of `--release`) and in CI over every
-compiled `stdlib/test/*.bt` and `stdlib/bootstrap-test/*.btscript` fixture,
-the same way `core_lint` already runs unconditionally today. A verifier
-failure is a compiler-internal bug (the lowering pass produced malformed
-IR), reported the same way a panic in codegen is reported today — it is
-not a new class of user-facing diagnostic and does not change what valid
-Beamtalk programs compile to.
+**Failure behavior.** The verifier runs in debug builds and CI
+unconditionally. In release builds, a `VerifyError` does **not** panic —
+per CLAUDE.md ("never panic on user input"; "always return
+`(Result, Vec<Diagnostic>)`"), it is reported as an internal-error
+diagnostic attached to the compile result while emission proceeds with the
+generator's output (i.e., release behavior on a verifier bug is *no worse
+than today*, plus a diagnostic; debug/CI behavior is a hard failure). A
+false positive in a shipped compiler must degrade to a warning, not a
+refusal to compile valid code.
 
-### Worked example: the bug class this closes
+### Verifier honesty — what this catches and what it cannot
 
-Recall [ADR 0110](0110-class-var-shadow-write-through-for-nlr-relay.md)'s
-motivating case:
+This section exists because the first draft of this ADR overclaimed, and
+the adversarial review caught it (verified against
+`wrap_body_with_nlr_catch`, `mod.rs:2480-2549`, and `NlrCatchVars`,
+`mod.rs:880-890`):
 
-```beamtalk
-Value subclass: CollectionDriver
-  classState: runs = 0
+- **The verifier checks what the lowering pass said, not what it meant.**
+  The lowering pass and the emitter share their source of truth
+  (`current_class_var()`, `ThreadingPlan`, `classify_body_expr`'s
+  outputs). A check comparing the generator against itself is silent when
+  both are consistently wrong. The checks above are chosen to be
+  *structural* — properties of the IR shape that don't depend on the
+  generator's beliefs being correct: a Bind either has a shadow-write
+  companion or it doesn't; a mode node either contains an unpack or it
+  doesn't; a version either has a producer in its frame or it doesn't.
+- **`ShadowWriteMissing` would not have caught ADR 0110's bug before it
+  was known.** Pre-0110, the shadow write didn't exist, the invariant was
+  unstated, and no verifier rule could have encoded it. The claim this ADR
+  makes is regression-pinning and forward extension: the invariant, once
+  paid for at production cost, becomes mechanically enforced at every
+  current and future mutation site, rather than living in a code comment
+  and one BUnit test. The unknown-unknown-hunting role belongs to
+  BT-3112's metamorphic harness.
+- **Part of the 0110 contract lives on the Erlang side and is outside any
+  Rust-side verifier's reach.** The shadow key shape and erase discipline
+  in `invoke_class_method/7` (`beamtalk_class_dispatch.erl`) must agree
+  with what codegen emits. Per CLAUDE.md's cross-boundary rule, that
+  agreement needs a **shared conformance fixture** (a compiled fixture
+  whose shadow key/erase behavior both sides assert against), not a
+  comment — added in Phase D alongside the `ShadowWriteMissing` check as
+  the two halves of the same contract.
 
-  class countedRun: aBlock over: aList -> Nil =>
-    self.runs := self.runs + 1
-    aList do: [:x | aBlock value: x]
-    nil
+### Worked example: what the IR and verifier actually do for the 0110 class
+
+Post-ADR-0110, `generate_field_assignment` (`expressions.rs:552`) emits,
+for a top-frame class-var mutation:
+
+```erlang
+let ClassVars1 = call 'maps':'put'('runs', Val, ClassVars0) in
+let _ = call 'erlang':'put'({'$bt_class_vars_shadow', ...}, ClassVars1) in
 ```
 
-A block escaping via `^` from inside `aList do: [...]` relays a foreign
-NLR whose carried state is the *wrong* frame's state — the mutation to
-`self.runs` is lost. Lowered to `ThreadedIr`, the method body looks
-schematically like:
+Lowered:
 
 ```
-Bind { target: ClassVars1, source: ClassVars0, op: Put(runs, ...) }
-NlrRelay { boundary: ClassMethod { has_class_vars: true }, token: T0, carries: ClassVars0 }
-                                                                    ^^^^^^^^^ wrong — should be ClassVars1
+Bind { target: ClassVars1@F0, source: ClassVars0@F0, op: Put(runs, ...), shadow_write: true }
+NlrCatch { boundary: ClassMethod { has_class_vars: true }, token: T0, frame: F0 }
 ```
 
-`verify()` reports `MutationLostAcrossRelay { mutated: ClassVars1, boundary:
-ClassMethod{..}, at: <line> }` — the exact shape of ADR 0110's bug, caught
-mechanically at compile-time-of-the-compiler (i.e., against the compiler's
-own test fixtures in CI) instead of via a user-filed production report.
-ADR 0110's shipped fix (the process-dictionary shadow write-through) is
-unaffected by this ADR — it is a runtime fix for a class of relay this IR
-happens to make mechanically checkable *in the codegen layer*, catching
-future variants of the same bug class before they reach runtime, not a
-replacement for the runtime mechanism itself.
+`verify()` is silent. If a future refactor of the emission site (or a new
+mutation path — say, a future `self.field +=`-style sugar lowered through a
+different function) produces `shadow_write: false` in a
+`has_class_vars: true` method, `verify()` reports `ShadowWriteMissing` at
+the Beamtalk source line — in CI, on the day the regression is written.
+That is the deliverable: the invariant ADR 0110 discovered at production
+cost becomes structurally un-forgettable.
 
 ### Observable behavior — unchanged
 
-Per the non-goals constraint, no Beamtalk program's compiled output or
-REPL behavior changes:
+No Beamtalk program's compiled output or REPL behavior changes:
 
 ```
 st> CollectionDriver runCount
@@ -325,422 +414,407 @@ st> CollectionProbe escapeAfterCountedRun: #(1, 2, 3)
 st> CollectionDriver runCount
 1
 ```
-(identical to ADR 0110's example — verified byte-for-byte via the existing
-codegen snapshot suite at the end of each migration phase, the same
-discipline ADR 0089 Phase B used.)
+(identical to ADR 0110's example — verified over the *expanded* snapshot
+corpus, Phase A3, at the end of each migration phase.)
 
 ## Prior Art
 
 | System | Approach | What we adopt / reject |
 |---|---|---|
-| **rustc: HIR → THIR → MIR** | Each IR is progressively simplified and single-purpose; MIR specifically exists to run flow-sensitive checks (the borrow checker) via a general dataflow framework (`rustc_mir_dataflow`), not to represent the whole language. [Source](https://github.com/rust-lang/rustc-dev-guide/blob/main/src/mir/index.md) | **Adopted:** the "small, single-purpose, narrowly-scoped IR whose job is to make one class of check possible" shape. rustc's precedent directly supports scoping this ADR to control-flow/state-threading only rather than building one IR that models everything, which is what makes the "no full-pipeline IR" non-goal defensible rather than merely expedient. |
-| **Swift SIL ownership verifier** | A static verifier over an SSA-form IR checks ownership-model invariants (no use-after-free, no leaks) at compile time, explicitly framed as catching bugs in *SILGen and optimization passes* — i.e. compiler bugs, not user bugs. [Source](https://forums.swift.org/t/proposal-sil-ownership-model-verifier/4665) | **Adopted:** the framing that this verifier's job is to catch *codegen's own* bugs (drift between `classify_body_expr` and `threaded_expr.rs`, a lowering pass that loses a mutation across a relay), the same role SIL's verifier plays for SILGen — not a new class of end-user diagnostic. |
-| **Cranelift's `verifier` module** | Cranelift IR (CLIF) ships an explicit, standard verifier pass checked in CI and (optionally) at each compilation, confirming CLIF invariants before lowering to machine code. | **Adopted:** "the verifier is a standard, expected part of a codegen backend that lowers through an internal IR," not a novel or heavyweight addition — reinforces this is ordinary compiler engineering for a project at Beamtalk's current maturity, not premature infrastructure. |
-| **MLIR dialects + per-op `Verifier`** | MLIR's core insight is that a compiler doesn't need one universal IR — narrow, purpose-built "dialects" coexist, each with its own verification trait, and only the parts of a program that need a dialect's semantics are lowered into it. | **Adopted as the closest structural analogy:** `ThreadedIr` is, in MLIR's vocabulary, a small dialect for exactly the control-flow/state-threading subset of the program, verified on its own terms, coexisting with AST-directed codegen for everything else — rather than a monolithic IR the whole pipeline must funnel through. |
-| **Erlang/OTP's `core_lint`** | Runs unconditionally as part of every `compile:forms([from_core \| Opts])` call, checking Core Erlang well-formedness (unbound/duplicate variables) — external to Beamtalk, downstream of code generation, syntactic only. | **Kept, complemented, not replaced.** `core_lint` is a real safety net for the well-formedness class of bug and stays exactly as-is (BT-3115). This ADR's verifier operates one layer earlier (Beamtalk's own lowering decisions) and catches the semantic class `core_lint` cannot see by construction — ADR 0110's bug was `core_lint`-clean. |
-| **Gleam's codegen** | Gleam has no actor/mutable-state threading requirement analogous to Beamtalk's (no built-in process/gen_server state model compiled through tail-recursive loops with version-counted map threading) — its `Document`-tree codegen (the direct ancestor of ADR 0018's) doesn't face this problem at all. | **Not directly transferable.** Unlike ADR 0089, where Gleam was strong comparative prior art for leaf-typing, Gleam's absence of this exact problem means it offers no guidance on the IR/verifier question — noted for completeness, not as a design input. |
-| **Pharo/Squeak Smalltalk** | Class-variable/instance-variable mutation is a direct memory write; a non-local return unwinds the real call stack via `BlockContext`, and there's no "commit" step for a mutation to survive — precisely the point ADR 0110 made about why this bug class is BEAM-specific, not Smalltalk-general. | **Confirms the constraint, not the solution.** Beamtalk inherits Smalltalk's mutable-variable *semantics* while compiling to an immutable substrate, so it must reconstruct "the assignment already happened" via functional threading — this ADR's IR/verifier targets exactly the reconstruction machinery that choice requires and that Smalltalk itself never needed. |
+| **rustc: HIR → THIR → MIR** | Each IR is progressively simplified and single-purpose; MIR specifically exists to run flow-sensitive checks (the borrow checker) via a general dataflow framework (`rustc_mir_dataflow`), not to represent the whole language. [Source](https://github.com/rust-lang/rustc-dev-guide/blob/main/src/mir/index.md) | **Adopted:** the "small, single-purpose, narrowly-scoped IR whose job is to make one class of check possible" shape — what makes the "no full-pipeline IR" non-goal defensible rather than merely expedient. |
+| **Swift SIL ownership verifier** | A static verifier over an SSA-form IR checks ownership-model invariants at compile time, explicitly framed as catching bugs in *SILGen and optimization passes* — compiler bugs, not user bugs. [Source](https://forums.swift.org/t/proposal-sil-ownership-model-verifier/4665) | **Adopted:** the framing that this verifier's job is to catch *codegen's own* bugs. **Adapted with a caveat SIL's docs are honest about and so is this ADR:** a verifier enforces stated invariants; SIL's ownership verifier postdates and encodes an ownership *model* — it did not discover the model. Same relationship as `ShadowWriteMissing` to ADR 0110. |
+| **Cranelift's `verifier` module** | CLIF ships an explicit verifier pass checked in CI and optionally per-compilation. | **Adopted:** "the verifier is a standard, expected part of a codegen backend that lowers through an internal IR" — ordinary compiler engineering, not novel infrastructure. |
+| **MLIR dialects + per-op `Verifier`** | Narrow, purpose-built dialects coexist, each with its own verification; only the program parts needing a dialect's semantics are lowered into it. | **Adopted as the closest structural analogy:** `ThreadedIr` is a small dialect for the control-flow/state-threading subset, verified on its own terms, coexisting with AST-directed codegen for everything else. |
+| **Erlang/OTP's `core_lint`** | Runs unconditionally on every `from_core` compile, checking well-formedness (unbound/duplicate variables) — downstream of codegen, syntactic only. | **Kept, complemented, not replaced.** It also serves as the release-mode backstop for several of this ADR's checks (see §Verifier honesty) — the verifier's gain over it for those is diagnosis quality and source attribution, and this ADR says so rather than claiming net-new detection. |
+| **Gleam's codegen** | No actor/mutable-state threading requirement analogous to Beamtalk's; its `Document`-tree codegen doesn't face this problem. | **Not directly transferable** — noted for completeness. |
+| **Pharo/Squeak Smalltalk** | Mutation is a direct memory write; NLR unwinds a real stack; no "commit" step exists for a mutation to survive. | **Confirms the constraint, not the solution:** Beamtalk inherits mutable-variable semantics on an immutable substrate, so it must reconstruct "the assignment already happened" via functional threading — this ADR targets the reconstruction machinery Smalltalk never needed. |
 
 ## User Impact
 
 | Persona | Impact |
 |---|---|
-| **Newcomer** | None. No language syntax, semantics, or REPL output changes — every compiled Beamtalk program produces byte-identical output before and after. |
-| **Smalltalk developer** | None directly; indirectly, this closes future variants of the ADR-0110 bug class (silently-lost mutations across `^`) before they ship, reinforcing the existing invariant that `^` is ordinary control flow, not a special case that can silently drop side effects. |
-| **Erlang/BEAM developer** | None to generated `.beam` artifacts. The verifier's error shapes (`UnboundVersion`, `MutationLostAcrossRelay`, …) will look familiar to anyone who has read a `core_lint` "unbound variable" message — same spirit, one layer earlier, with Beamtalk-source-line attribution instead of a raw Core Erlang variable name. |
-| **Production operator** | None. No runtime change; the verifier runs at compile time, in CI, against the compiler's own test fixtures — it is not part of the shipped runtime or the `beamtalk build` fast path beyond the (small, one-time-per-compile) cost of walking the lowered IR for the control-flow/state-threading subset of the module being compiled. |
-| **Tooling developer (LSP, debugger)** | Mildly positive, longer-term. A structured `ThreadedIr` with span information is a better foundation for future BT-aware diagnostics or a codegen-decision inspector (e.g. "why did this loop fall back to StateAcc?") than re-deriving that information from `BEAMTALK_CODEGEN_DIAGNOSTICS=1` log lines, though no such tooling is proposed as part of this ADR. |
-| **Compiler contributor** | The main audience. Adding a new stateful control-flow construct becomes "add a `ThreadedStmt` case + a verifier check" instead of "add Document-emission code and hope the four other `ThreadingPlan` call sites, the `BodyExprKind` classifier, and the `threaded_expr.rs` recognizer all still agree." The three duplicated version-counter services collapse into one `VersionedVar` type. Net positive with a real adjustment cost: this is new internal API surface (~S-to-M sized per migrated subsystem) that must be learned, on top of the existing `Document`/typed-leaf combinator surface (ADR 0089), which is unchanged. |
+| **Newcomer** | None. No language syntax, semantics, or REPL output changes. |
+| **Smalltalk developer** | None directly; indirectly, the invariant that `^` never silently drops side effects — established for class vars by ADR 0110 — becomes mechanically pinned against regression rather than convention-guarded. |
+| **Erlang/BEAM developer** | None to generated `.beam` artifacts. Verifier error shapes will read like `core_lint` messages one layer earlier, with Beamtalk-source attribution. |
+| **Production operator** | None at runtime. Verifier cost is compile-time only, budgeted and measured in Phase A0 before any migration proceeds; in release builds a verifier finding degrades to an internal-error diagnostic, never a panic or a refusal to compile (CLAUDE.md error-recovery rules). |
+| **Tooling developer (LSP, debugger)** | Mildly positive, longer-term: a structured `ThreadedIr` with spans is a better substrate for future "why did this loop fall back to StateAcc?" tooling than log-line parsing; no such tooling is proposed here. |
+| **Compiler contributor** | The main audience, and honestly a mixed bag: (+) adding a stateful construct becomes "add a `ThreadedStmt` case + verifier check" with single-sourced classifier/emitter decisions; the three duplicated counters collapse into one frame-disciplined type. (−) new internal API surface to learn; a real test-migration cost (see Consequences — the existing `Document`-asserting tests survive only via the `lower_and_render` shim committed to in Phase A1); and the in-scope files are under active feature development, so phases carry a stated conflict protocol (see Implementation). |
 
 ## Steelman Analysis
 
-### Option A: Narrow lowered IR + verifier, phase-gated by subsystem (Recommended)
+### Option A: Narrow lowered IR + verifier, phase-gated with a measurement gate (Recommended)
 
-- 🧑‍💻 **Newcomer-to-compiler-internals contributor**: "When I add a new stateful loop variant, the compiler tells me at CI time — with a Beamtalk-source-line-attributed error — if I got the state threading wrong, instead of me discovering it three weeks later as a silently-wrong runtime value like ADR 0110's bug."
-- 🎩 **Smalltalk purist**: "This is the same principle ADR 0110 already established for class vars — `^` must be ordinary control flow that never silently drops side effects — generalized from 'documented and runtime-patched for one case' to 'mechanically checked for the whole state-threading surface, before it ships.'"
-- ⚙️ **BEAM veteran**: "`core_lint` already proved the value of an unconditional structural check baked into the pipeline. This is the same idea one layer up — narrowly scoped, doesn't touch the wire, doesn't touch `Document`, doesn't touch the 90% of codegen that doesn't need it."
-- 🏭 **Operator**: "Zero runtime change, zero wire change. All risk is contained to compile-time internals, verified phase-by-phase against the existing byte-identical-snapshot discipline that already proved itself in ADR 0089's flag-day migration."
-- 🎨 **Language/compiler designer**: "This is the textbook 'narrow, purpose-built IR + verifier' shape (rustc's MIR, Swift's SIL, MLIR's dialects) applied at exactly the size Beamtalk's current problem calls for — not the 58K-LOC full-pipeline rewrite ADR 0088 correctly rejected, and not zero, which leaves six independently-drifting invariants as the only defense against a real, previously-shipped bug class."
+- 🧑‍💻 **Newcomer-to-compiler-internals contributor**: "When I add a new stateful loop variant or a new mutation-emission path, CI tells me — with a Beamtalk-source-attributed error — if I forgot the shadow write or emitted an unpack in a direct-params loop, instead of me discovering it as an erlc unbound-variable message pointing at generated code, or worse, as silently-wrong runtime state."
+- 🎩 **Smalltalk purist**: "ADR 0110 established that `^` must never silently drop side effects, at the cost of a shipped bug. This makes that invariant un-forgettable at every future mutation site instead of living in one test and a comment."
+- ⚙️ **BEAM veteran**: "`core_lint` proved the value of an unconditional structural check in the pipeline. This is the same idea one layer up, and it's honest that for several checks it improves the diagnosis rather than adds detection — that's still worth having when the alternative is an erlc error naming a generated variable three layers from the cause."
+- 🏭 **Operator**: "Zero runtime change, zero wire change, release-mode failure degrades to a diagnostic. The Phase A0 gate means if the IR's compile-time cost is real, the project stops before migrating anything — the ADR 0088 discipline applied in advance rather than in retrospect."
+- 🎨 **Language/compiler designer**: "The three version counters with three inconsistent disciplines — one of which (`self_version`) is saved/restored *nowhere* — is a latent bug factory independent of everything else in this ADR. The IR is the natural home for fixing it with frame identity rather than a fourth convention."
 
-### Option B: Verifier without IR — strengthen the current generator with a post-hoc validator only
+### Option B: Verifier without IR
 
-- 🧑‍💻 **Newcomer contributor**: "I don't have to learn a new IR type at all — the validator runs over what's already there."
-- 🎩 **Smalltalk purist**: "Minimal new machinery is more in the spirit of pragmatic, incremental Smalltalk-style development than committing to a new typed layer up front."
-- ⚙️ **BEAM veteran**: "`core_erlang_validity_tests.rs` already proved a post-hoc property-test validator has *some* value (BT-875 format-artifact detection) at very low cost. Why not extend that same style of check instead of adding a new internal representation?"
-- 🏭 **Operator**: "Lowest-risk option on the table. No new pipeline stage, no new pass ordering to get wrong, ships incrementally with no coordination against BT-3125's `AnalysisResult` threading."
-- 🎨 **Language designer (the sharpest form of this argument)**: "A verifier's value comes from what it checks, not from where the data it checks lives. If we can re-derive 'is this version linear, does this mutation survive this relay' by walking the *existing* generator state or rendered `Document` tree, we get the same safety without committing to a new IR that has to be kept in sync with codegen forever."
+Two forms, split per the adversarial review because they have opposite verdicts:
 
-**Why A wins despite this steelman.** The sharpest form of B's argument
-("value comes from the check, not the representation") is correct in the
-abstract but fails on this codebase's specific problem: the information
-`MutationLostAcrossRelay` needs (which version a relay's `carries` field
-descends from) **does not exist** once code is lowered to `Document`/text —
-it has to be *re-derived*, which means re-implementing the same
-classification logic `classify_body_expr` and `ThreadingPlan` already
-compute, a fourth time, in the validator. That is exactly the
-`architecture-principles.md` §6 duplication anti-pattern this ADR's own
-Context section documents happening three times already (`StateThreading`/
-`class_var_version`/`self_version`). A validator that re-derives semantic
-structure post-hoc is not lower-risk than an IR that carries that structure
-through explicitly — it is the same risk, hidden one layer deeper, plus a
-second implementation to keep in sync with the first. Building the small
-IR is not overhead layered on top of the fix; constructing the IR *is* the
-mechanism by which the classifier's and emitter's decisions stop being two
-independently-maintained things that must agree.
+**B1 — re-derive post-hoc (from Document/text or generator state after the
+fact).** Rejected for the reason the first draft gave, which survives
+review: the needed structure (version provenance, frame identity, mode
+membership) doesn't exist post-emission and re-deriving it means
+re-implementing `classify_body_expr`/`ThreadingPlan` a second time — the
+§6 duplication anti-pattern.
+
+**B2 — record decisions as they are made (the strong form, and this ADR's
+designated fallback).** `ThreadingPlan`, `BodyExprKind`, and the
+version-counter calls all exist as in-memory values at emission time
+today. Push each decision into a `Vec<Decision>` side-channel as it is
+made; verify that. Re-derives nothing, needs no emission restructuring,
+gets the mode/unpack and classifier/emitter checks always-on at a fraction
+of the cost.
+
+- 🧑‍💻 **Newcomer**: "No new pipeline stage to learn — the codegen I read is still the codegen that runs."
+- ⚙️ **BEAM veteran**: "This is the 90/10 point. The checks that survive the honesty analysis are exactly the ones this gets."
+- 🏭 **Operator**: "No migration freeze on 11K LOC of actively-developed files."
+- 🎨 **Language designer (sharpest form)**: "After the honesty corrections, the verifier's *checks* don't require the IR — they require the *decisions*, which already exist as data. The IR's remaining unique contribution is single-sourcing (one node, one emitter) and the counter unification. Is that worth the migration?"
+
+**Why A still wins, on the corrected claims — narrowly.** B2 checks that
+two independently-computed decisions agree; A removes the second
+computation. B2's recorder must itself be maintained at every decision
+site (a site that forgets to record is invisible to the validator — the
+same "remember to keep in sync" failure mode, relocated); A's IR is the
+decision record *and* the emission input, so an unrecorded decision cannot
+emit. And the counter unification with frame discipline (the
+`self_version` landmine) needs a typed home either way. But the margin is
+real only if the migration cost stays bounded — hence the Phase A0 gate,
+and hence B2's designation as the **explicit descope target** if A0 fails
+its threshold: everything in Phase A1 (types, checks, snapshot corpus)
+transfers to B2 directly.
 
 ### Option C: Status quo — `debug_assert!`s + `core_lint` + code review
 
-- 🧑‍💻 **Newcomer contributor**: "The state-threading code has worked for many releases. Six `debug_assert!`s plus attentive code review caught real bugs before (they're how ADR 0110's bug class was eventually found and fixed)."
-- 🎩 **Smalltalk purist**: "Smalltalk favors iterative refinement over up-front structure. Add checks where bugs are actually found, not speculatively."
-- ⚙️ **BEAM veteran**: "`debug_assert!` is idiomatic Rust for this; every Rust codebase has invariants it doesn't formally verify. This isn't unusual."
-- 🏭 **Operator**: "Zero migration cost, zero risk, ships nothing new."
-- 🎨 **Language designer**: "The `control_flow/` cluster is 16K LOC and has shipped correct code for most of its history. The base rate of this specific bug class (mutation-lost-across-relay) is one documented occurrence (ADR 0110) in the codebase's lifetime — is a whole new IR proportionate to a rate-one bug?"
+- 🧑‍💻 **Newcomer**: "The state-threading code has shipped correct for most of its history; review caught 0110 eventually."
+- ⚙️ **BEAM veteran**: "In release, all six assert-guarded failures degrade to `core_lint` errors anyway — there's a backstop, not a void."
+- 🏭 **Operator**: "Zero cost, zero risk, zero freeze."
+- 🎨 **Language designer**: "One shipped bug in the codebase's lifetime for this class; is any of this proportionate?"
 
-**Why A wins despite this steelman.** The rate-one framing undercounts the
-risk: ADR 0110's bug was found because it was *reachable* through a common,
-recommended pattern (`docs/beamtalk-language-features.md` itself
-recommends the collection-driven-block shape that triggered it) — not
-because it's rare in principle, but because most code doesn't happen to
-combine class-var mutation with a block that escapes through library code.
-`debug_assert!`s compile out of release builds entirely (the issue's
-original framing is correct on this point even where its LOC/count
-estimates were off), so they provide **zero** protection in the actual
-shipped compiler binary — only in `cargo test`/dev builds. And the six that
-do exist are concentrated on exactly one narrow slice (threading-mode/unpack
-agreement, classifier/emitter agreement) — they provide no coverage at all
-for the NLR-relay-loses-a-mutation class that ADR 0110 actually was. Status
-quo is not "we have a check and choose not to add another" — it is "we have
-no check for the bug class that has already shipped once."
+**Why A wins despite this steelman.** The corrected version of the
+argument, since the first draft overstated it: the six assertions *do*
+have a release-mode backstop (`core_lint`), but it fires far from the
+cause with an Erlang-level message about generated code, and it covers
+only the failures that happen to produce malformed output — a
+classification/emission drift that produces *well-formed but wrong* output
+(the 0110 shape) has no backstop at all. The status quo's real gap is not
+"zero protection" but "no protection for the silent-wrong class plus poor
+diagnosis for the loud class," and — decisively — nothing in the status
+quo addresses the `self_version` save/restore hole or prevents the next
+mutation-emission site from forgetting the shadow write.
 
-### Option D: Full-pipeline typed Core Erlang IR (revisiting ADR 0018's rejected alternative)
+### Option E: Metamorphic/differential testing first (BT-3112), IR later or never
 
-Referenced for completeness, not re-litigated — this is explicitly excluded
-as a non-goal by BT-3122. [ADR 0018](0018-document-tree-codegen.md)
-§Alternatives Considered #3 already rejected "Typed Core Erlang IR" covering
-all of codegen, for being "significantly more work... over-engineered for
-our needs — we don't transform or optimize the IR, we just emit it," while
-explicitly leaving the door open: *"A typed IR may become valuable later
-(for optimization passes, multiple backends), but it's premature now."*
-That reasoning holds unchanged for the ~90% of codegen (expressions,
-primitives, dispatch) this ADR does not touch — those code paths don't
-exhibit the multi-step, must-stay-synchronized decision structure that
-makes control-flow/state-threading specifically worth lowering.
+- 🧑‍💻 / ⚙️ / 🏭 / 🎨 (shared core argument): "BT-3112's planned metamorphic harness would have caught ADR 0110's actual bug — result-preservation under semantics-preserving transforms is precisely the oracle for 'right value, lost side effect.' It hunts unknown-unknowns, covers all of codegen (not just the in-scope 30%), requires no migration of working code, and is already committed roadmap. Run it first; buy the IR only if the harness finds bug clusters it can't localize."
+
+**Why this ADR proceeds anyway — as a complement, with the sequencing
+acknowledged.** The harness and the verifier answer different questions:
+the harness detects *that* a semantic property broke somewhere in a
+generated program; the verifier (and the IR's single-sourcing) prevents
+and localizes specific, known, named invariant violations at the source
+line that introduced them, and removes the classifier/emitter dual
+computation that produces them. The harness also does nothing for the
+counter-discipline defect, which is a compiler-internals problem invisible
+to any black-box oracle. This ADR's Phase A runs in parallel with
+BT-3112's early children, and the A0 gate provides the explicit
+reconsideration point if the harness's early results change the calculus.
+What this ADR does *not* claim is that the verifier substitutes for the
+harness — the first draft's error, corrected in §Verifier honesty.
 
 ### Tension Points
 
-- **Scope discipline is the whole argument.** BEAM veterans and operators
-  broadly favor A over C once the ADR-0110 gap is made concrete, but would
-  reject a version of A that crept toward D's full-pipeline scope — the
-  ADR's phase-gating (below) exists specifically to keep each phase's
-  migration cost visible and stoppable, learning directly from the ADR
-  0088 lesson (a large, ungated migration that had to be withdrawn after
-  Phase 0 measurement).
-- **B vs A is a real disagreement about where duplication risk lives**, not
-  a strawman — see the "why A wins" analysis above. If a future maintainer
-  finds `ThreadedIr` drifting out of sync with the AST-directed codegen it
-  sits next to (an IR that itself becomes stale relative to what it's
-  supposed to represent), that is the risk B's steelman correctly
-  identifies; this ADR's answer is that IR construction happens as an
-  explicit lowering step immediately before verification and Document
-  construction — there is no window where it can silently go stale,
-  unlike a validator re-deriving structure after the fact.
-- **Newcomers vs. compiler-internals contributors.** End users and
-  newcomers see zero impact either way (User Impact table) — the entire
-  cost/benefit of this decision is scoped to the small population of
-  contributors touching `control_flow/`/`gen_server/methods.rs`, which
-  argues for keeping the new API surface as small as BT-3122's scope
-  allows rather than over-generalizing it.
+- **A vs. B2 is the live disagreement** — reasonable engineers land on
+  either side of "single-sourcing is worth a phased migration of ~11K
+  LOC." This ADR's answer is conditional (the A0 gate + B2 as designated
+  descope), which is as honest as the disagreement allows.
+- **Scope discipline remains the whole argument for A over D** (the
+  full-pipeline IR): the phase gates and the measurement gate exist to
+  keep A from becoming D by accretion.
+- **Freeze cost vs. correctness payoff:** the in-scope files carry active
+  feature work (BT-references spanning BT-1275→BT-3055). The conflict
+  protocol (Implementation, below) is: feature work lands first, migration
+  phases rebase; each phase has a wall-clock cap, after which it is split
+  or abandoned rather than extended.
 
 ## Alternatives Considered
 
-### 1. Verifier without IR (post-hoc validator over current generator/Document state)
+### 1a. Verifier without IR — re-derive post-hoc
+See Steelman Option B1. **Rejected**: re-derivation duplicates the
+classifier/plan logic — the §6 anti-pattern.
 
-See Steelman Analysis. **Rejected**: the semantic structure the verifier
-needs (version provenance, mode/unpack agreement, mutation reachability
-across a relay) does not survive to `Document`/text — recovering it
-post-hoc means re-implementing `classify_body_expr`/`ThreadingPlan`'s logic
-a second time, the exact duplication this ADR's own IR unification is
-meant to close. Not a lower-risk option; the same risk one layer deeper,
-plus a second implementation to maintain.
+### 1b. Verifier without IR — record decisions as made
+See Steelman Option B2. **Not rejected — designated descope target.** If
+Phase A0's measurement fails its threshold, or if BT-3112's harness
+results change the value calculus before Phase B begins, this ADR's
+deliverables reduce to: Phase A1's types and checks re-hosted on a
+decision side-channel + Phase A2's counter unification + Phase A3's
+snapshot corpus. That outcome is explicitly acceptable and pre-planned,
+not a failure mode.
 
-### 2. Status quo — `debug_assert!`s + `core_lint` + code review
+### 2. Status quo
+See Steelman Option C. **Rejected** — on the corrected argument (no
+protection for the silent-wrong class; poor diagnosis for the loud class;
+`self_version` hole and shadow-write forgettability unaddressed).
 
-See Steelman Analysis. **Rejected**: `debug_assert!`s provide zero
-protection in release builds (confirmed: none of the six in-scope
-assertions run outside dev/test profiles), and none of the six cover the
-NLR-relay-loses-a-mutation class that ADR 0110 already shipped once.
-`core_lint` structurally cannot see this class of bug — the code it
-checked in ADR 0110's case was well-formed.
-
-### 3. Unify the three version counters only, no IR/verifier
-
-A narrower fix: collapse `StateThreading`/`class_var_version`/
-`self_version` into one `VersionedVar`-producing service (closing the
-`architecture-principles.md` §6 duplication directly) without building a
-lowered IR or verifier around it.
-
-**Rejected as insufficient on its own** (though this ADR's `VersionedVar`
-design absorbs it as a side effect): it removes the "three independently
-implemented counters" duplication smell but does nothing for the six
-`debug_assert!`-guarded "these two independently-computed decisions must
-agree" invariants, which are the actual mechanism behind ADR 0110's bug
-class. A shared counter type does not, by itself, check that a mutation
-survives an NLR relay or that a threading mode and its unpack logic agree
-— those checks require walking a structure that records the relationship
-between binds and relays, which is what the IR is for. Worth doing either
-way; this ADR folds it in rather than treating it as a separate, smaller
-project, since the IR's `VersionedVar` type is the natural home for the
-unification.
+### 3. Unify the three version counters only
+**Absorbed rather than rejected.** This is now precisely Phase A2, and it
+is independently justified — the review established it must be done as
+*naming-only* unification with per-prefix discipline preserved and pinned
+by tests, plus the typestate hardening of Alternative 5. What the full ADR
+adds beyond it is the single-sourcing of classifier/emitter decisions and
+the shadow-write contract check; the first draft's claim that the six
+`debug_assert!`s were "the actual mechanism behind ADR 0110's bug class"
+was wrong (none of the six is on 0110's path) and is withdrawn.
 
 ### 4. Full-pipeline typed Core Erlang IR
+**Rejected** — per ADR 0018's still-valid reasoning and BT-3122's explicit
+non-goal.
 
-See Steelman Analysis Option D. **Rejected**: already rejected once (ADR
-0018), for reasons that still hold for the 90% of codegen this ADR
-deliberately excludes; explicitly a non-goal per BT-3122.
+### 5. Typestate hardening in place (newtype `VersionedVar` + RAII branch guard, no IR)
+Make the version counters' invariants unrepresentable in place: a
+`VersionedVar` newtype whose only constructors are the `next_*` methods,
+emitter signatures taking `VersionedVar` instead of `String` (an
+unproduced version can no longer be named), and an RAII guard replacing
+`with_branch_context`'s manual save/restore (closing the `self_version`
+hole by construction). **Absorbed into Phase A2** — this is how the
+counter unification should be built regardless of whether the full IR
+lands, and it delivers `UnboundVersion`-by-construction (stronger than a
+check) for the counter slice specifically. It does not cover mode/unpack
+membership, classifier/emitter single-sourcing, or the shadow-write
+contract, which is what the IR proper adds.
+
+### 6. Erlang-side strengthening only
+The dialyzer-visible `{nlr_relay, ...}` outcome variant
+(ADR 0110 §Neutral) is today's strongest guard for the 0110 contract's
+runtime half. Strengthening it (EUnit conformance on
+`class_method_outcome()`, an FFI-rule check) is worth doing and Phase D's
+shared conformance fixture does part of it — but it cannot see the Rust
+side's emission decisions at all, so it is a complement, not an
+alternative. **Partially adopted** (the fixture); rejected as a
+substitute.
 
 ## Consequences
 
 ### Positive
-- **Closes a real, previously-shipped bug class mechanically.** The
-  `MutationLostAcrossRelay` check generalizes ADR 0110's fix from "one
-  documented and runtime-patched case" to "checked at compile time for the
-  entire control-flow/state-threading surface," before a future variant
-  reaches production.
-- **The six `debug_assert!`s become structural, always-on checks** instead
-  of dev-build-only spot checks that silently vanish in release — the
-  underlying invariants (threading-mode/unpack agreement,
-  classifier/emitter agreement) are enforced by construction rather than
-  by four/two independently-maintained runtime assertions.
-- **Closes a real, previously undocumented duplication instance**
-  (`StateThreading`/`class_var_version`/`self_version`) per
-  `architecture-principles.md` §6, without a separate migration project.
-- **`Document`, the typed-leaf API (ADR 0089), and the Wadler-Lindig
-  printer (ADR 0018) are entirely unchanged** — this ADR adds a stage
-  before them, not a replacement for anything already working.
-- **No wire change, no runtime change, no behavior change** — every phase
-  is gated on byte-identical `Document`/`.core` output, verified the same
-  way ADR 0089's flag-day migration was.
-- **Scoped and phase-gated**, learning directly from the ADR 0088 lesson:
-  each phase has an independent exit criterion (byte-identical snapshots +
-  verifier green + the corresponding `debug_assert!`s deleted), rather than
-  one large, hard-to-review migration.
+- **ADR 0110's invariant becomes structurally un-forgettable** at every
+  current and future class-var mutation site (`ShadowWriteMissing` +
+  the cross-boundary conformance fixture), instead of living in one
+  emission site's code and one BUnit test.
+- **The classifier/emitter and mode/unpack dual-computations are removed
+  by construction**, not just checked — one IR node, one emitter. The six
+  `debug_assert!`s are deleted with their invariants absorbed.
+- **The three-counter duplication and the `self_version` save/restore hole
+  are closed** with frame identity and typestate constructors (Phase A2 —
+  independently valuable even under the descope outcome).
+- **Diagnosis quality:** failures that today surface as erlc messages
+  about generated variables surface as Beamtalk-source-attributed verifier
+  errors in CI.
+- **`Document`, typed leaves, printer, wire, runtime: unchanged.**
+- **The decision is measurement-gated (Phase A0) with a pre-planned
+  descope target (Alternative 1b)** — the ADR 0088 lesson applied
+  prospectively.
 
 ### Negative
-- **New internal API surface to learn.** Contributors touching
-  `control_flow/`/`gen_server/methods.rs`'s state-versioning slice must
-  learn `ThreadedIr`/`ThreadedStmt`/`VersionedVar` in addition to the
-  existing `Document`/typed-leaf combinator surface. Scoped narrowly
-  (BT-3122's explicit non-goals) to limit this to the ~30% of codegen that
-  actually exhibits the multi-step-decision problem.
-- **Migration is multi-phase and multi-PR**, each touching working, tested
-  code (`while_loops.rs`, `counted_loops.rs`, `list_ops/`'s six files,
-  the actor/class-method threading slice of `gen_server/methods.rs`).
-  Mitigated the same way ADR 0089 Phase B was: byte-identical snapshot
-  parity as the hard gate on every phase, plus the full behavioral suite
-  (`just test-stdlib`/`test-bunit`/`test-repl-protocol`).
-- **The verifier can produce false confidence if its checks are
-  incomplete.** `MutationLostAcrossRelay` as specified catches the
-  ADR-0110 shape (a mutation whose version doesn't reach a relay's
-  `carries` field); it does not claim to catch every possible semantic bug
-  in state threading — only the class this ADR's research identified as
-  currently unchecked. Extending its checks as new bug classes are found
-  is expected, ongoing work, not a one-time deliverable.
-- **Coordination risk with BT-3111/BT-3125.** This ADR's lowering entry
-  point is designed to consume BT-3125's `lower_module_for_codegen`
-  output once that epic lands (per the Constraints section), but BT-3125
-  is independently in progress; if its design changes materially before
-  landing, this ADR's Phase E wiring point may need to be revisited. Phases
-  A–D do not depend on BT-3125 and are not blocked by this risk.
+- **New internal API surface** for contributors to the in-scope files.
+- **A real test-migration cost the first draft omitted:** ~1,484 `#[test]`s
+  and ~298 `to_pretty_string()` assertion sites live under `codegen/`
+  (`tests/control_flow.rs` alone is 2,591 lines; `list_ops/tests.rs`
+  2,660). Functions returning `ThreadedIr` instead of `Document` would
+  break every test asserting on their output. **Mitigation, committed in
+  Phase A1:** a `lower_and_render(…) -> Document` shim preserving existing
+  test call shapes verbatim; tests migrate opportunistically, never as a
+  phase precondition.
+- **Compile-time cost is real until measured:** IR construction allocates
+  a second representation for the hottest codegen paths. Phase A0 measures
+  it on a fixed fixture set against a pre-declared threshold (proposed:
+  abandon/descope if end-to-end `beamtalk build` on the fixture set
+  regresses > 3%; tune in `/plan-adr`).
+- **Migration freeze risk on actively-developed files.** Protocol:
+  feature work lands first and phases rebase; each phase carries a
+  wall-clock cap (proposed: one release cycle), after which it is split
+  or handed to the descope path rather than extended.
+- **The verifier can produce false confidence** — it enforces stated
+  invariants only. Unknown-unknown discovery remains BT-3112's harness's
+  job, and this ADR says so.
+- **Release-mode verifier findings are diagnostics, not errors** — a real
+  compiler-internal bug in release degrades to today's behavior plus a
+  warning. This is the CLAUDE.md-compliant choice, but it means the hard
+  guarantee is CI-time, not user-compile-time.
 
 ### Neutral
-- **`NlrBoundary` is reused, not redesigned.** The existing enum
-  (`ActorReply | ClassMethod{..} | ValueType`, `mod.rs:902-911`) and its
-  builder `nlr_arm_result()` become inputs to `ThreadedStmt::NlrRelay`
-  rather than being restructured.
-- **`ThreadingPlan`'s mode-selection logic (`select_direct_params`/
-  `select_tuple_acc`/`select_hybrid_params`, `BodyEffects` prescan,
-  `StateAccFallbackReason`) is reused as-is** — it already computes the
-  right answer; this ADR changes *when* that answer becomes durable data
-  (as an IR node) rather than being immediately consumed by Document
-  emission, and *what* checks run against it afterward.
-- **`BEAMTALK_CODEGEN_DIAGNOSTICS=1`'s existing diagnostic categories**
-  (`docs/development/debugging.md` §"Codegen Diagnostics") are unaffected;
-  they report the same decisions, now sourced from `ThreadedIr` instead of
-  inline generator state, with no change to their wording or gating env
-  vars.
+- **`NlrBoundary`, `ThreadingPlan`, `StateAccFallbackReason`,
+  `BodyExprKind` are reused, not redesigned** — the IR changes *when*
+  their outputs become durable data, not what they compute.
+- **The `BEAMTALK_CODEGEN_DIAGNOSTICS` pipeline keeps its wording and env
+  vars; firing *order* may shift** when plan selection moves into
+  lowering — ordered diagnostic-stream equality is therefore an explicit
+  per-phase exit criterion rather than an assumption.
+- **ADR 0110's runtime fix is untouched**; this ADR adds the compile-time
+  half of its contract, plus the shared conformance fixture the
+  cross-boundary rule in CLAUDE.md requires.
 
 ## Implementation
 
-Phase-gated by subsystem, per BT-3122's requirement to avoid the ADR 0088
-lesson (an unbounded, all-at-once migration). Each phase's exit criteria are
-the same: byte-identical `Document`/`.core` output on the existing codegen
-snapshot suite, verifier green on 100% of `stdlib/test/*.bt` and
-`stdlib/bootstrap-test/*.btscript` fixtures, full behavioral suite
-(`just test-stdlib`/`test-bunit`/`test-repl-protocol`) green, and the
-`debug_assert!`s superseded by that phase's verifier checks *deleted from
-source* (the forcing function that a phase is actually done, not merely
-running in parallel with the old mechanism — the same discipline ADR 0089
-used for `Document::String`/`Document::Eco`). The `/plan-adr` output
-decomposes these into implementation issues; this section names the
-commitment level.
+Phase-gated with a measurement gate at the front. Exit criteria for every
+migration phase (B–D): byte-identical output over the **expanded** snapshot
+corpus (A3), ordered diagnostic-stream equality, verifier green on all
+stdlib fixtures, full behavioral suite green, and the phase's superseded
+`debug_assert!`s deleted from source. The `/plan-adr` output decomposes
+into issues; this section names the commitment level.
 
-### Phase A — IR types + verifier skeleton (S)
-Define `VersionedVar`, `ThreadedStmt`, `VerifyError`, and `verify()` in a
-new `crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs`. Unify
-`StateThreading`/`class_var_version`/`self_version` behind `VersionedVar`.
-No codegen call site constructs `ThreadedIr` yet — this phase ships with
-unit tests only (verifier logic against hand-built IR fixtures), zero
-behavioral risk since nothing consumes it.
+### Phase A0 — Measurement gate (S)
+Prototype the IR types and lower *one* construct (`whileTrue:`
+direct-params) behind a flag; measure end-to-end `beamtalk build` on a
+fixed fixture set. Pre-declared gate: proceed only if regression ≤ 3%
+(threshold finalized in `/plan-adr`). On failure: descope to
+Alternative 1b, carrying Phases A1–A3 forward on the decision-side-channel
+design.
+
+### Phase A1 — IR types + verifier + test shim (S)
+`threaded_ir.rs`: `FrameId`, `VersionedVar`, `ThreadedStmt`,
+`VerifyError`, `verify()`, plus the `lower_and_render` test shim. Unit
+tests against hand-built IR fixtures. Nothing consumes the IR yet — this
+sub-phase is genuinely zero-behavioral-risk.
+
+### Phase A2 — Counter unification via typestate (S, snapshot-gated)
+`VersionedVar` newtype with constructor-only production, RAII branch
+guard replacing `with_branch_context`'s manual save/restore, per-prefix
+discipline preserved exactly (state: reset+restore; class_vars:
+restore-only + sticky mutated flag; self: **given** the save/restore it
+currently lacks, as an explicit, snapshot-gated behavior decision — if
+snapshots change, that's a bug find, not a regression). Discipline
+asymmetries pinned by dedicated tests. *Not* zero-risk, hence separated
+from A1 and gated on the corpus.
+
+### Phase A3 — Snapshot corpus expansion (S–M, prerequisite for B–D)
+Land fixtures covering the mode matrix — {DirectParams, TupleAcc, Hybrid,
+StateAcc} × {Actor, ValueType, ClassMethod} × {NLR present/absent} ×
+{class-var mutated/not} — before any migration phase. Measured baseline
+today: of 318 snapshots, `letrec` 1, `$bt_nlr` 1, `ClassVars1` 1,
+`class_vars_shadow` 1, `StateAcc` 4. Without this phase the parity gate is
+vacuous and the plan's "learning from ADR 0088" claim is unsupported.
 
 ### Phase B — `while_loops.rs` + `counted_loops.rs` (M)
-Migrate the `ThreadingPlan`-driven direct-params/tuple-acc/hybrid/StateAcc
-modes for `whileTrue:`/`whileFalse:`/`to:do:`/`to:by:do:`/`timesRepeat:` to
-construct `ThreadedIr` before Document emission. The four
-"unpack should emit no code" `debug_assert!`s
-(`while_loops.rs:317,454`, `control_flow/mod.rs:2522,2651`) are replaced by
-`ThreadingModeUnpackMismatch` and deleted from source.
+Migrate the letrec-loop family. Soft prerequisite: BT-3125 landed (so
+lowering consumes the threaded `AnalysisResult` from day one instead of
+building a to-be-deleted re-derivation). Deletes the four unpack
+`debug_assert!`s.
 
-### Phase C — `list_ops/` (M)
-Migrate `do:`/`collect:`/`select:`/`reject:`/`inject:into:`/`detect:`/
-`anySatisfy:`/`allSatisfy:`/`flatMap:`/`takeWhile:`/`dropWhile:`/
-`partition:`/`groupBy:`/`sort:` (the six `list_ops/` files, led by
-`transform_ops.rs` at 2074 lines and `search_ops.rs` at 917) to the same IR.
-Largest phase by LOC; no new invariant classes beyond Phase B's, so scoped
-as a mechanical follow-on rather than combined with B to keep each PR
-independently reviewable.
+### Phase C — `list_ops/` (L)
+Migrate the foldl list-op family — re-scoped **L** (the first draft's
+"mechanical follow-on, no new invariant classes" was wrong). New invariant
+classes Phase B never exercises, each needing IR modeling and verifier
+coverage: (1) the flat `{FoldAcc, Var1..VarN}` positional-unpack
+accumulator discipline (distinct from parameter threading); (2)
+`select_tuple_acc`'s ValueType-context exclusion (`control_flow/mod.rs:448-466`);
+(3) the recursive inter-construct `list_op_needs_stateacc_fallback`
+analysis for nested list ops; (4) early-exit ops (`detect:`,
+`anySatisfy:`, `takeWhile:`, …) changing accumulator liveness at the exit
+point. May split fold-shaped vs. early-exit-shaped in `/plan-adr`.
+`list_ops/tests.rs` (2,660 lines) migrates via the A1 shim.
 
-### Phase D — Actor/class-method state threading + NLR relay (L)
+### Phase D — Actor/class-method threading + NLR + shadow-write contract (L)
 Migrate the state-versioning slice of `gen_server/methods.rs`
-(`BodyExprKind` classification, `generate_body_exprs_with_reply`,
-`classify_body_expr`, the tier-2/mutation-threading helpers), the
-class-method `ClassVars` threading path (including ADR 0110's shadow-write
-mechanism, unaffected at runtime but now covered by
-`MutationLostAcrossRelay` at compile time), `conditionals.rs`'s
-mutation-inlining, and `exception_handling.rs`'s try/catch-with-mutation
-lowering. The two "must route through the Actor threaded emitter"
-`debug_assert!`s (`methods.rs:1258,1450`) are replaced by
-`UnboundVersion`/structural IR-construction guarantees and deleted — this
-is the phase that actually removes the classifier/emitter duplication,
-not merely checks for it. Largest and highest-risk phase; may itself split
-into sub-PRs (actor state, then class-method state, then NLR relay) during
-`/plan-adr` decomposition.
+(`BodyExprKind`, `generate_body_exprs_with_reply`, tier-2 helpers), the
+`ClassVars` threading path **including its `Bind`-emission sites in
+`expressions.rs:552` and `dispatch_codegen.rs:463`** (the scope correction
+— these are the producers of everything the verifier checks),
+`conditionals.rs`, `exception_handling.rs`, and `threaded_expr.rs`'s
+boundary adapter. Lands `ShadowWriteMissing` plus the **cross-boundary
+conformance fixture** pinning codegen's shadow-write emission against
+`invoke_class_method/7`'s key/erase discipline (CLAUDE.md cross-boundary
+rule). Deletes the two routing `debug_assert!`s. May split into sub-PRs in
+`/plan-adr`.
 
-### Phase E — Wire to BT-3125's prepared-AST boundary (S, coordinate)
-Once BT-3125 lands `lower_module_for_codegen(&mut module, &analysis)`, move
-this ADR's lowering entry point to consume the threaded `AnalysisResult`/
-`SemanticFacts` there, per the Constraints section, instead of any
-interim local re-derivation used in Phases A–D. If BT-3125 has not yet
-landed when Phases A–D are implemented, they read `AnalysisResult` the same
-way current codegen does (via whatever re-derivation exists at that time)
-— Phase E's job is exclusively to delete that interim path once the
-shared boundary exists, not to block Phases A–D on BT-3125's timeline.
+### Conflict protocol (all phases)
+Feature work in the in-scope files lands first; migration phases rebase.
+Each phase has a wall-clock cap (proposed: one release cycle); a phase
+that exceeds it is split or routed to the Alternative 1b descope, not
+extended.
 
 ### Affected Components
-- **New**: `crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs` —
-  `VersionedVar`, `ThreadedStmt`, `VerifyError`, `verify()`.
-- **Modified**: `control_flow/mod.rs`, `control_flow/while_loops.rs`,
-  `control_flow/counted_loops.rs`, `control_flow/list_ops/*.rs`,
-  `control_flow/conditionals.rs`, `control_flow/exception_handling.rs`,
-  `threaded_expr.rs` — construct `ThreadedIr` instead of emitting
-  `Document` directly for state-threading constructs; the four/two
-  `debug_assert!`s removed as their phases land.
-- **Modified**: `gen_server/methods.rs` — the state-versioning slice only
-  (Phase D); class/module registration scaffolding and ADR 0068 reflection
-  metadata (the other ~60% of the file) unaffected.
-- **Modified**: `mod.rs` — `StateThreading`/`class_var_version`/
-  `self_version` fields collapse behind `VersionedVar`; `NlrBoundary`
-  reused as-is inside `ThreadedStmt::NlrRelay`.
-- **Unchanged**: `document/` (ADR 0089 typed-leaf API and printer),
-  `dispatch_codegen.rs`, `expressions.rs`, `intrinsics.rs`,
-  `value_type_codegen.rs` (expression/primitive codegen — AST-directed,
-  out of scope), all Erlang-side runtime and wire format.
+- **New**: `codegen/core_erlang/threaded_ir.rs` (types, verifier, shim);
+  snapshot fixtures (A3); cross-boundary conformance fixture (D).
+- **Modified**: `control_flow/` (all production files), `threaded_expr.rs`,
+  `gen_server/methods.rs` (state-versioning slice), `mod.rs` (counters →
+  `VersionedVar` + RAII guard), **`expressions.rs` and
+  `dispatch_codegen.rs` (version-`Bind`/shadow-write emission sites only)**.
+- **Unchanged**: `document/` (ADR 0089), `intrinsics.rs`,
+  `value_type_codegen.rs`, the remainder of `expressions.rs`/
+  `dispatch_codegen.rs`, all Erlang-side runtime code (the conformance
+  fixture asserts against it but does not change it), wire format.
 
 ### Verification
-- **Snapshot parity**: existing codegen snapshot suite (the same one ADR
-  0089 Phase B verified byte-for-byte) must be unchanged after every phase.
-- **Verifier coverage**: `just` target (name TBD in `/plan-adr`, e.g.
-  `just verify-threaded-ir`) runs `verify()` over every compiled
-  `stdlib/test/*.bt`/`stdlib/bootstrap-test/*.btscript` fixture in CI,
-  reporting zero `VerifyError`s as a hard gate per phase.
-  `core_erlang_validity_tests.rs`'s existing three text-shape properties
-  are unaffected and continue running independently.
-- **Behavioral suite**: `just test-stdlib`, `just test-bunit`,
-  `just test-repl-protocol` green after every phase — the standard
-  behavior-preservation bar this codebase already uses for codegen
-  refactors (ADR 0089, ADR 0110).
-- **Regression test for the motivating case**: ADR 0110's
-  `CollectionDriver`/`CollectionProbe` repro (or an equivalent minimal
-  case) added as a verifier unit test asserting `MutationLostAcrossRelay`
-  fires on the *unfixed* shape and is silent on the *fixed* shape, so a
-  future regression in either the runtime shadow-write mechanism or a new
-  lowering path is caught by two independent layers (runtime behavior test
-  + compile-time verifier).
+- **Expanded snapshot corpus (A3) byte-parity** after every phase — the
+  real gate, replacing the first draft's reliance on a corpus measured at
+  1–4 relevant cases per phase.
+- **Ordered diagnostic-stream equality** (`BEAMTALK_CODEGEN_DIAGNOSTICS`
+  output as a sequence, not a set) after every phase.
+- **Verifier green** on all `stdlib/test/*.bt` +
+  `stdlib/bootstrap-test/*.btscript` fixtures in CI (`just` target named
+  in `/plan-adr`).
+- **Behavioral suite** (`just test-stdlib`/`test-bunit`/
+  `test-repl-protocol`) green after every phase.
+- **0110 contract, both halves**: `ShadowWriteMissing` unit tests (fires
+  when a top-frame class-var Bind in a `has_class_vars` method lacks the
+  shadow write; silent on the fixed shape) + the cross-boundary
+  conformance fixture against `invoke_class_method/7`. Honest framing per
+  §Verifier honesty: regression-pinning, not counterfactual detection.
 
 ## References
 
 - Related issues:
   - [BT-3122](https://linear.app/beamtalk/issue/BT-3122) — this ADR
-  - [BT-3111](https://linear.app/beamtalk/issue/BT-3111) — Epic:
-    Analysis→codegen handoff (single semantic source of truth);
-    coordination point for Phase E
-  - [BT-3125](https://linear.app/beamtalk/issue/BT-3125) — Writeback
-    passes consume threaded analysis; the `lower_module_for_codegen`
-    preparation step this ADR's lowering entry point slots into
-  - [BT-3112](https://linear.app/beamtalk/issue/BT-3112) — Epic:
-    Generated-code correctness (core_lint, semantic fuzzing, real
-    fixtures) — sibling correctness-net work; this ADR's verifier is a
-    complementary, compile-time-internal layer, distinct from that epic's
-    fuzzing/property-testing children
-  - [BT-3035](https://linear.app/beamtalk/issue/BT-3035) — Epic that
-    shipped ADR 0110's runtime fix; this ADR's `MutationLostAcrossRelay`
-    check generalizes detection of that bug class to compile time
-  - BT-3115 — `core_lint` readability fix (referenced in
-    `docs/development/debugging.md`)
+  - [BT-3111](https://linear.app/beamtalk/issue/BT-3111) /
+    [BT-3125](https://linear.app/beamtalk/issue/BT-3125) — analysis→codegen
+    handoff; BT-3125 is a soft prerequisite for Phase B onward
+  - [BT-3112](https://linear.app/beamtalk/issue/BT-3112) — generated-code
+    correctness epic; its metamorphic harness is the unknown-unknown
+    hunter this ADR's verifier explicitly does not replace (§Verifier
+    honesty, Steelman Option E)
+  - [BT-3035](https://linear.app/beamtalk/issue/BT-3035) — ADR 0110's
+    implementation epic; `ShadowWriteMissing` + the conformance fixture
+    pin its invariant
+  - BT-3115 — `core_lint` readability (the release-mode backstop this
+    ADR's checks improve upon rather than replace)
 - Related ADRs:
-  - [ADR 0018](0018-document-tree-codegen.md) — the `Document` tree this
-    ADR's IR sits *before*; §Alternatives Considered #3 previously
-    rejected a full-pipeline typed IR for reasons this ADR's narrower
-    scope deliberately avoids re-triggering
+  - [ADR 0018](0018-document-tree-codegen.md) — `Document` tree; its
+    §Alternatives #3 rejection of a full-pipeline IR still holds for
+    everything out of this ADR's scope
   - [ADR 0041](0041-universal-state-threading-block-protocol.md) — the
-    `{Value, StateAcc}` calling convention and 4-tuple NLR throw
-    convention this ADR's `ThreadedStmt`/`NlrRelay` formalize as data
-  - [ADR 0042](0042-immutable-value-objects-actor-mutable-state.md) —
-    actor mutable state vs. value-type immutability, the semantic split
-    `ThreadingBoundary`/`NlrBoundary` encode
-  - [ADR 0088](0088-direct-cerl-emission.md) — cerl-as-wire-format
-    proposal; stays closed/withdrawn; orthogonal to this ADR (wire
-    transport vs. internal lowering stage)
-  - [ADR 0089](0089-typed-document-leaves.md) — the typed-leaf `Document`
-    API this ADR's printer stage is unchanged; also this codebase's most
-    directly comparable prior large-scale phase-gated codegen migration
-    (byte-identical-snapshot discipline adopted here)
+    `{Value, StateAcc}` and 4-tuple NLR conventions formalized as IR data
+  - [ADR 0042](0042-immutable-value-objects-actor-mutable-state.md) — the
+    semantic split `NlrBoundary` encodes
+  - [ADR 0088](0088-direct-cerl-emission.md) — wire-format proposal,
+    closed; source of the measurement-gate discipline Phase A0 applies
+  - [ADR 0089](0089-typed-document-leaves.md) — typed-leaf printer,
+    unchanged; precedent for byte-parity migration (via ad-hoc `cmp -l`,
+    not a standing harness — which is why A3 exists)
   - [ADR 0109](0109-block-scoped-class-methods-run-blocks-in-the-caller.md)
-    — block-runs-where-invoked semantics underlying the NLR relay problem
+    — block-runs-where-invoked semantics underlying the relay problem
   - [ADR 0110](0110-class-var-shadow-write-through-for-nlr-relay.md) — the
-    shipped bug and runtime fix this ADR's verifier generalizes detection
-    of to compile time; not superseded or affected at runtime
+    shipped bug whose invariant this ADR pins; runtime fix untouched
 - Documentation:
-  - `docs/development/debugging.md` §"Codegen Diagnostics", §"core_lint
-    (BT-3115)"
-  - `docs/development/architecture-principles.md` §6 "Duplication & the
-    Shared-Leaf-Module Pattern" — the pattern this ADR's `VersionedVar`
-    unification follows
-- Code:
-  - `crates/beamtalk-core/src/codegen/core_erlang/control_flow/` (13
-    files, 16,329 LOC) — in scope
-  - `crates/beamtalk-core/src/codegen/core_erlang/threaded_expr.rs` (416
-    LOC) — in scope
-  - `crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs`
-    (5805 LOC; ≈1900–2400 lines state-versioning-specific) — in scope
-    (state-versioning slice only)
-  - `crates/beamtalk-core/src/codegen/core_erlang/mod.rs` — `NlrBoundary`,
-    `nlr_arm_result`, `ClassContext`, `ValueTypeContext`,
-    `with_branch_context`
-  - `crates/beamtalk-core/src/codegen/core_erlang/state_codegen.rs` —
-    `StateThreading`
-  - `crates/beamtalk-core/src/codegen/core_erlang/util.rs` —
-    `versioned_var`
-  - `crates/beamtalk-core/src/codegen/core_erlang_validity_tests.rs` —
-    existing text-shape property suite, unaffected
+  - `docs/development/debugging.md` §"Codegen Diagnostics", §"core_lint"
+  - `docs/development/architecture-principles.md` §6 (duplication /
+    shared-leaf pattern), CLAUDE.md cross-boundary conformance rule
+- Code (all under `crates/beamtalk-core/src/codegen/core_erlang/` unless
+  noted):
+  - `control_flow/` (13 files, 16,329 LOC), `threaded_expr.rs` (416),
+    `gen_server/methods.rs` (5805; ≈1900–2400 in scope) — in scope
+  - `expressions.rs:552`, `dispatch_codegen.rs:463` — the
+    version-`Bind`/shadow-write emission sites (scope correction)
+  - `mod.rs` — `NlrBoundary` (:902), `NlrCatchVars` (:880),
+    `wrap_body_with_nlr_catch` (:2480), `with_branch_context` (:2064),
+    counters (:1132, :1211, :2088, :2104)
+  - `state_codegen.rs:42` (`StateThreading`), `util.rs:38`
+    (`versioned_var`)
+  - `../core_erlang_validity_tests.rs` — existing text-shape properties,
+    unaffected
+  - `runtime/apps/beamtalk_runtime/src/beamtalk_class_dispatch.erl` —
+    `invoke_class_method/7`, the Erlang half of the 0110 contract
   - `runtime/apps/beamtalk_compiler/src/beamtalk_compile_diagnostics.erl`
     — `core_lint` integration

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -137,6 +137,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0108](0108-named-union-type-aliases.md) | Named Union Type Aliases (`type` Declarations) | Accepted | 2026-07-15 |
 | [0109](0109-block-scoped-class-methods-run-blocks-in-the-caller.md) | Block-Scoped Class Methods Run Their Block in the Caller's Process | Accepted | 2026-07-28 |
 | [0110](0110-class-var-shadow-write-through-for-nlr-relay.md) | Class-Variable Shadow Write-Through for Foreign NLR Relay | Accepted | 2026-08-02 |
+| [0111](0111-lowered-ir-verifier-for-state-threading.md) | Mid-Level Lowered IR + Verifier for State Threading, Control Flow, and Non-Local Return | Proposed | 2026-08-09 |
 
 > ADR 0086 was originally numbered 0069 (a collision with *Actor Observability and Tracing*) and was renumbered on 2026-05-25.
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -137,7 +137,7 @@ Each ADR follows the structure in [TEMPLATE.md](TEMPLATE.md). Key sections:
 | [0108](0108-named-union-type-aliases.md) | Named Union Type Aliases (`type` Declarations) | Accepted | 2026-07-15 |
 | [0109](0109-block-scoped-class-methods-run-blocks-in-the-caller.md) | Block-Scoped Class Methods Run Their Block in the Caller's Process | Accepted | 2026-07-28 |
 | [0110](0110-class-var-shadow-write-through-for-nlr-relay.md) | Class-Variable Shadow Write-Through for Foreign NLR Relay | Accepted | 2026-08-02 |
-| [0111](0111-lowered-ir-verifier-for-state-threading.md) | Mid-Level Lowered IR + Verifier for State Threading, Control Flow, and Non-Local Return | Proposed | 2026-08-09 |
+| [0111](0111-lowered-ir-verifier-for-state-threading.md) | Mid-Level Lowered IR + Verifier for State Threading, Control Flow, and Non-Local Return | Accepted | 2026-08-10 |
 
 > ADR 0086 was originally numbered 0069 (a collision with *Actor Observability and Tracing*) and was renumbered on 2026-05-25.
 


### PR DESCRIPTION
## Summary

Drafts ADR 0111, addressing [BT-3122](https://linear.app/beamtalk/issue/BT-3122): a mid-level lowered IR + verifier for the control-flow/state-threading core of codegen (the `control_flow/` cluster, `threaded_expr.rs`, the state-versioning slice of `gen_server/methods.rs`, and — a scope correction from review — the version-`Bind`-emission sites in `expressions.rs`/`dispatch_codegen.rs`).

The ADR was drafted via `/draft-adr` and then **revised in place after a `/review-adr` adversarial pass** whose load-bearing findings were verified against the code before being applied. The revision materially changed the claims:

- **Decision:** a narrow `ThreadedIr` (frame-identified state-version bindings, threading-mode selection, shadow-write emission, NLR boundaries) + a `verify()` pass between the AST and `Document` construction (ADR 0089's printer unchanged). No full-pipeline IR, no cerl-wire change (ADR 0088 stays closed), no behavior change. The decision is **gated**: Phase A0 measures IR cost against a pre-declared threshold before any migration, with a designated descope target (a record-decisions-as-made validator, Alternative 1b) if the gate fails.
- **Honest verifier claim (revised):** the verifier is *regression-pinning for known invariants*, not counterfactual bug detection — the adversarial pass established (verified against `wrap_body_with_nlr_catch`/`NlrCatchVars`) that no verifier over generator-derived IR would have caught ADR 0110's bug before the invariant was known. The `ShadowWriteMissing` check + a cross-boundary conformance fixture now pin ADR 0110's invariant mechanically at every current and future mutation site; unknown-unknown hunting is explicitly ceded to BT-3112's metamorphic harness.
- **Corrects BT-3122's estimates against direct measurement:** `control_flow/` is ~16K LOC (not 4.4K), 6 of 29 repo-wide `debug_assert!`s are in scope (all six are "two independently-computed decisions must agree" checks — the shape an IR removes by construction), `CoreErlangGenerator` has 36 fields (not ~90). Also measured: the existing snapshot corpus covers the in-scope constructs in only 1–4 of 318 snapshots, so corpus expansion (Phase A3) is a prerequisite deliverable, not an assumed safety net.
- **Folds in a related duplication fix:** three independently-implemented version counters (`StateThreading`, `class_var_version`, `self_version` — the last saved/restored nowhere across branches) collapse into one frame-identified, typestate-constructed `VersionedVar` with per-prefix discipline preserved and pinned by tests.
- **Coordinates with BT-3111/BT-3125** (soft prerequisite for Phase B onward) and **BT-3112** (complementary harness; explicit reconsideration point at the A0 gate).
- Includes prior art (rustc MIR, Swift SIL verifier, Cranelift, MLIR dialects, `core_lint`, Gleam, Pharo), steelman analysis across five alternatives (including the strong "record decisions as made" validator and metamorphic-testing-first), and a gated A0–D implementation plan with a conflict protocol for the actively-developed in-scope files.

Ready for acceptance decision. Per the issue, implementation issues are deliberately not created here — that's `/plan-adr`'s job after acceptance.

## Test plan

- [x] `docs/ADR/0111-lowered-ir-verifier-for-state-threading.md` created from `docs/ADR/TEMPLATE.md`, all sections filled in
- [x] `docs/ADR/README.md` index updated
- [x] Three-pass `/review-adr` completed: structural/factual (all citations verified against code), reasoning, and adversarial (independent agent; findings verified before applying)
- [x] All quantitative claims measured, not estimated (review bot independently re-verified every figure; final nit — 231 vs ~298 `to_pretty_string()` sites — fixed)
- [x] All cross-referenced ADRs (0018, 0041, 0042, 0088, 0089, 0109, 0110) and Linear issues (BT-3111, BT-3112, BT-3122, BT-3125, BT-3035) verified to exist and link correctly
- [x] No code changes — docs-only PR, `just ci` not applicable