### PR TITLE
Migrate while_loops + counted_loops to ThreadedIr; delete the 4 unpack debug_asserts (BT-3132)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -32,12 +32,13 @@ mod list_ops;
 mod while_loops;
 
 use super::document::{Document, join, leaf};
+use super::threaded_ir;
 use super::{
     CodeGenContext, CodeGenError, CoreErlangGenerator, OpenScopeResult, Result, block_analysis,
 };
 use crate::ast::Expression;
 use crate::docvec;
-use crate::source_analysis::Span;
+use crate::source_analysis::{Diagnostic, DiagnosticCategory, Span};
 
 // ─── ThreadingPlan ────────────────────────────────────────────────────────────
 
@@ -1155,6 +1156,52 @@ impl CoreErlangGenerator {
                 span,
             );
         }
+    }
+
+    /// BT-3132 (ADR 0111 Phase B): checks the "optimized threading mode
+    /// implies no `StateAcc` unpack" invariant via [`threaded_ir::verify`]
+    /// instead of a hand-rolled `debug_assert!` at each call site — this is
+    /// the single check behind all four of `while_loops.rs`'s and
+    /// `counted_loops.rs`'s (via this module's direct/hybrid counted-loop
+    /// generators) former "unpack should emit no code" `debug_assert!`s.
+    ///
+    /// `mode` is the loop's already-resolved [`threaded_ir::ThreadingMode`]
+    /// (`DirectParams` or `Hybrid` — the two production call sites this
+    /// check guards); `unpack_emitted` is exactly whether
+    /// `plan.generate_unpack_at_iteration_start(..)` returned any docs for
+    /// this loop.
+    ///
+    /// **Failure behavior** (ADR 0111 §The verifier): hard-fails in
+    /// debug/CI via `debug_assert!` — the same behavior the deleted
+    /// `debug_assert!`s had. In release builds (where `debug_assert!` is
+    /// compiled out), degrades to an internal-error diagnostic on the
+    /// compile result instead of silently doing nothing, per CLAUDE.md's
+    /// "never panic on user input" / structured-error rule — this is a
+    /// compiler-internal invariant, not a user-facing one, so the compile
+    /// still succeeds with the generator's (unverified) output.
+    pub(super) fn check_loop_unpack_invariant(
+        &mut self,
+        mode: threaded_ir::ThreadingMode,
+        threaded_locals: &[String],
+        unpack_emitted: bool,
+        span: Span,
+    ) {
+        let errors =
+            threaded_ir::verify_loop_unpack_invariant(mode, threaded_locals, unpack_emitted, span);
+        if errors.is_empty() {
+            return;
+        }
+        debug_assert!(
+            false,
+            "ThreadedIr verify found a loop threading-mode/unpack mismatch: {errors:?}"
+        );
+        self.add_codegen_warning(
+            Diagnostic::error(
+                format!("internal: loop threading-mode/unpack mismatch: {errors:?}"),
+                span,
+            )
+            .with_category(DiagnosticCategory::Type),
+        );
     }
 
     /// BT-1343: Emits a diagnostic for synchronous self-send detected in a loop body.
@@ -2523,9 +2570,11 @@ impl CoreErlangGenerator {
 
         // Register var → param bindings (no unpack docs emitted in direct-params mode).
         let unpack_docs = plan.generate_unpack_at_iteration_start(self);
-        debug_assert!(
-            unpack_docs.is_empty(),
-            "direct params: unpack should emit no code"
+        self.check_loop_unpack_invariant(
+            threaded_ir::ThreadingMode::DirectParams,
+            &plan.threaded_locals,
+            !unpack_docs.is_empty(),
+            body.span,
         );
 
         // Condition + true arm
@@ -2652,9 +2701,11 @@ impl CoreErlangGenerator {
 
         // Register local var bindings (no unpack docs emitted in hybrid mode).
         let unpack_docs = plan.generate_unpack_at_iteration_start(self);
-        debug_assert!(
-            unpack_docs.is_empty(),
-            "hybrid params: unpack should emit no code"
+        self.check_loop_unpack_invariant(
+            threaded_ir::ThreadingMode::Hybrid,
+            &plan.threaded_locals,
+            !unpack_docs.is_empty(),
+            body.span,
         );
 
         // Condition + true arm

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/while_loops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/while_loops.rs
@@ -333,7 +333,12 @@ impl CoreErlangGenerator {
         self.push_scope();
         // Register var bindings — no unpack docs in direct-params mode.
         let unpack_docs = plan.generate_unpack_at_iteration_start(self);
-        debug_assert!(unpack_docs.is_empty());
+        self.check_loop_unpack_invariant(
+            super::super::threaded_ir::ThreadingMode::DirectParams,
+            &plan.threaded_locals,
+            !unpack_docs.is_empty(),
+            body.span,
+        );
 
         // The condition closure captures the current vars from scope.
         // We pass only the params (not StateAcc) since there is no StateAcc.
@@ -470,9 +475,11 @@ impl CoreErlangGenerator {
 
         self.push_scope();
         let unpack_docs = plan.generate_unpack_at_iteration_start(self);
-        debug_assert!(
-            unpack_docs.is_empty(),
-            "hybrid while: unpack should emit no code"
+        self.check_loop_unpack_invariant(
+            super::super::threaded_ir::ThreadingMode::Hybrid,
+            &plan.threaded_locals,
+            !unpack_docs.is_empty(),
+            body.span,
         );
 
         docs.push(docvec![

--- a/crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs
@@ -6,19 +6,25 @@
 //!
 //! **DDD Context:** Compilation — Code Generation
 //!
-//! ## Status (BT-3129 — ADR 0111 Phase A0 + A1)
+//! ## Status (BT-3132 — ADR 0111 Phase B, first production migration)
 //!
 //! This module lands the IR types, the [`verify`] checker, and the
-//! [`lower_and_render`] test shim. **Nothing in production codegen constructs
-//! a [`ThreadedIr`] yet** — this is intentional and load-bearing for the
-//! Phase A0 measurement gate (see `docs/ADR/0111-lowered-ir-verifier-for-state-threading.md`
-//! §Phase A0/A1): the only call site that builds one is the flagged
-//! `whileTrue:`/`whileFalse:` direct-params prototype in
-//! `control_flow/while_loops.rs` (behind `BEAMTALK_THREADED_IR_WHILE=1`),
-//! whose output is deliberately discarded (via [`std::hint::black_box`]) —
-//! it exists purely to measure IR-construction/verification cost, never to
-//! change generated output. Migrating real call sites onto this IR is later
-//! work (BT-3131 onward).
+//! [`lower_and_render`] test shim (BT-3129), the unified `VersionedVar`/
+//! `VersionCounter` production path (BT-3131), and — as of BT-3132 —
+//! `while_loops.rs`'s and `counted_loops.rs`'s (via `control_flow/mod.rs`)
+//! direct-params/hybrid loop generators construct and [`verify`] a real
+//! [`ThreadedIr`] fragment for their per-iteration "optimized mode implies
+//! no `StateAcc` unpack" invariant, via [`verify_loop_unpack_invariant`] —
+//! this replaces the four `debug_assert!`s the pre-BT-3132 code used for the
+//! same check with [`VerifyError::ThreadingModeUnpackMismatch`]. The Phase
+//! A0 measurement prototype ([`prototype_direct_params_ir`], gated behind
+//! `BEAMTALK_THREADED_IR_WHILE=1`) remains alongside it — it measures a
+//! different, larger fixture (one `Bind` per threaded local's full
+//! per-iteration rebind) and its output is still discarded, unlike the
+//! unpack-invariant check's `Vec<VerifyError>`, which drives real
+//! debug-fail/release-diagnostic behavior. The rest of the four production
+//! generators' state (field mutations, NLR, shadow writes) does not yet
+//! construct `ThreadedIr` — later phases (BT-3133 onward) extend coverage.
 //!
 //! ## Scope
 //!
@@ -761,6 +767,71 @@ impl TokenId {
     fn render_name(self) -> String {
         super::util::versioned_var("CatchTok", self.0 as usize)
     }
+}
+
+// ─── Loop unpack-invariant check (BT-3132) ─────────────────────────────────
+
+/// Builds a minimal `ThreadedIr` fixture for one loop's per-iteration unpack
+/// step under `mode` (whichever of [`ThreadingMode::DirectParams`] /
+/// [`ThreadingMode::Hybrid`] the loop's `ThreadingPlan` resolved) and
+/// verifies it.
+///
+/// `unpack_emitted` must be exactly what
+/// `ThreadingPlan::generate_unpack_at_iteration_start` actually returned for
+/// this loop (non-empty iff every threaded local produced a `maps:get`
+/// unpack `Bind`) — this function checks the OBSERVED emission against the
+/// already-resolved mode, not a re-derivation of `ThreadingPlan`'s own
+/// `use_direct_params`/`use_hybrid_params` flags, so it stays a structural
+/// check on what was actually emitted rather than "the generator agreeing
+/// with itself" (ADR 0111 §Verifier honesty).
+///
+/// Replaces the four "unpack should emit no code" `debug_assert!`s
+/// (`while_loops.rs`'s direct-params/hybrid call sites, `counted_loops.rs`'s
+/// via `control_flow/mod.rs`'s direct/hybrid call sites) — their invariant
+/// is now [`VerifyError::ThreadingModeUnpackMismatch`].
+pub(super) fn verify_loop_unpack_invariant(
+    mode: ThreadingMode,
+    threaded_locals: &[String],
+    unpack_emitted: bool,
+    span: Span,
+) -> Vec<VerifyError> {
+    let frame = FrameId::new(1);
+    let body: Vec<ThreadedStmt> = if unpack_emitted {
+        threaded_locals
+            .iter()
+            .map(|local| {
+                let source = VersionedVar::new(VersionPrefix::Local(local.clone()), 0, frame);
+                let target = VersionedVar::new(VersionPrefix::Local(local.clone()), 1, frame);
+                ThreadedStmt::Bind {
+                    target,
+                    source,
+                    op: BindOp::Unpack {
+                        field: local.clone(),
+                    },
+                    shadow_write: false,
+                    span,
+                }
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let produces = body
+        .iter()
+        .filter_map(|stmt| match stmt {
+            ThreadedStmt::Bind { target, .. } => Some(target.clone()),
+            ThreadedStmt::Threaded { .. }
+            | ThreadedStmt::NlrCatch { .. }
+            | ThreadedStmt::Return(..) => None,
+        })
+        .collect();
+    verify(&[ThreadedStmt::Threaded {
+        mode,
+        frame,
+        body,
+        produces,
+        span,
+    }])
 }
 
 // ─── Phase A0 measurement prototype ────────────────────────────────────────
@@ -1515,5 +1586,101 @@ mod tests {
         unsafe {
             std::env::remove_var(PROTOTYPE_ENV_VAR);
         }
+    }
+
+    // ── verify_loop_unpack_invariant (BT-3132) ───────────────────────────
+    // Pins the production replacement for the four deleted
+    // "unpack should emit no code" `debug_assert!`s in `while_loops.rs` /
+    // `control_flow/mod.rs` (counted loops).
+
+    #[test]
+    fn verify_loop_unpack_invariant_silent_when_no_unpack_emitted_direct_params() {
+        // The expected, common case: direct-params mode with no unpack docs.
+        let errors = verify_loop_unpack_invariant(
+            ThreadingMode::DirectParams,
+            &["sum".to_string(), "count".to_string()],
+            false,
+            span(),
+        );
+        assert_eq!(errors, Vec::new());
+    }
+
+    #[test]
+    fn verify_loop_unpack_invariant_silent_when_no_unpack_emitted_hybrid() {
+        let errors =
+            verify_loop_unpack_invariant(ThreadingMode::Hybrid, &["n".to_string()], false, span());
+        assert_eq!(errors, Vec::new());
+    }
+
+    #[test]
+    fn verify_loop_unpack_invariant_fires_when_unpack_emitted_under_direct_params() {
+        // Simulates the regression the deleted debug_assert! guarded against:
+        // `generate_unpack_at_iteration_start` emitted unpack code even though
+        // the loop resolved to DirectParams mode. Asserts the exact error set
+        // (not just "contains a match") — pins that a single mismatched local
+        // produces exactly one finding, with no spurious UnboundVersion/
+        // NonLinearVersion noise from how the fixture is built.
+        let errors = verify_loop_unpack_invariant(
+            ThreadingMode::DirectParams,
+            &["sum".to_string()],
+            true,
+            span(),
+        );
+        assert_eq!(
+            errors.len(),
+            1,
+            "expected exactly one error, got: {errors:?}"
+        );
+        assert!(
+            matches!(
+                &errors[0],
+                VerifyError::ThreadingModeUnpackMismatch {
+                    mode: ThreadingMode::DirectParams,
+                    ..
+                }
+            ),
+            "expected ThreadingModeUnpackMismatch, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn verify_loop_unpack_invariant_fires_when_unpack_emitted_under_hybrid() {
+        // Two threaded locals: pins that each gets its own
+        // ThreadingModeUnpackMismatch finding, with no cross-local
+        // interference (e.g. NonLinearVersion from misattributed versions).
+        let errors = verify_loop_unpack_invariant(
+            ThreadingMode::Hybrid,
+            &["n".to_string(), "sum".to_string()],
+            true,
+            span(),
+        );
+        assert_eq!(
+            errors.len(),
+            2,
+            "expected exactly two errors, got: {errors:?}"
+        );
+        assert!(
+            errors.iter().all(|e| matches!(
+                e,
+                VerifyError::ThreadingModeUnpackMismatch {
+                    mode: ThreadingMode::Hybrid,
+                    ..
+                }
+            )),
+            "expected only ThreadingModeUnpackMismatch findings, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn verify_loop_unpack_invariant_silent_under_stateacc_with_unpack() {
+        // Sanity check: StateAcc mode legitimately emits unpack code, so this
+        // must stay silent — mirrors `verify_unpack_silent_inside_stateacc_mode`.
+        let errors = verify_loop_unpack_invariant(
+            ThreadingMode::StateAcc(StateAccFallbackReason::SelfSendInBody),
+            &["sum".to_string()],
+            true,
+            span(),
+        );
+        assert_eq!(errors, Vec::new());
     }
 }


### PR DESCRIPTION
Linear issue: https://linear.app/beamtalk/issue/BT-3132

## Summary

Phase 3 (Phase B) of ADR 0111 (Epic BT-3128) — the first production migration onto `ThreadedIr` + `verify()` (BT-3129) and the unified `VersionedVar`/`VersionCounter` (BT-3131).

The direct-params and hybrid loop generators in `while_loops.rs` and `counted_loops.rs` (via `control_flow/mod.rs`) now build a real `ThreadedIr` fragment for their per-iteration "optimized threading mode implies no `StateAcc` unpack" invariant and check it with `threaded_ir::verify()`, via new `verify_loop_unpack_invariant` / `check_loop_unpack_invariant` helpers.

## Key changes

- **Deletes the four "unpack should emit no code" `debug_assert!`s** — `while_loops.rs`'s direct-params/hybrid call sites, `control_flow/mod.rs`'s counted-loop direct/hybrid call sites. Their invariant is now `VerifyError::ThreadingModeUnpackMismatch`, checked against the *observed* unpack-doc emission (not a re-derivation of `ThreadingPlan`'s own mode flags), so the check stays structural rather than "the generator agreeing with itself" (ADR 0111 §Verifier honesty).
- **Failure behavior matches ADR 0111 §The verifier**: hard-fails via `debug_assert!` in debug/CI (identical to the deleted asserts' behavior), degrades to an internal-error diagnostic in release builds instead of silently doing nothing. Verified that `codegen_warnings` (where this diagnostic lands) is never wired into any pass/fail gate in the current compile pipeline — `generate_module` (the CLI's path) discards `.warnings` entirely, and `has_errors` in `beam_compiler.rs` is computed upstream of codegen from a separate diagnostics list — so this cannot turn a compiler-internal bug into a refusal to compile valid code.
- **Byte-identical output** confirmed over the expanded snapshot corpus (`test-package-compiler`, 478 tests, all pass with zero `.snap` diffs) and the full `test-stdlib`/`test-bunit`/`test-repl-protocol` suites.
- Adds targeted unit tests pinning both the silent (no mismatch) and firing (`ThreadingModeUnpackMismatch`) paths for `DirectParams`/`Hybrid`/`StateAcc` modes, with exact error-set assertions (not just "contains a match") to rule out spurious `NonLinearVersion`/`UnboundVersion` noise from the fixture construction.

## Test plan
- [x] `cargo test -p beamtalk-core --lib` — 5618 passed, 0 failed
- [x] `cargo test -p test-package-compiler` — 478 passed, 0 failed, zero snapshot diffs (byte-identical output)
- [x] `just test-stdlib` — 231 passed
- [x] `just test-bunit` — 3213 passed
- [x] `just test-repl-protocol` — 3 passed
- [x] `just clippy` / `just fmt-check` / `just lint` — clean
- [x] `just check-corpus` / `just check-generated-builtins` / `just check-surface-drift` — clean

One known-unrelated flake: `beamtalk-cli`'s `bt2424_default_deployment_keeps_epmd_off_public_interfaces` fails in this shared sandbox because `epmd` is genuinely bound to `0.0.0.0:4369` (confirmed via `/proc/net/tcp`) — an artifact of the shared multi-agent environment, not this change (unrelated crate, unrelated network-posture test, reproducible in isolation with no code changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oaVzae94hh9N1QTraqa8i

---
_Generated by [Claude Code](https://claude.ai/code/session_015oaVzae94hh9N1QTraqa8i)_