### PR TITLE
BT-3108: Workspace meta hygiene (drop write-only ETS mirror, validate class_sources on restore)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_module_name.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_module_name.erl
@@ -34,13 +34,19 @@ and other non-ASCII letters the same way both sides of the compiler agree on.
 `to_module_atom/1` and `to_stdlib_module_atom/1` build the two `bt@…`
 module-atom shapes the compiler and runtime use on trusted (already-atom)
 class names: unqualified static (`bt@{snake}`) and stdlib
-(`bt@stdlib@{snake}`). The package-qualified shape (`bt@{Package}@{snake}`)
-has one caller today — `beamtalk_repl_ops_dev:resolve_qualified_class_name/1`
-— which takes raw, unbounded REPL user input, so it deliberately builds the
-module name as a string and checks it with `list_to_existing_atom` (erroring
-rather than creating an atom) instead of going through an atom-returning
-helper here; adding one would either duplicate that safety check or invite
-misuse against untrusted input.
+(`bt@stdlib@{snake}`).
+
+The package-qualified shape (`bt@{Package}@{snake}`) is built by
+`to_qualified_module_atom/2` — takes the snake_case segment (already computed
+by the caller, so this makes no assumption about where it came from — a
+trusted atom via `camel_to_snake/1`, or raw REPL text) plus the package name,
+and never creates an atom: `list_to_existing_atom`, returning `undefined` on
+a miss rather than raising. BT-3108: previously had exactly one caller,
+`beamtalk_repl_ops_dev:resolve_qualified_class_name/1` (raw, unbounded REPL
+user input), which is why no atom-returning helper existed here before — a
+second caller (`beamtalk_workspace_meta`'s restore-time freshness check,
+trusted `ClassAtom` input) showed the `"bt@" ++ Package ++ "@" ++ Snake`
+assembly was the shared part, not the trust level of the input feeding it.
 
 ## Inverse (lossy — fallback only)
 
@@ -58,6 +64,7 @@ to this heuristic only when a module isn't a registered class.
     camel_to_snake/1,
     to_module_atom/1,
     to_stdlib_module_atom/1,
+    to_qualified_module_atom/2,
     is_stdlib_module/1,
     snake_to_class/1
 ]).
@@ -148,6 +155,30 @@ to_module_atom(ClassName) when is_atom(ClassName) ->
 -spec to_stdlib_module_atom(atom()) -> atom().
 to_stdlib_module_atom(ClassName) when is_atom(ClassName) ->
     to_atom("bt@stdlib@" ++ camel_to_snake(atom_to_list(ClassName))).
+
+-doc """
+Package-qualified module atom: `bt@{PackageName}@{Snake}`, or `undefined` if
+no such atom has ever been created in this VM.
+
+Unlike `to_module_atom/1`/`to_stdlib_module_atom/1`, never creates an atom
+(`list_to_existing_atom`, not `to_atom/1`'s create-on-miss fallback) — a
+package-qualified module only ever gets its atom from actually being
+compiled/loaded, never from a caller merely asking about it, so a miss here
+means "not loaded" and should resolve to that, not mint a fresh unused atom.
+`Snake` is the caller's already-computed snake_case class-name segment (e.g.
+via `camel_to_snake/1`), not a `ClassName` atom — this function makes no
+assumption about whether the caller's input was trusted.
+""".
+-spec to_qualified_module_atom(string(), binary() | string()) -> atom() | undefined.
+to_qualified_module_atom(Snake, PackageName) when is_binary(PackageName) ->
+    to_qualified_module_atom(Snake, binary_to_list(PackageName));
+to_qualified_module_atom(Snake, PackageName) when is_list(PackageName) ->
+    ModNameStr = "bt@" ++ PackageName ++ "@" ++ Snake,
+    try list_to_existing_atom(ModNameStr) of
+        Atom -> Atom
+    catch
+        error:badarg -> undefined
+    end.
 
 -spec to_atom(string()) -> atom().
 to_atom(Str) ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_module_name_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_module_name_tests.erl
@@ -85,6 +85,40 @@ to_stdlib_module_atom_acronym_test() ->
     ).
 
 %%% ============================================================================
+%%% to_qualified_module_atom/2 (BT-3108)
+%%% ============================================================================
+
+to_qualified_module_atom_found_test() ->
+    %% 'bt@bt3081test@counter' must already exist as an atom for the
+    %% existing-atom-only lookup to find it -- create it via to_module_atom-
+    %% style construction (never through to_qualified_module_atom itself,
+    %% which must not be what creates the atom under test).
+    % elp:fixme W0023 intentional atom creation
+    _ = list_to_atom("bt@bt3081test@counter"),
+    ?assertEqual(
+        'bt@bt3081test@counter',
+        beamtalk_module_name:to_qualified_module_atom("counter", <<"bt3081test">>)
+    ).
+
+to_qualified_module_atom_binary_and_string_package_agree_test() ->
+    % elp:fixme W0023 intentional atom creation
+    _ = list_to_atom("bt@bt3081agree@widget"),
+    ?assertEqual(
+        beamtalk_module_name:to_qualified_module_atom("widget", <<"bt3081agree">>),
+        beamtalk_module_name:to_qualified_module_atom("widget", "bt3081agree")
+    ).
+
+to_qualified_module_atom_never_creates_atom_test() ->
+    %% A snake/package combo that has never been turned into an atom in this
+    %% VM must resolve to undefined, not silently mint a new atom.
+    Unique = erlang:unique_integer([positive]),
+    Snake = "bt3108_never_created_" ++ integer_to_list(Unique),
+    ?assertEqual(
+        undefined,
+        beamtalk_module_name:to_qualified_module_atom(Snake, <<"nopkg">>)
+    ).
+
+%%% ============================================================================
 %%% is_stdlib_module/1
 %%% ============================================================================
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_dev.erl
@@ -2255,17 +2255,17 @@ resolve_qualified_class_name(ClassBin) when is_binary(ClassBin) ->
             PkgBin = binary:part(ClassBin, 0, Pos),
             ClassNameBin = binary:part(ClassBin, Pos + 1, byte_size(ClassBin) - Pos - 1),
             %% Convert class name to snake_case module name: bt@{pkg}@{snake_case}
-            %% BT-3081: delegates to beamtalk_module_name, the single Erlang-side
-            %% authority for the ClassName ⇄ bt@[pkg@]snake_case convention.
+            %% BT-3081 / BT-3108: delegates to beamtalk_module_name, the single
+            %% Erlang-side authority for the ClassName ⇄ bt@[pkg@]snake_case
+            %% convention. Never creates an atom for the untrusted ClassBin —
+            %% to_qualified_module_atom/2 only checks list_to_existing_atom.
             SnakeCase = beamtalk_module_name:camel_to_snake(binary_to_list(ClassNameBin)),
-            ModNameStr = "bt@" ++ binary_to_list(PkgBin) ++ "@" ++ SnakeCase,
-            try list_to_existing_atom(ModNameStr) of
+            case beamtalk_module_name:to_qualified_module_atom(SnakeCase, PkgBin) of
+                undefined ->
+                    {error, badarg};
                 _ModAtom ->
                     %% Module name atom exists — now resolve the class name atom
                     beamtalk_repl_errors:safe_to_existing_atom(ClassNameBin)
-            catch
-                error:badarg ->
-                    {error, badarg}
             end
     end.
 

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
@@ -659,9 +659,12 @@ load_metadata_from_disk(State) ->
     %% snapshot" moment — the last time class_sources/loaded_modules were
     %% written to disk. A .bt source file whose own mtime is newer than this
     %% was edited after that snapshot (e.g. externally, while the workspace
-    %% was down) and is therefore stale relative to it. `0` (file missing —
-    %% shouldn't happen, we're mid-read of it) sorts below every real
-    %% calendar:datetime(), so the newer-than check below degrades to "keep".
+    %% was down) and is therefore stale relative to it. Read just before
+    %% `file:read_file/1` below, so the only way this is `0` (file missing)
+    %% is a race where the file is deleted between the two calls — in which
+    %% case `file:read_file/1` itself hits `enoent` and this value goes
+    %% unused. `0` sorts below every real `calendar:datetime()` regardless,
+    %% so the newer-than check would degrade to "keep" even then.
     SnapshotMtime = filelib:last_modified(Path),
     case file:read_file(Path) of
         {ok, Binary} ->
@@ -757,6 +760,7 @@ load_metadata_from_disk(State) ->
                                                 K,
                                                 binary_to_list(V),
                                                 ValidatedModules,
+                                                State#state.package_name,
                                                 SnapshotMtime,
                                                 Acc
                                             );
@@ -948,19 +952,20 @@ loaded module (per `ValidatedModules`, itself already filtered to
 `code:is_loaded`) and — when that module has a known on-disk source path —
 that file's mtime is not newer than `SnapshotMtime` (the metadata.json
 snapshot the text was captured into). A class name that never became an atom
-in this VM, or whose module resolves outside the static `bt@{snake}`
-convention (e.g. a package-qualified class), fails the loaded-module check
-and is conservatively dropped rather than risk serving stale text.
+in this VM, or whose module resolves to neither naming convention
+`class_module_loaded/3` checks, fails the loaded-module check and is
+conservatively dropped rather than risk serving stale text.
 """.
 -spec keep_if_class_source_fresh(
     binary(),
     string(),
     #{atom() => string() | undefined},
+    binary() | undefined,
     calendar:datetime() | 0,
     #{binary() => string()}
 ) -> #{binary() => string()}.
-keep_if_class_source_fresh(ClassNameBin, Source, ValidatedModules, SnapshotMtime, Acc) ->
-    case class_module_loaded(ClassNameBin, ValidatedModules) of
+keep_if_class_source_fresh(ClassNameBin, Source, ValidatedModules, PackageName, SnapshotMtime, Acc) ->
+    case class_module_loaded(ClassNameBin, ValidatedModules, PackageName) of
         {true, SourcePath} ->
             case source_file_newer_than(SourcePath, SnapshotMtime) of
                 true -> Acc;
@@ -971,31 +976,79 @@ keep_if_class_source_fresh(ClassNameBin, Source, ValidatedModules, SnapshotMtime
     end.
 
 -doc """
-Whether `ClassNameBin` currently resolves (via the static `bt@{snake_case}`
-naming convention, ADR 0016) to a module present in `ValidatedModules` — i.e.
-a module `code:is_loaded/1` confirmed loaded during this same restore pass.
+Whether `ClassNameBin` currently resolves to a module present in
+`ValidatedModules` — i.e. a module `code:is_loaded/1` confirmed loaded during
+this same restore pass. Tries, in order:
+
+1. The unqualified static `bt@{snake_case}` convention (ADR 0016) —
+   `beamtalk_module_name:to_module_atom/1`.
+2. When `PackageName` is known (this project has a `[package] name = ...` in
+   `beamtalk.toml`): the package-qualified `bt@{package}@{snake_case}`
+   convention a `src/`-located file compiles under
+   (`beamtalk_repl_loader:resolve_package_module/4`'s common case — a class
+   directly in `src/` whose file basename matches the class name). Built via
+   `list_to_existing_atom` (never creates an atom): if this module was never
+   loaded this session, no atom for it exists, so the lookup fails cleanly
+   rather than fabricating a fresh atom that can't be in `ValidatedModules`
+   anyway.
+
+Does **not** cover every module-naming shape `resolve_package_module/4` can
+produce (e.g. a class under a `src/` subdirectory, or a file basename that
+doesn't match its class name both use extra `@`-segments derived from the
+file path, which this class-name-only check has no way to reconstruct) —
+those fail both checks and are conservatively dropped, same as before this
+fix, not silently misclassified as fresh.
+
 Returns `{true, SourcePath}` (SourcePath possibly `undefined`, e.g. a
 REPL-typed class with no backing file) on success.
 """.
--spec class_module_loaded(binary(), #{atom() => string() | undefined}) ->
+-spec class_module_loaded(binary(), #{atom() => string() | undefined}, binary() | undefined) ->
     {true, string() | undefined} | false.
-class_module_loaded(ClassNameBin, ValidatedModules) ->
+class_module_loaded(ClassNameBin, ValidatedModules, PackageName) ->
     case safe_existing_atom(ClassNameBin) of
         undefined ->
             false;
         ClassAtom ->
-            ModuleAtom = beamtalk_module_name:to_module_atom(ClassAtom),
-            case maps:find(ModuleAtom, ValidatedModules) of
-                {ok, SourcePath} -> {true, SourcePath};
-                error -> false
+            UnqualifiedAtom = beamtalk_module_name:to_module_atom(ClassAtom),
+            case maps:find(UnqualifiedAtom, ValidatedModules) of
+                {ok, SourcePath} ->
+                    {true, SourcePath};
+                error ->
+                    case qualified_module_atom(ClassAtom, PackageName) of
+                        undefined ->
+                            false;
+                        QualifiedAtom ->
+                            case maps:find(QualifiedAtom, ValidatedModules) of
+                                {ok, SourcePath} -> {true, SourcePath};
+                                error -> false
+                            end
+                    end
             end
+    end.
+
+-doc """
+Package-qualified module atom (`bt@{PackageName}@{snake_case}`) for
+`ClassAtom`, or `undefined` when `PackageName` is unknown or no such atom has
+ever been created in this VM (`list_to_existing_atom` — see
+`class_module_loaded/3`'s doc for why this never creates one).
+""".
+-spec qualified_module_atom(atom(), binary() | undefined) -> atom() | undefined.
+qualified_module_atom(_ClassAtom, undefined) ->
+    undefined;
+qualified_module_atom(ClassAtom, PackageName) when is_binary(PackageName) ->
+    Snake = beamtalk_module_name:camel_to_snake(atom_to_list(ClassAtom)),
+    ModNameStr = "bt@" ++ binary_to_list(PackageName) ++ "@" ++ Snake,
+    try list_to_existing_atom(ModNameStr) of
+        Atom -> Atom
+    catch
+        error:badarg -> undefined
     end.
 
 -doc """
 Whether `SourcePath`'s current on-disk mtime is strictly newer than
 `SnapshotMtime`. No signal (`SourcePath` undefined, or the file no longer
 exists on disk) is treated as "not stale" — there is nothing to compare
-against, so `class_module_loaded/2` is the only gate in that case.
+against, so `class_module_loaded/3` is the only gate in that case.
 """.
 -spec source_file_newer_than(string() | undefined, calendar:datetime() | 0) -> boolean().
 source_file_newer_than(undefined, _SnapshotMtime) ->

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
@@ -50,10 +50,15 @@ and can be queried by other components (e.g., idle monitor).
 -define(WORKSPACE_META_TABLE, beamtalk_workspace_registry).
 % Debounce disk writes to every 2 seconds
 -define(PERSIST_DELAY_MS, 2000).
-%% BT-2621: ETS row key for the cached git repo toplevel. Stored as a separate
-%% small row (`{?GIT_TOPLEVEL_KEY, ProjectPath, Toplevel}`) rather than inside
-%% the mirrored #state{} so the git hot path reads only this tuple, not a copy
-%% of the whole state (which carries class sources and loaded modules).
+%% BT-2621: ETS row key for the cached git repo toplevel. Stored as its own
+%% small row (`{?GIT_TOPLEVEL_KEY, ProjectPath, Toplevel}`) so the git hot path
+%% reads only this tuple via `ets:lookup/2` without a gen_server round-trip.
+%% BT-3108: this used to sit alongside a `{metadata, #state{}}` row that
+%% mirrored the *entire* gen_server state (including class_sources and
+%% loaded_modules) into ETS after nearly every mutation — pure copy cost,
+%% since nothing in-tree ever read it (every public getter already goes
+%% through `gen_server:call`). That row is gone; this is now the table's only
+%% content.
 -define(GIT_TOPLEVEL_KEY, git_toplevel).
 
 -record(state, {
@@ -491,9 +496,6 @@ init(InitialMetadata) ->
         monitor_refs = #{}
     },
 
-    %% Store initial state in ETS
-    store_state_in_ets(State),
-
     %% Load persisted metadata if exists
     State2 = load_metadata_from_disk(State),
 
@@ -528,7 +530,6 @@ handle_call(all_class_sources, _From, State) ->
 handle_call({set_class_source, ClassName, Source}, _From, State) ->
     Sources = State#state.class_sources,
     State2 = State#state{class_sources = Sources#{ClassName => Source}},
-    store_state_in_ets(State2),
     {reply, ok, schedule_persist(State2)};
 handle_call(get_file_mtimes, _From, State) ->
     {reply, {ok, State#state.file_mtimes}, State};
@@ -536,7 +537,6 @@ handle_call({get_setting, Key, Default}, _From, State) ->
     {reply, maps:get(Key, State#state.settings, Default), State};
 handle_call({set_setting, Key, Value}, _From, State) ->
     State2 = State#state{settings = (State#state.settings)#{Key => Value}},
-    store_state_in_ets(State2),
     {reply, ok, schedule_persist(State2)};
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
@@ -544,7 +544,6 @@ handle_call(_Request, _From, State) ->
 handle_cast(update_activity, State) ->
     Now = erlang:system_time(second),
     State2 = State#state{last_activity = Now},
-    store_state_in_ets(State2),
     {noreply, schedule_persist(State2)};
 handle_cast({register_actor, Pid}, State) ->
     Actors = State#state.supervised_actors,
@@ -560,11 +559,9 @@ handle_cast({register_actor, Pid}, State) ->
                     monitor_refs = MonRefs#{Pid => Ref}
                 }
         end,
-    store_state_in_ets(State2),
     {noreply, schedule_persist(State2)};
 handle_cast({unregister_actor, Pid}, State) ->
     State2 = remove_actor(Pid, State),
-    store_state_in_ets(State2),
     {noreply, schedule_persist(State2)};
 handle_cast({register_module, Module, NewSource}, State) ->
     Modules = State#state.loaded_modules,
@@ -575,33 +572,27 @@ handle_cast({register_module, Module, NewSource}, State) ->
             _ -> NewSource
         end,
     State2 = State#state{loaded_modules = Modules#{Module => EffectiveSource}},
-    store_state_in_ets(State2),
     {noreply, schedule_persist(State2)};
 handle_cast({unregister_module, Module}, State) ->
     %% BT-1239: Remove a module when removeFromSystem is called.
     Modules = State#state.loaded_modules,
     State2 = State#state{loaded_modules = maps:remove(Module, Modules)},
-    store_state_in_ets(State2),
     {noreply, schedule_persist(State2)};
 handle_cast({remove_class_source, ClassName}, State) ->
     %% BT-3105: Remove a class's stored source when removeFromSystem is called.
     Sources = State#state.class_sources,
     State2 = State#state{class_sources = maps:remove(ClassName, Sources)},
-    store_state_in_ets(State2),
     {noreply, schedule_persist(State2)};
 handle_cast({set_file_mtime, FilePath, Mtime}, State) ->
     Mtimes = State#state.file_mtimes,
     State2 = State#state{file_mtimes = Mtimes#{FilePath => Mtime}},
-    store_state_in_ets(State2),
     {noreply, State2};
 handle_cast(clear_file_mtimes, State) ->
     State2 = State#state{file_mtimes = #{}},
-    store_state_in_ets(State2),
     {noreply, State2};
 handle_cast({remove_file_mtime, FilePath}, State) ->
     Mtimes = State#state.file_mtimes,
     State2 = State#state{file_mtimes = maps:remove(FilePath, Mtimes)},
-    store_state_in_ets(State2),
     {noreply, State2};
 handle_cast({set_git_toplevel, ProjectPath, Toplevel}, State) ->
     %% BT-2621: cache the resolved toplevel in its own ETS row (single entry,
@@ -622,7 +613,6 @@ handle_info(persist_to_disk, State) ->
 handle_info({'DOWN', _Ref, process, Pid, _Reason}, State) ->
     %% Actor exited, remove from tracked list and monitor refs
     State2 = remove_actor(Pid, State),
-    store_state_in_ets(State2),
     {noreply, schedule_persist(State2)};
 handle_info(_Info, State) ->
     {noreply, State}.
@@ -657,14 +647,6 @@ schedule_persist(#state{persist_timer = OldTimer} = State) ->
     NewRef = erlang:send_after(?PERSIST_DELAY_MS, self(), persist_to_disk),
     State#state{persist_timer = NewRef}.
 
--doc "Store state in ETS for fast read access".
-store_state_in_ets(State) ->
-    case ets:whereis(?WORKSPACE_META_TABLE) of
-        % Table doesn't exist yet, skip
-        undefined -> ok;
-        _Tid -> ets:insert(?WORKSPACE_META_TABLE, {metadata, State})
-    end.
-
 -doc """
 Load metadata from disk if available.
 Skipped in run mode (metadata_path = undefined).
@@ -673,6 +655,14 @@ load_metadata_from_disk(#state{metadata_path = undefined} = State) ->
     State;
 load_metadata_from_disk(State) ->
     Path = State#state.metadata_path,
+    %% BT-3108: the mtime of metadata.json itself stands in for "the persisted
+    %% snapshot" moment — the last time class_sources/loaded_modules were
+    %% written to disk. A .bt source file whose own mtime is newer than this
+    %% was edited after that snapshot (e.g. externally, while the workspace
+    %% was down) and is therefore stale relative to it. `0` (file missing —
+    %% shouldn't happen, we're mid-read of it) sorts below every real
+    %% calendar:datetime(), so the newer-than check below degrades to "keep".
+    SnapshotMtime = filelib:last_modified(Path),
     case file:read_file(Path) of
         {ok, Binary} ->
             try json:decode(Binary) of
@@ -683,6 +673,16 @@ load_metadata_from_disk(State) ->
 
                     %% Restore loaded_modules with source paths (atoms persist across restarts).
                     %% Handles both old format ([binary()]) and new format ([#{name,source}]).
+                    %% BT-3108: an entry survives only if its module is
+                    %% *currently* loaded in the code server — an atom that
+                    %% merely still exists proves nothing (the module behind
+                    %% it may never load again this session, e.g. after a
+                    %% true VM restart rather than an in-process gen_server
+                    %% restart). Dropping it here is safe: load-project's
+                    %% separate file_mtimes reset (below) already forces a
+                    %% fresh mtime check for every file on the next load, so
+                    %% an under-restored entry just means "treat as unloaded",
+                    %% never "serve stale content".
                     ModulesRaw = maps:get(<<"loaded_modules">>, Map, []),
                     Modules =
                         case ModulesRaw of
@@ -695,7 +695,7 @@ load_metadata_from_disk(State) ->
                                 %% Old format: just the module name
                                 case safe_existing_atom(Bin) of
                                     undefined -> false;
-                                    Atom -> {true, {Atom, undefined}}
+                                    Atom -> keep_if_module_loaded(Atom, undefined)
                                 end;
                             (#{<<"name">> := NameBin} = Entry) ->
                                 %% New format: #{name, source}
@@ -709,13 +709,14 @@ load_metadata_from_disk(State) ->
                                                 null -> undefined;
                                                 _ -> normalize_source_path(RawSource)
                                             end,
-                                        {true, {Atom, Source}}
+                                        keep_if_module_loaded(Atom, Source)
                                 end;
                             (_) ->
                                 false
                         end,
                         Modules
                     ),
+                    ValidatedModules = maps:from_list(ModuleAtoms),
 
                     %% Restore timestamps and project path if present
                     CreatedAt =
@@ -735,6 +736,16 @@ load_metadata_from_disk(State) ->
                         end,
 
                     %% Restore class sources map (binary class name → source string).
+                    %% BT-3108: an entry survives only if (a) the class it
+                    %% names currently resolves to a *loaded* module — no live
+                    %% class means no `>>`-patch target and no guarantee the
+                    %% text describes what this VM actually compiled — and
+                    %% (b) that module's on-disk source file (if known) is not
+                    %% newer than SnapshotMtime, i.e. it wasn't edited after
+                    %% the source text was last persisted. Either failure
+                    %% mirrors the file_mtimes reset just below: drop rather
+                    %% than risk serving stale text to method patching or
+                    %% re-check compiles.
                     ClassSourcesRaw = maps:get(<<"class_sources">>, Map, #{}),
                     ClassSources =
                         case is_map(ClassSourcesRaw) of
@@ -742,7 +753,13 @@ load_metadata_from_disk(State) ->
                                 maps:fold(
                                     fun
                                         (K, V, Acc) when is_binary(K), is_binary(V) ->
-                                            Acc#{K => binary_to_list(V)};
+                                            keep_if_class_source_fresh(
+                                                K,
+                                                binary_to_list(V),
+                                                ValidatedModules,
+                                                SnapshotMtime,
+                                                Acc
+                                            );
                                         (_, _, Acc) ->
                                             Acc
                                     end,
@@ -768,7 +785,7 @@ load_metadata_from_disk(State) ->
                         last_activity = LastActive,
                         % Always start fresh
                         supervised_actors = [],
-                        loaded_modules = maps:from_list(ModuleAtoms),
+                        loaded_modules = ValidatedModules,
                         class_sources = ClassSources,
                         %% BT-1685: File mtimes always start fresh — files may
                         %% have changed between sessions, so first load-project
@@ -909,6 +926,84 @@ safe_existing_atom(Binary) ->
         Atom -> Atom
     catch
         _:_ -> undefined
+    end.
+
+-doc """
+BT-3108: keep a restored `loaded_modules` entry only if `Atom`'s module is
+currently loaded in the code server. Returns the `lists:filtermap/2` shape
+directly so restore call sites stay a one-liner.
+""".
+-spec keep_if_module_loaded(atom(), string() | undefined) ->
+    {true, {atom(), string() | undefined}} | false.
+keep_if_module_loaded(Atom, Source) ->
+    case code:is_loaded(Atom) of
+        false -> false;
+        {file, _} -> {true, {Atom, Source}}
+    end.
+
+-doc """
+BT-3108: fold step for restoring a single `class_sources` entry. Adds
+`ClassNameBin => Source` to `Acc` only if the class is currently backed by a
+loaded module (per `ValidatedModules`, itself already filtered to
+`code:is_loaded`) and — when that module has a known on-disk source path —
+that file's mtime is not newer than `SnapshotMtime` (the metadata.json
+snapshot the text was captured into). A class name that never became an atom
+in this VM, or whose module resolves outside the static `bt@{snake}`
+convention (e.g. a package-qualified class), fails the loaded-module check
+and is conservatively dropped rather than risk serving stale text.
+""".
+-spec keep_if_class_source_fresh(
+    binary(),
+    string(),
+    #{atom() => string() | undefined},
+    calendar:datetime() | 0,
+    #{binary() => string()}
+) -> #{binary() => string()}.
+keep_if_class_source_fresh(ClassNameBin, Source, ValidatedModules, SnapshotMtime, Acc) ->
+    case class_module_loaded(ClassNameBin, ValidatedModules) of
+        {true, SourcePath} ->
+            case source_file_newer_than(SourcePath, SnapshotMtime) of
+                true -> Acc;
+                false -> Acc#{ClassNameBin => Source}
+            end;
+        false ->
+            Acc
+    end.
+
+-doc """
+Whether `ClassNameBin` currently resolves (via the static `bt@{snake_case}`
+naming convention, ADR 0016) to a module present in `ValidatedModules` — i.e.
+a module `code:is_loaded/1` confirmed loaded during this same restore pass.
+Returns `{true, SourcePath}` (SourcePath possibly `undefined`, e.g. a
+REPL-typed class with no backing file) on success.
+""".
+-spec class_module_loaded(binary(), #{atom() => string() | undefined}) ->
+    {true, string() | undefined} | false.
+class_module_loaded(ClassNameBin, ValidatedModules) ->
+    case safe_existing_atom(ClassNameBin) of
+        undefined ->
+            false;
+        ClassAtom ->
+            ModuleAtom = beamtalk_module_name:to_module_atom(ClassAtom),
+            case maps:find(ModuleAtom, ValidatedModules) of
+                {ok, SourcePath} -> {true, SourcePath};
+                error -> false
+            end
+    end.
+
+-doc """
+Whether `SourcePath`'s current on-disk mtime is strictly newer than
+`SnapshotMtime`. No signal (`SourcePath` undefined, or the file no longer
+exists on disk) is treated as "not stale" — there is nothing to compare
+against, so `class_module_loaded/2` is the only gate in that case.
+""".
+-spec source_file_newer_than(string() | undefined, calendar:datetime() | 0) -> boolean().
+source_file_newer_than(undefined, _SnapshotMtime) ->
+    false;
+source_file_newer_than(SourcePath, SnapshotMtime) when is_list(SourcePath) ->
+    case filelib:last_modified(SourcePath) of
+        0 -> false;
+        Mtime -> Mtime > SnapshotMtime
     end.
 
 -doc """

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_meta.erl
@@ -1029,20 +1029,18 @@ class_module_loaded(ClassNameBin, ValidatedModules, PackageName) ->
 -doc """
 Package-qualified module atom (`bt@{PackageName}@{snake_case}`) for
 `ClassAtom`, or `undefined` when `PackageName` is unknown or no such atom has
-ever been created in this VM (`list_to_existing_atom` — see
-`class_module_loaded/3`'s doc for why this never creates one).
+ever been created in this VM. Delegates to
+`beamtalk_module_name:to_qualified_module_atom/2` (BT-3108 review follow-up:
+extracted there so this isn't a second independent copy of the
+`bt@{pkg}@{snake}` assembly alongside
+`beamtalk_repl_ops_dev:resolve_qualified_class_name/1`'s).
 """.
 -spec qualified_module_atom(atom(), binary() | undefined) -> atom() | undefined.
 qualified_module_atom(_ClassAtom, undefined) ->
     undefined;
 qualified_module_atom(ClassAtom, PackageName) when is_binary(PackageName) ->
     Snake = beamtalk_module_name:camel_to_snake(atom_to_list(ClassAtom)),
-    ModNameStr = "bt@" ++ binary_to_list(PackageName) ++ "@" ++ Snake,
-    try list_to_existing_atom(ModNameStr) of
-        Atom -> Atom
-    catch
-        error:badarg -> undefined
-    end.
+    beamtalk_module_name:to_qualified_module_atom(Snake, PackageName).
 
 -doc """
 Whether `SourcePath`'s current on-disk mtime is strictly newer than

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_meta_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_meta_tests.erl
@@ -52,6 +52,27 @@ load_fake_class_module(ClassNameAtom) ->
     {module, Mod} = code:load_binary(Mod, atom_to_list(Mod) ++ ".beam", Bin),
     Mod.
 
+%% BT-3108: like load_fake_class_module/1, but under the package-qualified
+%% bt@{PackageName}@{snake_case} module name a src/-located file in a
+%% packaged project actually compiles under
+%% (beamtalk_repl_loader:resolve_package_module/4's common case) — used to
+%% cover class_module_loaded/3's package-qualified branch.
+load_fake_class_module_qualified(ClassNameAtom, PackageName) ->
+    Snake = beamtalk_module_name:camel_to_snake(atom_to_list(ClassNameAtom)),
+    ModNameStr = "bt@" ++ binary_to_list(PackageName) ++ "@" ++ Snake,
+    % elp:fixme W0023 intentional atom creation
+    ModuleAtom = list_to_atom(ModNameStr),
+    Forms = [
+        {attribute, 1, module, ModuleAtom},
+        {attribute, 2, export, [{noop, 0}]},
+        {function, 3, noop, 0, [
+            {clause, 3, [], [], [{atom, 3, ok}]}
+        ]}
+    ],
+    {ok, Mod, Bin} = compile:forms(Forms),
+    {module, Mod} = code:load_binary(Mod, atom_to_list(Mod) ++ ".beam", Bin),
+    Mod.
+
 %% Mirror beamtalk_workspace_meta's metadata_path computation so tests check
 %% the same file the module would write to.
 metadata_path_for(WsId) ->
@@ -1039,6 +1060,49 @@ class_source_survives_restart_when_module_loaded_test() ->
         gen_server:stop(Pid2)
     after
         _ = file:delete(MetaFile),
+        _ = code:purge(ModuleAtom),
+        _ = code:delete(ModuleAtom)
+    end.
+
+%% BT-3108 review follow-up: a class_sources entry for a class in a
+%% *packaged* project — the common case, not an edge case — survives restore.
+%% Its module is registered under the package-qualified bt@{pkg}@{snake} name
+%% (resolve_package_module/4's shape for a src/-located file), not the
+%% unqualified bt@{snake} name class_module_loaded/3 originally only checked.
+class_source_survives_restart_for_packaged_project_test() ->
+    stop_if_running(),
+    ProjectDir = filename:join(
+        temp_dir_meta(),
+        "bt-meta-pkg-" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    ok = filelib:ensure_path(ProjectDir),
+    ok = file:write_file(
+        filename:join(ProjectDir, "beamtalk.toml"),
+        <<"[package]\nname = \"bt3108pkg\"\n">>
+    ),
+    ProjectPath = list_to_binary(ProjectDir),
+    WsId = <<"clssrc_pkg_", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
+    MetaFile = metadata_path_for(WsId),
+    _ = file:delete(MetaFile),
+    ModuleAtom = load_fake_class_module_qualified('Bt3108Pkg', <<"bt3108pkg">>),
+    try
+        Init = #{
+            workspace_id => WsId,
+            project_path => ProjectPath,
+            created_at => erlang:system_time(second)
+        },
+        {ok, Pid1} = beamtalk_workspace_meta:start_link(Init),
+        Source = "Object subclass: Bt3108Pkg [\n  bar => 1\n]\n",
+        ok = beamtalk_workspace_meta:register_module(ModuleAtom),
+        ok = beamtalk_workspace_meta:set_class_source(<<"Bt3108Pkg">>, Source),
+        gen_server:stop(Pid1),
+        timer:sleep(50),
+        {ok, Pid2} = beamtalk_workspace_meta:start_link(Init),
+        ?assertEqual(Source, beamtalk_workspace_meta:get_class_source(<<"Bt3108Pkg">>)),
+        gen_server:stop(Pid2)
+    after
+        _ = file:delete(MetaFile),
+        _ = file:del_dir_r(ProjectDir),
         _ = code:purge(ModuleAtom),
         _ = code:delete(ModuleAtom)
     end.

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_meta_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_meta_tests.erl
@@ -9,6 +9,7 @@ Unit tests for beamtalk_workspace_meta module
 Tests workspace metadata tracking and activity updates.
 """.
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/file.hrl").
 
 %%====================================================================
 %% Tests
@@ -33,6 +34,23 @@ stop_if_running() ->
             gen_server:stop(Pid),
             timer:sleep(10)
     end.
+
+%% BT-3108: compile and load a trivial module named after ClassNameAtom's
+%% static bt@{snake_case} module (ADR 0016), so `code:is_loaded/1` reports it
+%% loaded the same way a real compiled .bt class would — without needing the
+%% full compiler pipeline in a unit test. Returns the module atom.
+load_fake_class_module(ClassNameAtom) ->
+    ModuleAtom = beamtalk_module_name:to_module_atom(ClassNameAtom),
+    Forms = [
+        {attribute, 1, module, ModuleAtom},
+        {attribute, 2, export, [{noop, 0}]},
+        {function, 3, noop, 0, [
+            {clause, 3, [], [], [{atom, 3, ok}]}
+        ]}
+    ],
+    {ok, Mod, Bin} = compile:forms(Forms),
+    {module, Mod} = code:load_binary(Mod, atom_to_list(Mod) ++ ".beam", Bin),
+    Mod.
 
 %% Mirror beamtalk_workspace_meta's metadata_path computation so tests check
 %% the same file the module would write to.
@@ -994,11 +1012,16 @@ set_git_toplevel_when_not_started_test() ->
 
 %%% Class source persistence round-trip (covers class_sources restore branch)
 
-class_source_survives_restart_test() ->
+%% BT-3108: a class_sources entry survives restore only when its class
+%% resolves to a currently-loaded module (here: an in-process gen_server
+%% restart, so the fake module stays loaded across it, same as a real .bt
+%% class would after a supervisor-restart rather than a full VM restart).
+class_source_survives_restart_when_module_loaded_test() ->
     stop_if_running(),
     WsId = <<"clssrc_", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
     MetaFile = metadata_path_for(WsId),
     _ = file:delete(MetaFile),
+    ModuleAtom = load_fake_class_module('Bt3108Foo'),
     try
         Init = #{
             workspace_id => WsId,
@@ -1006,12 +1029,126 @@ class_source_survives_restart_test() ->
             created_at => erlang:system_time(second)
         },
         {ok, Pid1} = beamtalk_workspace_meta:start_link(Init),
-        Source = "Object subclass: Foo [\n  bar => 1\n]\n",
-        ok = beamtalk_workspace_meta:set_class_source(<<"Foo">>, Source),
+        Source = "Object subclass: Bt3108Foo [\n  bar => 1\n]\n",
+        ok = beamtalk_workspace_meta:register_module(ModuleAtom),
+        ok = beamtalk_workspace_meta:set_class_source(<<"Bt3108Foo">>, Source),
         gen_server:stop(Pid1),
         timer:sleep(50),
         {ok, Pid2} = beamtalk_workspace_meta:start_link(Init),
-        ?assertEqual(Source, beamtalk_workspace_meta:get_class_source(<<"Foo">>)),
+        ?assertEqual(Source, beamtalk_workspace_meta:get_class_source(<<"Bt3108Foo">>)),
+        gen_server:stop(Pid2)
+    after
+        _ = file:delete(MetaFile),
+        _ = code:purge(ModuleAtom),
+        _ = code:delete(ModuleAtom)
+    end.
+
+%% BT-3108: a class_sources entry whose class never resolves to a loaded
+%% module (no register_module call, module never compiled/loaded this
+%% session) is dropped on restore rather than served as if still current.
+class_source_dropped_when_module_not_loaded_test() ->
+    stop_if_running(),
+    WsId = <<"clssrc_gone_", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
+    MetaFile = metadata_path_for(WsId),
+    _ = file:delete(MetaFile),
+    %% Ensure the class-name atom itself exists (so restore gets past
+    %% safe_existing_atom/1) without ever loading a module for it — isolates
+    %% "atom exists but module isn't loaded" from "atom never existed".
+    % elp:fixme W0023 intentional atom creation
+    ClassAtom = list_to_atom(
+        "Bt3108Gone" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    ClassBin = atom_to_binary(ClassAtom, utf8),
+    try
+        Init = #{
+            workspace_id => WsId,
+            project_path => <<"/bt_test/clssrc_gone">>,
+            created_at => erlang:system_time(second)
+        },
+        {ok, Pid1} = beamtalk_workspace_meta:start_link(Init),
+        Source = "Object subclass: " ++ atom_to_list(ClassAtom) ++ " [\n  bar => 1\n]\n",
+        ok = beamtalk_workspace_meta:set_class_source(ClassBin, Source),
+        gen_server:stop(Pid1),
+        timer:sleep(50),
+        {ok, Pid2} = beamtalk_workspace_meta:start_link(Init),
+        ?assertEqual(undefined, beamtalk_workspace_meta:get_class_source(ClassBin)),
+        gen_server:stop(Pid2)
+    after
+        _ = file:delete(MetaFile)
+    end.
+
+%% BT-3108: a class_sources entry whose backing .bt file was edited (mtime
+%% bumped) after metadata.json's own last-write snapshot is discarded on
+%% restore, even though its module is still loaded — the persisted text can
+%% no longer be trusted to match what's on disk.
+class_source_dropped_when_source_file_newer_than_snapshot_test() ->
+    stop_if_running(),
+    WsId = <<"clssrc_stale_", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
+    MetaFile = metadata_path_for(WsId),
+    _ = file:delete(MetaFile),
+    Tmp = filename:join(
+        temp_dir_meta(), "bt-meta-clssrc-" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    ok = filelib:ensure_path(Tmp),
+    SourceFile = filename:join(Tmp, "bt3108stale.bt"),
+    ModuleAtom = load_fake_class_module('Bt3108Stale'),
+    try
+        ok = file:write_file(SourceFile, <<"Object subclass: Bt3108Stale [\n  bar => 1\n]\n">>),
+        Init = #{
+            workspace_id => WsId,
+            project_path => <<"/bt_test/clssrc_stale">>,
+            created_at => erlang:system_time(second)
+        },
+        {ok, Pid1} = beamtalk_workspace_meta:start_link(Init),
+        Source = "Object subclass: Bt3108Stale [\n  bar => 1\n]\n",
+        ok = beamtalk_workspace_meta:register_module(ModuleAtom, SourceFile),
+        ok = beamtalk_workspace_meta:set_class_source(<<"Bt3108Stale">>, Source),
+        %% terminate/2 persists synchronously, so metadata.json's mtime is
+        %% pinned to "now" the moment gen_server:stop/1 returns.
+        gen_server:stop(Pid1),
+        timer:sleep(50),
+        %% Bump the source file's mtime strictly past metadata.json's.
+        {ok, MetaFileInfo} = file:read_file_info(MetaFile),
+        NewerMtime = calendar:gregorian_seconds_to_datetime(
+            calendar:datetime_to_gregorian_seconds(MetaFileInfo#file_info.mtime) + 10
+        ),
+        ok = file:write_file_info(SourceFile, MetaFileInfo#file_info{mtime = NewerMtime}),
+        {ok, Pid2} = beamtalk_workspace_meta:start_link(Init),
+        ?assertEqual(undefined, beamtalk_workspace_meta:get_class_source(<<"Bt3108Stale">>)),
+        gen_server:stop(Pid2)
+    after
+        _ = file:delete(MetaFile),
+        _ = file:del_dir_r(Tmp),
+        _ = code:purge(ModuleAtom),
+        _ = code:delete(ModuleAtom)
+    end.
+
+%%% BT-3108: loaded_modules entries are also validated against code:is_loaded
+%%% on restore, not just restored on the strength of their atom still existing.
+
+loaded_modules_dropped_when_module_not_loaded_test() ->
+    stop_if_running(),
+    WsId = <<"ldmod_gone_", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
+    MetaFile = metadata_path_for(WsId),
+    _ = file:delete(MetaFile),
+    % elp:fixme W0023 intentional atom creation
+    ModuleAtom = list_to_atom(
+        "bt3108_unloaded_" ++ integer_to_list(erlang:unique_integer([positive]))
+    ),
+    try
+        Init = #{
+            workspace_id => WsId,
+            project_path => <<"/bt_test/ldmod_gone">>,
+            created_at => erlang:system_time(second)
+        },
+        {ok, Pid1} = beamtalk_workspace_meta:start_link(Init),
+        %% Registered, but no module code was ever compiled/loaded for this atom.
+        ok = beamtalk_workspace_meta:register_module(ModuleAtom),
+        gen_server:stop(Pid1),
+        timer:sleep(50),
+        {ok, Pid2} = beamtalk_workspace_meta:start_link(Init),
+        {ok, Modules} = beamtalk_workspace_meta:loaded_modules(),
+        ?assertNot(lists:keymember(ModuleAtom, 1, Modules)),
         gen_server:stop(Pid2)
     after
         _ = file:delete(MetaFile)


### PR DESCRIPTION
## Summary
- Removes `store_state_in_ets/1` and the write-only `{metadata, #state{}}` ETS mirror. Nothing in-tree read that row (every public getter goes through `gen_server:call`); the separately-keyed git-toplevel row, which is read on the `git_status` hot path, is retained
- On restore from `metadata.json`, `class_sources` entries are dropped unless their class's module is currently loaded and the on-disk source file is not newer than the persisted snapshot (`metadata.json`'s own mtime stands in for "as of this snapshot")
- `loaded_modules` entries are similarly kept only if the module is currently loaded — mirroring the `file_mtimes` reset rationale so a stale restored entry is never served as current

## Test plan
- [x] EUnit: restart with a stale persisted `class_sources` entry → the stale text is not served to `get_class_source/1`
- [x] `just test` — full suite green (Rust, stdlib, BUnit, Erlang runtime unit tests)
- [x] `just ci` (via pre-push hook) — clippy, dialyzer, formatting all pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrSTdNT5xJQeXMv39YkELU)_