### PR TITLE
refactor: extract shared hierarchy_for_lint helper BT-3103

### DIFF
--- a/crates/beamtalk-core/src/lint/dead_block_assignment.rs
+++ b/crates/beamtalk-core/src/lint/dead_block_assignment.rs
@@ -39,8 +39,7 @@ use std::collections::HashSet;
 use crate::ast::{
     Block, ClassKind, Expression, ExpressionStatement, MethodDefinition, Module, StringSegment,
 };
-use crate::lint::LintPass;
-use crate::semantic_analysis::ClassHierarchy;
+use crate::lint::{LintPass, hierarchy_for_lint};
 use crate::source_analysis::{Diagnostic, DiagnosticCategory};
 
 /// Lint pass that warns about dead variable assignments inside blocks on value types.
@@ -52,16 +51,9 @@ impl LintPass for DeadBlockAssignmentPass {
         let mut scope = LintScope::new();
         walk_expr_seq(&module.expressions, &mut scope, None, diagnostics);
 
-        // BT-3092: `run_lint_passes` runs on the freshly-parsed module, before
-        // `apply_class_kind_writeback` (which only runs inside codegen). So
-        // `class.class_kind` here is still `ClassKind::from_superclass_name`'s
-        // shallow, direct-superclass-only placeholder — it misses indirect
-        // Actor subclasses (e.g. `class Foo extends Bar` where `Bar extends
-        // Actor`). Build a lightweight hierarchy from this module and use
-        // `resolve_class_kind`, the single authority for actor/value
-        // classification (BT-3086), which walks the full ancestor chain.
-        let (hierarchy_result, _hierarchy_diagnostics) = ClassHierarchy::build(module);
-        let hierarchy = hierarchy_result.expect("ClassHierarchy::build is infallible");
+        // BT-3092: see `hierarchy_for_lint` doc comment for why this is needed
+        // instead of `class.class_kind`.
+        let hierarchy = hierarchy_for_lint(module);
 
         for class in &module.classes {
             // Skip Actor subclasses (including indirect ones) — block

--- a/crates/beamtalk-core/src/lint/mod.rs
+++ b/crates/beamtalk-core/src/lint/mod.rs
@@ -31,6 +31,7 @@ mod value_like_object;
 // ── add new lint modules here (alphabetical) ──────────────────────────────
 
 use crate::ast::Module;
+use crate::semantic_analysis::ClassHierarchy;
 use crate::source_analysis::Diagnostic;
 
 /// A single lint pass.
@@ -39,6 +40,22 @@ use crate::source_analysis::Diagnostic;
 /// [`Severity::Lint`] into `diagnostics`.
 pub(crate) trait LintPass {
     fn check(&self, module: &Module, diagnostics: &mut Vec<Diagnostic>);
+}
+
+/// Build a [`ClassHierarchy`] for ancestor-aware class-kind resolution in lint passes.
+///
+/// `run_lint_passes` runs on the freshly-parsed module, before
+/// `apply_class_kind_writeback` (which only runs inside codegen). So
+/// `class.class_kind` is still `ClassKind::from_superclass_name`'s shallow,
+/// direct-superclass-only placeholder — it misses indirect Actor/Value
+/// subclasses (e.g. `class Foo extends Bar` where `Bar extends Actor`).
+/// Lint passes that need correct actor/value classification should build a
+/// hierarchy from this module and use `resolve_class_kind`, the single
+/// authority for actor/value classification (BT-3086), which walks the full
+/// ancestor chain (BT-3092, BT-3098).
+pub(crate) fn hierarchy_for_lint(module: &Module) -> ClassHierarchy {
+    let (hierarchy_result, _hierarchy_diagnostics) = ClassHierarchy::build(module);
+    hierarchy_result.expect("ClassHierarchy::build is infallible")
 }
 
 /// Construct the ordered list of all active lint passes.

--- a/crates/beamtalk-core/src/lint/value_like_object.rs
+++ b/crates/beamtalk-core/src/lint/value_like_object.rs
@@ -25,7 +25,7 @@
 use std::collections::HashSet;
 
 use crate::ast::{ClassDefinition, ClassKind, Expression, Identifier, MethodDefinition, Module};
-use crate::lint::LintPass;
+use crate::lint::{LintPass, hierarchy_for_lint};
 use crate::semantic_analysis::ClassHierarchy;
 use crate::source_analysis::Diagnostic;
 
@@ -41,17 +41,9 @@ pub(crate) struct ValueLikeObjectPass;
 
 impl LintPass for ValueLikeObjectPass {
     fn check(&self, module: &Module, diagnostics: &mut Vec<Diagnostic>) {
-        // BT-3098: `run_lint_passes` runs on the freshly-parsed module, before
-        // `apply_class_kind_writeback` (which only runs inside codegen). So
-        // `class.class_kind` here is still `ClassKind::from_superclass_name`'s
-        // shallow, direct-superclass-only placeholder — it misses indirect
-        // Value/Actor subclasses (e.g. `class Foo extends Bar` where `Bar
-        // extends Value`). Build a lightweight hierarchy from this module and
-        // use `resolve_class_kind`, the single authority for actor/value
-        // classification (BT-3086), which walks the full ancestor chain.
-        // Same pattern as BT-3092's fix in `dead_block_assignment.rs`.
-        let (hierarchy_result, _hierarchy_diagnostics) = ClassHierarchy::build(module);
-        let hierarchy = hierarchy_result.expect("ClassHierarchy::build is infallible");
+        // BT-3098: see `hierarchy_for_lint` doc comment for why this is needed
+        // instead of `class.class_kind`.
+        let hierarchy = hierarchy_for_lint(module);
 
         for class in &module.classes {
             check_class(class, &hierarchy, diagnostics);


### PR DESCRIPTION
## Summary

`dead_block_assignment.rs` and `value_like_object.rs` each duplicated the same three-line block: build a `ClassHierarchy` from the module, `.expect("ClassHierarchy::build is infallible")`, discard the hierarchy diagnostics — plus a near-identical explanatory comment. Per this repo's no-duplicate-implementations rule, this is now consolidated into a single `hierarchy_for_lint(module: &Module) -> ClassHierarchy` helper in `lint/mod.rs`, called from both passes.

- Added `lint::hierarchy_for_lint`, documenting why lint passes need ancestor-aware `ClassHierarchy` resolution instead of the pre-writeback `class.class_kind` placeholder (BT-3092, BT-3098).
- `dead_block_assignment.rs` and `value_like_object.rs` now call the shared helper instead of duplicating the `ClassHierarchy::build(...).expect(...)` boilerplate.
- No behavior change — all existing lint tests pass unmodified.

Fixes BT-3103.

## Test plan

- [x] `cargo test -p beamtalk-core lint::` — 104 tests pass
- [x] `cargo test -p beamtalk-core --lib` — 5620 tests pass
- [x] `cargo clippy -p beamtalk-core --lib -- -D warnings` — clean
- [x] `cargo fmt -p beamtalk-core -- --check` — clean
- [x] Full pre-push CI hook (build, clippy, dialyzer, erlang/elixir formatting/lint) passed

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01TSJY4oL5wNzRhVbF5gs4rc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSJY4oL5wNzRhVbF5gs4rc)_