### PR TITLE
BT-3107: Single write path for class metadata (merge API, one superclass source)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
@@ -22,7 +22,7 @@ that the Behaviour/Class libraries can rely on.
 
 | Erlang function             | Backing data source / derivation                          |
 |-----------------------------|------------------------------------------------------------|
-| classSuperclass/1           | Direct superclass from class gen_server state             |
+| classSuperclass/1           | Direct superclass from unified class metadata (ETS, BT-3107) |
 | classAllSuperclasses/1      | Recursively walks the superclass chain from classSuperclass/1 |
 | classSubclasses/1           | Direct subclasses from class registry                     |
 | classAllSubclasses/1        | All subclasses from class registry                        |
@@ -108,8 +108,11 @@ ADR 0032: Returns a proper #beamtalk_object{} instead of a bare atom,
 fixing the inconsistency where `Counter class` returned an object but
 `Counter superclass` returned an atom.
 
-BT-942: Uses __beamtalk_meta/0 when available; falls back to gen_server
-for dynamic classes created via beamtalk_class_builder.
+BT-942: Uses __beamtalk_meta/0 when available; falls back to the
+deadlock-safe metadata lookup (`beamtalk_object_class:superclass_safe/1`,
+BT-3107) for dynamic classes created via beamtalk_class_builder — the same
+ETS source `beamtalk_class_dispatch` reads, instead of a separate
+`gen_server:call` that could disagree with it mid-reload.
 """.
 -spec classSuperclass(#beamtalk_object{}) -> #beamtalk_object{} | 'nil'.
 classSuperclass(Self) ->
@@ -120,7 +123,7 @@ classSuperclass(Self) ->
             {ok, Meta} ->
                 maps:get(superclass, Meta);
             not_available ->
-                case gen_server:call(ClassPid, superclass) of
+                case beamtalk_object_class:superclass_safe(ClassPid) of
                     none -> nil;
                     Name -> Name
                 end
@@ -211,7 +214,8 @@ the same Class/Behaviour/Object protocol).
 -spec classAllSuperclasses(#beamtalk_object{}) -> [#beamtalk_object{}].
 classAllSuperclasses(#beamtalk_object{class = 'Metaclass', pid = ClassPid}) ->
     %% BT-2194: walk the parallel metaclass hierarchy (returns metaclass objects).
-    SuperName = gen_server:call(ClassPid, superclass),
+    %% BT-3107: deadlock-safe metadata lookup, same source dispatch reads.
+    SuperName = beamtalk_object_class:superclass_safe(ClassPid),
     MetaSupers = walk_hierarchy(
         SuperName,
         fun(_CN, CPid, Acc) ->
@@ -239,7 +243,8 @@ classAllSuperclasses(#beamtalk_object{class = 'Metaclass', pid = ClassPid}) ->
     lists:reverse(MetaSupers) ++ lists:reverse(InstanceSupers);
 classAllSuperclasses(Self) ->
     ClassPid = erlang:element(4, Self),
-    SuperName = gen_server:call(ClassPid, superclass),
+    %% BT-3107: deadlock-safe metadata lookup, same source dispatch reads.
+    SuperName = beamtalk_object_class:superclass_safe(ClassPid),
     Supers = walk_hierarchy(
         SuperName,
         fun(CN, CPid, Acc) ->
@@ -1046,12 +1051,16 @@ ADR 0036: Backs `@primitive "metaclassSuperclass"` in Metaclass.bt.
 The superclass of Counter's metaclass is the metaclass of Counter's superclass.
 Example: `Counter class superclass == Actor class`.
 
-BT-1186: Now uses gen_server:call(Pid, superclass) directly. BT-1185 fixed
-apply_class_info/2 to update the gen_server superclass from __beamtalk_meta/0,
-so the gen_server always holds the correct superclass.
+BT-1186: Previously used gen_server:call(Pid, superclass) directly (BT-1185
+fixed apply_class_info/2 to update the gen_server superclass from
+__beamtalk_meta/0, so the gen_server always held the correct superclass).
+
+BT-3107: Now uses `beamtalk_object_class:superclass_safe/1` — the same
+unified-metadata ETS source `beamtalk_class_dispatch` reads — instead of a
+separate `gen_server:call`, so this and dispatch can never disagree mid-reload.
 
 BT-2217: Grounds the parallel chain at `ProtoObject class superclass == Class`
-(ADR 0036). When the gen_server reports no superclass, return the instance-side
+(ADR 0036). When the lookup reports no superclass, return the instance-side
 `Class` class object. From there, subsequent `superclass` sends route through
 the regular instance-side dispatch (`classSuperclass`), unfolding
 `Class → Behaviour → Object → ProtoObject` via the standard walker. `Class`
@@ -1061,7 +1070,7 @@ in that case, preserving the pre-grounding behaviour.
 -spec metaclassSuperclass(#beamtalk_object{}) -> #beamtalk_object{} | 'nil'.
 metaclassSuperclass(Self) ->
     Pid = erlang:element(4, Self),
-    case gen_server:call(Pid, superclass) of
+    case beamtalk_object_class:superclass_safe(Pid) of
         none ->
             atom_to_class_object('Class');
         SuperName ->
@@ -1237,7 +1246,9 @@ walk_hierarchy(ClassName, Fun, Acc) ->
                     {halt, Result} ->
                         {found, {result, Result}};
                     {cont, NewAcc} ->
-                        case gen_server:call(ClassPid, superclass) of
+                        %% BT-3107: deadlock-safe metadata lookup, same source
+                        %% dispatch reads, instead of a separate gen_server:call.
+                        case beamtalk_object_class:superclass_safe(ClassPid) of
                             none -> {found, {result, NewAcc}};
                             Super -> {next, {Super, NewAcc}}
                         end

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_metadata.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_metadata.erl
@@ -60,6 +60,7 @@ a table deleted between an existence check and the op (teardown/shutdown).
 -export([
     new/0,
     insert/5,
+    merge_identity/5,
     delete/1,
     lookup_module/1,
     lookup_methods/1,
@@ -74,7 +75,8 @@ a table deleted between an existence check and the op (teardown/shutdown).
     lookup_class_method_fun/2,
     delete_class_method_funs/1,
     has_runtime_class_methods/1,
-    set_runtime_class_methods/2
+    set_runtime_class_methods/2,
+    reset_runtime_class_methods/1
 ]).
 
 -define(TABLE, beamtalk_class_metadata).
@@ -159,15 +161,23 @@ ensure_table(Table, Opts) ->
 %%====================================================================
 
 -doc """
-Insert or overwrite the **entire** metadata row for a class.
+Insert or overwrite the **entire** metadata row for a class — row *creation*.
 
 This is a full-row write, not a per-field merge: every call replaces all of
-`module`, `selectors`, `superclass`, and `is_abstract`. The class gen_server
-always supplies all four together (`init`/`update_class`), so the write is
-atomic for readers. Do NOT call this to update a single field — the others
-would be wiped. Pass `undefined` only to leave a field genuinely unset (used by
-tests that exercise one field in isolation, and by callers that don't know
-`is_abstract` — BT-3047 / ADR 0109 amendment).
+`module`, `selectors`, `superclass`, `is_abstract`, **and resets
+`has_runtime_class_methods` to `false`**. The class gen_server calls this only
+from `init/1`, where the row is genuinely new (or being recreated after
+teardown), so resetting the gate is correct — a brand-new row has no runtime
+funs installed yet. Pass `undefined` only to leave a field genuinely unset
+(used by tests that exercise one field in isolation, and by callers that don't
+know `is_abstract` — BT-3047 / ADR 0109 amendment).
+
+BT-3107: do NOT call this to update an **existing** row — besides wiping any
+field you don't pass explicitly, it silently drops
+`has_runtime_class_methods`, discarding every runtime class method unless the
+caller remembers a follow-up `seed_runtime_class_methods/2` (the documented
+footgun this issue closed). Use `merge_identity/5` for updating an existing
+row instead; it never touches the gate.
 """.
 -spec insert(
     class_name(),
@@ -195,6 +205,58 @@ insert(Name, Module, Selectors, Superclass, IsAbstract) ->
             new(),
             ets:insert(?TABLE, Row),
             ok
+    end.
+
+-doc """
+Merge identity fields into an **existing** metadata row — row *update*.
+
+BT-3107: per-field update of `module`, `selectors`, `superclass`, and
+`is_abstract` via `ets:update_element/3`; unlike `insert/5` it never touches
+`has_runtime_class_methods`, so a caller that reloads a class's identity
+cannot accidentally wipe its runtime class methods by forgetting a follow-up
+`seed_runtime_class_methods/2` call. A caller that genuinely needs to drop the
+gate (e.g. because it just purged the funs table via
+`delete_class_method_funs/1`) must say so explicitly via
+`reset_runtime_class_methods/1` — the two are never an implicit side effect of
+each other.
+
+Falls back to a full `insert/5` (gate defaults to `false`) if no row exists
+yet for `Name` — the reload path this backs (`beamtalk_object_class:
+apply_class_info/2`) always has a row already (the class went through
+`init/1`), but this keeps the function correct standalone and in tests.
+""".
+-spec merge_identity(
+    class_name(),
+    module() | undefined,
+    [selector()] | undefined,
+    superclass() | undefined,
+    boolean() | undefined
+) ->
+    ok.
+merge_identity(Name, Module, Selectors, Superclass, IsAbstract) ->
+    new(),
+    %% ets:update_element/3 does NOT raise on a missing key — it returns
+    %% `false` (only a missing/unwritable *table* raises badarg) — so the
+    %% fallback to row creation must branch on the boolean return, not on a
+    %% caught exception.
+    try
+        ets:update_element(?TABLE, Name, [
+            {#class_metadata.module, Module},
+            {#class_metadata.selectors, Selectors},
+            {#class_metadata.superclass, Superclass},
+            {#class_metadata.is_abstract, IsAbstract}
+        ])
+    of
+        true ->
+            ok;
+        false ->
+            %% No existing row — fall back to row creation. A brand-new row
+            %% has no funs to preserve, so insert/5's gate reset is correct.
+            insert(Name, Module, Selectors, Superclass, IsAbstract)
+    catch
+        error:badarg ->
+            %% Table vanished between new/0 and the update — recreate via insert/5.
+            insert(Name, Module, Selectors, Superclass, IsAbstract)
     end.
 
 -doc """
@@ -489,6 +551,28 @@ set_runtime_class_methods(Name, Selectors) ->
         ets:update_element(?TABLE, Name, [
             {#class_metadata.selectors, Selectors},
             {#class_metadata.has_runtime_class_methods, true}
+        ]),
+        ok
+    catch
+        error:badarg -> ok
+    end.
+
+-doc """
+Explicitly clear the "has runtime class methods" gate, independent of any
+other field.
+
+BT-3107: pairs with `delete_class_method_funs/1` when purging a class's funs
+table ahead of a reload — together they are the reload path's explicit,
+self-documenting substitute for `insert/5`'s old implicit reset via full-row
+overwrite (see `merge_identity/5`, which deliberately leaves the gate alone).
+A no-op if the row is absent.
+""".
+-spec reset_runtime_class_methods(class_name()) -> ok.
+reset_runtime_class_methods(Name) ->
+    new(),
+    try
+        ets:update_element(?TABLE, Name, [
+            {#class_metadata.has_runtime_class_methods, false}
         ]),
         ok
     catch

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_registry.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_registry.erl
@@ -21,7 +21,7 @@ Extracted from `beamtalk_object_class` (BT-576) for single-responsibility.
 - Class hierarchy ETS table management
 - Inheritance queries (inherits_from/2)
 - Class object identity checks (is_class_object/1, is_class_name/1)
-- Flattened method table invalidation broadcasts
+- Class-redefinition collision-warning tracking (record/drain)
 """.
 
 -include("beamtalk.hrl").
@@ -293,6 +293,14 @@ BT-737: Called by the REPL load handler after loading a file, to collect
 warnings and surface them to the client. Removes entries from the table.
 BT-742: Drains ALL packages for each class name. Use
 drain_class_warnings_by_qualified_names/1 for per-package precision.
+
+BT-3107: Non-atomic (`match_object` then `delete_object`) — a concurrent
+insert landing between the two survives, unlike
+`drain_class_warnings_by_qualified_names/1`'s atomic `ets:take/2`. Acceptable
+here because "ALL packages for a class name" is inherently a wider,
+best-effort sweep (the caller already can't pin down which package's warning
+it wants); a warning added mid-drain is picked up by the next drain instead of
+being dropped.
 """.
 -spec drain_class_warnings_by_names([atom()]) -> [{atom(), atom(), atom()}].
 drain_class_warnings_by_names(ClassNames) ->
@@ -325,6 +333,11 @@ Drain collision warnings for the given {Package, ClassName} pairs.
 BT-742: Package-aware drain that only removes warnings for the specified
 package, leaving other packages' warnings intact. Use this from reload
 handlers where the package context is known.
+
+BT-3107: Atomic (`ets:take/2`) — stronger than
+`drain_class_warnings_by_names/1`'s match-then-delete, since the package
+context here is precise enough that a concurrent insert for the same
+{Package, ClassName} key should not silently survive the drain.
 """.
 -spec drain_class_warnings_by_qualified_names([{atom() | undefined, atom()}]) ->
     [{atom(), atom(), atom()}].

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
@@ -49,6 +49,7 @@ and join the `beamtalk_classes` pg group for enumeration.
     class_name/1,
     module_name/1,
     module_name_safe/1,
+    superclass_safe/1,
     class_send/3,
     local_call/3,
     set_class_var/3,
@@ -277,6 +278,36 @@ module_name_safe(ClassPid) ->
     end.
 
 -doc """
+Get the superclass, preferring a deadlock-safe metadata lookup (BT-3107).
+
+Mirrors `module_name_safe/1` (BT-3054): resolves via
+`beamtalk_class_registry:class_name_for_pid/1` (a pure ETS reverse lookup, no
+message send) followed by `beamtalk_class_metadata:lookup_superclass/1` — the
+same ETS row `beamtalk_class_dispatch` reads on the dispatch hot path, kept in
+sync with the process dictionary by `sync_identity/6` at every `init/1` and
+`apply_class_info/2`. Falls back to `superclass/1`'s `gen_server:call` only if
+either lookup misses.
+
+Before BT-3107, `beamtalk_behaviour_intrinsics` read the superclass via
+`gen_server:call(ClassPid, superclass)` — a second, independent source from
+the one dispatch uses, which could disagree with it mid-reload (ADR 0057).
+Prefer this function at any reflection/hierarchy-walk call site instead.
+""".
+-spec superclass_safe(pid()) -> class_name() | none.
+superclass_safe(ClassPid) when ClassPid =:= self() ->
+    get(beamtalk_class_superclass);
+superclass_safe(ClassPid) ->
+    case beamtalk_class_registry:class_name_for_pid(ClassPid) of
+        {ok, ClassName} ->
+            case beamtalk_class_metadata:lookup_superclass(ClassName) of
+                {ok, Super} -> Super;
+                not_found -> superclass(ClassPid)
+            end;
+        not_found ->
+            superclass(ClassPid)
+    end.
+
+-doc """
 Send a message to a class object synchronously (BT-246 / ADR 0013 Phase 1).
 
 Delegates to beamtalk_class_dispatch (BT-704).
@@ -497,15 +528,27 @@ init({ClassName, ClassInfo}) ->
         maps:get(class_methods, ClassInfo, #{})
     ),
 
-    %% BT-2222: One unified metadata row carries hierarchy + module + class-method
-    %% selectors. The module name enables deadlock-free lookup during supervisor
-    %% init (BT-1285); the selector set lets the inherited class-method chain walk
-    %% in beamtalk_class_dispatch avoid gen_server hops (BT-2008). BT-3047 / ADR
-    %% 0109 amendment: is_abstract rides along so instantiation intrinsics can
-    %% look it up by class name too, without a gen_server hop.
-    beamtalk_class_metadata:insert(
-        ClassName, Module, maps:keys(ClassMethods), Superclass, IsAbstract
-    ),
+    %% BT-893: Store class metadata in process dictionary so class_send can
+    %% bypass gen_server for self-calls (new/spawn from within class methods).
+    put(beamtalk_class_name, ClassName),
+    %% BT-2222 / BT-3107: One unified metadata row carries hierarchy + module +
+    %% class-method selectors, written together with the matching PD caches by
+    %% sync_identity/6. The module name enables deadlock-free lookup during
+    %% supervisor init (BT-1285); the selector set lets the inherited
+    %% class-method chain walk in beamtalk_class_dispatch avoid gen_server hops
+    %% (BT-2008). BT-3047 / ADR 0109 amendment: is_abstract rides along so
+    %% instantiation intrinsics can look it up by class name too, without a
+    %% gen_server hop.
+    sync_identity(ClassName, Module, Superclass, IsAbstract, maps:keys(ClassMethods), create),
+
+    %% BT-3107: Clear any runtime class-method funs left behind by a *hard*
+    %% crash of the previous incarnation of this class process — a hard crash
+    %% skips terminate/2 (see module_name_safe/1's doc), so the funs table rows
+    %% from before the crash can otherwise survive into the restarted process
+    %% even though sync_identity/6 above just created a fresh row with the gate
+    %% off. Mirrors the reload path in apply_class_info/2. A no-op for a class
+    %% that never crashed (nothing to clear).
+    beamtalk_class_metadata:delete_class_method_funs(ClassName),
 
     %% ADR 0084 / BT-2266: Seed the runtime class-method fun retrieval store for
     %% any builder-supplied class methods that arrived as funs (#{block, arity}).
@@ -513,25 +556,20 @@ init({ClassName, ClassInfo}) ->
     %% their dispatch never reads the funs table.
     seed_runtime_class_methods(ClassName, ClassMethods),
 
-    %% BT-893: Store class metadata in process dictionary so class_send can
-    %% bypass gen_server for self-calls (new/spawn from within class methods).
-    put(beamtalk_class_name, ClassName),
-    put(beamtalk_class_module, Module),
-    put(beamtalk_class_is_abstract, IsAbstract),
     %% BT-2275: Cache field defaults in the process dictionary so the `self new`
     %% self-instantiation path (which runs inside this gen_server) can build a
     %% generic instance for a module-less class without a gen_server:call to self.
     FieldDefaults = maps:get(field_defaults, ClassInfo, #{}),
     put(beamtalk_class_field_defaults, FieldDefaults),
-    %% BT-2277: Cache the local instance-method map and superclass so fun-backed
-    %% instance dispatch that happens *inside* this gen_server (e.g. a class method
-    %% does `Inst := self new` then `Inst someMethod`) can resolve the block fun
-    %% without a deadlocking `gen_server:call(self(), ...)`. The cache is the local
-    %% (non-inherited) methods only; inherited methods live in ancestor processes
-    %% and are reachable without deadlock. Kept in sync by the {put_method, ...}
-    %% handler so hot-patched methods stay visible to self-dispatch.
+    %% BT-2277: Cache the local instance-method map so fun-backed instance
+    %% dispatch that happens *inside* this gen_server (e.g. a class method does
+    %% `Inst := self new` then `Inst someMethod`) can resolve the block fun
+    %% without a deadlocking `gen_server:call(self(), ...)`. The cache is the
+    %% local (non-inherited) methods only; inherited methods live in ancestor
+    %% processes and are reachable without deadlock. Kept in sync by the
+    %% {put_method, ...} handler so hot-patched methods stay visible to
+    %% self-dispatch.
     put(beamtalk_class_instance_methods, InstanceMethods),
-    put(beamtalk_class_superclass, Superclass),
 
     %% BT-1768: Record pid→classname mapping for crash recovery.
     %% This entry survives process death, allowing class_send to identify
@@ -1517,6 +1555,51 @@ meta_to_methods(MetaMethodInfo, _FallbackMethods) when is_map(MetaMethodInfo) ->
     {MetaMethodInfo, ReturnTypes}.
 
 -doc """
+Write a class's identity facts — module, superclass, is_abstract, and local
+class-method selectors — to the process-dictionary caches and the unified
+`beamtalk_class_metadata` ETS row in one place (BT-3107).
+
+`init/1` and `apply_class_info/2` used to each perform these writes via
+several separate `put/2` calls plus a trailing
+`beamtalk_class_metadata:insert/5`, spread across many lines with unrelated
+code in between — a mid-function reader (dispatch, reflection, a hot-patch
+racing the same class process) could observe the PD and ETS copies
+disagreeing. Routing both call sites through this one function collapses that
+window to this call's own internal ordering (PD first — the self-view used by
+self-dispatch inside this gen_server — ETS last, published for other
+processes), so a future edit cannot silently reintroduce "module written
+here, superclass written 40 lines later" drift.
+
+`Mode` selects the ETS write:
+
+* `create` — `beamtalk_class_metadata:insert/5`, a full fresh row. Used by
+  `init/1`; `has_runtime_class_methods` starts `false` (a brand-new row has
+  no funs yet — the caller's own `seed_runtime_class_methods/2` call raises
+  the gate afterward if needed).
+* `merge` — `beamtalk_class_metadata:merge_identity/5`, a per-field update
+  that leaves `has_runtime_class_methods` untouched. Used by
+  `apply_class_info/2`'s reload path; a caller that needs to drop the gate
+  (e.g. because it just purged the funs table) must call
+  `beamtalk_class_metadata:reset_runtime_class_methods/1` explicitly rather
+  than relying on this call's side effect.
+""".
+-spec sync_identity(
+    class_name(), atom(), class_name() | none, boolean(), [selector()], create | merge
+) -> ok.
+sync_identity(ClassName, Module, Superclass, IsAbstract, Selectors, Mode) ->
+    put(beamtalk_class_module, Module),
+    put(beamtalk_class_is_abstract, IsAbstract),
+    put(beamtalk_class_superclass, Superclass),
+    case Mode of
+        create ->
+            beamtalk_class_metadata:insert(ClassName, Module, Selectors, Superclass, IsAbstract);
+        merge ->
+            beamtalk_class_metadata:merge_identity(
+                ClassName, Module, Selectors, Superclass, IsAbstract
+            )
+    end.
+
+-doc """
 Seed the runtime class-method fun retrieval store from a class_methods map.
 
 ADR 0084 / BT-2266: picks out the entries that carry a `block` (runtime/builder
@@ -1621,9 +1704,10 @@ ADR 0050 Phase 5: Static metadata read from __beamtalk_meta/0 on the new module.
 """.
 -spec apply_class_info(#class_state{}, map()) -> #class_state{}.
 apply_class_info(State, ClassInfo) ->
-    %% BT-893: Keep process dictionary in sync with state for self-instantiation.
+    %% BT-893: NewModule/NewIsAbstract/NewSuperclass are written to the process
+    %% dictionary together with the ETS metadata row, in one place, by
+    %% sync_identity/6 below (BT-3107) — not here.
     NewModule = maps:get(module, ClassInfo, State#class_state.module),
-    put(beamtalk_class_module, NewModule),
 
     %% ADR 0050 Phase 5: Prefer meta from ClassInfo when available (same reason as init/1:
     %% erlang:function_exported/3 returns false during on_load, so read_meta/1 returns #{}).
@@ -1638,7 +1722,6 @@ apply_class_info(State, ClassInfo) ->
         Meta,
         maps:get(is_abstract, ClassInfo, State#class_state.is_abstract)
     ),
-    put(beamtalk_class_is_abstract, NewIsAbstract),
 
     %% BT-2275: Reconcile field defaults on reload (ADR 0082 "disk wins").
     %% A compiled reload supplies no field_defaults (defaults are baked into the
@@ -1686,27 +1769,33 @@ apply_class_info(State, ClassInfo) ->
             %% corrected value from compiled module
             {ok, S} -> S
         end,
-    %% BT-2277: Reconcile the self-dispatch caches on reload, mirroring the
-    %% field-defaults handling above so fun-backed instance dispatch from inside
-    %% the class process resolves against the current method set / hierarchy.
+    %% BT-2277: Reconcile the self-dispatch instance-method cache on reload,
+    %% mirroring the field-defaults handling above so fun-backed instance
+    %% dispatch from inside the class process resolves against the current
+    %% method set. (Superclass/module/is_abstract PD caches are written by
+    %% sync_identity/6 below, together with the ETS row.)
     put(beamtalk_class_instance_methods, NewInstanceMethods),
-    put(beamtalk_class_superclass, NewSuperclass),
-    %% BT-2222: Single metadata-row update keeps hierarchy + module + selectors in
-    %% sync on hot reload (all three may change: new superclass, recompiled module,
-    %% added class methods).
+    %% BT-2222 / BT-3107: One call writes module + superclass + is_abstract +
+    %% selectors to both the process dictionary and the unified metadata row,
+    %% so dispatch/reflection never observe them at different points mid-reload
+    %% (all four may change: new superclass, recompiled module, added class
+    %% methods).
     %%
     %% ADR 0084 / BT-2266: reload is memory-vs-disk reconciliation (ADR 0082) —
-    %% disk wins. Purge stale runtime class-method funs, then insert (which resets
-    %% the gate flag to false), then re-seed from the incoming class methods. A
-    %% pure compiled reload thus drops runtime funs; a builder re-register that
-    %% supplies funs re-installs them.
+    %% disk wins. Purge stale runtime class-method funs and explicitly reset the
+    %% gate (BT-3107: no longer an implicit side effect of a full-row
+    %% overwrite — merge_identity/5 below leaves it alone), then re-seed from
+    %% the incoming class methods. A pure compiled reload thus drops runtime
+    %% funs; a builder re-register that supplies funs re-installs them.
     beamtalk_class_metadata:delete_class_method_funs(State#class_state.name),
-    beamtalk_class_metadata:insert(
+    beamtalk_class_metadata:reset_runtime_class_methods(State#class_state.name),
+    sync_identity(
         State#class_state.name,
         NewModule,
-        maps:keys(NewClassMethods),
         NewSuperclass,
-        NewIsAbstract
+        NewIsAbstract,
+        maps:keys(NewClassMethods),
+        merge
     ),
     seed_runtime_class_methods(State#class_state.name, NewClassMethods),
 

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_metadata_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_metadata_tests.erl
@@ -339,6 +339,124 @@ delete_row_purges_funs_test() ->
     end).
 
 %%====================================================================
+%% merge_identity/5 + reset_runtime_class_methods/1 (BT-3107)
+%%====================================================================
+
+%% merge_identity/5 updates the identity fields exactly like insert/5 would.
+merge_identity_updates_identity_fields_test() ->
+    with_clean_tables(fun() ->
+        ok = beamtalk_class_metadata:insert('Reload', old_mod, [a], 'Object', undefined),
+        ok = beamtalk_class_metadata:merge_identity('Reload', new_mod, [a, b], 'Value', true),
+        ?assertEqual({ok, new_mod}, beamtalk_class_metadata:lookup_module('Reload')),
+        ?assertEqual({ok, new_mod, [a, b]}, beamtalk_class_metadata:lookup_methods('Reload')),
+        ?assertEqual({ok, 'Value'}, beamtalk_class_metadata:lookup_superclass('Reload')),
+        ?assertEqual({ok, true}, beamtalk_class_metadata:lookup_is_abstract('Reload'))
+    end).
+
+%% Unlike insert/5, merge_identity/5 never resets has_runtime_class_methods —
+%% this is the core BT-3107 guarantee: a reload that goes through
+%% merge_identity/5 cannot silently drop runtime class methods just because it
+%% forgot to re-seed them afterward.
+merge_identity_preserves_runtime_class_methods_gate_test() ->
+    with_clean_tables(fun() ->
+        ok = beamtalk_class_metadata:insert('Preserved', m, [], 'Object', undefined),
+        Info = #{block => fun(_, CV) -> CV end, arity => 2},
+        ok = beamtalk_class_metadata:put_class_method_fun('Preserved', bump, Info),
+        ok = beamtalk_class_metadata:set_runtime_class_methods('Preserved', [bump]),
+        ?assert(beamtalk_class_metadata:has_runtime_class_methods('Preserved')),
+        %% Update identity fields only — no re-seed call at all.
+        ok = beamtalk_class_metadata:merge_identity('Preserved', m2, [bump], 'Value', false),
+        ?assert(beamtalk_class_metadata:has_runtime_class_methods('Preserved')),
+        ?assertEqual(
+            {ok, Info}, beamtalk_class_metadata:lookup_class_method_fun('Preserved', bump)
+        ),
+        ?assertEqual({ok, m2}, beamtalk_class_metadata:lookup_module('Preserved')),
+        ?assertEqual({ok, 'Value'}, beamtalk_class_metadata:lookup_superclass('Preserved'))
+    end).
+
+%% merge_identity/5 falls back to a full-row create when no row exists yet.
+merge_identity_creates_row_when_absent_test() ->
+    with_clean_tables(fun() ->
+        ?assertEqual(not_found, beamtalk_class_metadata:lookup_module('Fresh')),
+        ok = beamtalk_class_metadata:merge_identity('Fresh', m, [a], 'Object', false),
+        ?assertEqual({ok, m}, beamtalk_class_metadata:lookup_module('Fresh')),
+        ?assertEqual({ok, m, [a]}, beamtalk_class_metadata:lookup_methods('Fresh')),
+        ?assertNot(beamtalk_class_metadata:has_runtime_class_methods('Fresh'))
+    end).
+
+%% reset_runtime_class_methods/1 explicitly clears the gate without touching
+%% the other identity fields.
+reset_runtime_class_methods_clears_gate_only_test() ->
+    with_clean_tables(fun() ->
+        ok = beamtalk_class_metadata:insert('Reset', m, [], 'Object', true),
+        Info = #{block => fun(_, CV) -> CV end, arity => 2},
+        ok = beamtalk_class_metadata:put_class_method_fun('Reset', bump, Info),
+        ok = beamtalk_class_metadata:set_runtime_class_methods('Reset', [bump]),
+        ?assert(beamtalk_class_metadata:has_runtime_class_methods('Reset')),
+        ok = beamtalk_class_metadata:reset_runtime_class_methods('Reset'),
+        ?assertNot(beamtalk_class_metadata:has_runtime_class_methods('Reset')),
+        %% Other fields are untouched by the reset.
+        ?assertEqual({ok, m}, beamtalk_class_metadata:lookup_module('Reset')),
+        ?assertEqual({ok, 'Object'}, beamtalk_class_metadata:lookup_superclass('Reset')),
+        ?assertEqual({ok, true}, beamtalk_class_metadata:lookup_is_abstract('Reset'))
+    end).
+
+%% reset_runtime_class_methods/1 is a no-op when the row is absent.
+reset_runtime_class_methods_when_row_absent_test() ->
+    with_clean_tables(fun() ->
+        ?assertEqual(ok, beamtalk_class_metadata:reset_runtime_class_methods('NeverSeen'))
+    end).
+
+%% The reload sequence this issue was written for: purge funs, explicitly
+%% reset the gate, merge in new identity, re-seed from the new class methods —
+%% mirrors beamtalk_object_class:apply_class_info/2's actual call order.
+%% Verifies the reload path preserves runtime class methods without relying on
+%% any particular ordering between the merge and the re-seed (BT-3107 AC).
+reload_sequence_preserves_and_replaces_runtime_class_methods_test() ->
+    with_clean_tables(fun() ->
+        ok = beamtalk_class_metadata:insert('Live', m, [bump], 'Object', undefined),
+        OldInfo = #{block => fun(_, CV) -> CV end, arity => 2},
+        ok = beamtalk_class_metadata:put_class_method_fun('Live', bump, OldInfo),
+        ok = beamtalk_class_metadata:set_runtime_class_methods('Live', [bump]),
+        ?assert(beamtalk_class_metadata:has_runtime_class_methods('Live')),
+
+        %% Reload with a *new* runtime fun for the same selector (as
+        %% seed_runtime_class_methods/2 would do from beamtalk_object_class).
+        NewInfo = #{block => fun(_, CV) -> CV end, arity => 2},
+        ok = beamtalk_class_metadata:delete_class_method_funs('Live'),
+        ok = beamtalk_class_metadata:reset_runtime_class_methods('Live'),
+        ok = beamtalk_class_metadata:merge_identity('Live', m2, [bump], 'Object', false),
+        ok = beamtalk_class_metadata:put_class_method_fun('Live', bump, NewInfo),
+        ok = beamtalk_class_metadata:set_runtime_class_methods('Live', [bump]),
+
+        ?assert(beamtalk_class_metadata:has_runtime_class_methods('Live')),
+        ?assertEqual({ok, NewInfo}, beamtalk_class_metadata:lookup_class_method_fun('Live', bump)),
+        ?assertEqual({ok, m2}, beamtalk_class_metadata:lookup_module('Live'))
+    end).
+
+%% A reload with no runtime funs in the new definition correctly drops the
+%% gate (the explicit reset_runtime_class_methods/1 call does this — no
+%% seed_runtime_class_methods/2 call follows since there are no funs to seed).
+reload_sequence_drops_gate_when_no_new_funs_test() ->
+    with_clean_tables(fun() ->
+        ok = beamtalk_class_metadata:insert('WasRuntime', m, [bump], 'Object', undefined),
+        OldInfo = #{block => fun(_, CV) -> CV end, arity => 2},
+        ok = beamtalk_class_metadata:put_class_method_fun('WasRuntime', bump, OldInfo),
+        ok = beamtalk_class_metadata:set_runtime_class_methods('WasRuntime', [bump]),
+        ?assert(beamtalk_class_metadata:has_runtime_class_methods('WasRuntime')),
+
+        %% Reload with a pure compiled class method (no `block` — not a
+        %% runtime fun), so nothing re-seeds the gate.
+        ok = beamtalk_class_metadata:delete_class_method_funs('WasRuntime'),
+        ok = beamtalk_class_metadata:reset_runtime_class_methods('WasRuntime'),
+        ok = beamtalk_class_metadata:merge_identity('WasRuntime', m2, [bump], 'Object', false),
+
+        ?assertNot(beamtalk_class_metadata:has_runtime_class_methods('WasRuntime')),
+        ?assertEqual(error, beamtalk_class_metadata:lookup_class_method_fun('WasRuntime', bump)),
+        ?assertEqual({ok, m2}, beamtalk_class_metadata:lookup_module('WasRuntime'))
+    end).
+
+%%====================================================================
 %% all_builtins
 %%====================================================================
 


### PR DESCRIPTION
## Summary
- `beamtalk_class_metadata:merge_identity/5` (new) does a per-field `ets:update_element/3` update of an existing row without touching `has_runtime_class_methods`, replacing `insert/5`'s old implicit-overwrite footgun for reload call sites. `reset_runtime_class_methods/1` (new) makes dropping the gate an explicit, separate call
- `beamtalk_object_class:sync_identity/6` (new) is the single call site that writes module/superclass/is_abstract/selectors to both the process dictionary and the ETS row together, used by both `init/1` (create mode) and `apply_class_info/2` (merge mode)
- `beamtalk_object_class:superclass_safe/1` (new) resolves superclass via the same `beamtalk_class_metadata` ETS row `beamtalk_class_dispatch` reads. `beamtalk_behaviour_intrinsics`'s reflection call sites (`classSuperclass`, `classAllSuperclasses`, `metaclassSuperclass`, `walk_hierarchy`) now use it instead of a separate `gen_server:call(Pid, superclass)`, closing the two-source-of-truth gap
- `init/1` now clears stale `beamtalk_class_method_funs` rows via `delete_class_method_funs/1` before seeding, giving crash-restart parity with the reload path (which already did this)
- `beamtalk_class_registry.erl`: stale flattened-method-table moduledoc replaced; documented the differing atomicity guarantee between `drain_class_warnings_by_names/1` (match-then-delete) and `drain_class_warnings_by_qualified_names/1` (atomic `ets:take/2`)

## Test plan
- [x] EUnit: reload path preserves runtime class methods without an explicit re-seed ordering dependency
- [x] `just test` — full suite green (Rust, stdlib, BUnit, Erlang runtime unit tests)
- [x] `just ci` (via pre-push hook) — clippy, dialyzer, formatting all pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrSTdNT5xJQeXMv39YkELU)_