### PR TITLE
BT-3110: Small cache hygiene (changelog ordered_set, clear/0 moduledocs, native-mtime leak)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_alias_xref.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_alias_xref.erl
@@ -86,9 +86,10 @@ every other ADR 0105/0108 hot-reload mechanism already documents and accepts.
 ## Session-only, never persisted
 
 Mirrors every other ADR 0105/0108 store: state lives in this gen_server's
-`#state{}`, supervised under `beamtalk_workspace_sup`. `clear/0` gives tests
-(and a future `Workspace changes revert:`) an explicit reset without a
-restart.
+`#state{}`, supervised under `beamtalk_workspace_sup`. `clear/0` is
+test-only for now: it gives tests an explicit reset without a restart. It is
+not called on the `Workspace changes revert:` path today; a future revert
+enhancement may wire it in, but that has not happened yet.
 """.
 
 -include_lib("kernel/include/logger.hrl").
@@ -201,7 +202,7 @@ dependents_of(AliasNameBin) when is_binary(AliasNameBin) ->
         exit:{timeout, _} -> []
     end.
 
--doc "Clear every recorded edge (tests; a future `Workspace changes revert:`).".
+-doc "Clear every recorded edge. Test-only for now (a future `Workspace changes revert:` may call it — not wired in yet).".
 -spec clear() -> ok.
 clear() ->
     try

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_load.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_load.erl
@@ -242,6 +242,11 @@ do_sync_project_clean(AbsPath, IncludeTests, Force, SessionPid) ->
                     code:delete(ModName),
                     code:purge(ModName)
             end,
+            %% BT-3110: erase the compile-time mtime persistent_term entry along
+            %% with the module — otherwise it outlives the module forever (one
+            %% entry per ever-deleted native module, each `put` also scanning
+            %% every scheduler for global GC).
+            erase_native_compile_mtime(ModName),
             beamtalk_workspace_meta:remove_file_mtime(P)
         end,
         DeletedErl
@@ -1742,6 +1747,21 @@ get_native_compile_mtime(ModAtom) ->
         error:badarg ->
             {{0, 0, 0}, {0, 0, 0}}
     end.
+
+-doc """
+Erase the recorded compile-time mtime for `ModAtom`, if any.
+
+Called when a native module's .erl source is deleted (the module is unloaded
+from the VM and its mtime tracking should go with it) so the
+`{beamtalk_native_mtime, ModAtom}` `persistent_term` entry does not linger
+forever — a missing entry already degrades safely to `get_native_compile_mtime/1`
+returning the epoch (forced recompile), so this is purely hygiene, not a
+correctness fix. A no-op if nothing was recorded for `ModAtom`.
+""".
+-spec erase_native_compile_mtime(atom()) -> ok.
+erase_native_compile_mtime(ModAtom) ->
+    _ = persistent_term:erase({beamtalk_native_mtime, ModAtom}),
+    ok.
 
 %%% ===================================================================
 %%% BT-1685: Incremental load-project helpers

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
@@ -258,6 +258,9 @@ Return all entries (including prior-epoch and orphan), oldest first.
 
 Returns `[]` when the ChangeLog server has not been started (the ETS table is
 absent), so callers on a node without a workspace do not crash.
+
+`?ETS_TABLE` is an `ordered_set` keyed by the monotonic `seq`, so table
+traversal already yields ascending key order — no per-call sort needed.
 """.
 -spec entries() -> [entry()].
 entries() ->
@@ -265,8 +268,7 @@ entries() ->
         undefined ->
             [];
         _ ->
-            Es = [E || {_Seq, E} <- ets:tab2list(?ETS_TABLE)],
-            lists:keysort(#entry.seq, Es)
+            [E || {_Seq, E} <- ets:tab2list(?ETS_TABLE)]
     end.
 
 -doc """
@@ -1385,7 +1387,7 @@ log_path(ChangesDir) -> filename:join(ChangesDir, "changes.jsonl").
 ensure_ets() ->
     case ets:whereis(?ETS_TABLE) of
         undefined ->
-            ets:new(?ETS_TABLE, [named_table, public, set, {read_concurrency, true}]);
+            ets:new(?ETS_TABLE, [named_table, public, ordered_set, {read_concurrency, true}]);
         _ ->
             ets:delete_all_objects(?ETS_TABLE)
     end,

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_findings_store.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_findings_store.erl
@@ -89,7 +89,10 @@ no disk — mirroring `beamtalk_workspace_signature_store` (BT-2777). It is
 supervised under `beamtalk_workspace_sup` alongside the signature store, so a
 workspace restart (a fresh BEAM node) starts a fresh, empty store — exactly
 the ADR's "workspace restart... session state, never persisted" clearing
-rule. `clear/0` gives callers (and tests) an explicit full reset without a
+rule. `Workspace changes revert:` does not call `clear/0` — a revert
+re-installs a method through the normal install path, which already calls
+`clear_owner/1` for the reverted class (see "Clearing-by-replacement" above).
+`clear/0` is test-only: it gives tests an explicit full reset without a
 restart.
 
 ## Known, accepted concurrency gaps (adversarial review, BT-2779)
@@ -229,8 +232,10 @@ all() ->
 
 -doc """
 Clear every recorded finding for every owner and origin (workspace restart
-is the natural clear via supervision; this is the explicit reset for
-`Workspace changes revert:` callers that want a full wipe, and for tests).
+is the natural clear via supervision; this is the explicit reset for tests
+that want a full wipe). Test-only — not called on the
+`Workspace changes revert:` path, which uses `clear_owner/1` instead (see the
+moduledoc).
 """.
 -spec clear() -> ok.
 clear() ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_shape_store.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_shape_store.erl
@@ -63,8 +63,11 @@ before the failed attempt — there is nothing to undo.
 
 Mirrors `beamtalk_workspace_signature_store`: state lives in this
 gen_server's `#state{}` map, supervised under `beamtalk_workspace_sup`, so a
-workspace restart starts fresh. `clear/0` gives callers (`Workspace changes
-revert:`, tests) an explicit reset without a restart.
+workspace restart starts fresh. `Workspace changes revert:` does not call
+`clear/0` — a revert re-installs a method/class through the normal
+`prime/1`/`capture/1` path, which already keeps this store's per-class
+generations correct one class at a time. `clear/0` is test-only: it gives
+tests an explicit full reset without a restart.
 
 ## Known, accepted concurrency gap (adversarial review, BT-2780)
 
@@ -154,7 +157,7 @@ meta. Exposed for the shape re-check trigger and for tests.
 previous(ClassNameBin) when is_binary(ClassNameBin) ->
     gen_server:call(?MODULE, {previous, ClassNameBin}).
 
--doc "Clear every recorded generation (`Workspace changes revert:`, tests).".
+-doc "Clear every recorded generation. Test-only (see the moduledoc).".
 -spec clear() -> ok.
 clear() ->
     gen_server:call(?MODULE, clear).

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_signature_store.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_signature_store.erl
@@ -37,9 +37,11 @@ State lives in this gen_server's process dictionary-free `#state{}` map —
 plain in-memory, no ETS, no disk. It is supervised under
 `beamtalk_workspace_sup` alongside `beamtalk_workspace_meta`, so a workspace
 restart (a fresh BEAM node) starts a fresh, empty store — exactly the ADR's
-"session state, never persisted to the artifact" requirement. `clear/0` gives
-callers (e.g. `Workspace changes revert:`) an explicit reset without a full
-restart.
+"session state, never persisted to the artifact" requirement. `Workspace
+changes revert:` does not call `clear/0` — a revert re-installs a method
+through the normal `capture/4`/`rollback/4` path, which already keeps this
+store's per-selector generations correct one selector at a time. `clear/0` is
+test-only: it gives tests an explicit full reset without a restart.
 """.
 
 -include_lib("kernel/include/logger.hrl").
@@ -134,9 +136,10 @@ rollback(ClassName, Selector, Side, PreviousSignature) when
     gen_server:call(?MODULE, {rollback, ClassName, Selector, Side, PreviousSignature}).
 
 -doc """
-Clear every recorded generation (`Workspace changes revert:`, tests). The next
-`capture/4` for any selector re-seeds from `__beamtalk_meta/0` as if this were
-a fresh workspace.
+Clear every recorded generation. Test-only (not called on the
+`Workspace changes revert:` path — see the moduledoc). The next `capture/4`
+for any selector re-seeds from `__beamtalk_meta/0` as if this were a fresh
+workspace.
 """.
 -spec clear() -> ok.
 clear() ->


### PR DESCRIPTION
## Summary
- `beamtalk_changelog_entries` is now an `ordered_set` keyed by the monotonic `seq`, so `entries/0` no longer re-sorts the whole table on every call
- Corrected the four `clear/0` moduledocs (`beamtalk_workspace_signature_store`, `beamtalk_workspace_shape_store`, `beamtalk_workspace_findings_store`, `beamtalk_alias_xref`) that falsely claimed a production `Workspace changes revert:` caller; each is now documented per-store as test-only, noting the actual revert mechanism where one exists (e.g. `clear_owner/1`, `prime/1`/`capture/1`)
- `{beamtalk_native_mtime, Mod}` `persistent_term` entries are now erased when a native module's `.erl` source is deleted, instead of leaking forever

## Test plan
- [x] Changelog tests pass unmodified
- [x] `just test` — full suite green (Rust, stdlib, BUnit, Erlang runtime unit tests)
- [x] `just ci` (via pre-push hook) — clippy, dialyzer, formatting all pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrSTdNT5xJQeXMv39YkELU)_