### PR TITLE
refactor: consolidate 8 parse_module test helpers into shared parse_bt

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/block_analyzer.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/block_analyzer.rs
@@ -357,26 +357,12 @@ impl Analyser {
 #[cfg(test)]
 mod tests {
     use crate::semantic_analysis::{BlockContext, analyse};
-    use crate::source_analysis::Severity;
-
-    fn parse_module(src: &str) -> crate::ast::Module {
-        let tokens = crate::source_analysis::lex_with_eof(src);
-        let (module, diagnostics) = crate::source_analysis::parse(tokens);
-        let parse_errors: Vec<_> = diagnostics
-            .iter()
-            .filter(|d| d.severity == Severity::Error)
-            .collect();
-        assert!(
-            parse_errors.is_empty(),
-            "Test fixture failed to parse cleanly: {parse_errors:?}"
-        );
-        module
-    }
+    use crate::test_helpers::test_support::parse_bt;
 
     #[test]
     fn control_flow_block_has_control_flow_context() {
         let src = "Object subclass: Foo\n  bar => true ifTrue: [42]";
-        let module = parse_module(src);
+        let module = parse_bt(src);
         let result = analyse(&module);
         assert!(
             result
@@ -395,7 +381,7 @@ mod tests {
     #[test]
     fn stored_block_has_stored_context() {
         let src = "Object subclass: Foo\n  bar =>\n    f := [42].\n    f";
-        let module = parse_module(src);
+        let module = parse_bt(src);
         let result = analyse(&module);
         assert!(
             result
@@ -414,7 +400,7 @@ mod tests {
     #[test]
     fn outer_variable_captured_in_block() {
         let src = "Object subclass: Foo\n  bar =>\n    x := 42.\n    [:y | x + y]";
-        let module = parse_module(src);
+        let module = parse_bt(src);
         let result = analyse(&module);
         let has_capture = result
             .block_info
@@ -434,7 +420,7 @@ mod tests {
     #[test]
     fn field_mutation_in_stored_block_produces_error() {
         let src = "Object subclass: Foo\n  state: x = 0\n  bar =>\n    f := [self.x := 1].\n    f";
-        let module = parse_module(src);
+        let module = parse_bt(src);
         let result = analyse(&module);
         assert!(
             result
@@ -453,7 +439,7 @@ mod tests {
         // different method whose State never seeded the captured variable's
         // '__local__' key, silently returning the stale definition-time value.
         let src = "Actor subclass: Ctr\n  state: total = 0\n  state: callback = nil\n\n  setup =>\n    count := 0\n    self.callback := [:n | count := count + n]\n\n  process: n =>\n    self.callback value: n\n";
-        let module = parse_module(src);
+        let module = parse_bt(src);
         let result = analyse(&module);
         assert!(
             result
@@ -473,7 +459,7 @@ mod tests {
         // arm's own diagnostic is for the captured-local-ONLY case; firing both
         // for the same closure would be confusing, redundant double-reporting.
         let src = "Actor subclass: Ctr\n  state: total = 0\n\n  setup =>\n    count := 0\n    self.callback := [:n | self.total := n. count := count + n]\n";
-        let module = parse_module(src);
+        let module = parse_bt(src);
         let result = analyse(&module);
         assert_eq!(
             result.diagnostics.len(),
@@ -498,7 +484,7 @@ mod tests {
         // codegen's prescan_tier2_local_vars proves per-method safety for this
         // shape (BT-2797), and it's the well-established BT-856 pattern.
         let src = "Object subclass: Foo\n  bar =>\n    count := 0\n    blk := [:n | count := count + n]\n    blk value: 5";
-        let module = parse_module(src);
+        let module = parse_bt(src);
         let result = analyse(&module);
         assert!(
             !result
@@ -513,7 +499,7 @@ mod tests {
     #[test]
     fn block_passed_as_message_arg_has_passed_context() {
         let src = "Object subclass: Foo\n  bar => self doWith: [42]";
-        let module = parse_module(src);
+        let module = parse_bt(src);
         let result = analyse(&module);
         assert!(
             result

--- a/crates/beamtalk-core/src/semantic_analysis/collision_checker.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/collision_checker.rs
@@ -423,20 +423,7 @@ fn check_transitive_reference(
 mod tests {
     use super::*;
     use crate::source_analysis::Severity;
-
-    fn parse_module(src: &str) -> Module {
-        let tokens = crate::source_analysis::lex_with_eof(src);
-        let (module, diagnostics) = crate::source_analysis::parse(tokens);
-        let parse_errors: Vec<_> = diagnostics
-            .iter()
-            .filter(|d| d.severity == Severity::Error)
-            .collect();
-        assert!(
-            parse_errors.is_empty(),
-            "Test fixture failed to parse cleanly: {parse_errors:?}"
-        );
-        module
-    }
+    use crate::test_helpers::test_support::parse_bt;
 
     fn make_registry(entries: &[(&str, &str, &str)]) -> DependencyRegistry {
         let mut registry = DependencyRegistry::new();
@@ -545,7 +532,7 @@ mod tests {
         ]);
 
         // Source uses unqualified Parser
-        let module = parse_module("Parser new");
+        let module = parse_bt("Parser new");
         let mut diagnostics = Vec::new();
         check_collision_at_use_sites(&module, &registry, &mut diagnostics);
 
@@ -576,7 +563,7 @@ mod tests {
         ]);
 
         // Source does not use Parser at all
-        let module = parse_module("42 + 1");
+        let module = parse_bt("42 + 1");
         let mut diagnostics = Vec::new();
         check_collision_at_use_sites(&module, &registry, &mut diagnostics);
 
@@ -590,7 +577,7 @@ mod tests {
     fn no_collision_for_single_export() {
         let registry = make_registry(&[("Helper", "utils", "bt@utils@helper")]);
 
-        let module = parse_module("Helper new");
+        let module = parse_bt("Helper new");
         let mut diagnostics = Vec::new();
         check_collision_at_use_sites(&module, &registry, &mut diagnostics);
 
@@ -607,7 +594,7 @@ mod tests {
             ("Base", "pkg_b", "bt@pkg_b@base"),
         ]);
 
-        let module = parse_module("Base subclass: Derived\n  value => 1");
+        let module = parse_bt("Base subclass: Derived\n  value => 1");
         let mut diagnostics = Vec::new();
         check_collision_at_use_sites(&module, &registry, &mut diagnostics);
 
@@ -633,7 +620,7 @@ mod tests {
         ]);
 
         // Source uses qualified json@Parser — no collision
-        let module = parse_module("json@Parser new");
+        let module = parse_bt("json@Parser new");
         let mut diagnostics = Vec::new();
         check_collision_at_use_sites(&module, &registry, &mut diagnostics);
 
@@ -651,7 +638,7 @@ mod tests {
         ]);
 
         // Standalone method on ambiguous class name
-        let module = parse_module("Parser >> customParse: input => input");
+        let module = parse_bt("Parser >> customParse: input => input");
         let mut diagnostics = Vec::new();
         check_collision_at_use_sites(&module, &registry, &mut diagnostics);
 
@@ -675,7 +662,7 @@ mod tests {
         ]);
 
         // Qualified standalone method — no collision
-        let module = parse_module("json@Parser >> customParse: input => input");
+        let module = parse_bt("json@Parser >> customParse: input => input");
         let mut diagnostics = Vec::new();
         check_collision_at_use_sites(&module, &registry, &mut diagnostics);
 
@@ -688,7 +675,7 @@ mod tests {
     #[test]
     fn collision_with_empty_registry_is_noop() {
         let registry = DependencyRegistry::new();
-        let module = parse_module("Parser new");
+        let module = parse_bt("Parser new");
         let mut diagnostics = Vec::new();
         check_collision_at_use_sites(&module, &registry, &mut diagnostics);
         assert!(diagnostics.is_empty());
@@ -717,7 +704,7 @@ mod tests {
             vec!["json".to_string()],
         )]);
 
-        let module = parse_module("StringUtils new");
+        let module = parse_bt("StringUtils new");
         let mut diagnostics = Vec::new();
         check_transitive_dep_usage(&module, &registry, false, &mut diagnostics);
 
@@ -755,7 +742,7 @@ mod tests {
             vec!["json".to_string()],
         )]);
 
-        let module = parse_module("StringUtils new");
+        let module = parse_bt("StringUtils new");
         let mut diagnostics = Vec::new();
         check_transitive_dep_usage(&module, &registry, true, &mut diagnostics);
 
@@ -778,7 +765,7 @@ mod tests {
             Vec::new(),
         )]);
 
-        let module = parse_module("Helper new");
+        let module = parse_bt("Helper new");
         let mut diagnostics = Vec::new();
         check_transitive_dep_usage(&module, &registry, false, &mut diagnostics);
 
@@ -798,7 +785,7 @@ mod tests {
             vec!["json".to_string()],
         )]);
 
-        let module = parse_module("42 + 1");
+        let module = parse_bt("42 + 1");
         let mut diagnostics = Vec::new();
         check_transitive_dep_usage(&module, &registry, false, &mut diagnostics);
 
@@ -818,7 +805,7 @@ mod tests {
             vec!["framework".to_string()],
         )]);
 
-        let module = parse_module("Base subclass: MyClass\n  value => 1");
+        let module = parse_bt("Base subclass: MyClass\n  value => 1");
         let mut diagnostics = Vec::new();
         check_transitive_dep_usage(&module, &registry, false, &mut diagnostics);
 

--- a/crates/beamtalk-core/src/semantic_analysis/lowering.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/lowering.rs
@@ -78,20 +78,7 @@ pub fn lower_module_for_codegen(
 mod tests {
     use super::*;
     use crate::ast::{ClassKind, SupervisorKind};
-
-    fn parse_module(src: &str) -> Module {
-        let tokens = crate::source_analysis::lex_with_eof(src);
-        let (module, diagnostics) = crate::source_analysis::parse(tokens);
-        let parse_errors: Vec<_> = diagnostics
-            .iter()
-            .filter(|d| d.severity == crate::source_analysis::Severity::Error)
-            .collect();
-        assert!(
-            parse_errors.is_empty(),
-            "Test fixture failed to parse cleanly: {parse_errors:?}"
-        );
-        module
-    }
+    use crate::test_helpers::test_support::parse_bt;
 
     fn build_hierarchy(module: &Module) -> ClassHierarchy {
         let (result, diagnostics) = ClassHierarchy::build(module);
@@ -114,7 +101,7 @@ mod tests {
     fn applies_all_three_writebacks() {
         let src =
             "Supervisor subclass: WebApp\n  bar => 42\n\nTestCase subclass: MyTest\n  baz => 1";
-        let mut module = parse_module(src);
+        let mut module = parse_bt(src);
         let hierarchy = build_hierarchy(&module);
         let method_return_types = crate::semantic_analysis::type_checker::infer_method_return_types(
             &module, &hierarchy, None,
@@ -146,7 +133,7 @@ mod tests {
     #[test]
     fn does_not_infer_when_map_is_empty() {
         let src = "Object subclass: Foo\n  bar => 42";
-        let mut module = parse_module(src);
+        let mut module = parse_bt(src);
         let hierarchy = build_hierarchy(&module);
         lower_module_for_codegen(&mut module, &hierarchy, &HashMap::new());
         assert!(

--- a/crates/beamtalk-core/src/semantic_analysis/name_resolver.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/name_resolver.rs
@@ -696,23 +696,10 @@ impl Default for NameResolver {
 mod tests {
     use super::*;
     use crate::source_analysis::{Severity, Span};
-
-    fn parse_module(src: &str) -> crate::ast::Module {
-        let tokens = crate::source_analysis::lex_with_eof(src);
-        let (module, diagnostics) = crate::source_analysis::parse(tokens);
-        let parse_errors: Vec<_> = diagnostics
-            .iter()
-            .filter(|d| d.severity == Severity::Error)
-            .collect();
-        assert!(
-            parse_errors.is_empty(),
-            "Test fixture failed to parse cleanly: {parse_errors:?}"
-        );
-        module
-    }
+    use crate::test_helpers::test_support::parse_bt;
 
     fn run(src: &str) -> NameResolver {
-        let module = parse_module(src);
+        let module = parse_bt(src);
         let mut resolver = NameResolver::new();
         resolver.resolve_module(&module);
         resolver
@@ -906,7 +893,7 @@ mod tests {
 
     #[test]
     fn define_known_vars_prevents_undefined_error() {
-        let module = parse_module("sessionVar");
+        let module = parse_bt("sessionVar");
         let mut resolver = NameResolver::new();
         resolver.define_known_vars(&["sessionVar"], Span::new(0, 0));
         resolver.resolve_module(&module);

--- a/crates/beamtalk-core/src/semantic_analysis/primitive_validator.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/primitive_validator.rs
@@ -277,12 +277,7 @@ fn validate_intrinsic_name(name: &str, span: Span, diagnostics: &mut Vec<Diagnos
 mod tests {
     use super::*;
     use crate::source_analysis::{lex_with_eof, parse};
-
-    fn parse_module(source: &str) -> Module {
-        let tokens = lex_with_eof(source);
-        let (module, _) = parse(tokens);
-        module
-    }
+    use crate::test_helpers::test_support::parse_bt;
 
     /// Wraps a `@primitive` expression in a class method body for parser acceptance.
     fn stdlib_method(primitive: &str) -> String {
@@ -291,7 +286,7 @@ mod tests {
 
     #[test]
     fn primitive_in_stdlib_mode_no_error() {
-        let module = parse_module(&stdlib_method("@primitive \"+\""));
+        let module = parse_bt(&stdlib_method("@primitive \"+\""));
         let options = CompilerOptions {
             stdlib_mode: true,
             ..Default::default()
@@ -305,7 +300,7 @@ mod tests {
 
     #[test]
     fn primitive_in_user_code_error() {
-        let module = parse_module(&stdlib_method("@primitive \"+\""));
+        let module = parse_bt(&stdlib_method("@primitive \"+\""));
         let options = CompilerOptions::default();
         let diags = validate_primitives(&module, &options);
         assert_eq!(diags.len(), 1);
@@ -321,7 +316,7 @@ mod tests {
 
     #[test]
     fn primitive_with_allow_primitives_warning() {
-        let module = parse_module(&stdlib_method("@primitive \"+\""));
+        let module = parse_bt(&stdlib_method("@primitive \"+\""));
         let options = CompilerOptions {
             allow_primitives: true,
             ..Default::default()
@@ -334,7 +329,7 @@ mod tests {
 
     #[test]
     fn unknown_structural_intrinsic_error() {
-        let module = parse_module(&stdlib_method("@primitive unknownFoo"));
+        let module = parse_bt(&stdlib_method("@primitive unknownFoo"));
         let options = CompilerOptions {
             stdlib_mode: true,
             ..Default::default()
@@ -347,7 +342,7 @@ mod tests {
 
     #[test]
     fn known_structural_intrinsic_no_error() {
-        let module = parse_module(&stdlib_method("@primitive basicNew"));
+        let module = parse_bt(&stdlib_method("@primitive basicNew"));
         let options = CompilerOptions {
             stdlib_mode: true,
             ..Default::default()
@@ -362,7 +357,7 @@ mod tests {
     #[test]
     fn quoted_selector_always_accepted() {
         // Quoted selectors are runtime-dispatch, no intrinsic name validation
-        let module = parse_module(&stdlib_method("@primitive \"anyRandomName\""));
+        let module = parse_bt(&stdlib_method("@primitive \"anyRandomName\""));
         let options = CompilerOptions {
             stdlib_mode: true,
             ..Default::default()
@@ -374,7 +369,7 @@ mod tests {
     #[test]
     fn primitive_in_class_method_validated() {
         let source = "Object subclass: MyInt\n  + other => @primitive \"+\"";
-        let module = parse_module(source);
+        let module = parse_bt(source);
         let options = CompilerOptions::default();
         let diags = validate_primitives(&module, &options);
         assert_eq!(diags.len(), 1);
@@ -384,7 +379,7 @@ mod tests {
     #[test]
     fn primitive_in_class_method_stdlib_ok() {
         let source = "Object subclass: MyInt\n  + other => @primitive \"+\"";
-        let module = parse_module(source);
+        let module = parse_bt(source);
         let options = CompilerOptions {
             stdlib_mode: true,
             ..Default::default()
@@ -396,7 +391,7 @@ mod tests {
     #[test]
     fn multiple_primitives_multiple_errors() {
         let source = "Object subclass: T\n  m => @primitive \"+\". @primitive unknownFoo";
-        let module = parse_module(source);
+        let module = parse_bt(source);
         let options = CompilerOptions::default();
         let diags = validate_primitives(&module, &options);
         // At least 2 errors: one for stdlib restriction on '+', one for stdlib + unknown on unknownFoo

--- a/crates/beamtalk-core/src/semantic_analysis/return_type_writeback.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/return_type_writeback.rs
@@ -203,20 +203,7 @@ pub fn clear_return_type_writeback_for_keys(
 mod tests {
     use super::*;
     use crate::semantic_analysis::ClassHierarchy;
-
-    fn parse_module(src: &str) -> Module {
-        let tokens = crate::source_analysis::lex_with_eof(src);
-        let (module, diagnostics) = crate::source_analysis::parse(tokens);
-        let parse_errors: Vec<_> = diagnostics
-            .iter()
-            .filter(|d| d.severity == crate::source_analysis::Severity::Error)
-            .collect();
-        assert!(
-            parse_errors.is_empty(),
-            "Test fixture failed to parse cleanly: {parse_errors:?}"
-        );
-        module
-    }
+    use crate::test_helpers::test_support::parse_bt;
 
     fn build_hierarchy(module: &Module) -> ClassHierarchy {
         let (result, diagnostics) = ClassHierarchy::build(module);
@@ -232,7 +219,7 @@ mod tests {
     #[test]
     fn writeback_sets_return_type_for_integer_method() {
         let src = "Object subclass: Foo\n  bar => 42";
-        let mut module = parse_module(src);
+        let mut module = parse_bt(src);
         let hierarchy = build_hierarchy(&module);
         apply_return_type_writeback(&mut module, &hierarchy, None);
         let return_type = &module.classes[0].methods[0].return_type;
@@ -245,7 +232,7 @@ mod tests {
     #[test]
     fn writeback_preserves_explicit_annotation() {
         let src = "Object subclass: Foo\n  bar -> Integer => 42";
-        let mut module = parse_module(src);
+        let mut module = parse_bt(src);
         let hierarchy = build_hierarchy(&module);
         let original = module.classes[0].methods[0].return_type.clone();
         assert!(
@@ -263,7 +250,7 @@ mod tests {
     fn writeback_does_not_set_type_for_dynamic_method() {
         // A method whose body type cannot be statically resolved stays None
         let src = "Object subclass: Foo\n  bar: x => x doSomething";
-        let mut module = parse_module(src);
+        let mut module = parse_bt(src);
         let hierarchy = build_hierarchy(&module);
         apply_return_type_writeback(&mut module, &hierarchy, None);
         let return_type = &module.classes[0].methods[0].return_type;
@@ -283,7 +270,7 @@ mod tests {
         };
 
         let src = "Object subclass: Foo\n  bar: x => Erlang lists reverse: x";
-        let mut module = parse_module(src);
+        let mut module = parse_bt(src);
         let hierarchy = build_hierarchy(&module);
 
         let mut registry = NativeTypeRegistry::new();
@@ -310,7 +297,7 @@ mod tests {
         );
 
         // Registry-blind default (None) preserves the previous behaviour.
-        let mut module_without_registry = parse_module(src);
+        let mut module_without_registry = parse_bt(src);
         apply_return_type_writeback(&mut module_without_registry, &hierarchy, None);
         assert!(
             module_without_registry.classes[0].methods[0]

--- a/crates/beamtalk-core/src/semantic_analysis/validators/package_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/package_validators.rs
@@ -257,17 +257,12 @@ fn check_pattern_packages(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::source_analysis::{Severity, lex_with_eof, parse};
-
-    fn parse_module(src: &str) -> Module {
-        let tokens = lex_with_eof(src);
-        let (module, _diags) = parse(tokens);
-        module
-    }
+    use crate::source_analysis::Severity;
+    use crate::test_helpers::test_support::parse_bt;
 
     #[test]
     fn known_package_qualifier_no_error() {
-        let module = parse_module("json@Parser parse: input");
+        let module = parse_bt("json@Parser parse: input");
         let mut known = HashSet::new();
         known.insert("json".to_string());
         let mut diags = Vec::new();
@@ -282,7 +277,7 @@ mod tests {
 
     #[test]
     fn unknown_package_qualifier_produces_error() {
-        let module = parse_module("xml@Parser parse: input");
+        let module = parse_bt("xml@Parser parse: input");
         let mut known = HashSet::new();
         known.insert("json".to_string());
         let mut diags = Vec::new();
@@ -298,7 +293,7 @@ mod tests {
 
     #[test]
     fn empty_known_packages_skips_validation() {
-        let module = parse_module("xml@Parser parse: input");
+        let module = parse_bt("xml@Parser parse: input");
         let known = HashSet::new();
         let mut diags = Vec::new();
         check_package_qualifiers(&module, &known, &mut diags);
@@ -311,7 +306,7 @@ mod tests {
 
     #[test]
     fn unqualified_class_reference_no_error() {
-        let module = parse_module("Counter spawn");
+        let module = parse_bt("Counter spawn");
         let mut known = HashSet::new();
         known.insert("json".to_string());
         let mut diags = Vec::new();
@@ -325,7 +320,7 @@ mod tests {
 
     #[test]
     fn qualified_in_method_body_checked() {
-        let module = parse_module("Object subclass: Foo\n  bar => xml@Parser parse: \"test\"");
+        let module = parse_bt("Object subclass: Foo\n  bar => xml@Parser parse: \"test\"");
         let mut known = HashSet::new();
         known.insert("json".to_string());
         let mut diags = Vec::new();
@@ -341,7 +336,7 @@ mod tests {
 
     #[test]
     fn qualified_in_standalone_method_target() {
-        let module = parse_module("xml@Parser >> lenient => 42");
+        let module = parse_bt("xml@Parser >> lenient => 42");
         let mut known = HashSet::new();
         known.insert("json".to_string());
         let mut diags = Vec::new();
@@ -357,7 +352,7 @@ mod tests {
 
     #[test]
     fn qualified_in_standalone_method_target_known() {
-        let module = parse_module("json@Parser >> lenient => 42");
+        let module = parse_bt("json@Parser >> lenient => 42");
         let mut known = HashSet::new();
         known.insert("json".to_string());
         let mut diags = Vec::new();
@@ -375,7 +370,7 @@ mod tests {
 
     #[test]
     fn multiple_unknown_packages_multiple_errors() {
-        let module = parse_module("a := xml@Parser parse: \"x\".\nb := yaml@Loader load: \"y\"");
+        let module = parse_bt("a := xml@Parser parse: \"x\".\nb := yaml@Loader load: \"y\"");
         let mut known = HashSet::new();
         known.insert("json".to_string());
         let mut diags = Vec::new();
@@ -394,7 +389,7 @@ mod tests {
 
     #[test]
     fn qualified_in_block_body() {
-        let module = parse_module("[:x | xml@Parser parse: x]");
+        let module = parse_bt("[:x | xml@Parser parse: x]");
         let mut known = HashSet::new();
         known.insert("json".to_string());
         let mut diags = Vec::new();
@@ -410,7 +405,7 @@ mod tests {
 
     #[test]
     fn qualified_superclass_unknown_package() {
-        let module = parse_module("xml@Parser subclass: LenientParser\n  parse => 42");
+        let module = parse_bt("xml@Parser subclass: LenientParser\n  parse => 42");
         let mut known = HashSet::new();
         known.insert("json".to_string());
         let mut diags = Vec::new();
@@ -427,7 +422,7 @@ mod tests {
 
     #[test]
     fn qualified_superclass_known_package() {
-        let module = parse_module("json@Parser subclass: LenientParser\n  parse => 42");
+        let module = parse_bt("json@Parser subclass: LenientParser\n  parse => 42");
         let mut known = HashSet::new();
         known.insert("json".to_string());
         let mut diags = Vec::new();

--- a/crates/beamtalk-core/src/semantic_analysis/validators/visibility_validators.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/validators/visibility_validators.rs
@@ -1113,15 +1113,10 @@ fn check_shadow_for_method_class_side(
 mod tests {
     use super::*;
     use crate::semantic_analysis::class_hierarchy::ClassInfo;
-    use crate::source_analysis::{Severity, lex_with_eof, parse};
+    use crate::source_analysis::Severity;
+    use crate::test_helpers::test_support::parse_bt;
     use ecow::EcoString;
     use std::collections::HashMap;
-
-    fn parse_module(src: &str) -> Module {
-        let tokens = lex_with_eof(src);
-        let (module, _diags) = parse(tokens);
-        module
-    }
 
     fn build_hierarchy_with_internal_class(
         module: &Module,
@@ -1162,7 +1157,7 @@ mod tests {
 
     #[test]
     fn e0401_cross_package_superclass_reference() {
-        let module = parse_module("ParserState subclass: MyParser\n  parse => 42");
+        let module = parse_bt("ParserState subclass: MyParser\n  parse => 42");
         let h = build_hierarchy_with_internal_class(&module, "ParserState", "json");
         let mut diags = Vec::new();
         check_class_visibility(
@@ -1185,7 +1180,7 @@ mod tests {
 
     #[test]
     fn e0401_same_package_no_error() {
-        let module = parse_module(
+        let module = parse_bt(
             "internal Object subclass: ParserState\n  reset => nil\n\nParserState subclass: ExtendedState\n  parse => 42",
         );
         let (Ok(mut h), _) = ClassHierarchy::build(&module) else {
@@ -1209,7 +1204,7 @@ mod tests {
 
     #[test]
     fn e0401_public_class_cross_package_no_error() {
-        let module = parse_module("Object subclass: MyParser\n  parse => 42");
+        let module = parse_bt("Object subclass: MyParser\n  parse => 42");
         let (Ok(mut h), _) = ClassHierarchy::build(&module) else {
             panic!("build should succeed");
         };
@@ -1258,7 +1253,7 @@ mod tests {
 
     #[test]
     fn e0401_type_annotation_cross_package() {
-        let module = parse_module("Object subclass: Foo\n  process: input :: ParserState => 42");
+        let module = parse_bt("Object subclass: Foo\n  process: input :: ParserState => 42");
         let h = build_hierarchy_with_internal_class(&module, "ParserState", "json");
         let mut diags = Vec::new();
         check_class_visibility(
@@ -1279,7 +1274,7 @@ mod tests {
 
     #[test]
     fn e0401_return_type_cross_package() {
-        let module = parse_module("Object subclass: Foo\n  getState -> ParserState => nil");
+        let module = parse_bt("Object subclass: Foo\n  getState -> ParserState => nil");
         let h = build_hierarchy_with_internal_class(&module, "ParserState", "json");
         let mut diags = Vec::new();
         check_class_visibility(
@@ -1300,7 +1295,7 @@ mod tests {
 
     #[test]
     fn e0401_no_check_without_current_package() {
-        let module = parse_module("ParserState subclass: MyParser\n  parse => 42");
+        let module = parse_bt("ParserState subclass: MyParser\n  parse => 42");
         let h = build_hierarchy_with_internal_class(&module, "ParserState", "json");
         let mut diags = Vec::new();
         check_class_visibility(&module, &h, &AliasRegistry::new(), None, &mut diags);
@@ -1313,7 +1308,7 @@ mod tests {
 
     #[test]
     fn e0401_state_type_annotation_cross_package() {
-        let module = parse_module("Object subclass: Foo\n  state: buf :: ParserState = nil");
+        let module = parse_bt("Object subclass: Foo\n  state: buf :: ParserState = nil");
         let h = build_hierarchy_with_internal_class(&module, "ParserState", "json");
         let mut diags = Vec::new();
         check_class_visibility(
@@ -1335,7 +1330,7 @@ mod tests {
     #[test]
     fn e0401_class_reference_in_expression() {
         // A class reference to an internal class in a method body expression
-        let module = parse_module("Object subclass: Foo\n  bar => ParserState new");
+        let module = parse_bt("Object subclass: Foo\n  bar => ParserState new");
         let h = build_hierarchy_with_internal_class(&module, "ParserState", "json");
         let mut diags = Vec::new();
         check_class_visibility(
@@ -1357,7 +1352,7 @@ mod tests {
     #[test]
     fn e0401_class_reference_in_top_level_expression() {
         // A class reference at the top level
-        let module = parse_module("ParserState new");
+        let module = parse_bt("ParserState new");
         let h = build_hierarchy_with_internal_class(&module, "ParserState", "json");
         let mut diags = Vec::new();
         check_class_visibility(
@@ -1381,7 +1376,7 @@ mod tests {
     #[test]
     fn e0402_internal_class_in_public_return_type() {
         // A public class with a public method returning an internal class from same package
-        let module = parse_module(
+        let module = parse_bt(
             "internal Object subclass: TokenBuffer\n  data => nil\n\n\
              Object subclass: Parser\n  tokenize: input :: String -> TokenBuffer => nil",
         );
@@ -1404,7 +1399,7 @@ mod tests {
 
     #[test]
     fn e0402_internal_class_in_public_param_type() {
-        let module = parse_module(
+        let module = parse_bt(
             "internal Object subclass: TokenBuffer\n  data => nil\n\n\
              Object subclass: Parser\n  process: buf :: TokenBuffer => nil",
         );
@@ -1427,7 +1422,7 @@ mod tests {
 
     #[test]
     fn e0402_internal_class_in_state_type_annotation() {
-        let module = parse_module(
+        let module = parse_bt(
             "internal Object subclass: TokenBuffer\n  data => nil\n\n\
              Object subclass: Parser\n  state: buf :: TokenBuffer = nil",
         );
@@ -1451,7 +1446,7 @@ mod tests {
     #[test]
     fn e0402_no_error_internal_class_on_internal_class() {
         // Internal class using internal class in signature — no leak
-        let module = parse_module(
+        let module = parse_bt(
             "internal Object subclass: TokenBuffer\n  data => nil\n\n\
              internal Object subclass: InternalParser\n  tokenize: input :: String -> TokenBuffer => nil",
         );
@@ -1478,7 +1473,7 @@ mod tests {
     #[test]
     fn e0402_no_error_internal_method_on_public_class() {
         // Internal method on a public class can reference internal classes
-        let module = parse_module(
+        let module = parse_bt(
             "internal Object subclass: TokenBuffer\n  data => nil\n\n\
              Object subclass: Parser\n  internal tokenize: input :: String -> TokenBuffer => nil",
         );
@@ -1504,7 +1499,7 @@ mod tests {
 
     #[test]
     fn e0402_no_check_without_current_package() {
-        let module = parse_module(
+        let module = parse_bt(
             "internal Object subclass: TokenBuffer\n  data => nil\n\n\
              Object subclass: Parser\n  tokenize: input :: String -> TokenBuffer => nil",
         );
@@ -1546,7 +1541,7 @@ mod tests {
     fn e0402_public_signature_directly_referencing_internal_alias() {
         // A public method returning an internal alias directly — mirrors
         // ADR 0071's existing rule for internal classes.
-        let module = parse_module(
+        let module = parse_bt(
             "internal type ParserState = Integer\n\n\
              Object subclass: Parser\n  tokenize: input :: String -> ParserState => nil",
         );
@@ -1566,7 +1561,7 @@ mod tests {
     fn e0402_no_error_internal_method_referencing_internal_alias() {
         // Internal-on-internal is fine — an internal method on a public
         // class can reference an internal alias without leaking it.
-        let module = parse_module(
+        let module = parse_bt(
             "internal type ParserState = Integer\n\n\
              Object subclass: Parser\n  internal tokenize: input :: String -> ParserState => nil",
         );
@@ -1587,7 +1582,7 @@ mod tests {
     #[test]
     fn alias_leak_public_alias_directly_exposes_internal_alias() {
         // `public type Pub = InternalAlias | String` — direct one-hop case.
-        let module = parse_module("internal type Priv = Integer\ntype Pub = Priv | String");
+        let module = parse_bt("internal type Priv = Integer\ntype Pub = Priv | String");
         let (h, alias_registry) = build_hierarchy_and_aliases(&module, "json");
         let mut diags = Vec::new();
         check_alias_leaked_visibility(&module, &h, &alias_registry, Some("json"), &mut diags);
@@ -1604,7 +1599,7 @@ mod tests {
     fn alias_leak_multi_hop_through_intermediate_public_alias() {
         // `type Pub = Mid`, `type Mid = Priv` (internal) — the leak must be
         // found by following the chain, not just Pub's own written RHS.
-        let module = parse_module("internal type Priv = Integer\ntype Mid = Priv\ntype Pub = Mid");
+        let module = parse_bt("internal type Priv = Integer\ntype Mid = Priv\ntype Pub = Mid");
         let (h, alias_registry) = build_hierarchy_and_aliases(&module, "json");
         let mut diags = Vec::new();
         check_alias_leaked_visibility(&module, &h, &alias_registry, Some("json"), &mut diags);
@@ -1624,7 +1619,7 @@ mod tests {
         // `type Pub = Aa | Bb`, `type Aa = Priv`, `type Bb = Priv` (internal)
         // — both branches of the diamond reach `Priv`; the leak must be
         // reported exactly once, not once per path.
-        let module = parse_module(
+        let module = parse_bt(
             "internal type Priv = Integer\ntype Aa = Priv\ntype Bb = Priv\ntype Pub = Aa | Bb",
         );
         let (h, alias_registry) = build_hierarchy_and_aliases(&module, "json");
@@ -1649,7 +1644,7 @@ mod tests {
         // reported as the leak, recursing further into its own expansion to
         // separately flag `InternalClass` is redundant noise (both diagnostics
         // are "true", but the user only needs to fix the first boundary).
-        let module = parse_module(
+        let module = parse_bt(
             "internal Object subclass: InternalClass\n  reset => nil\n\n\
              internal type InternalMid = InternalClass\n\
              type Pub = InternalMid",
@@ -1682,7 +1677,7 @@ mod tests {
         // behavior (fixing the innermost boundary, 'Mid', makes both
         // diagnostics disappear) — pinned explicitly so the count doesn't
         // silently change in either direction.
-        let module = parse_module("internal type Priv = Integer\ntype Mid = Priv\ntype High = Mid");
+        let module = parse_bt("internal type Priv = Integer\ntype Mid = Priv\ntype High = Mid");
         let (h, alias_registry) = build_hierarchy_and_aliases(&module, "json");
         let mut diags = Vec::new();
         check_alias_leaked_visibility(&module, &h, &alias_registry, Some("json"), &mut diags);
@@ -1713,7 +1708,7 @@ mod tests {
     fn alias_leak_through_generic_type_argument() {
         // `type Pub = List(Priv)` — the leak-check must recurse into a
         // Generic annotation's type arguments, not just its base name.
-        let module = parse_module("internal type Priv = Integer\ntype Pub = List(Priv)");
+        let module = parse_bt("internal type Priv = Integer\ntype Pub = List(Priv)");
         let (h, alias_registry) = build_hierarchy_and_aliases(&module, "json");
         let mut diags = Vec::new();
         check_alias_leaked_visibility(&module, &h, &alias_registry, Some("json"), &mut diags);
@@ -1731,8 +1726,7 @@ mod tests {
     fn alias_leak_through_intersection_and_difference() {
         // `type Pub = (Priv & String) \ Symbol` — both the Intersection and
         // Difference recursion arms must be walked.
-        let module =
-            parse_module("internal type Priv = Integer\ntype Pub = (Priv & String) \\ Symbol");
+        let module = parse_bt("internal type Priv = Integer\ntype Pub = (Priv & String) \\ Symbol");
         let (h, alias_registry) = build_hierarchy_and_aliases(&module, "json");
         let mut diags = Vec::new();
         check_alias_leaked_visibility(&module, &h, &alias_registry, Some("json"), &mut diags);
@@ -1751,7 +1745,7 @@ mod tests {
         // `type Pub = ParserState` where `ParserState` is an internal class
         // — the leakage check also walks through to internal classes, not
         // just internal aliases.
-        let module = parse_module("type Pub = ParserState");
+        let module = parse_bt("type Pub = ParserState");
         let h = build_hierarchy_with_internal_class(&module, "ParserState", "json");
         let protocol_registry = ProtocolRegistry::new();
         let mut alias_registry = AliasRegistry::new();
@@ -1773,7 +1767,7 @@ mod tests {
     fn alias_leak_internal_alias_is_not_checked_itself() {
         // Internal-on-internal is fine: an internal alias's own RHS may
         // reference anything visible in its own package without leaking.
-        let module = parse_module("internal type Priv = ParserState");
+        let module = parse_bt("internal type Priv = ParserState");
         let h = build_hierarchy_with_internal_class(&module, "ParserState", "json");
         let protocol_registry = ProtocolRegistry::new();
         let mut alias_registry = AliasRegistry::new();
@@ -1791,7 +1785,7 @@ mod tests {
 
     #[test]
     fn alias_leak_no_check_without_current_package() {
-        let module = parse_module("internal type Priv = Integer\ntype Pub = Priv | String");
+        let module = parse_bt("internal type Priv = Integer\ntype Pub = Priv | String");
         let (h, alias_registry) = build_hierarchy_and_aliases(&module, "json");
         let mut diags = Vec::new();
         check_alias_leaked_visibility(&module, &h, &alias_registry, None, &mut diags);


### PR DESCRIPTION
## Summary

- Eight `#[cfg(test)]` modules in `crates/beamtalk-core/src/semantic_analysis/` each contained a private `fn parse_module` that duplicated `crate::test_helpers::test_support::parse_bt`
- Two sibling modules (`reserved_name_validators.rs`, `operator_validators.rs`) already used `parse_bt` directly — the pattern was established but the duplicates remained
- Removes all 8 copies and replaces each with an import of the shared helper
- The two simplified variants (`package_validators.rs`, `primitive_validator.rs`) that previously swallowed parse diagnostics now get `parse_bt`'s stricter assertion for free

## Files changed

| File | Change |
|------|--------|
| `semantic_analysis/lowering.rs` | Remove `fn parse_module`, import `parse_bt`, rename 2 calls |
| `semantic_analysis/block_analyzer.rs` | Remove `fn parse_module` + unused `Severity` import, import `parse_bt`, rename 8 calls |
| `semantic_analysis/name_resolver.rs` | Remove `fn parse_module`, import `parse_bt`, rename 2 calls |
| `semantic_analysis/return_type_writeback.rs` | Remove `fn parse_module`, import `parse_bt`, rename 5 calls |
| `semantic_analysis/collision_checker.rs` | Remove `fn parse_module`, import `parse_bt`, rename many calls |
| `semantic_analysis/validators/visibility_validators.rs` | Remove simplified `fn parse_module`, drop `lex_with_eof`/`parse` imports, import `parse_bt`, rename many calls |
| `semantic_analysis/validators/package_validators.rs` | Remove simplified `fn parse_module`, drop `lex_with_eof`/`parse` imports, import `parse_bt`, rename many calls |
| `semantic_analysis/primitive_validator.rs` | Remove simplified `fn parse_module`, import `parse_bt`, rename 9 calls (keep `lex_with_eof`/`parse` — used in another test) |

## Test plan

- [x] `cargo check --package beamtalk-core` — clean
- [x] `cargo clippy --package beamtalk-core` — clean
- [x] `cargo test --package beamtalk-core` — 1242 tests pass
- [x] Pre-push hooks (clippy, fmt, dialyzer, lint) — all passed

Closes #3325. Applies `docs/development/architecture-principles.md` §6 (Shared-Leaf-Module Pattern).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzhoeG5bMB7Jc3Jn6GMSYW)_