### PR TITLE
Docs accuracy pass: testing-strategy counts, coverage-analysis, architecture incrementality claims (BT-3121)

### DIFF
--- a/docs/beamtalk-architecture.md
+++ b/docs/beamtalk-architecture.md
@@ -134,11 +134,30 @@ For Beamtalk, self-hosting would delay shipping by 1+ years with no user-facing 
 
 ### Incremental Compilation
 
-The compiler daemon maintains state between compilations:
+Incremental compilation works differently for the editor-facing language
+service than for batch builds — neither is a Salsa-style graph of memoized
+queries; both are coarser, file-granularity caches:
 
-- **File cache**: Only reparse changed files
-- **Dependency graph**: Only recompile affected modules
-- **Query cache**: Salsa-style incremental computation
+- **Language service (`SimpleLanguageService`, used by the LSP):** caches
+  each file's source text, parsed AST, and diagnostics in a per-file
+  `FileData` map (`crates/beamtalk-core/src/language_service/mod.rs`), and
+  merges cross-file class/alias/protocol/extension info into a `ProjectIndex`.
+  Editing a file reparses only that file and calls `ProjectIndex::update_file`
+  (or `remove_file` on delete) to refresh the project-wide index —
+  file-granularity invalidation, not whole-project reanalysis.
+- **Batch builds (`beamtalk build`):** a two-pass, mtime-keyed cache. Pass 1
+  (class indexing) persists per-file class/alias/extension metadata to
+  `.beamtalk-pass1-cache.json`, keyed by source mtime, so unchanged files skip
+  re-parsing (`crates/beamtalk-cli/src/commands/build_cache.rs`, BT-1683).
+  Pass 2 (codegen) compares each source file's mtime against its `.beam`
+  output's mtime and recompiles only files that changed
+  (`crates/beamtalk-cli/src/commands/build.rs`). A toolchain provenance stamp
+  (ADR 0098) gates both passes ahead of the mtime checks, so a compiler/OTP
+  version change forces a full rebuild regardless of mtime.
+
+Query-based incrementality (a Salsa-style dependency graph of memoized
+queries) does not exist today — it's deliberately deferred until profiling
+shows these file-granularity caches aren't enough at scale.
 
 Target: **<50ms** for single-file change to loaded code.
 
@@ -276,7 +295,10 @@ Protocol: JSON-RPC 2.0 (same as LSP)
 
 ### Compiler State
 
-The daemon maintains:
+Illustrative sketch of the state a persistent compiler process would need to
+track — see "Incremental Compilation" above for what's actually implemented
+today (`SimpleLanguageService`'s per-file cache and `ProjectIndex`, plus the
+batch build's two-pass mtime cache; there is no query-graph database):
 
 ```rust
 struct CompilerState {
@@ -285,9 +307,6 @@ struct CompilerState {
 
     // Module dependency graph
     deps: DependencyGraph,
-
-    // Salsa-style incremental queries
-    db: CompilerDatabase,
 
     // Connected BEAM nodes for hot reload
     nodes: Vec<NodeConnection>,

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -711,7 +711,7 @@ number that goes stale. Shape and relative speed are stable and shown below:
 | Layer | Count (derive with) | Speed | What it tests |
 |-------|----------------------|-------|----------------|
 | Rust unit tests | `grep -r '#\[test\]' crates --include='*.rs' \| wc -l` | ~5s | Parser, AST, codegen |
-| Erlang unit tests | `grep -rE '_test\(\)\s*->\|_test_\(\)\s*->' runtime/apps --include='*_tests.erl' \| wc -l` | ~3s | Runtime, primitives, object system |
+| Erlang unit tests | `grep -rE '_test\(\)\s*->\|_test_\(\)\s*->' runtime/apps --include='*_tests.erl' \| wc -l` (all 4 apps; "Erlang Runtime Unit Tests" below covers `beamtalk_runtime` only) | ~3s | Runtime, primitives, object system |
 | Compiler snapshots | `find test-package-compiler/cases -mindepth 1 -maxdepth 1 -type d \| wc -l` cases (×4 generated tests each) | ~2s | Codegen output stability |
 | **Stdlib tests** | **`find stdlib/bootstrap-test -name '*.btscript' \| wc -l` (~11 files, fixed by design)** | **~14s** | **Bootstrap primitives (expression tests)** |
 | **BUnit tests** | **`find stdlib/test -maxdepth 1 -name '*.bt' \| wc -l`** | **—** | **Language features (TestCase classes)** |

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -34,7 +34,7 @@ cargo clippy --all-targets -- -D warnings
 cargo fmt --all -- --check
 cargo test --all-targets
 just test-stdlib         # Bootstrap expression tests (fast, ~14s)
-just test-bunit          # BUnit TestCase tests (~85 files)
+just test-bunit          # BUnit TestCase tests (grows continuously — see "BUnit Tests" below for a count command)
 just test-parity         # Cross-surface parity tests (BT-2077, ~30s)
 just test-repl-protocol  # REPL TCP-protocol tests (slower, ~50s)
 ```
@@ -186,7 +186,10 @@ Standard Rust `#[test]` functions colocated with the code they test.
 
 **Location:** `crates/*/src/*.rs` (in `#[cfg(test)] mod tests { ... }`)
 
-**Count:** ~200 tests
+**Count:** grows continuously (thousands, the large majority in `beamtalk-core`) — get the current total with:
+```bash
+grep -r '#\[test\]' crates --include='*.rs' | wc -l
+```
 
 **Example** ([erlang.rs](../../crates/beamtalk-core/src/erlang.rs)):
 ```rust
@@ -314,10 +317,7 @@ Counter spawn
 ```
 
 **Bootstrap files (DO NOT migrate to BUnit):**
-`arithmetic.bt`, `booleans.bt`, `equality.bt`, `errors.bt`, `exceptions.bt`, `custom_exceptions.bt`, `erlang_exceptions.bt`, `integer_test.bt`, `float.bt`, `string_methods.bt`, `string_ops.bt`, `symbol.bt`, `literals.bt`, `value_types.bt`
-
-Also kept as expression tests due to compile-time type check constraints:
-`stack_frames.bt`, `class_hierarchy.bt`
+`arithmetic.btscript`, `blocks.btscript`, `booleans.btscript`, `equality.btscript`, `erlang_exceptions.btscript`, `errors.btscript`, `exceptions.btscript`, `float.btscript`, `literals.btscript`, `string_methods.btscript`, `symbol.btscript`
 
 **When to use stdlib expression tests:**
 | Test needs... | Use stdlib test? |
@@ -328,7 +328,7 @@ Also kept as expression tests due to compile-time type check constraints:
 | All other language feature tests | ❌ No — use BUnit tests |
 
 **Adding a new stdlib test:**
-1. Create `stdlib/bootstrap-test/my_feature.bt`
+1. Create `stdlib/bootstrap-test/my_feature.btscript`
 2. Add expressions with `// => expected_result` annotations
 3. Run `just test-stdlib`
 
@@ -342,7 +342,10 @@ SUnit-style test classes that subclass `TestCase`. The primary home for language
 
 **Location:** `stdlib/test/*.bt` (project test directory)
 
-**Count:** ~85 test files
+**Count:** grows continuously (hundreds of files) — get the current total with:
+```bash
+find stdlib/test -maxdepth 1 -name '*.bt' | wc -l
+```
 
 **Command:** `just test-bunit` or `beamtalk test`
 
@@ -523,7 +526,10 @@ REPL TCP-protocol integration tests that require a running REPL daemon. (Previou
 
 **Location:** `tests/repl-protocol/`
 
-**Test cases:** `tests/repl-protocol/cases/*.btscript` (~23 files)
+**Test cases:** `tests/repl-protocol/cases/*.btscript` — grows continuously; get the current total with:
+```bash
+find tests/repl-protocol/cases -name '*.btscript' | wc -l
+```
 
 **Test harness:** `crates/beamtalk-cli/tests/repl_protocol.rs`
 
@@ -675,38 +681,41 @@ just ci
 #   just lint            # Clippy + fmt-check + dialyzer
 #   just test            # Rust unit tests + runtime EUnit
 #   just test-stdlib     # Bootstrap expression tests (~14s)
-#   just test-bunit      # BUnit TestCase tests (~85 files)
+#   just test-bunit      # BUnit TestCase tests (grows continuously — see "BUnit Tests" above for a count command)
 #   just test-repl-protocol  # REPL TCP-protocol tests (~50s)
 ```
 
 ### Testing Pyramid
 
-The test suite follows a proper testing pyramid after [ADR 0014](../ADR/0014-beamtalk-test-framework.md):
+The test suite follows a proper testing pyramid after [ADR 0014](../ADR/0014-beamtalk-test-framework.md).
+Layer counts grow continuously as the language and stdlib grow — each layer's
+section above gives a command to derive its current count rather than a
+number that goes stale. Shape and relative speed are stable and shown below:
 
 ```
             ╱╲
-           ╱  ╲        E2E Tests (~36 files)
+           ╱  ╲        E2E Tests (many files)
           ╱    ╲       REPL/workspace integration — slow (~50s)
          ╱──────╲
-        ╱        ╲     BUnit Tests (~85 files)
+        ╱        ╲     BUnit Tests (most files, growing fastest)
        ╱          ╲    Language feature tests — fast (`just test-bunit`)
       ╱────────────╲
-     ╱              ╲  Stdlib Tests (~11 files)
+     ╱              ╲  Stdlib Tests (~11 files, fixed by design)
     ╱                ╲ Bootstrap expression tests — fast (~14s)
    ╱──────────────────╲
-  ╱                    ╲ Rust + Erlang Unit Tests (~600+ tests)
+  ╱                    ╲ Rust + Erlang Unit Tests (most tests overall)
  ╱                      ╲ Parser, codegen, runtime modules — fast (~10s)
 ╱────────────────────────╲
 ```
 
-| Layer | Count | Speed | What it tests |
-|-------|-------|-------|---------------|
-| Rust unit tests | ~600 tests | ~5s | Parser, AST, codegen |
-| Erlang unit tests | ~100 tests | ~3s | Runtime, primitives, object system |
-| Compiler snapshots | ~51 cases | ~2s | Codegen output stability |
-| **Stdlib tests** | **~11 files** | **~14s** | **Bootstrap primitives (expression tests)** |
-| **BUnit tests** | **~85 files** | **—** | **Language features (TestCase classes)** |
-| E2E tests | ~36 files | ~50s | REPL/workspace integration |
+| Layer | Count (derive with) | Speed | What it tests |
+|-------|----------------------|-------|----------------|
+| Rust unit tests | `grep -r '#\[test\]' crates --include='*.rs' \| wc -l` | ~5s | Parser, AST, codegen |
+| Erlang unit tests | `grep -rE '_test\(\)\s*->\|_test_\(\)\s*->' runtime/apps --include='*_tests.erl' \| wc -l` | ~3s | Runtime, primitives, object system |
+| Compiler snapshots | `find test-package-compiler/cases -mindepth 1 -maxdepth 1 -type d \| wc -l` cases (×4 generated tests each) | ~2s | Codegen output stability |
+| **Stdlib tests** | **`find stdlib/bootstrap-test -name '*.btscript' \| wc -l` (~11 files, fixed by design)** | **~14s** | **Bootstrap primitives (expression tests)** |
+| **BUnit tests** | **`find stdlib/test -maxdepth 1 -name '*.bt' \| wc -l`** | **—** | **Language features (TestCase classes)** |
+| E2E tests | `find tests/repl-protocol/cases -name '*.btscript' \| wc -l` | ~50s | REPL/workspace integration |
 
 ### Cross-Repo Package Tests
 
@@ -808,7 +817,7 @@ stdlib/test/fixtures/
 ├── typed_counter.bt      # Typed actor with Integer state
 ├── typed_account.bt      # Typed actor with Integer + String state
 ├── math_helper.bt        # Value type with recursion helpers
-└── ...                   # ~46 fixture files
+└── ...                   # grows continuously; `find stdlib/test/fixtures -maxdepth 1 -name '*.bt' | wc -l`
 ```
 
 **Erlang fixtures:** `test_*.erl` in `runtime/apps/beamtalk_runtime/test/` for reusable actors.
@@ -855,7 +864,7 @@ mod tests {
 
 ### Adding a Stdlib Test (Bootstrap Primitives)
 
-1. Create `stdlib/bootstrap-test/my_feature.bt`
+1. Create `stdlib/bootstrap-test/my_feature.btscript`
 2. Add expressions with `// => expected_result` annotations
 3. Optionally use `// @load path/to/fixture.bt` for fixtures
 4. Run `just test-stdlib`
@@ -975,7 +984,7 @@ Fuzzing tests the parser's robustness by feeding it random or mutated input to d
 
 **Location:** `fuzz/fuzz_targets/parse_arbitrary.rs`
 
-**Corpus:** `fuzz/corpus/parse_arbitrary/` (32 seed files from examples/ and tests/repl-protocol/cases/)
+**Corpus:** `fuzz/corpus/parse_arbitrary/` (seed files from examples/ and tests/repl-protocol/cases/ — `find fuzz/corpus/parse_arbitrary -maxdepth 1 -type f | wc -l` for the current count)
 
 ### Running Locally
 

--- a/docs/internal/coverage-analysis.md
+++ b/docs/internal/coverage-analysis.md
@@ -1,10 +1,18 @@
 # Core Erlang Compilation Verification Coverage Analysis
 
-**Status:** Current as of 39 test cases - Updated regularly
+**Status:** Test case count grows continuously — derive it rather than trust a
+baked-in number (see below).
 
 ## Test Case Count
-- **Total test cases**: 39
-- **Total tests**: 156 (39 cases × 4 tests each: lexer, parser, codegen, compiles)
+
+Each case generates 4 tests (lexer, parser, codegen, compiles — see the
+"Compiler Snapshot Tests" section of
+[testing-strategy.md](../development/testing-strategy.md)). Get the current
+totals with:
+```bash
+cases=$(find test-package-compiler/cases -mindepth 1 -maxdepth 1 -type d | wc -l)
+echo "cases=$cases tests=$((cases * 4))"
+```
 - **All compilation tests passing**: ✓
 
 ## Expression Types Coverage
@@ -12,20 +20,20 @@
 ### Literals
 | Type | Covered | Test Cases |
 |------|---------|------------|
-| Integer | ✓ | hello_world, stdlib_integer, binary_operators, many others |
+| Integer | ✓ | hello_world, ws_stdlib_integer, binary_operators, many others |
 | Float | ✓ | Implicitly tested in arithmetic |
-| String | ✓ | hello_world, string_operations, stdlib_string |
-| Symbol | ✓ | map_literals, stdlib_dictionary |
+| String | ✓ | hello_world, string_operations, ws_stdlib_string |
+| Symbol | ✓ | map_literals, ws_stdlib_dictionary |
 | Character | ✓ | Literal type exists, tested via stdlib |
-| Array | ✓ | stdlib_array |
+| Array | ✓ | ws_stdlib_array |
 
 ### Expressions
 | Type | Covered | Test Cases |
 |------|---------|------------|
 | Identifier | ✓ | All test cases |
-| Block | ✓ | blocks_no_args, empty_blocks, nested_blocks, stdlib_block |
+| Block | ✓ | blocks_no_args, empty_blocks, nested_blocks, ws_stdlib_block |
 | MessageSend (Unary) | ✓ | async_unary_message, unary_operators, cascades |
-| MessageSend (Binary) | ✓ | binary_operators, stdlib_integer |
+| MessageSend (Binary) | ✓ | binary_operators, ws_stdlib_integer |
 | MessageSend (Keyword) | ✓ | async_keyword_message, nested_keyword_messages, multi_keyword_complex_args |
 | Assignment | ✓ | actor_state_mutation, all test cases |
 | FieldAccess | ✓ | actor_state_mutation |
@@ -41,9 +49,9 @@
 | + | erlang:'+' | actor_spawn, binary_operators | ✓ |
 | - | erlang:'-' | blocks_no_args, binary_operators | ✓ |
 | * | erlang:'*' | cascade_complex, binary_operators | ✓ |
-| / | erlang:'/' | stdlib_integer, binary_operators | ✓ |
-| % | erlang:'rem' | stdlib_integer, binary_operators | ✓ |
-| =:= | erlang:'=:=' | stdlib_integer, binary_operators | ✓ |
+| / | erlang:'/' | ws_stdlib_integer, binary_operators | ✓ |
+| % | erlang:'rem' | ws_stdlib_integer, binary_operators | ✓ |
+| =:= | erlang:'=:=' | ws_stdlib_integer, binary_operators | ✓ |
 | == | erlang:'==' | binary_operators | ✓ |
 | /= | erlang:'/=' | binary_operators | ✓ |
 | =/= | erlang:'=/=' | binary_operators | ✓ |
@@ -52,7 +60,7 @@
 | <= | erlang:'=<' | binary_operators | ✓ |
 | >= | erlang:'>=' | binary_operators | ✓ |
 | ** | math:pow + round | binary_operators | ✓ |
-| ++ | iolist_to_binary | stdlib_string, binary_operators | ✓ |
+| ++ | iolist_to_binary | ws_stdlib_string, binary_operators | ✓ |
 
 **Coverage**: 15/15 operators (100%)
 - All documented operators are fully implemented and tested
@@ -65,12 +73,12 @@
 |---------|------|-----------|
 | negated | Integer | unary_operators |
 | abs | Integer | unary_operators |
-| isZero | Integer | stdlib_integer, unary_operators |
-| isEven | Integer | stdlib_integer, unary_operators |
-| isOdd | Integer | stdlib_integer, unary_operators |
-| not | Boolean | stdlib_boolean, unary_operators |
-| value | Block evaluation | stdlib_block, unary_operators |
-| repeat | Block loop | stdlib_block |
+| isZero | Integer | ws_stdlib_integer, unary_operators |
+| isEven | Integer | ws_stdlib_integer, unary_operators |
+| isOdd | Integer | ws_stdlib_integer, unary_operators |
+| not | Boolean | ws_stdlib_boolean, unary_operators |
+| value | Block evaluation | ws_stdlib_block, unary_operators |
+| repeat | Block loop | ws_stdlib_block |
 | spawn | Actor creation | actor_spawn |
 | await | Future resolution | async_with_await |
 
@@ -80,12 +88,12 @@
 
 | Message | Parameters | Test Case |
 |---------|------------|-----------|
-| value | 0 args | stdlib_block |
-| value: | 1 arg | stdlib_block |
-| value:value: | 2 args | stdlib_block |
-| whileTrue: | 1 arg | stdlib_block |
-| whileFalse: | 1 arg | stdlib_block |
-| repeat | 0 args | stdlib_block |
+| value | 0 args | ws_stdlib_block |
+| value: | 1 arg | ws_stdlib_block |
+| value:value: | 2 args | ws_stdlib_block |
+| whileTrue: | 1 arg | ws_stdlib_block |
+| whileFalse: | 1 arg | ws_stdlib_block |
+| repeat | 0 args | ws_stdlib_block |
 
 **Coverage**: All block evaluation patterns tested
 
@@ -93,12 +101,12 @@
 
 | Message | Test Case |
 |---------|-----------|
-| ifTrue:ifFalse: | stdlib_boolean |
-| ifTrue: | stdlib_boolean |
-| ifFalse: | stdlib_boolean |
-| and: | stdlib_boolean |
-| or: | stdlib_boolean |
-| not | stdlib_boolean, unary_operators |
+| ifTrue:ifFalse: | ws_stdlib_boolean |
+| ifTrue: | ws_stdlib_boolean |
+| ifFalse: | ws_stdlib_boolean |
+| and: | ws_stdlib_boolean |
+| or: | ws_stdlib_boolean |
+| not | ws_stdlib_boolean, unary_operators |
 
 **Coverage**: Complete boolean control flow
 
@@ -106,28 +114,32 @@
 
 | Message | Test Case |
 |---------|-----------|
-| at: | map_literals, stdlib_dictionary |
-| at:put: | map_literals, stdlib_dictionary |
-| at:ifAbsent: | stdlib_dictionary |
-| includesKey: | stdlib_dictionary |
-| keys | stdlib_dictionary |
-| values | stdlib_dictionary |
-| size | stdlib_dictionary |
+| at: | map_literals, ws_stdlib_dictionary |
+| at:put: | map_literals, ws_stdlib_dictionary |
+| at:ifAbsent: | ws_stdlib_dictionary |
+| includesKey: | ws_stdlib_dictionary |
+| keys | ws_stdlib_dictionary |
+| values | ws_stdlib_dictionary |
+| size | ws_stdlib_dictionary |
 
 **Coverage**: Core map operations tested
 
 ## Gen_Server Callbacks Coverage
 
-All gen_server callbacks are automatically generated for every actor module:
+All gen_server callbacks are automatically generated for every actor module.
+Get the current count of cases that declare `Actor subclass:` with:
+```bash
+grep -l 'Actor subclass:' test-package-compiler/cases/*/main.bt | wc -l
+```
 
 | Callback | Generated | Test Coverage |
 |----------|-----------|---------------|
-| init/1 | ✓ | Every actor test (37 cases) |
-| handle_cast/2 | ✓ | Every actor test (37 cases) |
-| handle_call/3 | ✓ | Every actor test (37 cases) |
-| code_change/3 | ✓ | Every actor test (37 cases) |
-| terminate/2 | ✓ | Every actor test (37 cases) |
-| spawn/0 | ✓ | actor_spawn + 36 others |
+| init/1 | ✓ | Every actor test |
+| handle_cast/2 | ✓ | Every actor test |
+| handle_call/3 | ✓ | Every actor test |
+| code_change/3 | ✓ | Every actor test |
+| terminate/2 | ✓ | Every actor test |
+| spawn/0 | ✓ | actor_spawn + others |
 | spawnWith:/1 | ✓ | actor_spawn_with_args |
 
 **Coverage**: 100% - All callbacks generated and compile-tested
@@ -164,7 +176,14 @@ Based on the analysis:
 
 ### Code Generation Functions
 
-Out of 37 generate_* functions:
+Codegen has since been split from a single `mod.rs` into many files under
+`crates/beamtalk-core/src/codegen/core_erlang/` (e.g. `dispatch_codegen.rs`,
+`expressions.rs`, `gen_server/callbacks.rs`, `gen_server/dispatch.rs`,
+`gen_server/methods.rs`, `operators.rs`, `value_type_codegen.rs`), so a single
+file-local function count no longer applies. Get the current total with:
+```bash
+grep -rc 'fn generate_' crates/beamtalk-core/src/codegen | awk -F: '{sum+=$2} END {print sum}'
+```
 - Module structure: generate_module, generate_repl_module (✓)
 - Actor lifecycle: generate_spawn*, generate_init, generate_start_link (✓)
 - Gen_server callbacks: generate_handle_*, generate_code_change, generate_terminate (✓)
@@ -194,7 +213,7 @@ The test suite provides comprehensive coverage of Core Erlang code generation:
 - **All literal types**: Covered
 - **Special messages**: Block, Boolean, Dictionary, Integer - all covered
 
-**Note on operator coverage**: The codegen module has implementations for `**`, `==`, and `!=` operators, but these cannot currently be parsed (see `generate_binary_op()` in `mod.rs` lines 2469-2511). These represent dead code paths until parser support is added (tracked in BT-128).
+**Note on operator coverage**: The codegen module has implementations for `**`, `==`, and `!=` operators, but these cannot currently be parsed (see `generate_binary_op()` in `crates/beamtalk-core/src/codegen/core_erlang/operators.rs`). These represent dead code paths until parser support is added (tracked in BT-128).
 
 Every test case includes a compilation verification test that runs `erlc +from_core` to ensure the generated Core Erlang is syntactically valid and compiles to BEAM bytecode.
 


### PR DESCRIPTION
Linear issue: https://linear.app/beamtalk/issue/BT-3121/docs-accuracy-pass-testing-strategy-counts-coverage-analysis

## Summary

Docs-accuracy-only pass across three files. No restructuring — every edit corrects a claim contradicted by the current tree, or replaces a hardcoded count with a command to derive it (so it can't rot the same way again).

### `docs/development/testing-strategy.md`
- Rust `#[test]` count: `~200`/`~600` (pyramid) → replaced with `grep -r '#\[test\]' crates --include='*.rs' | wc -l` (currently ~7,700, vs. the claimed ~600).
- BUnit test file count: `~85 files` → actual is ~290; replaced with a `find` command.
- E2E (`tests/repl-protocol`) case count: `~23`/`~36` (two different stale numbers in the same doc) → actual is 93; replaced with a `find` command.
- Compiler snapshot case count (pyramid): `~51` → actual is 79; replaced with a `find` command.
- Erlang unit test count (pyramid): `~100` → actual is thousands; replaced with a `grep` command, with a note on scope vs. the "Erlang Runtime Unit Tests" section below it.
- Bootstrap test file list: named 14 files with `.bt` extension and several that no longer exist (`custom_exceptions.bt`, `integer_test.bt`, `string_ops.bt`, `value_types.bt`, `stack_frames.bt`, `class_hierarchy.bt` — all since migrated to BUnit); actual directory has 11 `.btscript` files. Fixed the list and the "Adding a new stdlib test" instructions to use the real `.btscript` extension.
- Fuzz corpus seed count and BUnit fixture count: replaced hardcoded numbers with `find` commands.

### `docs/internal/coverage-analysis.md`
- Headline claim: 39 test-package-compiler cases / 156 tests → actual is 79 cases / 316 tests; replaced with a derive command.
- Case names throughout the coverage tables referenced `stdlib_integer`, `stdlib_string`, `stdlib_boolean`, `stdlib_block`, `stdlib_dictionary`, `stdlib_array` — these were renamed to `ws_stdlib_*` at some point; updated all references.
- "Every actor test (37 cases)" / "actor_spawn + 36 others" — actual `Actor subclass:` case count is 12; replaced with a derive command rather than re-baking a new stale number.
- "Out of 37 generate_* functions" in a single `mod.rs` — codegen has since been split into many files under `codegen/core_erlang/`; corrected the file layout description and replaced the count with a derive command (currently 339).
- Fixed a stale file/line citation (`generate_binary_op()` in `mod.rs` lines 2469-2511 → `codegen/core_erlang/operators.rs`, no line numbers since they drift).

### `docs/beamtalk-architecture.md`
- "Incremental Compilation" section claimed a "Query cache: Salsa-style incremental computation" that does not exist. Replaced with the real design: `SimpleLanguageService`'s per-file `FileData` cache + file-granularity `ProjectIndex` invalidation (LSP-side), and the two-pass mtime-keyed `Pass1Cache`/`build.rs` cache (batch-build-side). Explicitly notes query-based incrementality is deliberately deferred, without preempting BT-3120's future move to content-hash keying (per task instructions — described today's mtime-based design only).
- Fixed the same fabricated "Salsa-style incremental queries" field duplicated in the illustrative `CompilerState` struct a few paragraphs later, which would otherwise have contradicted the corrected section above it.

### Out of scope (noted, not fixed here)
`beamtalk-architecture.md`'s "Compiler Daemon" / "Live Development Flow" sections describe a `beamtalk daemon start` subcommand and JSON-RPC IPC protocol that doesn't appear to exist in the current CLI (`crates/beamtalk-cli/src/commands/` has no `daemon` command). This is a much larger drift than the "Incremental Compilation" section BT-3121 scoped in on, so it's left for a follow-up rather than expanding this PR's scope.

## Test plan
- [x] `just ci-changed` — full build, clippy, dialyzer, fmt (Rust/Erlang/JS/Elixir/Beamtalk), stdlib tests, BUnit tests (3215 tests), Erlang runtime tests, corpus/surface-drift checks — all green.
- [x] Every embedded derive command in the docs was run against the actual tree to confirm it produces the number cited alongside it.
- [x] Grepped all three docs for remaining stale case names / hardcoded counts after editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CpGgaYYFRpYuikkqiWiEoq)_