### PR TITLE
BT-3105: Class removal purges all derived registries

### DIFF
--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -33,6 +33,7 @@ to avoid temp files on disk (BT-48).
     version/0,
     compile_core_erlang/1,
     register_class/2,
+    remove_class/1,
     get_classes/0,
     register_aliases/1,
     get_aliases/0,
@@ -561,6 +562,25 @@ register_class(ClassName, MetaMap) ->
     ok.
 
 -doc """
+Remove a class from the compiler server's ambient class cache (BT-3105).
+
+Called when a class is removed from the system, closing the class-removal
+gap in the `classes` accumulator documented in BT-2916: redefinition already
+overwrites via `register_class/2`, but until now there was no removal path,
+so the compiler kept type-checking against classes long gone from the
+runtime. Fire-and-forget cast, silently dropped if the server is not
+running, mirroring `register_class/2`'s degrade-silently contract.
+""".
+-spec remove_class(atom()) -> ok.
+remove_class(ClassName) ->
+    try
+        gen_server:cast(?MODULE, {remove_class, ClassName})
+    catch
+        _:_ -> ok
+    end,
+    ok.
+
+-doc """
 Return the current ambient class cache map (`register_class/2`'s
 accumulator).
 
@@ -890,6 +910,10 @@ handle_call(_Request, _From, State) ->
 handle_cast({register_class, ClassName, MetaMap}, State) ->
     %% ADR 0050 Phase 3: Accumulate class metadata; overwrite on redefinition.
     NewClasses = maps:put(ClassName, MetaMap, State#state.classes),
+    {noreply, State#state{classes = NewClasses}};
+handle_cast({remove_class, ClassName}, State) ->
+    %% BT-3105: Drop a removed class from the ambient cache.
+    NewClasses = maps:remove(ClassName, State#state.classes),
     {noreply, State#state{classes = NewClasses}};
 handle_cast(_Msg, State) ->
     {noreply, State}.

--- a/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
+++ b/runtime/apps/beamtalk_compiler/src/beamtalk_compiler_server.erl
@@ -570,6 +570,14 @@ overwrites via `register_class/2`, but until now there was no removal path,
 so the compiler kept type-checking against classes long gone from the
 runtime. Fire-and-forget cast, silently dropped if the server is not
 running, mirroring `register_class/2`'s degrade-silently contract.
+
+Not called from production code: `beamtalk_class_lifecycle:purge_compiler_cache/1`
+(the real caller, in `beamtalk_runtime`) intentionally bypasses this wrapper
+with a raw `gen_server:cast(beamtalk_compiler_server, {remove_class, ClassName})`
+to avoid a compile-time dependency in the wrong direction (`beamtalk_runtime`
+must not depend on `beamtalk_compiler` — see that module's doc). This
+exported function exists for same-app callers and is exercised directly by
+its own tests.
 """.
 -spec remove_class(atom()) -> ok.
 remove_class(ClassName) ->

--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compiler_server_tests.erl
@@ -186,7 +186,11 @@ class_cache_test_() ->
         {"register twice → overwrites", fun register_class_overwrites/0},
         {"clear_classes → cache emptied", fun clear_classes_empties/0},
         {"crash recovery → no builtins in cache", fun crash_recovery_populates/0},
-        {"register_class when server down → no crash", fun register_when_down/0}
+        {"register_class when server down → no crash", fun register_when_down/0},
+        {"remove_class → class no longer in cache", fun remove_class_removes/0},
+        {"remove_class leaves other classes untouched", fun remove_class_leaves_others/0},
+        {"remove_class of unregistered class is a no-op", fun remove_class_unknown_is_noop/0},
+        {"remove_class when server down → no crash", fun remove_class_when_down/0}
     ]}.
 
 register_class_visible() ->
@@ -238,6 +242,43 @@ register_when_down() ->
     %% Calling register_class/2 when the server is not running must not crash.
     application:stop(beamtalk_compiler),
     ?assertEqual(ok, beamtalk_compiler_server:register_class('TestDown', #{class => 'TestDown'})),
+    application:start(beamtalk_compiler).
+
+%% BT-3105: remove_class/1 drops a class from the ambient cache.
+remove_class_removes() ->
+    beamtalk_compiler_server:clear_classes(),
+    Meta = #{class => 'TestBT3105', superclass => 'Object', fields => []},
+    beamtalk_compiler_server:register_class('TestBT3105', Meta),
+    ?assert(maps:is_key('TestBT3105', beamtalk_compiler_server:get_classes())),
+
+    ok = beamtalk_compiler_server:remove_class('TestBT3105'),
+
+    ?assertNot(maps:is_key('TestBT3105', beamtalk_compiler_server:get_classes())).
+
+remove_class_leaves_others() ->
+    beamtalk_compiler_server:clear_classes(),
+    beamtalk_compiler_server:register_class(
+        'TestBT3105A', #{class => 'TestBT3105A', superclass => 'Object', fields => []}
+    ),
+    beamtalk_compiler_server:register_class(
+        'TestBT3105B', #{class => 'TestBT3105B', superclass => 'Object', fields => []}
+    ),
+
+    ok = beamtalk_compiler_server:remove_class('TestBT3105A'),
+
+    Classes = beamtalk_compiler_server:get_classes(),
+    ?assertNot(maps:is_key('TestBT3105A', Classes)),
+    ?assert(maps:is_key('TestBT3105B', Classes)).
+
+remove_class_unknown_is_noop() ->
+    beamtalk_compiler_server:clear_classes(),
+    ?assertEqual(ok, beamtalk_compiler_server:remove_class('TestBT3105NeverRegistered')),
+    ?assertEqual(#{}, beamtalk_compiler_server:get_classes()).
+
+remove_class_when_down() ->
+    %% Calling remove_class/1 when the server is not running must not crash.
+    application:stop(beamtalk_compiler),
+    ?assertEqual(ok, beamtalk_compiler_server:remove_class('TestBT3105Down')),
     application:start(beamtalk_compiler).
 
 %%% ---------------------------------------------------------------

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
@@ -558,6 +558,10 @@ Cleanup sequence:
   1. Stop all live actors of this class (via beamtalk_actor_registry)
   2. Stop the class gen_server (terminate/2 removes ETS entry and pg group)
   3. Purge the BEAM module (code:soft_purge + code:delete)
+  4. Purge derived registries — xref, extensions, protocol registry,
+     compiler cache, workspace class_sources (BT-3105, via
+     beamtalk_class_lifecycle:class_removed/2)
+  5. Notify the workspace layer / REPL sessions (publish_class_removed/2)
 """.
 -spec classRemoveFromSystemByName(atom()) -> 'nil'.
 classRemoveFromSystemByName(ClassName) ->
@@ -625,6 +629,12 @@ classRemoveFromSystemByName(ClassName) ->
                                 soft_purge_after_delete,
                                 code:soft_purge(Module)
                             ),
+                            %% BT-3105: Purge every derived registry (xref,
+                            %% extensions, protocol registry, compiler cache,
+                            %% workspace class_sources) — the single teardown
+                            %% path, run before the workspace/REPL notification
+                            %% below.
+                            ok = beamtalk_class_lifecycle:class_removed(ClassName, Module),
                             publish_class_removed(ClassName, Module),
                             nil;
                         Subclasses ->

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_lifecycle.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_lifecycle.erl
@@ -1,0 +1,140 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_class_lifecycle).
+
+%%% **DDD Context:** Object System Context
+
+-moduledoc """
+Single teardown path for class removal (BT-3105).
+
+`beamtalk_behaviour_intrinsics:classRemoveFromSystemByName/1` stops live
+actors, stops the class gen_server (whose `terminate/2` removes the
+`beamtalk_class_metadata` row, the ETS hierarchy entry, and the pg group),
+and purges the BEAM module — but that leaves five *derived* registries
+holding stale rows for the removed class:
+
+- `beamtalk_xref` — per-method cross-reference rows (only `update_class` →
+  `refresh_xref` purged these; class removal never did).
+- `beamtalk_extensions` — extension methods registered *on* the class,
+  across all three of its tables (main registry, sources, conflict
+  history). Left live, these stay dispatchable, and resurrect if a class of
+  the same name is later re-created (extensions are keyed by class *name*
+  atom, not by the class's pid/module).
+- `beamtalk_protocol_registry` — a protocol whose defining module is purged
+  had no unregister path at all until this existed.
+- `beamtalk_compiler_server` — the ambient class-metadata cache
+  (`register_class/2`'s accumulator, BT-2916) never shrank, so the compiler
+  kept type-checking against classes long gone from the runtime.
+- `beamtalk_workspace_meta` — the `class_sources` map (only `set_class_source/2`
+  existed; no delete), so a removed class's source text leaked, including
+  into the persisted `metadata.json`.
+
+`class_removed/2` is the single call site `classRemoveFromSystemByName/1`
+invokes once its safety checks pass and the class process has been stopped;
+each purge below targets a disjoint table/process, so there is no ordering
+requirement between them.
+
+## Dependency direction
+
+`beamtalk_runtime` (this module's app) sits *below* `beamtalk_compiler` and
+`beamtalk_workspace` in the dependency graph — neither appears in
+`beamtalk_runtime.app.src`'s `applications` list, and this module must never
+gain a compile-time dependency on either (a plain `Module:function()` call
+would count, even though Erlang has no linker to enforce it). The two
+derived registries that live in those upper apps are therefore purged with a
+direct `gen_server:cast/2` to the well-known *registered name* — the same
+"registered-name trick" `beamtalk_behaviour_intrinsics:publish_class_removed/2`
+already uses for `beamtalk_workspace_meta`'s `unregister_module` cast (and
+`stop_class_actors/1` / `classReload/1` use elsewhere). `gen_server:cast/2`
+never raises for an unregistered name — it degrades to a silent no-op — so
+these two casts need no `noproc` guard, matching `publish_class_removed/2`'s
+existing call.
+
+The three registries that live in `beamtalk_runtime` itself (xref,
+extensions, protocol registry) are purged via ordinary direct calls — no
+dependency-direction concern, since they live in this app.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([class_removed/2]).
+
+-doc """
+Purge every derived registry entry for a class removed via
+`classRemoveFromSystemByName/1`.
+
+`ClassName` is the removed class's name atom; `Module` is the BEAM module
+that defined it. Called after the class gen_server has been stopped and the
+BEAM module purged, before `nil` is returned to the caller. Always returns
+`ok` — every individual purge already degrades silently when its target
+registry/process is absent (early bootstrap, a minimal embedded runtime, a
+non-REPL run), so class removal itself is never blocked by this cleanup.
+""".
+-spec class_removed(atom(), atom()) -> ok.
+class_removed(ClassName, Module) ->
+    purge_xref(ClassName),
+    purge_extensions(ClassName),
+    purge_protocol(Module),
+    purge_compiler_cache(ClassName),
+    purge_workspace_class_source(ClassName),
+    ok.
+
+-doc """
+Purge `ClassName`'s rows from `beamtalk_xref` — both instance- and
+class-side method entries, and its sends/references. Guarded on
+`whereis/1` (not a try/catch), matching `beamtalk_object_class:refresh_xref/2`'s
+existing guard style for the same call.
+""".
+-spec purge_xref(atom()) -> ok.
+purge_xref(ClassName) ->
+    case erlang:whereis(beamtalk_xref) of
+        undefined ->
+            ok;
+        _Pid ->
+            ok = beamtalk_xref:purge_class(ClassName)
+    end.
+
+-doc """
+Purge every extension registered on `ClassName` — instance-side (keyed by
+the class name atom) and class-side (keyed by the metaclass tag, e.g.
+`'Counter class'`), which the extension registry stores as two distinct ETS
+keys (mirrors `beamtalk_protocol_registry:class_has_class_method/2`'s
+lookup convention for the same split).
+""".
+-spec purge_extensions(atom()) -> ok.
+purge_extensions(ClassName) ->
+    beamtalk_extensions:purge_class(ClassName),
+    ClassTag = beamtalk_class_registry:class_object_tag(ClassName),
+    beamtalk_extensions:purge_class(ClassTag),
+    ok.
+
+-doc """
+Unregister every protocol defined by `Module` (the removed class's BEAM
+module) from `beamtalk_protocol_registry`.
+""".
+-spec purge_protocol(atom()) -> ok.
+purge_protocol(Module) ->
+    beamtalk_protocol_registry:unregister_protocol(Module).
+
+-doc """
+Drop `ClassName` from `beamtalk_compiler_server`'s ambient class cache via
+the registered-name cast (see this module's doc — no compile-time
+dependency on `beamtalk_compiler`).
+""".
+-spec purge_compiler_cache(atom()) -> ok.
+purge_compiler_cache(ClassName) ->
+    gen_server:cast(beamtalk_compiler_server, {remove_class, ClassName}),
+    ok.
+
+-doc """
+Drop `ClassName`'s stored source text from `beamtalk_workspace_meta`'s
+`class_sources` map via the registered-name cast (see this module's doc —
+no compile-time dependency on `beamtalk_workspace`). `class_sources` is
+keyed by binary class name, so `ClassName` is converted before sending.
+""".
+-spec purge_workspace_class_source(atom()) -> ok.
+purge_workspace_class_source(ClassName) ->
+    ClassNameBin = atom_to_binary(ClassName, utf8),
+    gen_server:cast(beamtalk_workspace_meta, {remove_class_source, ClassNameBin}),
+    ok.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_lifecycle.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_lifecycle.erl
@@ -82,18 +82,14 @@ class_removed(ClassName, Module) ->
 
 -doc """
 Purge `ClassName`'s rows from `beamtalk_xref` — both instance- and
-class-side method entries, and its sends/references. Guarded on
-`whereis/1` (not a try/catch), matching `beamtalk_object_class:refresh_xref/2`'s
-existing guard style for the same call.
+class-side method entries, and its sends/references. Run best-effort via
+`beamtalk_extensions:safe_xref/1` (BT-2301's existing helper) so a dead or
+restarting `beamtalk_xref` cannot raise out of this stage and skip the
+other four purges below it.
 """.
 -spec purge_xref(atom()) -> ok.
 purge_xref(ClassName) ->
-    case erlang:whereis(beamtalk_xref) of
-        undefined ->
-            ok;
-        _Pid ->
-            ok = beamtalk_xref:purge_class(ClassName)
-    end.
+    beamtalk_extensions:safe_xref(fun() -> beamtalk_xref:purge_class(ClassName) end).
 
 -doc """
 Purge every extension registered on `ClassName` — instance-side (keyed by

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_extensions.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_extensions.erl
@@ -81,7 +81,8 @@ See: docs/internal/design-self-as-object.md Section "Extension Registry Design"
     listAllWithSource/0,
     getSource/2,
     conflicts/0,
-    has/2
+    has/2,
+    safe_xref/1
 ]).
 
 -include_lib("kernel/include/logger.hrl").

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_extensions.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_extensions.erl
@@ -73,6 +73,7 @@ See: docs/internal/design-self-as-object.md Section "Extension Registry Design"
     register/4,
     register/5,
     unregister/2,
+    purge_class/1,
     lookup/2,
     list/1,
     extenders_of/1,
@@ -103,13 +104,22 @@ Creates three tables:
 - beamtalk_extension_conflicts: History of conflicting registrations
 
 This should be called once during application startup.
+
+BT-3105: All three tables carry `beamtalk_class_registry:heir_option/0` (the
+runtime supervisor, once it is alive) so an owner crash hands the tables off
+instead of destroying every registered extension — the same survival pattern
+`beamtalk_class_metadata`/`beamtalk_class_registry` already use.
 """.
 -spec init() -> ok.
 init() ->
+    HeirOpts = beamtalk_class_registry:heir_option(),
+
     %% Create main registry table
     case ets:info(?EXTENSIONS_TABLE) of
         undefined ->
-            ets:new(?EXTENSIONS_TABLE, [set, public, named_table, {read_concurrency, true}]);
+            ets:new(?EXTENSIONS_TABLE, [
+                set, public, named_table, {read_concurrency, true} | HeirOpts
+            ]);
         _ ->
             % Already exists
             ok
@@ -118,7 +128,9 @@ init() ->
     %% Create sources table (BT-2196)
     case ets:info(?SOURCES_TABLE) of
         undefined ->
-            ets:new(?SOURCES_TABLE, [set, public, named_table, {read_concurrency, true}]);
+            ets:new(?SOURCES_TABLE, [
+                set, public, named_table, {read_concurrency, true} | HeirOpts
+            ]);
         _ ->
             % Already exists
             ok
@@ -127,7 +139,9 @@ init() ->
     %% Create conflicts tracking table
     case ets:info(?CONFLICTS_TABLE) of
         undefined ->
-            ets:new(?CONFLICTS_TABLE, [bag, public, named_table, {read_concurrency, true}]);
+            ets:new(?CONFLICTS_TABLE, [
+                bag, public, named_table, {read_concurrency, true} | HeirOpts
+            ]);
         _ ->
             % Already exists
             ok
@@ -242,6 +256,46 @@ unregister(Class, Selector) when is_atom(Class), is_atom(Selector) ->
     %% no-op if the xref gen_server is unavailable (BT-2301).
     safe_xref(fun() -> beamtalk_xref:purge_method(Class, false, Selector) end),
     ok.
+
+-doc """
+Purge every extension registered under the class key `Class` (BT-3105).
+
+Called from `beamtalk_class_lifecycle:class_removed/2` when a class is
+removed from the system, so its extensions stop being dispatchable and do
+not resurrect if a class of the same name is later re-created (extensions
+are keyed by class *name* atom, not by the class's pid/module, so a stale
+row would otherwise silently reattach to the new class). Deletes every
+`{Class, Selector}` row via `unregister/2` (dispatch, source, xref), plus
+any conflict history recorded under `Class` in the conflicts table.
+
+`Class` is the literal ETS key: pass the class name atom to purge instance
+extensions, or `beamtalk_class_registry:class_object_tag/1`'s result to
+purge class-side extensions — the two are stored under separate keys
+(mirrors `class_has_class_method/2`'s lookup convention). Idempotent — a
+class with no extensions is a no-op.
+
+Guards against the tables not existing yet (early bootstrap, or a minimal
+embedded runtime that never calls `init/0`) — a caller during class removal
+must not crash the whole `classRemoveFromSystemByName/1` because this
+tooling registry was never initialised, mirroring `getSource/2`'s /
+`listAllWithSource/0`'s existing `badarg` guard in this module.
+""".
+-spec purge_class(atom()) -> ok.
+purge_class(Class) when is_atom(Class) ->
+    try
+        lists:foreach(
+            fun({Selector, _Owner}) -> unregister(Class, Selector) end,
+            list(Class)
+        ),
+        %% Best-effort: also drop conflict history for this class so
+        %% conflicts/0 doesn't keep surfacing methods that no longer exist.
+        _ = ets:match_delete(?CONFLICTS_TABLE, {{Class, '_'}, '_', '_'}),
+        ok
+    catch
+        error:badarg ->
+            %% Extensions table(s) not initialised yet (early bootstrap).
+            ok
+    end.
 
 -doc """
 Lookup an extension method.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_protocol_registry.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_protocol_registry.erl
@@ -55,6 +55,7 @@ See also: beamtalk_behaviour_intrinsics — backs the class-side primitives
 -export([
     init/0,
     register_protocol/1,
+    unregister_protocol/1,
     conforms_to/2,
     protocols_for_class/1,
     required_methods/1,
@@ -75,6 +76,10 @@ Initialize the protocol registry ETS table.
 
 Called during application startup (beamtalk_runtime_app:start/2) before
 any compiled modules load their protocol definitions.
+
+BT-3105: Carries `beamtalk_class_registry:heir_option/0` (the runtime
+supervisor, once it is alive) so an owner crash hands the table off instead
+of destroying every registered protocol.
 """.
 -spec init() -> ok.
 init() ->
@@ -85,6 +90,7 @@ init() ->
                 set,
                 public,
                 {read_concurrency, true}
+                | beamtalk_class_registry:heir_option()
             ]),
             ok;
         _ ->
@@ -129,6 +135,35 @@ register_protocol(BadInfo) ->
         #{domain => [beamtalk, runtime]}
     ),
     ok.
+
+-doc """
+Unregister every protocol whose `module` metadata field matches `Module`
+(BT-3105).
+
+Called from `beamtalk_class_lifecycle:class_removed/2` when the class
+defining a protocol is removed from the system — until now there was no
+unregister path at all, so a protocol whose defining module was purged
+stayed registered (and conformance-checkable) forever. A no-op when the
+table has not been initialised, or when no registered protocol carries a
+`module` field matching `Module` (protocols registered before BT-2615 have
+no `module` field and are never matched).
+
+Does not tear down the protocol's own sealed class object (created by
+`maybe_create_protocol_class/2`) — that is a separate class removal, out of
+scope here; this only purges the registry row so `is_protocol/1` and
+`conforms_to/2` stop seeing it.
+""".
+-spec unregister_protocol(atom()) -> ok.
+unregister_protocol(Module) when is_atom(Module) ->
+    case ets:info(?PROTOCOL_TABLE) of
+        undefined ->
+            ok;
+        _ ->
+            _ = ets:select_delete(?PROTOCOL_TABLE, [
+                {{'_', #{module => '$1'}}, [{'=:=', '$1', {const, Module}}], [true]}
+            ]),
+            ok
+    end.
 
 %%% ============================================================================
 %%% Query API

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_behaviour_intrinsics_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_behaviour_intrinsics_tests.erl
@@ -2124,6 +2124,70 @@ bt1982_class_remove_success_when_registry_absent_test_() ->
         ]
     end}.
 
+%%% ============================================================================
+%%% BT-3105: classRemoveFromSystemByName purges derived registries
+%%% ============================================================================
+
+%% The observable bug this issue fixes: an extension registered on a class
+%% must stop being dispatchable once the class is removed, and must not
+%% resurrect if a class of the same name is later re-created (extensions are
+%% keyed by class *name* atom, not by the class's pid/module, so a stale row
+%% would otherwise silently reattach to the new class).
+bt3105_removed_class_extension_not_dispatchable_and_does_not_resurrect_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                beamtalk_extensions:init(),
+                ModAtom = bt3105_ext_removable_mod,
+                Forms = [
+                    {attribute, 1, module, ModAtom},
+                    {attribute, 2, export, []}
+                ],
+                {ok, ModAtom, Bin} = compile:forms(Forms, [return_errors]),
+                {module, ModAtom} = code:load_binary(
+                    ModAtom, "bt3105_ext_removable_mod.erl", Bin
+                ),
+                ClassName = 'BT3105ExtRemovable',
+                ClassInfo = #{
+                    name => ClassName,
+                    module => ModAtom,
+                    superclass => none,
+                    instance_methods => #{},
+                    class_methods => #{}
+                },
+                {ok, _Pid} = beamtalk_object_class:start(ClassName, ClassInfo),
+
+                %% Register an extension on the class and confirm it is live.
+                ExtFun = fun(_Args, _Self) -> greeted end,
+                ok = beamtalk_extensions:register(ClassName, 'greet', ExtFun, bt3105_test),
+                ?assert(beamtalk_extensions:has(ClassName, 'greet')),
+
+                %% Remove the class: exercises the full teardown path.
+                ?assertEqual(
+                    nil, beamtalk_behaviour_intrinsics:classRemoveFromSystemByName(ClassName)
+                ),
+
+                %% The extension is gone — no longer dispatchable.
+                ?assertNot(beamtalk_extensions:has(ClassName, 'greet')),
+                ?assertEqual(not_found, beamtalk_extensions:lookup(ClassName, 'greet')),
+
+                %% Redefine a class under the same name: the old extension
+                %% must not resurrect.
+                {ok, Pid2} = beamtalk_object_class:start(ClassName, ClassInfo),
+                try
+                    ?assertNot(beamtalk_extensions:has(ClassName, 'greet')),
+                    ?assertEqual(not_found, beamtalk_extensions:lookup(ClassName, 'greet'))
+                after
+                    try
+                        gen_server:stop(Pid2, normal, 5000)
+                    catch
+                        _:_ -> ok
+                    end
+                end
+            end)
+        ]
+    end}.
+
 %% metaclassAllMethods returns the combined method set (class-side + Behaviour
 %% protocol). Even for a dynamic class without the stdlib Class hierarchy
 %% loaded, the function should at least return a list.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_lifecycle_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_lifecycle_tests.erl
@@ -1,0 +1,284 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_class_lifecycle_tests).
+
+-moduledoc """
+EUnit tests for beamtalk_class_lifecycle:class_removed/2 (BT-3105).
+
+Exercises each of the five derived-registry purges directly against
+`class_removed/2` — xref, extensions (both instance- and class-side),
+protocol registry, the compiler server's ambient class cache, and workspace
+metadata's class_sources map. The end-to-end path through
+`beamtalk_behaviour_intrinsics:classRemoveFromSystemByName/1` (extension
+dispatch, redefinition-does-not-resurrect) is covered separately in
+`beamtalk_behaviour_intrinsics_tests.erl`.
+""".
+-include_lib("eunit/include/eunit.hrl").
+
+%%% ============================================================================
+%%% Setup / Teardown
+%%% ============================================================================
+
+%% Stand up (idempotently) every registry class_removed/2 touches, and clear
+%% the ones scoped to this module's app so tests don't see each other's rows.
+setup() ->
+    case pg:start_link() of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
+    beamtalk_extensions:init(),
+    beamtalk_protocol_registry:init(),
+    case whereis(beamtalk_xref) of
+        undefined -> {ok, _} = beamtalk_xref:start_link();
+        _ -> ok
+    end,
+    ok.
+
+teardown(_) ->
+    ok.
+
+%% True when beamtalk_compiler_server is reachable — some standalone EUnit
+%% runs of just this app may not have started the beamtalk_compiler
+%% application. Compiler-cache assertions gate on this so they don't fail
+%% spuriously outside the full `--app=beamtalk_runtime,beamtalk_workspace,
+%% beamtalk_compiler` run.
+compiler_server_available() ->
+    case application:ensure_all_started(beamtalk_compiler) of
+        {ok, _} -> true;
+        {error, _} -> false
+    end.
+
+%% Stop any pre-existing beamtalk_workspace_meta process so each test that
+%% needs one starts from a clean slate and stops its own — mirrors
+%% beamtalk_activity_tracking_tests.erl / beamtalk_workspace_meta_tests.erl's
+%% convention. Leaving a stray instance running would break other test
+%% modules that assert on the "no workspace started" error path (e.g.
+%% beamtalk_logging_config_tests.erl).
+stop_workspace_meta_if_running() ->
+    case whereis(beamtalk_workspace_meta) of
+        undefined -> ok;
+        Pid -> gen_server:stop(Pid)
+    end.
+
+%% Start a throwaway workspace_meta (repl => false, so it never touches
+%% disk) for the duration of `Fun/1`, passing whether it actually started —
+%% `false` on a standalone EUnit run where beamtalk_workspace is unreachable.
+%% Always stops the process it started before returning, even on failure.
+with_workspace_meta(Fun) ->
+    stop_workspace_meta_if_running(),
+    case
+        beamtalk_workspace_meta:start_link(#{
+            workspace_id => <<"bt3105-lifecycle-test">>,
+            created_at => erlang:system_time(second),
+            repl => false
+        })
+    of
+        {ok, Pid} ->
+            try
+                Fun(true)
+            after
+                gen_server:stop(Pid)
+            end;
+        {error, _} ->
+            Fun(false)
+    end.
+
+%%% ============================================================================
+%%% class_removed/2 — per-registry purges
+%%% ============================================================================
+
+class_removed_purges_xref_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                ClassName = 'BT3105LifecycleXref',
+                Entry = beamtalk_xref:build_method_entry(
+                    false, 'foo', <<"foo => 1">>, indexed, class_body
+                ),
+                ok = beamtalk_xref:register_class(ClassName, [Entry]),
+                ?assertEqual(
+                    [{ClassName, false}], beamtalk_xref:implementors_of('foo')
+                ),
+
+                ok = beamtalk_class_lifecycle:class_removed(ClassName, bt3105_lifecycle_mod),
+
+                ?assertEqual([], beamtalk_xref:implementors_of('foo'))
+            end)
+        ]
+    end}.
+
+class_removed_purges_instance_and_class_side_extensions_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                ClassName = 'BT3105LifecycleExt',
+                ClassTag = beamtalk_class_registry:class_object_tag(ClassName),
+                Fun = fun(_Args, _Self) -> ok end,
+                ok = beamtalk_extensions:register(ClassName, 'instSel', Fun, mylib),
+                ok = beamtalk_extensions:register(ClassTag, 'classSel', Fun, mylib),
+                ?assert(beamtalk_extensions:has(ClassName, 'instSel')),
+                ?assert(beamtalk_extensions:has(ClassTag, 'classSel')),
+
+                ok = beamtalk_class_lifecycle:class_removed(ClassName, bt3105_lifecycle_mod2),
+
+                ?assertNot(beamtalk_extensions:has(ClassName, 'instSel')),
+                ?assertNot(beamtalk_extensions:has(ClassTag, 'classSel'))
+            end)
+        ]
+    end}.
+
+class_removed_unregisters_protocol_by_module_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                Module = bt3105_lifecycle_proto_mod,
+                beamtalk_protocol_registry:register_protocol(#{
+                    name => 'BT3105LifecycleProto',
+                    module => Module,
+                    required_methods => [],
+                    type_params => [],
+                    extending => undefined
+                }),
+                ?assert(beamtalk_protocol_registry:is_protocol('BT3105LifecycleProto')),
+
+                ok = beamtalk_class_lifecycle:class_removed('BT3105LifecycleProto', Module),
+
+                ?assertNot(beamtalk_protocol_registry:is_protocol('BT3105LifecycleProto'))
+            end)
+        ]
+    end}.
+
+class_removed_drops_compiler_cache_entry_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                case compiler_server_available() of
+                    false ->
+                        %% Compiler app unreachable in this standalone run — skip.
+                        ok;
+                    true ->
+                        ClassName = 'BT3105LifecycleCompiler',
+                        beamtalk_compiler_server:register_class(
+                            ClassName, #{class => ClassName}
+                        ),
+                        ?assert(
+                            maps:is_key(ClassName, beamtalk_compiler_server:get_classes())
+                        ),
+
+                        ok = beamtalk_class_lifecycle:class_removed(
+                            ClassName, bt3105_lifecycle_mod3
+                        ),
+                        %% remove_class is a cast; get_classes/0 is a synchronous
+                        %% call to the same gen_server mailbox, so it is
+                        %% guaranteed to observe the preceding cast.
+                        ?assertNot(
+                            maps:is_key(ClassName, beamtalk_compiler_server:get_classes())
+                        )
+                end
+            end)
+        ]
+    end}.
+
+class_removed_drops_workspace_class_source_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(
+                with_workspace_meta(fun
+                    (false) ->
+                        %% Workspace app unreachable in this standalone run — skip.
+                        ok;
+                    (true) ->
+                        ClassName = 'BT3105LifecycleWorkspace',
+                        ClassNameBin = atom_to_binary(ClassName, utf8),
+                        ok = beamtalk_workspace_meta:set_class_source(
+                            ClassNameBin, "Object subclass: BT3105LifecycleWorkspace []"
+                        ),
+                        ?assertNotEqual(
+                            undefined, beamtalk_workspace_meta:get_class_source(ClassNameBin)
+                        ),
+
+                        ok = beamtalk_class_lifecycle:class_removed(
+                            ClassName, bt3105_lifecycle_mod4
+                        ),
+                        timer:sleep(50),
+
+                        ?assertEqual(
+                            undefined, beamtalk_workspace_meta:get_class_source(ClassNameBin)
+                        )
+                end)
+            )
+        ]
+    end}.
+
+%% class_removed/2 purges every registry in one call — a class with rows in
+%% all five, then a single call, then every registry reports it gone.
+class_removed_purges_all_five_registries_together_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(
+                with_workspace_meta(fun(WorkspaceOk) ->
+                    ClassName = 'BT3105LifecycleAll',
+                    Module = bt3105_lifecycle_all_mod,
+                    ClassTag = beamtalk_class_registry:class_object_tag(ClassName),
+
+                    Entry = beamtalk_xref:build_method_entry(
+                        false, 'bar', <<"bar => 2">>, indexed, class_body
+                    ),
+                    ok = beamtalk_xref:register_class(ClassName, [Entry]),
+
+                    Fun = fun(_Args, _Self) -> ok end,
+                    ok = beamtalk_extensions:register(ClassName, 'ext1', Fun, mylib),
+                    ok = beamtalk_extensions:register(ClassTag, 'ext2', Fun, mylib),
+
+                    beamtalk_protocol_registry:register_protocol(#{
+                        name => ClassName,
+                        module => Module,
+                        required_methods => [],
+                        type_params => [],
+                        extending => undefined
+                    }),
+
+                    CompilerOk = compiler_server_available(),
+                    case CompilerOk of
+                        true ->
+                            beamtalk_compiler_server:register_class(
+                                ClassName, #{class => ClassName}
+                            );
+                        false ->
+                            ok
+                    end,
+
+                    ClassNameBin = atom_to_binary(ClassName, utf8),
+                    case WorkspaceOk of
+                        true -> ok = beamtalk_workspace_meta:set_class_source(ClassNameBin, "src");
+                        false -> ok
+                    end,
+
+                    ok = beamtalk_class_lifecycle:class_removed(ClassName, Module),
+
+                    ?assertEqual([], beamtalk_xref:implementors_of('bar')),
+                    ?assertNot(beamtalk_extensions:has(ClassName, 'ext1')),
+                    ?assertNot(beamtalk_extensions:has(ClassTag, 'ext2')),
+                    ?assertNot(beamtalk_protocol_registry:is_protocol(ClassName)),
+                    case CompilerOk of
+                        true ->
+                            ?assertNot(
+                                maps:is_key(ClassName, beamtalk_compiler_server:get_classes())
+                            );
+                        false ->
+                            ok
+                    end,
+                    case WorkspaceOk of
+                        true ->
+                            timer:sleep(50),
+                            ?assertEqual(
+                                undefined, beamtalk_workspace_meta:get_class_source(ClassNameBin)
+                            );
+                        false ->
+                            ok
+                    end
+                end)
+            )
+        ]
+    end}.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_extensions_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_extensions_tests.erl
@@ -955,3 +955,74 @@ unregister_unknown_is_noop_test_() ->
             end)
         ]
     end}.
+
+%%% ============================================================================
+%%% BT-3105: purge_class/1 — full purge on class removal
+%%% ============================================================================
+
+purge_class_removes_every_extension_and_xref_row_test_() ->
+    {setup, fun xref_setup/0, fun xref_cleanup/1, fun(_) ->
+        [
+            ?_test(begin
+                Fun = fun(_Args, _Self) -> ok end,
+                %% Two extensions on the target class, plus a sibling class's
+                %% extension that must survive the purge untouched.
+                ok = beamtalk_extensions:register(
+                    'BT3105Target', 'shout', Fun, mylib, <<"shout => self asUppercase">>
+                ),
+                ok = beamtalk_extensions:register('BT3105Target', 'whisper', Fun, mylib),
+                ok = beamtalk_extensions:register('BT3105Sibling', 'greet', Fun, mylib),
+
+                ?assert(beamtalk_extensions:has('BT3105Target', 'shout')),
+                ?assert(beamtalk_extensions:has('BT3105Target', 'whisper')),
+                ?assertEqual(
+                    [{'BT3105Target', false}], beamtalk_xref:implementors_of('shout')
+                ),
+
+                ok = beamtalk_extensions:purge_class('BT3105Target'),
+
+                %% Both extensions on the target are gone from every table.
+                ?assertNot(beamtalk_extensions:has('BT3105Target', 'shout')),
+                ?assertNot(beamtalk_extensions:has('BT3105Target', 'whisper')),
+                ?assertEqual(not_found, beamtalk_extensions:lookup('BT3105Target', 'shout')),
+                ?assertEqual(not_found, beamtalk_extensions:getSource('BT3105Target', 'shout')),
+                ?assertEqual([], beamtalk_xref:implementors_of('shout')),
+                ?assertEqual([], beamtalk_extensions:list('BT3105Target')),
+
+                %% Sibling class untouched.
+                ?assert(beamtalk_extensions:has('BT3105Sibling', 'greet'))
+            end)
+        ]
+    end}.
+
+purge_class_is_noop_for_class_with_no_extensions_test_() ->
+    {setup, fun xref_setup/0, fun xref_cleanup/1, fun(_) ->
+        [
+            ?_test(begin
+                ?assertEqual(ok, beamtalk_extensions:purge_class('BT3105NeverRegistered'))
+            end)
+        ]
+    end}.
+
+purge_class_purges_class_side_extensions_separately_test_() ->
+    {setup, fun xref_setup/0, fun xref_cleanup/1, fun(_) ->
+        [
+            ?_test(begin
+                Fun = fun(_Args, _Self) -> ok end,
+                InstanceClass = 'BT3105Meta',
+                ClassSideTag = beamtalk_class_registry:class_object_tag(InstanceClass),
+                ok = beamtalk_extensions:register(InstanceClass, 'greet', Fun, mylib),
+                ok = beamtalk_extensions:register(ClassSideTag, 'make', Fun, mylib),
+
+                %% Purging only the instance-side key leaves the class-side
+                %% extension untouched — the two are stored under separate
+                %% ETS keys.
+                ok = beamtalk_extensions:purge_class(InstanceClass),
+                ?assertNot(beamtalk_extensions:has(InstanceClass, 'greet')),
+                ?assert(beamtalk_extensions:has(ClassSideTag, 'make')),
+
+                ok = beamtalk_extensions:purge_class(ClassSideTag),
+                ?assertNot(beamtalk_extensions:has(ClassSideTag, 'make'))
+            end)
+        ]
+    end}.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_protocol_registry_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_protocol_registry_tests.erl
@@ -416,3 +416,75 @@ protocol_info_before_init_test() ->
 all_protocol_names_empty_test() ->
     setup(),
     ?assertEqual([], beamtalk_protocol_registry:all_protocol_names()).
+
+%%% ============================================================================
+%%% BT-3105: unregister_protocol/1 — purge on defining-module removal
+%%% ============================================================================
+
+unregister_protocol_removes_matching_module_test() ->
+    setup(),
+    beamtalk_protocol_registry:register_protocol(#{
+        name => 'BT3105Proto',
+        module => 'bt3105_proto_mod',
+        required_methods => [#{selector => 'asString', arity => 0}],
+        type_params => [],
+        extending => undefined
+    }),
+    ?assert(beamtalk_protocol_registry:is_protocol('BT3105Proto')),
+
+    ok = beamtalk_protocol_registry:unregister_protocol('bt3105_proto_mod'),
+
+    ?assertNot(beamtalk_protocol_registry:is_protocol('BT3105Proto')),
+    ?assertEqual(undefined, beamtalk_protocol_registry:protocol_info('BT3105Proto')).
+
+%% Two protocols share nothing but the table; unregistering one module's
+%% protocol must not disturb a protocol defined by a different module.
+unregister_protocol_leaves_other_modules_protocols_test() ->
+    setup(),
+    beamtalk_protocol_registry:register_protocol(#{
+        name => 'BT3105ProtoA',
+        module => 'bt3105_mod_a',
+        required_methods => [],
+        type_params => [],
+        extending => undefined
+    }),
+    beamtalk_protocol_registry:register_protocol(#{
+        name => 'BT3105ProtoB',
+        module => 'bt3105_mod_b',
+        required_methods => [],
+        type_params => [],
+        extending => undefined
+    }),
+
+    ok = beamtalk_protocol_registry:unregister_protocol('bt3105_mod_a'),
+
+    ?assertNot(beamtalk_protocol_registry:is_protocol('BT3105ProtoA')),
+    ?assert(beamtalk_protocol_registry:is_protocol('BT3105ProtoB')).
+
+%% A protocol registered without a `module` field (pre-BT-2615 shape) is
+%% never matched — unregistering by module name is a harmless no-op.
+unregister_protocol_skips_protocol_without_module_field_test() ->
+    setup(),
+    beamtalk_protocol_registry:register_protocol(#{
+        name => 'BT3105NoModule',
+        required_methods => [],
+        type_params => [],
+        extending => undefined
+    }),
+
+    ok = beamtalk_protocol_registry:unregister_protocol('bt3105_unrelated_mod'),
+
+    ?assert(beamtalk_protocol_registry:is_protocol('BT3105NoModule')).
+
+unregister_protocol_unknown_module_is_noop_test() ->
+    setup(),
+    ?assertEqual(ok, beamtalk_protocol_registry:unregister_protocol('bt3105_never_registered')).
+
+unregister_protocol_before_init_test() ->
+    case ets:info(beamtalk_protocol_registry) of
+        undefined ->
+            ?assertEqual(ok, beamtalk_protocol_registry:unregister_protocol('bt3105_any_mod')),
+            beamtalk_protocol_registry:init();
+        _ ->
+            ?assertEqual(ok, beamtalk_protocol_registry:unregister_protocol('bt3105_any_mod'))
+    end.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
@@ -25,7 +25,7 @@ and can be queried by other components (e.g., idle monitor).
 -export([start_link/1, get_metadata/0, update_activity/0, get_last_activity/0]).
 -export([register_actor/1, unregister_actor/1, supervised_actors/0]).
 -export([register_module/1, register_module/2, unregister_module/1, loaded_modules/0]).
--export([set_class_source/2, get_class_source/1, all_class_sources/0]).
+-export([set_class_source/2, get_class_source/1, all_class_sources/0, remove_class_source/1]).
 %% BT-1685: File mtime tracking for incremental load-project.
 -export([set_file_mtime/2, get_file_mtimes/0, clear_file_mtimes/0, remove_file_mtime/1]).
 -export([get_package_name/0]).
@@ -257,6 +257,26 @@ get_class_source(ClassName) when is_binary(ClassName) ->
     catch
         exit:{noproc, _} ->
             undefined
+    end.
+
+-doc """
+Remove stored source text for a class (BT-3105).
+
+Called when a class is removed from the system (`removeFromSystem` /
+`classRemoveFromSystemByName/1`), so a stale `class_sources` entry for a
+removed class does not survive — including in the persisted
+`metadata.json` — the way it did before this existed (only `set_class_source/2`
+was available). Mirrors `unregister_module/1`'s BT-1239 precedent: a
+fire-and-forget cast that degrades silently (returns `ok`) if the server is
+not running. Idempotent — removing a class with no stored source is a no-op.
+""".
+-spec remove_class_source(binary()) -> ok.
+remove_class_source(ClassName) when is_binary(ClassName) ->
+    try
+        gen_server:cast(?MODULE, {remove_class_source, ClassName})
+    catch
+        exit:{noproc, _} ->
+            ok
     end.
 
 -doc """
@@ -561,6 +581,12 @@ handle_cast({unregister_module, Module}, State) ->
     %% BT-1239: Remove a module when removeFromSystem is called.
     Modules = State#state.loaded_modules,
     State2 = State#state{loaded_modules = maps:remove(Module, Modules)},
+    store_state_in_ets(State2),
+    {noreply, schedule_persist(State2)};
+handle_cast({remove_class_source, ClassName}, State) ->
+    %% BT-3105: Remove a class's stored source when removeFromSystem is called.
+    Sources = State#state.class_sources,
+    State2 = State#state{class_sources = maps:remove(ClassName, Sources)},
     store_state_in_ets(State2),
     {noreply, schedule_persist(State2)};
 handle_cast({set_file_mtime, FilePath, Mtime}, State) ->

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_meta_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_meta_tests.erl
@@ -443,6 +443,52 @@ get_class_source_when_not_started_test() ->
     %% Should return undefined gracefully
     ?assertEqual(undefined, beamtalk_workspace_meta:get_class_source(<<"Foo">>)).
 
+%%% Class source removal tests (BT-3105)
+
+remove_class_source_test() ->
+    stop_if_running(),
+    {ok, Pid} = beamtalk_workspace_meta:start_link(test_metadata()),
+
+    Source = "Object subclass: BT3105Removed [\n  x := 0\n]\n",
+    ok = beamtalk_workspace_meta:set_class_source(<<"BT3105Removed">>, Source),
+    ?assertEqual(Source, beamtalk_workspace_meta:get_class_source(<<"BT3105Removed">>)),
+
+    ok = beamtalk_workspace_meta:remove_class_source(<<"BT3105Removed">>),
+    timer:sleep(50),
+    ?assertEqual(undefined, beamtalk_workspace_meta:get_class_source(<<"BT3105Removed">>)),
+
+    gen_server:stop(Pid).
+
+%% Removing one class's source leaves a sibling class's source untouched.
+remove_class_source_leaves_others_test() ->
+    stop_if_running(),
+    {ok, Pid} = beamtalk_workspace_meta:start_link(test_metadata()),
+
+    ok = beamtalk_workspace_meta:set_class_source(<<"BT3105A">>, "source A"),
+    ok = beamtalk_workspace_meta:set_class_source(<<"BT3105B">>, "source B"),
+
+    ok = beamtalk_workspace_meta:remove_class_source(<<"BT3105A">>),
+    timer:sleep(50),
+
+    ?assertEqual(undefined, beamtalk_workspace_meta:get_class_source(<<"BT3105A">>)),
+    ?assertEqual("source B", beamtalk_workspace_meta:get_class_source(<<"BT3105B">>)),
+
+    gen_server:stop(Pid).
+
+remove_class_source_nonexistent_test() ->
+    stop_if_running(),
+    {ok, Pid} = beamtalk_workspace_meta:start_link(test_metadata()),
+    %% Removing a class source that was never set should not crash.
+    ?assertEqual(ok, beamtalk_workspace_meta:remove_class_source(<<"NeverSet">>)),
+    timer:sleep(50),
+
+    gen_server:stop(Pid).
+
+remove_class_source_when_not_started_test() ->
+    stop_if_running(),
+    %% Should not crash when server is not running.
+    ?assertEqual(ok, beamtalk_workspace_meta:remove_class_source(<<"Foo">>)).
+
 %%% Debounce coalescing test
 
 debounce_coalesces_rapid_changes_test() ->


### PR DESCRIPTION
## Summary
- Adds a single `beamtalk_class_lifecycle` teardown path invoked from `classRemoveFromSystemByName/1` that purges the removed class from all derived registries: `beamtalk_xref`, `beamtalk_extensions` (all three tables), `beamtalk_protocol_registry` (new `unregister_protocol/1`), `beamtalk_compiler_server` (new `remove_class/1`), and `beamtalk_workspace_meta` (new `remove_class_source/1`)
- Fixes the observable bug where extensions on a removed class stayed dispatchable and could resurrect if the class name was reused
- Closes the compiler ambient-cache no-removal limitation documented in BT-2916

## Test plan
- [x] EUnit: define class → add extension → remove class → extension no longer dispatchable; redefine same class name → old extension does not resurrect
- [x] EUnit: remove class → xref holds no rows for it; compiler_server `get_classes/0` no longer includes it; workspace_meta no longer returns its source
- [x] EUnit: protocol module removal unregisters the protocol
- [x] `just test` — full suite green (Rust, stdlib, BUnit, Erlang runtime unit tests)
- [x] `just ci` (via pre-push hook) — clippy, dialyzer, formatting all pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrSTdNT5xJQeXMv39YkELU)_