### PR TITLE
Key Pass1Cache and change detection on content hash instead of mtime (BT-3120)

### DIFF
--- a/crates/beamtalk-cli/src/commands/build.rs
+++ b/crates/beamtalk-cli/src/commands/build.rs
@@ -19,12 +19,13 @@ use tracing::{debug, error, info, instrument, warn};
 use super::app_file;
 use super::manifest;
 use super::manifest::NativeDependencyMap;
-use super::util::mtime_of;
+use super::util::content_hash_of;
 
 /// Result of per-file change detection.
 ///
-/// Compares each `.bt` source file's modification time against its corresponding
-/// `.beam` output to determine which files need recompilation.
+/// Compares each `.bt` source file's content hash against the hash recorded
+/// for its corresponding `.beam` output (BT-3120) to determine which files
+/// need recompilation.
 #[derive(Debug)]
 #[allow(clippy::struct_field_names)] // `_files` postfix is clearer for this domain struct
 pub(crate) struct ChangeDetectionResult {
@@ -37,6 +38,11 @@ pub(crate) struct ChangeDetectionResult {
     /// These are reported as warnings but not deleted (users may have manually
     /// placed files or renamed sources intentionally).
     pub orphaned_beam_files: Vec<Utf8PathBuf>,
+    /// Content hash of every source file considered in this pass, keyed by
+    /// path string (BT-3120). Callers persist this via
+    /// `build_cache::save_beam_hash_cache` after a successful build, so the
+    /// next `detect_changes` call has something to compare against.
+    pub source_hashes: HashMap<String, String>,
 }
 
 /// Detect which source files have changed relative to their compiled `.beam` output.
@@ -45,18 +51,54 @@ pub(crate) struct ChangeDetectionResult {
 /// using the same module naming scheme as the build pipeline. A file is considered
 /// changed if:
 /// - Its `.beam` does not exist (new file or first build)
-/// - Its mtime is newer than the `.beam` mtime
+/// - Its content hash differs from the hash recorded for it in the beam-hash
+///   sidecar (BT-3120), including when no hash was recorded at all
+///
+/// mtime is deliberately not used for this decision: it lies under git
+/// operations (branch switches restore old content under a fresh mtime) and
+/// under tools that preserve or backdate mtimes on write, either of which can
+/// make an mtime-keyed check serve a stale `.beam`.
 ///
 /// Also detects orphaned `.beam` files (no corresponding `.bt` source) and reports
 /// them as warnings.
 ///
-/// When `force` is true, all source files are treated as changed regardless of mtime.
+/// When `force` is true, all source files are treated as changed regardless of
+/// their recorded hash.
+///
+/// `known_hashes` is an optional set of already-computed content hashes,
+/// keyed by path string — for a manifest-based package build, `build_rs`'s
+/// Pass 1 (`build_cache::incremental_build_class_module_index`) has already
+/// hashed every source file's content this same build (BT-3120), so a hit
+/// here skips reading and hashing that file's content a second time. A miss
+/// (manifest-less builds, where Pass 1 never runs; or any file Pass 1
+/// couldn't read) falls back to hashing it directly here, same as before —
+/// `known_hashes` is purely an optimization, never a correctness dependency.
 pub(crate) fn detect_changes(
     source_files: &[Utf8PathBuf],
     build_dir: &Utf8Path,
     file_module_pairs: &[(Utf8PathBuf, String, Utf8PathBuf)],
     force: bool,
+    known_hashes: &HashMap<String, String>,
 ) -> ChangeDetectionResult {
+    // BT-3120: content hash of each source file as of the last successful
+    // `.beam` build, keyed by path string.
+    let previous_hashes = super::build_cache::load_beam_hash_cache(build_dir);
+
+    // Hash every source file up front — both to decide staleness below and
+    // to hand back to the caller for persisting after a successful build.
+    // Reuse Pass 1's hash when we already have one (see `known_hashes`'s doc)
+    // rather than reading and hashing the file's content again.
+    let mut source_hashes: HashMap<String, String> = HashMap::new();
+    for (source_file, _module_name, _core_file) in file_module_pairs {
+        if let Some(hash) = known_hashes
+            .get(source_file.as_str())
+            .cloned()
+            .or_else(|| content_hash_of(source_file))
+        {
+            source_hashes.insert(source_file.as_str().to_string(), hash);
+        }
+    }
+
     if force {
         info!("Force build requested — all files will be recompiled");
         // Still detect orphaned .beam files so users get consistent warnings
@@ -69,6 +111,7 @@ pub(crate) fn detect_changes(
             changed_files: source_files.to_vec(),
             unchanged_files: Vec::new(),
             orphaned_beam_files,
+            source_hashes,
         };
     }
 
@@ -88,22 +131,21 @@ pub(crate) fn detect_changes(
             continue;
         }
 
-        // Compare mtimes: source newer than beam → needs recompilation
-        let source_mtime = mtime_of(source_file);
-        let beam_mtime = mtime_of(&beam_file);
-
-        match (source_mtime, beam_mtime) {
-            (Some(src_t), Some(beam_t)) if src_t > beam_t => {
-                debug!(file = %source_file, "Source newer than .beam — needs recompilation");
-                changed_files.push(source_file.clone());
-            }
-            (Some(_), Some(_)) => {
-                debug!(file = %source_file, "Up-to-date");
+        // Compare content hashes: no hash, or a hash mismatch, needs recompilation.
+        match source_hashes.get(source_file.as_str()) {
+            Some(current_hash)
+                if previous_hashes.get(source_file.as_str()) == Some(current_hash) =>
+            {
+                debug!(file = %source_file, "Up-to-date (content hash unchanged)");
                 unchanged_files.push(source_file.clone());
             }
-            _ => {
-                // If we can't read mtimes, err on the side of recompilation
-                debug!(file = %source_file, "Cannot read mtime — needs recompilation");
+            Some(_) => {
+                debug!(file = %source_file, "Content hash changed — needs recompilation");
+                changed_files.push(source_file.clone());
+            }
+            None => {
+                // If we can't read the source, err on the side of recompilation.
+                debug!(file = %source_file, "Cannot read source — needs recompilation");
                 changed_files.push(source_file.clone());
             }
         }
@@ -125,6 +167,7 @@ pub(crate) fn detect_changes(
         changed_files,
         unchanged_files,
         orphaned_beam_files,
+        source_hashes,
     }
 }
 
@@ -210,8 +253,9 @@ struct BuildPassesResult {
 ///
 /// This command compiles .bt files to .beam bytecode via Core Erlang.
 ///
-/// When `force` is false, per-file change detection compares `.bt` source mtimes
-/// against `.beam` output mtimes and only recompiles changed files.
+/// When `force` is false, per-file change detection compares each `.bt`
+/// source's content hash against the hash recorded for its `.beam` output
+/// (BT-3120) and only recompiles changed files.
 #[instrument(skip_all, fields(path = %path))]
 pub fn build(path: &str, options: &beamtalk_core::CompilerOptions, force: bool) -> Result<()> {
     info!("Starting build");
@@ -445,6 +489,11 @@ struct ClassIndexResult {
     cached_asts: HashMap<Utf8PathBuf, CachedAst>,
     /// Whether the manifest changed, forcing Pass 2 recompilation.
     force_pass2: bool,
+    /// Content hash of every Pass-1-scanned source file, keyed by path
+    /// string (BT-3120) — empty for manifest-less builds, where Pass 1 never
+    /// runs. Reused by `detect_changes` (Pass 2) so it doesn't re-hash a file
+    /// whose content Pass 1 already hashed this same build.
+    source_hashes: HashMap<String, String>,
 }
 
 /// Phase 5-6: Build the class index (Pass 1) and merge dependency indexes.
@@ -452,6 +501,7 @@ struct ClassIndexResult {
 /// Computes module names for all source files, builds the class-to-module and
 /// class-to-superclass indexes, merges dependency class indexes, and validates
 /// stdlib reservation violations.
+#[allow(clippy::too_many_lines)] // linear merge pipeline (source + N deps) — split adds indirection, not clarity
 fn build_class_index(
     env: &BuildEnvironment,
     dep_ctx: &DependencyContext,
@@ -477,6 +527,7 @@ fn build_class_index(
         extension_index,
         cached_asts,
         force_pass2,
+        source_hashes,
     ) = if let Some(pkg) = pkg_manifest {
         let result = super::build_cache::incremental_build_class_module_index(
             &env.source_files,
@@ -495,6 +546,7 @@ fn build_class_index(
             result.extension_index,
             result.cached_asts,
             result.manifest_invalidated,
+            result.source_hashes,
         )
     } else {
         (
@@ -504,6 +556,7 @@ fn build_class_index(
             beamtalk_core::compilation::extension_index::ExtensionIndex::new(),
             HashMap::new(),
             false,
+            HashMap::new(),
         )
     };
 
@@ -603,6 +656,7 @@ fn build_class_index(
         dep_registry,
         cached_asts,
         force_pass2,
+        source_hashes,
     })
 }
 
@@ -829,8 +883,16 @@ fn execute_build_passes(
     let file_module_pairs = compute_file_module_pairs(env)?;
 
     // BT-1682: Per-file change detection — only recompile files whose source
-    // is newer than the corresponding .beam output.
-    let changes = detect_changes(&env.source_files, &env.build_dir, &file_module_pairs, force);
+    // is newer than the corresponding .beam output. Pass 1's already-computed
+    // content hashes (`index.source_hashes`, BT-3120) let this skip re-hashing
+    // any file Pass 1 already hashed this build.
+    let changes = detect_changes(
+        &env.source_files,
+        &env.build_dir,
+        &file_module_pairs,
+        force,
+        &index.source_hashes,
+    );
 
     // Warn about orphaned .beam files (source deleted but .beam remains)
     for orphan in &changes.orphaned_beam_files {
@@ -908,6 +970,11 @@ fn execute_build_passes(
         changes.unchanged_files.len(),
         file_module_pairs.len(),
     )?;
+
+    // BT-3120: only persist the beam-hash sidecar once compilation has
+    // actually succeeded (the `?` above already returned on failure) — the
+    // saved hashes assert "this content produced the `.beam` now on disk".
+    super::build_cache::save_beam_hash_cache(&env.build_dir, &changes.source_hashes);
 
     let diagnostic_summary = beamtalk_core::source_analysis::DiagnosticSummary::from_diagnostics(
         &all_build_diags,
@@ -4082,7 +4149,19 @@ mod tests {
         assert!(build_dir.join("beamtalk_myapp_app.erl").exists());
     }
 
-    // ── BT-1682: Change detection tests ──────────────────────────────
+    // ── BT-1682 / BT-3120: Change detection tests ────────────────────
+
+    /// Helper: seed the beam-hash sidecar as if `file` was last successfully
+    /// compiled at its *current* on-disk content — i.e. record today's hash
+    /// as "the content that produced the `.beam`". Simulates a prior
+    /// successful `detect_changes` + compile + `save_beam_hash_cache` cycle
+    /// without needing a real compiler.
+    fn seed_beam_hash(build_dir: &Utf8Path, file: &Utf8Path) {
+        let hash = content_hash_of(file).expect("test file must be readable");
+        let mut hashes = super::super::build_cache::load_beam_hash_cache(build_dir);
+        hashes.insert(file.as_str().to_string(), hash);
+        super::super::build_cache::save_beam_hash_cache(build_dir, &hashes);
+    }
 
     /// Helper: create `file_module_pairs` matching the format used by the build pipeline.
     fn make_pairs(
@@ -4113,7 +4192,7 @@ mod tests {
         let source_files = vec![src_dir.join("counter.bt")];
         let pairs = make_pairs(&source_files, &build_dir);
 
-        let result = detect_changes(&source_files, &build_dir, &pairs, false);
+        let result = detect_changes(&source_files, &build_dir, &pairs, false, &HashMap::new());
         assert_eq!(result.changed_files.len(), 1);
         assert!(result.unchanged_files.is_empty());
         assert!(result.orphaned_beam_files.is_empty());
@@ -4133,7 +4212,7 @@ mod tests {
         let source_files = vec![src_dir.join("counter.bt")];
         let pairs = make_pairs(&source_files, &build_dir);
 
-        let result = detect_changes(&source_files, &build_dir, &pairs, false);
+        let result = detect_changes(&source_files, &build_dir, &pairs, false, &HashMap::new());
         assert_eq!(
             result.changed_files.len(),
             1,
@@ -4151,17 +4230,18 @@ mod tests {
         fs::create_dir_all(&src_dir).unwrap();
         fs::create_dir_all(&build_dir).unwrap();
 
-        // Create source FIRST (older mtime)
-        write_test_file(&src_dir.join("counter.bt"), "counter := [0].");
-        // Small delay to ensure mtime differs
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        // Then create beam (newer mtime)
+        let source_file = src_dir.join("counter.bt");
+        write_test_file(&source_file, "counter := [0].");
         write_test_file(&build_dir.join("bt@counter.beam"), "BEAM");
+        // Record the current content hash as "what produced this .beam"
+        // (BT-3120) — without this the sidecar has no prior hash to compare
+        // against, and the file must be recompiled once regardless of mtime.
+        seed_beam_hash(&build_dir, &source_file);
 
-        let source_files = vec![src_dir.join("counter.bt")];
+        let source_files = vec![source_file.clone()];
         let pairs = make_pairs(&source_files, &build_dir);
 
-        let result = detect_changes(&source_files, &build_dir, &pairs, false);
+        let result = detect_changes(&source_files, &build_dir, &pairs, false, &HashMap::new());
         assert!(
             result.changed_files.is_empty(),
             "Up-to-date file should not be changed"
@@ -4178,20 +4258,139 @@ mod tests {
         fs::create_dir_all(&src_dir).unwrap();
         fs::create_dir_all(&build_dir).unwrap();
 
-        // Create beam FIRST (older mtime)
+        let source_file = src_dir.join("counter.bt");
+        write_test_file(&source_file, "counter := [0].");
         write_test_file(&build_dir.join("bt@counter.beam"), "BEAM");
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        // Then modify source (newer mtime)
-        write_test_file(&src_dir.join("counter.bt"), "counter := [1].");
+        seed_beam_hash(&build_dir, &source_file);
 
-        let source_files = vec![src_dir.join("counter.bt")];
+        // Modify the source after the .beam was built from it.
+        write_test_file(&source_file, "counter := [1].");
+
+        let source_files = vec![source_file];
         let pairs = make_pairs(&source_files, &build_dir);
 
-        let result = detect_changes(&source_files, &build_dir, &pairs, false);
+        let result = detect_changes(&source_files, &build_dir, &pairs, false, &HashMap::new());
         assert_eq!(
             result.changed_files.len(),
             1,
             "Modified source should be changed"
+        );
+        assert!(result.unchanged_files.is_empty());
+    }
+
+    /// BT-3120: a source rewritten with identical content but a backdated (or
+    /// preserved) mtime must still be treated as up-to-date — the hash, not
+    /// the mtime, is authoritative.
+    #[test]
+    fn test_detect_changes_touch_without_change_not_recompiled() {
+        let temp = TempDir::new().unwrap();
+        let project = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let src_dir = project.join("src");
+        let build_dir = project.join("build");
+        fs::create_dir_all(&src_dir).unwrap();
+        fs::create_dir_all(&build_dir).unwrap();
+
+        let source_file = src_dir.join("counter.bt");
+        write_test_file(&source_file, "counter := [0].");
+        write_test_file(&build_dir.join("bt@counter.beam"), "BEAM");
+        seed_beam_hash(&build_dir, &source_file);
+
+        // Rewrite the exact same content (a `touch`, or an editor
+        // save-without-edit) — bumps mtime, leaves bytes unchanged.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        write_test_file(&source_file, "counter := [0].");
+
+        let source_files = vec![source_file];
+        let pairs = make_pairs(&source_files, &build_dir);
+
+        let result = detect_changes(&source_files, &build_dir, &pairs, false, &HashMap::new());
+        assert!(
+            result.changed_files.is_empty(),
+            "touch-without-change must not trigger recompilation"
+        );
+        assert_eq!(result.unchanged_files.len(), 1);
+    }
+
+    /// BT-3120: `known_hashes` (Pass 1's already-computed content hashes) must
+    /// actually be consulted instead of always re-hashing from disk — proven
+    /// here by seeding a deliberately wrong hash for the file and observing
+    /// `detect_changes` trust it (report the file changed) even though its
+    /// real on-disk content is unchanged from what produced the `.beam`. A
+    /// no-op `known_hashes` (the `HashMap::new()` used by every other test in
+    /// this module) would instead fall back to hashing the file directly and
+    /// correctly report it unchanged — so this test also pins that the
+    /// fallback and fast paths are actually two different code paths, not
+    /// one being silently skipped.
+    #[test]
+    fn test_detect_changes_trusts_known_hashes_over_rereading() {
+        let temp = TempDir::new().unwrap();
+        let project = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let src_dir = project.join("src");
+        let build_dir = project.join("build");
+        fs::create_dir_all(&src_dir).unwrap();
+        fs::create_dir_all(&build_dir).unwrap();
+
+        let source_file = src_dir.join("counter.bt");
+        write_test_file(&source_file, "counter := [0].");
+        write_test_file(&build_dir.join("bt@counter.beam"), "BEAM");
+        seed_beam_hash(&build_dir, &source_file);
+
+        let source_files = vec![source_file.clone()];
+        let pairs = make_pairs(&source_files, &build_dir);
+
+        // A "known" hash that does NOT match either the file's real content
+        // or the beam-hash sidecar's recorded hash — if `detect_changes`
+        // trusts it, the file is reported changed; if it were silently
+        // ignored in favour of re-reading the file, it would be unchanged.
+        let mut known_hashes = HashMap::new();
+        known_hashes.insert(
+            source_file.as_str().to_string(),
+            "not-the-real-hash".to_string(),
+        );
+
+        let result = detect_changes(&source_files, &build_dir, &pairs, false, &known_hashes);
+        assert_eq!(
+            result.changed_files,
+            vec![source_file],
+            "a precomputed hash from known_hashes must be trusted, not silently discarded"
+        );
+        assert!(result.unchanged_files.is_empty());
+    }
+
+    /// BT-3120 acceptance criterion: `git checkout` restoring older content
+    /// under a newer mtime must still be recompiled — mtime ordering must
+    /// not be trusted.
+    #[test]
+    fn test_detect_changes_branch_switch_scenario() {
+        let temp = TempDir::new().unwrap();
+        let project = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let src_dir = project.join("src");
+        let build_dir = project.join("build");
+        fs::create_dir_all(&src_dir).unwrap();
+        fs::create_dir_all(&build_dir).unwrap();
+
+        let source_file = src_dir.join("counter.bt");
+        write_test_file(&source_file, "counter := [0]. \"main branch\"");
+        write_test_file(&build_dir.join("bt@counter.beam"), "BEAM");
+        seed_beam_hash(&build_dir, &source_file);
+
+        // `git checkout old-branch`: older content, but git always stamps
+        // the checkout with a fresh (newer) mtime — content is what changed,
+        // not recency.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        write_test_file(
+            &source_file,
+            "counter := [-1]. \"old branch, checked out later\"",
+        );
+
+        let source_files = vec![source_file.clone()];
+        let pairs = make_pairs(&source_files, &build_dir);
+
+        let result = detect_changes(&source_files, &build_dir, &pairs, false, &HashMap::new());
+        assert_eq!(
+            result.changed_files.len(),
+            1,
+            "checked-out content differs from what produced the .beam — must rebuild"
         );
         assert!(result.unchanged_files.is_empty());
     }
@@ -4205,15 +4404,17 @@ mod tests {
         fs::create_dir_all(&src_dir).unwrap();
         fs::create_dir_all(&build_dir).unwrap();
 
-        // Source older than beam — normally unchanged
-        write_test_file(&src_dir.join("counter.bt"), "counter := [0].");
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        let source_file = src_dir.join("counter.bt");
+        write_test_file(&source_file, "counter := [0].");
         write_test_file(&build_dir.join("bt@counter.beam"), "BEAM");
+        // Even though the recorded hash matches (normally unchanged), --force
+        // must still mark it changed.
+        seed_beam_hash(&build_dir, &source_file);
 
-        let source_files = vec![src_dir.join("counter.bt")];
+        let source_files = vec![source_file];
         let pairs = make_pairs(&source_files, &build_dir);
 
-        let result = detect_changes(&source_files, &build_dir, &pairs, true);
+        let result = detect_changes(&source_files, &build_dir, &pairs, true, &HashMap::new());
         assert_eq!(
             result.changed_files.len(),
             1,
@@ -4233,7 +4434,6 @@ mod tests {
 
         // Source file exists for counter but not for deleted_module
         write_test_file(&src_dir.join("counter.bt"), "counter := [0].");
-        std::thread::sleep(std::time::Duration::from_millis(50));
         write_test_file(&build_dir.join("bt@counter.beam"), "BEAM");
         // Orphaned beam — no corresponding .bt
         write_test_file(&build_dir.join("bt@deleted_module.beam"), "BEAM");
@@ -4241,7 +4441,7 @@ mod tests {
         let source_files = vec![src_dir.join("counter.bt")];
         let pairs = make_pairs(&source_files, &build_dir);
 
-        let result = detect_changes(&source_files, &build_dir, &pairs, false);
+        let result = detect_changes(&source_files, &build_dir, &pairs, false, &HashMap::new());
         assert_eq!(
             result.orphaned_beam_files.len(),
             1,
@@ -4264,27 +4464,26 @@ mod tests {
         fs::create_dir_all(&src_dir).unwrap();
         fs::create_dir_all(&build_dir).unwrap();
 
-        // File 1: up-to-date (source older than beam)
-        write_test_file(&src_dir.join("stable.bt"), "stable := [1].");
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        // File 1: up-to-date (hash matches what produced the .beam)
+        let stable_file = src_dir.join("stable.bt");
+        write_test_file(&stable_file, "stable := [1].");
         write_test_file(&build_dir.join("bt@stable.beam"), "BEAM");
+        seed_beam_hash(&build_dir, &stable_file);
 
-        // File 2: modified (beam older than source)
+        // File 2: modified after its .beam was recorded
+        let changed_file = src_dir.join("changed.bt");
+        write_test_file(&changed_file, "changed := [1].");
         write_test_file(&build_dir.join("bt@changed.beam"), "BEAM");
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        write_test_file(&src_dir.join("changed.bt"), "changed := [2].");
+        seed_beam_hash(&build_dir, &changed_file);
+        write_test_file(&changed_file, "changed := [2].");
 
         // File 3: new (no beam exists)
         write_test_file(&src_dir.join("new_file.bt"), "new_file := [3].");
 
-        let source_files = vec![
-            src_dir.join("changed.bt"),
-            src_dir.join("new_file.bt"),
-            src_dir.join("stable.bt"),
-        ];
+        let source_files = vec![changed_file, src_dir.join("new_file.bt"), stable_file];
         let pairs = make_pairs(&source_files, &build_dir);
 
-        let result = detect_changes(&source_files, &build_dir, &pairs, false);
+        let result = detect_changes(&source_files, &build_dir, &pairs, false, &HashMap::new());
         assert_eq!(
             result.changed_files.len(),
             2,
@@ -4311,7 +4510,7 @@ mod tests {
         let source_files: Vec<Utf8PathBuf> = Vec::new();
         let pairs: Vec<(Utf8PathBuf, String, Utf8PathBuf)> = Vec::new();
 
-        let result = detect_changes(&source_files, &build_dir, &pairs, false);
+        let result = detect_changes(&source_files, &build_dir, &pairs, false, &HashMap::new());
         assert!(
             result.orphaned_beam_files.is_empty(),
             "Non-bt@ beam files should not be flagged as orphaned"

--- a/crates/beamtalk-cli/src/commands/build.rs
+++ b/crates/beamtalk-cli/src/commands/build.rs
@@ -71,8 +71,14 @@ pub(crate) struct ChangeDetectionResult {
 /// hashed every source file's content this same build (BT-3120), so a hit
 /// here skips reading and hashing that file's content a second time. A miss
 /// (manifest-less builds, where Pass 1 never runs; or any file Pass 1
-/// couldn't read) falls back to hashing it directly here, same as before —
-/// `known_hashes` is purely an optimization, never a correctness dependency.
+/// couldn't read) falls back to hashing it directly here, same as before.
+/// `known_hashes` is mainly an optimization, but not purely one: a file
+/// edited in the window between Pass 1 hashing it and this call reuses the
+/// now-stale Pass-1-time hash for this build cycle. That's narrow and
+/// self-healing (Pass 1 always re-reads from disk on the next build), never
+/// a permanent stale skip, but it means a same-build edit isn't caught as
+/// immediately as the old mtime-based check (which re-read mtime fresh at
+/// this call site).
 pub(crate) fn detect_changes(
     source_files: &[Utf8PathBuf],
     build_dir: &Utf8Path,

--- a/crates/beamtalk-cli/src/commands/build_cache.rs
+++ b/crates/beamtalk-cli/src/commands/build_cache.rs
@@ -834,8 +834,12 @@ mod tests {
         // before — simulating a tool that preserves or backdates mtime on
         // write (or a same-second write on a coarse-grained filesystem).
         fs::write(&file, "counter := [1].").unwrap();
-        let file_handle = fs::File::open(&file).unwrap();
-        file_handle.set_modified(old_mtime).unwrap();
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&file)
+            .unwrap()
+            .set_modified(old_mtime)
+            .unwrap();
         assert_eq!(
             mtime_of(&file),
             Some(old_mtime),

--- a/crates/beamtalk-cli/src/commands/build_cache.rs
+++ b/crates/beamtalk-cli/src/commands/build_cache.rs
@@ -5,11 +5,23 @@
 //!
 //! Serialises the class indexes and `ClassInfo` vectors that Pass 1 produces so
 //! that unchanged files can be skipped on the next build. The cache stores
-//! per-file metadata keyed by source path, together with the file's modification
-//! time so staleness can be detected cheaply.
+//! per-file metadata keyed by source path, together with a SHA-256 hash of the
+//! file's contents so staleness can be detected correctly (BT-3120) — mtime is
+//! not used for this decision because it lies under git operations (branch
+//! switches restore old content under a fresh mtime) and under tools that
+//! preserve or backdate mtimes on write, either of which can make an
+//! mtime-keyed cache serve stale (incorrect) results.
 //!
-//! The cache is invalidated entirely when `beamtalk.toml` changes (mtime check)
-//! or when `--force` is used.
+//! The cache is invalidated entirely when `beamtalk.toml` changes (mtime check
+//! — the manifest itself isn't content-hashed, only source files are) or when
+//! `--force` is used.
+//!
+//! This module also owns the sibling "beam hash" sidecar
+//! ([`load_beam_hash_cache`]/[`save_beam_hash_cache`]) that backs
+//! `build.rs`'s `detect_changes`: the content hash of each source file as of
+//! its last successful `.beam` compilation. It's a separate cache from
+//! [`Pass1Cache`] because `detect_changes` runs for every build — including
+//! manifest-less single-file builds, where `Pass1Cache` never applies.
 
 use beamtalk_core::compilation::extension_index::{
     ExtensionIndex, ExtensionKey, ExtensionLocation,
@@ -23,7 +35,9 @@ use std::fs;
 use std::time::SystemTime;
 use tracing::{debug, info, warn};
 
-use super::util::mtime_of;
+#[cfg(test)]
+use super::util::content_hash_of;
+use super::util::{content_hashes_of, mtime_of};
 
 /// Name of the cache file stored inside the build directory.
 const CACHE_FILENAME: &str = ".beamtalk-pass1-cache.json";
@@ -31,7 +45,9 @@ const CACHE_FILENAME: &str = ".beamtalk-pass1-cache.json";
 /// Current cache format version. Bump when the serialised layout changes.
 /// v2: `ClassInfo` gained `surface_incomplete` (BT-2796); entries gained
 /// per-file extension definitions (BT-2795).
-const CACHE_VERSION: u32 = 2;
+/// v3: `CacheEntry.mtime` replaced by `CacheEntry.content_hash` — staleness
+/// is now keyed on file content, not filesystem mtime (BT-3120).
+const CACHE_VERSION: u32 = 3;
 
 /// On-disk representation of the Pass 1 metadata cache.
 ///
@@ -56,9 +72,10 @@ pub(crate) struct Pass1Cache {
 /// Cached metadata for a single source file.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct CacheEntry {
-    /// Source file modification time when this entry was recorded.
-    #[serde(with = "system_time_required_serde")]
-    mtime: SystemTime,
+    /// SHA-256 content hash of the source file when this entry was recorded
+    /// (BT-3120). The source of truth for staleness — see the module doc for
+    /// why mtime isn't used.
+    content_hash: String,
 
     /// Classes defined in this file, mapped to their compiled module name.
     /// E.g. `"Counter" → "bt@my_app@counter"`.
@@ -92,6 +109,11 @@ pub(crate) struct IncrementalPass1Result {
     /// Whether the manifest changed and forced a full cache invalidation.
     /// When true, Pass 2 should also force-recompile all files.
     pub manifest_invalidated: bool,
+    /// Content hash of every file in `source_files`, keyed by path string
+    /// (BT-3120) — computed once for this Pass 1 pass and handed back so
+    /// Pass 2's `detect_changes` can reuse them instead of re-hashing every
+    /// file's content a second time. See [`super::util::content_hashes_of`].
+    pub source_hashes: HashMap<String, String>,
 }
 
 /// Result of loading the cache — distinguishes "no cache" from "manifest invalidated".
@@ -204,6 +226,90 @@ pub(crate) fn discard_pass1_cache(build_dir: &Utf8Path) {
     }
 }
 
+/// Name of the sidecar file recording, for each source file, the content
+/// hash that produced its currently-compiled `.beam` (BT-3120).
+const BEAM_HASH_CACHE_FILENAME: &str = ".beamtalk-beam-hashes.json";
+
+/// Format version for the beam-hash sidecar. Bump when the layout changes.
+const BEAM_HASH_CACHE_VERSION: u32 = 1;
+
+/// On-disk representation of the beam-hash sidecar.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct BeamHashCache {
+    /// Format version — if this doesn't match `BEAM_HASH_CACHE_VERSION` the
+    /// cache is discarded silently (every file is then treated as changed
+    /// until the next successful build repopulates it).
+    version: u32,
+    /// Source path (as string) → content hash of the source that produced
+    /// the `.beam` currently on disk for it.
+    hashes: HashMap<String, String>,
+}
+
+/// Load the beam-hash sidecar for `build_dir`.
+///
+/// Returns an empty map on any miss — no file, corrupt JSON, or a version
+/// mismatch. `detect_changes` treats a file with no recorded hash as changed,
+/// so a miss just costs one extra rebuild per affected file, never a stale
+/// skip.
+pub(crate) fn load_beam_hash_cache(build_dir: &Utf8Path) -> HashMap<String, String> {
+    let cache_path = build_dir.join(BEAM_HASH_CACHE_FILENAME);
+    let Ok(data) = fs::read_to_string(&cache_path) else {
+        debug!("No beam-hash cache found at {cache_path}");
+        return HashMap::new();
+    };
+
+    let Ok(cache) = serde_json::from_str::<BeamHashCache>(&data) else {
+        warn!("Beam-hash cache is corrupt or unreadable — treating all files as changed");
+        return HashMap::new();
+    };
+
+    if cache.version != BEAM_HASH_CACHE_VERSION {
+        info!(
+            cached = cache.version,
+            current = BEAM_HASH_CACHE_VERSION,
+            "Beam-hash cache version mismatch — treating all files as changed"
+        );
+        return HashMap::new();
+    }
+
+    debug!(
+        entries = cache.hashes.len(),
+        "Loaded beam-hash cache from {cache_path}"
+    );
+    cache.hashes
+}
+
+/// Save the beam-hash sidecar to `build_dir`.
+///
+/// Call only after a successful `.beam` compile — the saved hashes assert
+/// "this content produced the `.beam` now on disk". Best-effort like
+/// [`save_cache`]: serialization or I/O failures are logged, never fatal.
+pub(crate) fn save_beam_hash_cache(build_dir: &Utf8Path, hashes: &HashMap<String, String>) {
+    let cache = BeamHashCache {
+        version: BEAM_HASH_CACHE_VERSION,
+        hashes: hashes.clone(),
+    };
+
+    let cache_path = build_dir.join(BEAM_HASH_CACHE_FILENAME);
+    let data = match serde_json::to_string(&cache) {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(error = %e, "Failed to serialise beam-hash cache");
+            return;
+        }
+    };
+
+    if let Err(e) = fs::write(&cache_path, &data) {
+        warn!(error = %e, "Failed to write beam-hash cache to {cache_path}");
+        return;
+    }
+
+    debug!(
+        entries = cache.hashes.len(),
+        "Saved beam-hash cache to {cache_path}"
+    );
+}
+
 /// Perform an incremental Pass 1 scan.
 ///
 /// Loads the existing cache (if any), determines which files are stale,
@@ -220,6 +326,15 @@ pub(crate) fn incremental_build_class_module_index(
     manifest_path: Option<&Utf8Path>,
     force: bool,
 ) -> Result<IncrementalPass1Result> {
+    // BT-3120: hash every source file's content exactly once for this Pass 1
+    // pass. `partition_files` (staleness) and `build_cache_entries` (the
+    // updated cache) both need every file's hash; computing it once here and
+    // passing it into both — instead of each calling `content_hash_of`
+    // independently — halves Pass 1's own content-hashing work, and the
+    // result is handed back to the caller so Pass 2 doesn't hash a third
+    // time. See `content_hashes_of`'s doc for why this matters.
+    let source_hashes = content_hashes_of(source_files);
+
     // If forced, skip cache entirely
     if force {
         info!("Force build — ignoring Pass 1 cache");
@@ -236,10 +351,13 @@ pub(crate) fn incremental_build_class_module_index(
             source_files,
             source_root,
             pkg_name,
-            &class_module_index,
-            &class_superclass_index,
-            &all_class_infos,
-            &extension_index,
+            &Pass1Indexes {
+                class_module_index: &class_module_index,
+                class_superclass_index: &class_superclass_index,
+                all_class_infos: &all_class_infos,
+                extension_index: &extension_index,
+            },
+            &source_hashes,
         );
         save_cache(build_dir, manifest_path, file_entries);
 
@@ -250,6 +368,7 @@ pub(crate) fn incremental_build_class_module_index(
             extension_index,
             cached_asts,
             manifest_invalidated: false,
+            source_hashes,
         });
     }
 
@@ -264,7 +383,7 @@ pub(crate) fn incremental_build_class_module_index(
 
     // Determine which files need re-scanning
     let (stale_files, fresh_files) = match &cache {
-        Some(c) => partition_files(source_files, c),
+        Some(c) => partition_files(source_files, c, &source_hashes),
         None => (source_files.to_vec(), Vec::new()),
     };
 
@@ -334,10 +453,13 @@ pub(crate) fn incremental_build_class_module_index(
         source_files,
         source_root,
         pkg_name,
-        &class_module_index,
-        &class_superclass_index,
-        &all_class_infos,
-        &extension_index,
+        &Pass1Indexes {
+            class_module_index: &class_module_index,
+            class_superclass_index: &class_superclass_index,
+            all_class_infos: &all_class_infos,
+            extension_index: &extension_index,
+        },
+        &source_hashes,
     );
     save_cache(build_dir, manifest_path, file_entries);
 
@@ -348,30 +470,40 @@ pub(crate) fn incremental_build_class_module_index(
         extension_index,
         cached_asts,
         manifest_invalidated,
+        source_hashes,
     })
 }
 
 /// Partition source files into stale (need re-scan) and fresh (cache hit).
 ///
+/// `hashes` is `source_files`' content hashes, keyed by path string —
+/// precomputed once by the caller via [`content_hashes_of`] rather than
+/// hashed again per file here (BT-3120).
+///
 /// A file is considered stale if:
 /// - It has no cache entry
-/// - Its mtime is different from the cached mtime
-/// - Its mtime cannot be read (err on the side of re-scanning)
+/// - Its content hash differs from the cached content hash (BT-3120)
+/// - Its content cannot be read (err on the side of re-scanning)
 fn partition_files(
     source_files: &[Utf8PathBuf],
     cache: &Pass1Cache,
+    hashes: &HashMap<String, String>,
 ) -> (Vec<Utf8PathBuf>, Vec<Utf8PathBuf>) {
     let mut stale = Vec::new();
     let mut fresh = Vec::new();
 
     for file in source_files {
         if let Some(entry) = cache.entries.get(file.as_str()) {
-            let current_mtime = mtime_of(file);
-            if current_mtime == Some(entry.mtime) {
-                fresh.push(file.clone());
-            } else {
-                debug!(file = %file, "Cache stale — mtime changed");
-                stale.push(file.clone());
+            match hashes.get(file.as_str()) {
+                Some(hash) if *hash == entry.content_hash => fresh.push(file.clone()),
+                Some(_) => {
+                    debug!(file = %file, "Cache stale — content changed");
+                    stale.push(file.clone());
+                }
+                None => {
+                    debug!(file = %file, "Cannot read file content — treating as stale");
+                    stale.push(file.clone());
+                }
             }
         } else {
             debug!(file = %file, "No cache entry — new file");
@@ -387,20 +519,37 @@ fn partition_files(
     (stale, fresh)
 }
 
+/// The merged Pass 1 indexes `build_cache_entries` reads from — bundled into
+/// one borrow so the function stays under clippy's argument-count limit
+/// (BT-3120 added the `hashes` parameter, which would otherwise push it over).
+/// Mirrors the corresponding fields of [`IncrementalPass1Result`].
+struct Pass1Indexes<'a> {
+    class_module_index: &'a HashMap<String, String>,
+    class_superclass_index: &'a HashMap<String, String>,
+    all_class_infos: &'a [ClassInfo],
+    extension_index: &'a ExtensionIndex,
+}
+
 /// Build cache entries from the current Pass 1 results.
 ///
-/// Each source file gets an entry with its current mtime and the subset of
-/// class/superclass indexes that belong to it (determined by module name
-/// prefix matching).
+/// Each source file gets an entry with its current content hash (BT-3120,
+/// taken from the precomputed `hashes` map — see [`content_hashes_of`] —
+/// rather than re-hashed here) and the subset of class/superclass indexes
+/// that belong to it (determined by module name prefix matching).
 fn build_cache_entries(
     source_files: &[Utf8PathBuf],
     source_root: Option<&Utf8Path>,
     pkg_name: &str,
-    class_module_index: &HashMap<String, String>,
-    class_superclass_index: &HashMap<String, String>,
-    all_class_infos: &[ClassInfo],
-    extension_index: &ExtensionIndex,
+    indexes: &Pass1Indexes<'_>,
+    hashes: &HashMap<String, String>,
 ) -> HashMap<String, CacheEntry> {
+    let Pass1Indexes {
+        class_module_index,
+        class_superclass_index,
+        all_class_infos,
+        extension_index,
+    } = *indexes;
+
     // Build a reverse index: module_name → Vec<(class_name, module_name)>
     // This avoids O(files * classes) iteration in the loop below.
     let mut module_to_classes: HashMap<&str, Vec<&str>> = HashMap::new();
@@ -420,7 +569,7 @@ fn build_cache_entries(
     let mut entries = HashMap::new();
 
     for file in source_files {
-        let Some(mtime) = mtime_of(file) else {
+        let Some(content_hash) = hashes.get(file.as_str()).cloned() else {
             continue;
         };
 
@@ -450,7 +599,7 @@ fn build_cache_entries(
         entries.insert(
             file.as_str().to_string(),
             CacheEntry {
-                mtime,
+                content_hash,
                 class_module_index: file_class_module_index,
                 class_superclass_index: file_superclass_index,
                 class_infos: file_class_infos,
@@ -460,33 +609,6 @@ fn build_cache_entries(
     }
 
     entries
-}
-
-/// Serde support for `SystemTime` (required field) via duration-since-epoch.
-mod system_time_required_serde {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-    #[derive(Serialize, Deserialize)]
-    struct Epoch {
-        secs: u64,
-        nanos: u32,
-    }
-
-    #[allow(clippy::trivially_copy_pass_by_ref)] // serde serialize_with requires &T
-    pub fn serialize<S: Serializer>(time: &SystemTime, serializer: S) -> Result<S::Ok, S::Error> {
-        let dur = time.duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO);
-        let epoch = Epoch {
-            secs: dur.as_secs(),
-            nanos: dur.subsec_nanos(),
-        };
-        epoch.serialize(serializer)
-    }
-
-    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<SystemTime, D::Error> {
-        let epoch = Epoch::deserialize(deserializer)?;
-        Ok(UNIX_EPOCH + Duration::new(epoch.secs, epoch.nanos))
-    }
 }
 
 /// Serde support for `Option<SystemTime>` via duration-since-epoch.
@@ -549,7 +671,7 @@ mod tests {
             "/src/counter.bt".to_string(),
             CacheEntry {
                 extensions: Vec::new(),
-                mtime: SystemTime::now(),
+                content_hash: "deadbeef".to_string(),
                 class_module_index: cmi,
                 class_superclass_index: csi,
                 class_infos: Vec::new(),
@@ -638,8 +760,8 @@ mod tests {
         fs::write(&file_b, "b").unwrap();
         fs::write(&file_c, "c").unwrap();
 
-        let mtime_a = mtime_of(&file_a).unwrap();
-        let mtime_b = mtime_of(&file_b).unwrap();
+        let hash_a = content_hash_of(&file_a).unwrap();
+        let hash_b = content_hash_of(&file_b).unwrap();
 
         // Build a cache with a and b (but not c)
         let mut entries = HashMap::new();
@@ -647,7 +769,7 @@ mod tests {
             file_a.as_str().to_string(),
             CacheEntry {
                 extensions: Vec::new(),
-                mtime: mtime_a,
+                content_hash: hash_a,
                 class_module_index: HashMap::new(),
                 class_superclass_index: HashMap::new(),
                 class_infos: Vec::new(),
@@ -657,7 +779,7 @@ mod tests {
             file_b.as_str().to_string(),
             CacheEntry {
                 extensions: Vec::new(),
-                mtime: mtime_b,
+                content_hash: hash_b,
                 class_module_index: HashMap::new(),
                 class_superclass_index: HashMap::new(),
                 class_infos: Vec::new(),
@@ -672,9 +794,184 @@ mod tests {
 
         // file_a: fresh, file_b: fresh, file_c: new (stale)
         let source_files = vec![file_a.clone(), file_b.clone(), file_c.clone()];
-        let (stale, fresh) = partition_files(&source_files, &cache);
+        let hashes = content_hashes_of(&source_files);
+        let (stale, fresh) = partition_files(&source_files, &cache, &hashes);
         assert_eq!(fresh, vec![file_a, file_b]);
         assert_eq!(stale, vec![file_c]);
+    }
+
+    /// BT-3120: a file whose content changed but whose mtime was backdated
+    /// (or preserved) by the writing tool must still be detected as stale —
+    /// staleness comes from the content hash, never from mtime.
+    #[test]
+    fn test_partition_files_stale_on_content_change_with_backdated_mtime() {
+        let temp = TempDir::new().unwrap();
+        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let file = dir.join("a.bt");
+
+        fs::write(&file, "counter := [0].").unwrap();
+        let old_hash = content_hash_of(&file).unwrap();
+        let old_mtime = mtime_of(&file).unwrap();
+
+        let mut entries = HashMap::new();
+        entries.insert(
+            file.as_str().to_string(),
+            CacheEntry {
+                extensions: Vec::new(),
+                content_hash: old_hash,
+                class_module_index: HashMap::new(),
+                class_superclass_index: HashMap::new(),
+                class_infos: Vec::new(),
+            },
+        );
+        let cache = Pass1Cache {
+            version: CACHE_VERSION,
+            manifest_mtime: None,
+            entries,
+        };
+
+        // Change the content, then force the mtime back to what it was
+        // before — simulating a tool that preserves or backdates mtime on
+        // write (or a same-second write on a coarse-grained filesystem).
+        fs::write(&file, "counter := [1].").unwrap();
+        let file_handle = fs::File::open(&file).unwrap();
+        file_handle.set_modified(old_mtime).unwrap();
+        assert_eq!(
+            mtime_of(&file),
+            Some(old_mtime),
+            "mtime must be back to its old value for this test to be meaningful"
+        );
+
+        let hashes = content_hashes_of(std::slice::from_ref(&file));
+        let (stale, fresh) = partition_files(std::slice::from_ref(&file), &cache, &hashes);
+        assert_eq!(
+            stale,
+            vec![file],
+            "content changed under an unchanged mtime must still be detected as stale"
+        );
+        assert!(fresh.is_empty());
+    }
+
+    /// BT-3120: rewriting identical content (e.g. a `touch`, or a build tool
+    /// that always rewrites its output) bumps mtime but must not be treated
+    /// as stale — only a content change should trigger re-scanning.
+    #[test]
+    fn test_partition_files_fresh_on_touch_without_content_change() {
+        let temp = TempDir::new().unwrap();
+        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let file = dir.join("a.bt");
+
+        fs::write(&file, "counter := [0].").unwrap();
+        let hash = content_hash_of(&file).unwrap();
+
+        let mut entries = HashMap::new();
+        entries.insert(
+            file.as_str().to_string(),
+            CacheEntry {
+                extensions: Vec::new(),
+                content_hash: hash,
+                class_module_index: HashMap::new(),
+                class_superclass_index: HashMap::new(),
+                class_infos: Vec::new(),
+            },
+        );
+        let cache = Pass1Cache {
+            version: CACHE_VERSION,
+            manifest_mtime: None,
+            entries,
+        };
+
+        // Rewrite the exact same content — this changes mtime but not bytes.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        fs::write(&file, "counter := [0].").unwrap();
+
+        let hashes = content_hashes_of(std::slice::from_ref(&file));
+        let (stale, fresh) = partition_files(std::slice::from_ref(&file), &cache, &hashes);
+        assert_eq!(
+            fresh,
+            vec![file],
+            "touch-without-change must not be treated as stale"
+        );
+        assert!(stale.is_empty());
+    }
+
+    /// BT-3120 acceptance criterion: build with content A, then simulate a
+    /// `git checkout` that restores older content B under a *newer* mtime
+    /// (git always sets mtime to the checkout time, regardless of the
+    /// content's age) — the cache must still detect the content change and
+    /// mark the file stale. A subsequent touch-without-change (mtime bump,
+    /// same content) must not cause another rebuild.
+    #[test]
+    fn test_partition_files_branch_switch_scenario() {
+        let temp = TempDir::new().unwrap();
+        let dir = Utf8PathBuf::from_path_buf(temp.path().to_path_buf()).unwrap();
+        let file = dir.join("a.bt");
+
+        // "main" branch content, built once.
+        fs::write(&file, "counter := [0].").unwrap();
+        let hash_main = content_hash_of(&file).unwrap();
+        let mut entries = HashMap::new();
+        entries.insert(
+            file.as_str().to_string(),
+            CacheEntry {
+                extensions: Vec::new(),
+                content_hash: hash_main,
+                class_module_index: HashMap::new(),
+                class_superclass_index: HashMap::new(),
+                class_infos: Vec::new(),
+            },
+        );
+        let cache = Pass1Cache {
+            version: CACHE_VERSION,
+            manifest_mtime: None,
+            entries,
+        };
+
+        // `git checkout old-branch`: older (different) content, fresh mtime.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        fs::write(&file, "counter := [-1]. \"older branch content\"").unwrap();
+
+        let hashes = content_hashes_of(std::slice::from_ref(&file));
+        let (stale, fresh) = partition_files(std::slice::from_ref(&file), &cache, &hashes);
+        assert_eq!(
+            stale,
+            vec![file.clone()],
+            "checked-out content differs from the cached hash — must rebuild"
+        );
+        assert!(fresh.is_empty());
+
+        // Re-cache as if the rebuild happened, then touch without changing
+        // content (e.g. a second `git checkout` back to the same content, or
+        // an editor save-without-edit).
+        let hash_old_branch = content_hash_of(&file).unwrap();
+        let mut entries2 = HashMap::new();
+        entries2.insert(
+            file.as_str().to_string(),
+            CacheEntry {
+                extensions: Vec::new(),
+                content_hash: hash_old_branch,
+                class_module_index: HashMap::new(),
+                class_superclass_index: HashMap::new(),
+                class_infos: Vec::new(),
+            },
+        );
+        let cache2 = Pass1Cache {
+            version: CACHE_VERSION,
+            manifest_mtime: None,
+            entries: entries2,
+        };
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        fs::write(&file, "counter := [-1]. \"older branch content\"").unwrap();
+
+        let hashes2 = content_hashes_of(std::slice::from_ref(&file));
+        let (stale2, fresh2) = partition_files(std::slice::from_ref(&file), &cache2, &hashes2);
+        assert_eq!(
+            fresh2,
+            vec![file],
+            "touch-without-change after the rebuild must not recompile"
+        );
+        assert!(stale2.is_empty());
     }
 
     #[test]
@@ -752,6 +1049,18 @@ mod extension_cache_tests {
         )
         .unwrap();
         assert_eq!(first.extension_index.len(), 1, "extension scanned");
+        // BT-3120: Pass 1 hands back every scanned file's content hash so
+        // Pass 2 (`detect_changes`) can reuse it instead of re-hashing.
+        assert_eq!(
+            first.source_hashes.len(),
+            2,
+            "source_hashes covers every source file, not just stale ones"
+        );
+        assert_eq!(
+            first.source_hashes.get(ext_file.as_str()),
+            content_hash_of(&ext_file).as_ref(),
+            "returned hash must match the file's actual content hash"
+        );
 
         // Second build: all files fresh — extensions must come from the cache.
         let second = incremental_build_class_module_index(
@@ -777,6 +1086,14 @@ mod extension_cache_tests {
                 .len(),
             1,
             "cached extension regroups under its defining file"
+        );
+        // BT-3120: even on an all-fresh (cache-hit) build, every file is
+        // still hashed once so `source_hashes` stays complete for Pass 2 —
+        // the fresh/stale split only affects re-scanning, not hashing.
+        assert_eq!(
+            second.source_hashes.len(),
+            2,
+            "source_hashes stays complete on an all-fresh build"
         );
 
         // Third build: the defining file is deleted — its cached extensions

--- a/crates/beamtalk-cli/src/commands/util.rs
+++ b/crates/beamtalk-cli/src/commands/util.rs
@@ -6,8 +6,10 @@
 //! **DDD Context:** CLI
 
 use beamtalk_core::file_walker::FileWalker;
+use beamtalk_workspace::hex_encode;
 use camino::{Utf8Path, Utf8PathBuf};
 use miette::{Context, IntoDiagnostic, Result};
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::time::SystemTime;
 
@@ -37,6 +39,50 @@ pub(crate) enum Expected {
 /// Read the modification time of a file, returning `None` on any error.
 pub(super) fn mtime_of(path: &Utf8Path) -> Option<SystemTime> {
     fs::metadata(path).ok()?.modified().ok()
+}
+
+/// SHA-256 content hash of a file, as a lowercase hex string, or `None` if
+/// the file cannot be read.
+///
+/// BT-3120: the source of truth for batch-build staleness checks
+/// (`Pass1Cache` and `detect_changes`'s `.bt`-vs-`.beam` decision). Unlike
+/// mtime, a content hash cannot be fooled by git branch switches (which
+/// restore old content under a fresh mtime) or by tools that preserve or
+/// backdate mtimes on write — both of which make mtime-only staleness checks
+/// either spuriously rebuild (benign) or, worse, incorrectly skip a rebuild
+/// (a stale `.beam`). Reuses `sha2`, already a dependency of this crate and
+/// of `beamtalk-workspace`, and that crate's [`beamtalk_workspace::hex_encode`]
+/// leaf for the digest-to-hex-string step — no new hash crate, and no
+/// second copy of the hex-encoding loop, is introduced.
+pub(super) fn content_hash_of(path: &Utf8Path) -> Option<String> {
+    let bytes = fs::read(path).ok()?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let digest = hasher.finalize();
+    Some(hex_encode(&digest))
+}
+
+/// [`content_hash_of`] for every file in `paths`, keyed by path string.
+///
+/// BT-3120: a single build hashes each source file's content in more than
+/// one place — Pass 1's staleness check and cache-entry rebuild
+/// (`build_cache::partition_files` / `build_cache::build_cache_entries`),
+/// and Pass 2's `.beam` staleness check (`detect_changes`). Computing every
+/// file's hash once here and threading the map through those call sites
+/// (rather than each calling [`content_hash_of`] independently) keeps a
+/// build to one content-hash pass per file instead of two or three — the
+/// difference between a `stat()` and hashing full file contents is real, and
+/// BT-3120's acceptance criteria specifically calls out "no measurable
+/// regression in warm no-op build time". Files that can't be read are
+/// omitted, matching [`content_hash_of`]'s `None`-on-error behaviour —
+/// callers already treat a missing hash as "must recompute".
+pub(super) fn content_hashes_of(
+    paths: &[Utf8PathBuf],
+) -> std::collections::HashMap<String, String> {
+    paths
+        .iter()
+        .filter_map(|p| content_hash_of(p).map(|h| (p.as_str().to_string(), h)))
+        .collect()
 }
 
 /// Find the project root by requiring a `beamtalk.toml` in the current directory.
@@ -82,6 +128,67 @@ pub fn find_files(path: &Utf8Path, extensions: &[&str]) -> Result<Vec<Utf8PathBu
 mod tests {
     use super::*;
     use std::fs;
+
+    #[test]
+    fn test_content_hash_of_stable_for_same_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = Utf8Path::from_path(dir.path()).unwrap();
+        let file = dir_path.join("a.bt");
+        fs::write(&file, "counter := [0].").unwrap();
+
+        let hash1 = content_hash_of(&file).unwrap();
+        let hash2 = content_hash_of(&file).unwrap();
+        assert_eq!(
+            hash1, hash2,
+            "hashing the same content must be deterministic"
+        );
+        assert_eq!(hash1.len(), 64, "SHA-256 hex digest is 64 chars");
+    }
+
+    #[test]
+    fn test_content_hash_of_changes_with_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = Utf8Path::from_path(dir.path()).unwrap();
+        let file = dir_path.join("a.bt");
+
+        fs::write(&file, "counter := [0].").unwrap();
+        let hash_a = content_hash_of(&file).unwrap();
+
+        fs::write(&file, "counter := [1].").unwrap();
+        let hash_b = content_hash_of(&file).unwrap();
+
+        assert_ne!(hash_a, hash_b, "different content must hash differently");
+    }
+
+    #[test]
+    fn test_content_hash_of_same_content_different_mtime() {
+        // BT-3120: the hash must depend only on bytes, not on filesystem
+        // metadata — rewriting identical content (which bumps mtime) must
+        // produce the same hash.
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = Utf8Path::from_path(dir.path()).unwrap();
+        let file = dir_path.join("a.bt");
+
+        fs::write(&file, "counter := [0].").unwrap();
+        let hash_a = content_hash_of(&file).unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        fs::write(&file, "counter := [0].").unwrap();
+        let hash_b = content_hash_of(&file).unwrap();
+
+        assert_eq!(
+            hash_a, hash_b,
+            "identical content must hash the same regardless of mtime"
+        );
+    }
+
+    #[test]
+    fn test_content_hash_of_missing_file_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = Utf8Path::from_path(dir.path()).unwrap();
+        let missing = dir_path.join("does-not-exist.bt");
+        assert!(content_hash_of(&missing).is_none());
+    }
 
     #[test]
     fn test_find_files_single_file() {

--- a/crates/beamtalk-cli/tests/cli/cli_build.rs
+++ b/crates/beamtalk-cli/tests/cli/cli_build.rs
@@ -76,6 +76,53 @@ fn build_force_recompiles_unchanged_sources() {
         .success();
 }
 
+/// BT-3120 acceptance criterion, exercised through the real `beamtalk build`
+/// subprocess rather than the internal `detect_changes`/`partition_files`
+/// unit tests: rewriting a source file with byte-for-byte identical content
+/// (e.g. `touch`, or an editor save-without-edit) bumps its mtime but must
+/// not trigger recompilation — only a genuine content change should. An
+/// mtime-keyed cache would recompile on the touch alone; a content-hash-keyed
+/// one must not.
+#[test]
+fn build_touch_without_content_change_is_not_recompiled() {
+    let project = cli_common::fixture_project();
+    let greeter = project.path().join("src/Greeter.bt");
+    let original = std::fs::read_to_string(&greeter).unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("build")
+        .assert()
+        .success();
+
+    // Rewrite the exact same bytes — this changes the file's mtime (most
+    // filesystems have at best millisecond, often only second, resolution,
+    // so sleep past that) but not its content.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    std::fs::write(&greeter, &original).unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("build")
+        .assert()
+        .success()
+        .stderr(contains("unchanged").or(contains("nothing to compile")));
+
+    // A genuine content change on the same file must still be recompiled.
+    std::fs::write(&greeter, format!("{original}\n  goodbye => \"goodbye\"\n")).unwrap();
+
+    cli_common::beamtalk()
+        .current_dir(project.path())
+        .arg("build")
+        .assert()
+        .success()
+        // Only `src/Greeter.bt` is a build source in this fixture (the test
+        // file under `test/` isn't part of `beamtalk build`'s source set),
+        // so a genuine change to it recompiles the project's one file —
+        // i.e. NOT the "all unchanged" no-op message from the touch above.
+        .stderr(contains("unchanged").not());
+}
+
 // ---------------------------------------------------------------------------
 // BT-2920: E0401/E0402 visibility checks must fire at build time
 // ---------------------------------------------------------------------------

--- a/crates/beamtalk-workspace/src/lib.rs
+++ b/crates/beamtalk-workspace/src/lib.rs
@@ -21,6 +21,24 @@ use sha2::{Digest, Sha256};
 /// deregistration polling, registration lookup.
 pub mod epmd;
 
+/// Lowercase-hex-encode a byte slice.
+///
+/// The shared leaf under every hash-to-hex-string need in these tools —
+/// [`hash_workspace_path_string`] here and the source-content hashing in
+/// `beamtalk-cli`'s `commands::util::content_hash_of` both hex-encode a
+/// SHA-256 digest and must not each carry their own copy of this formatting
+/// loop (see `docs/development/architecture-principles.md` § Duplication &
+/// the Shared-Leaf-Module Pattern).
+#[must_use]
+pub fn hex_encode(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
+            let _ = write!(s, "{b:02x}");
+            s
+        })
+}
+
 /// SHA256-hash a path string down to a 12-hex-char workspace ID.
 ///
 /// The pure half of [`generate_workspace_id`] — no filesystem access, no
@@ -36,13 +54,7 @@ pub fn hash_workspace_path_string(path_str: &str) -> String {
     let result = hasher.finalize();
 
     // Use first 12 hex chars (6 bytes) for readability — take first 6 bytes
-    result
-        .iter()
-        .take(6)
-        .fold(String::with_capacity(12), |mut s, b| {
-            let _ = write!(s, "{b:02x}");
-            s
-        })
+    hex_encode(&result[..6])
 }
 
 /// Generate a workspace ID from a project path.

--- a/docs/beamtalk-architecture.md
+++ b/docs/beamtalk-architecture.md
@@ -145,15 +145,21 @@ queries; both are coarser, file-granularity caches:
   Editing a file reparses only that file and calls `ProjectIndex::update_file`
   (or `remove_file` on delete) to refresh the project-wide index —
   file-granularity invalidation, not whole-project reanalysis.
-- **Batch builds (`beamtalk build`):** a two-pass, mtime-keyed cache. Pass 1
-  (class indexing) persists per-file class/alias/extension metadata to
-  `.beamtalk-pass1-cache.json`, keyed by source mtime, so unchanged files skip
-  re-parsing (`crates/beamtalk-cli/src/commands/build_cache.rs`, BT-1683).
-  Pass 2 (codegen) compares each source file's mtime against its `.beam`
-  output's mtime and recompiles only files that changed
-  (`crates/beamtalk-cli/src/commands/build.rs`). A toolchain provenance stamp
-  (ADR 0098) gates both passes ahead of the mtime checks, so a compiler/OTP
-  version change forces a full rebuild regardless of mtime.
+- **Batch builds (`beamtalk build`):** a two-pass, content-hash-keyed cache
+  (BT-3120). Pass 1 (class indexing) persists per-file class/alias/extension
+  metadata to `.beamtalk-pass1-cache.json`, keyed by a SHA-256 hash of the
+  source file's contents, so unchanged files skip re-parsing
+  (`crates/beamtalk-cli/src/commands/build_cache.rs`, BT-1683). Pass 2
+  (codegen) compares each source file's content hash against the hash
+  recorded (in a sidecar, `.beamtalk-beam-hashes.json`) for the content that
+  produced its current `.beam` output, and recompiles only files whose hash
+  differs (`crates/beamtalk-cli/src/commands/build.rs`). Content hashing
+  replaced mtime comparison because mtime lies under git operations (a
+  branch switch restores old content under a fresh mtime) and under tools
+  that preserve or backdate mtimes on write — either of which could make an
+  mtime-keyed cache serve a stale `.beam`. A toolchain provenance stamp (ADR
+  0098) gates both passes ahead of the hash checks, so a compiler/OTP version
+  change forces a full rebuild regardless of source content.
 
 Query-based incrementality (a Salsa-style dependency graph of memoized
 queries) does not exist today — it's deliberately deferred until profiling
@@ -298,7 +304,7 @@ Protocol: JSON-RPC 2.0 (same as LSP)
 Illustrative sketch of the state a persistent compiler process would need to
 track — see "Incremental Compilation" above for what's actually implemented
 today (`SimpleLanguageService`'s per-file cache and `ProjectIndex`, plus the
-batch build's two-pass mtime cache; there is no query-graph database):
+batch build's two-pass content-hash cache; there is no query-graph database):
 
 ```rust
 struct CompilerState {

--- a/docs/beamtalk-tooling.md
+++ b/docs/beamtalk-tooling.md
@@ -79,10 +79,10 @@ Every build runs through three sequential phases:
 
 ### Incremental Compilation
 
-Beamtalk uses mtime-based change detection to avoid redundant work:
+Beamtalk uses content-hash-based change detection to avoid redundant work (BT-3120):
 
-- Each `.bt` source file is compared against its corresponding `.beam` output. If the source is newer (or no `.beam` exists), the file is recompiled.
-- **Pass 1 caching** — The class-module index from Pass 1 is cached in `_build/dev/ebin/.beamtalk-pass1-cache.json`. On subsequent builds, only files whose source has changed since the cache was written are re-parsed. Unchanged files reuse their cached class metadata. If the `beamtalk.toml` manifest changes, the entire cache is invalidated and all files are re-parsed.
+- Each `.bt` source file's SHA-256 content hash is compared against the hash recorded for it in a `.beamtalk-beam-hashes.json` sidecar (the hash that produced its current `.beam`). If the hashes differ (or no `.beam` exists), the file is recompiled. mtime is deliberately not used for this decision — it lies under git operations (a branch switch restores old content under a fresh mtime) and under tools that preserve or backdate mtimes on write, either of which could make an mtime-keyed check serve a stale `.beam`.
+- **Pass 1 caching** — The class-module index from Pass 1 is cached in `_build/dev/ebin/.beamtalk-pass1-cache.json`, also keyed by each file's content hash. On subsequent builds, only files whose content hash has changed since the cache was written are re-parsed. Unchanged files reuse their cached class metadata. If the `beamtalk.toml` manifest changes (an mtime check — the manifest itself isn't content-hashed), the entire cache is invalidated and all files are re-parsed.
 - **Force rebuild** — `beamtalk build --force` ignores all caches and recompiles everything. Useful after toolchain upgrades or when build artifacts may be stale (e.g. switching git branches or worktrees).
 - **Orphan detection** — `.beam` files with no corresponding `.bt` source are reported as warnings (the source may have been deleted or renamed).
 
@@ -113,6 +113,7 @@ All build output goes under `_build/` in the project root. The `BuildLayout` str
     dev/
       ebin/                        — compiled .beam files from .bt sources
         .beamtalk-pass1-cache.json — Pass 1 incremental cache
+        .beamtalk-beam-hashes.json — Pass 2 .beam staleness sidecar (BT-3120)
       native/
         ebin/                      — compiled .beam files from native .erl sources
         include/                   — generated headers (e.g. beamtalk_classes.hrl)


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-3120/key-pass1cache-and-change-detection-on-content-hash-instead-of-mtime

## Summary

Batch incrementality (`beamtalk build`) was keyed on file mtime, which lies under git operations — a branch switch restores old content under a fresh mtime — and under tools that preserve or backdate mtimes on write, either of which can make an mtime-keyed cache serve a stale `.beam`. This replaces mtime with a SHA-256 content hash as the staleness signal.

- `CacheEntry.mtime` → `CacheEntry.content_hash` (SHA-256); `CACHE_VERSION` bumped 2 → 3.
- `build.rs::detect_changes`'s `.bt`-vs-`.beam` decision now compares content hashes via a new `.beamtalk-beam-hashes.json` sidecar (`load_beam_hash_cache`/`save_beam_hash_cache`) recording the hash that produced each `.beam`, instead of comparing `.bt` mtime against `.beam` mtime.
- The manifest (`beamtalk.toml`) invalidation check stays mtime-based (out of scope — only per-file source staleness is keyed on content).
- Each source file's content hash is computed once per build and threaded through Pass 1 (`partition_files`, `build_cache_entries`) and Pass 2 (`detect_changes`) instead of re-hashed independently in each place, so a build hashes a file's content once rather than two or three times — keeping warm no-op build time in line with the old mtime-based scheme.
- Extracted a shared `hex_encode` leaf into `beamtalk-workspace` so the new content-hash formatting doesn't duplicate `hash_workspace_path_string`'s existing hex-encoding loop (`docs/development/architecture-principles.md` § Duplication & the Shared-Leaf-Module Pattern).
- Updated `docs/beamtalk-architecture.md` and `docs/beamtalk-tooling.md`'s incremental-compilation descriptions, previously rewritten for the mtime-based design by the sibling BT-3121 docs pass, to describe the new hash-keyed design.

## Testing

- Unit tests: branch-switch scenario (content differs under a *newer* mtime → rebuilds; a subsequent touch-without-change → does not rebuild), backdated/preserved-mtime content change (still detected as stale), and a real CLI-level subprocess test (`build_touch_without_content_change_is_not_recompiled`) that rewrites a source file with identical bytes through the actual `beamtalk build` binary and asserts no recompilation, then asserts a genuine content change does recompile.
- `just ci` green (Rust, stdlib, BUnit, Erlang runtime, integration, parity, REPL protocol tests, surface-parity drift check).
- `just clippy` / `just fmt-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpGgaYYFRpYuikkqiWiEoq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CpGgaYYFRpYuikkqiWiEoq)_