### PR TITLE
docs: update ADR 0105 to reflect BT-3109's fix of BT-2806's restore race

### DIFF
--- a/docs/ADR/0105-live-image-recheck-on-reload.md
+++ b/docs/ADR/0105-live-image-recheck-on-reload.md
@@ -33,9 +33,15 @@ no later reload happens to re-check; from BT-2779), [BT-2805](https://linear.app
 retyped field, by list order, when a single reload retypes two or more
 fields; from BT-2780), and [BT-2806](https://linear.app/beamtalk/issue/BT-2806)
 (BT-2782's pre-save advisory: an untested compiler-port-exit degradation path
-in `recheck_image_class/2`, and a non-self-healing race where the precheck's
-ambient-cache restore can clobber a genuinely concurrent `register_class/2`
-commit). Enabling ADRs (all landed): 0087 (xref), 0082 (edit/save), 0100
+in `recheck_image_class/2` and `recheck_owner_for_leaf_change/3`, and a
+non-self-healing race where the precheck's ambient-cache restore could
+clobber a genuinely concurrent `register_class/2` commit — both now resolved:
+the exit-catch path is covered by a regression test, and the restore race is
+closed by construction, not merely mitigated, by
+[BT-3109](https://linear.app/beamtalk/issue/BT-3109)'s per-request
+`class_hierarchy` overlay, which replaced the mutate-then-restore mechanism
+entirely so there is no shared state left to clobber; BT-2806 is Done).
+Enabling ADRs (all landed): 0087 (xref), 0082 (edit/save), 0100
 (severity), 0022 (compiler port), 0104 (actor/`spawnWith:` checking).
 
 **Status:** Implemented — all five phases (BT-2776…BT-2783) landed: the


### PR DESCRIPTION
## Summary

- [BT-3109](https://linear.app/beamtalk/issue/BT-3109) (#3315) replaced `beamtalk_recheck`'s pre-save advisory ambient-cache mutate/restore mechanism with a per-request `class_hierarchy` overlay that never writes to `beamtalk_compiler_server` shared state, closing [BT-2806](https://linear.app/beamtalk/issue/BT-2806)'s "restore-clobbers-commit race" **by construction**.
- Updates `docs/ADR/0105-live-image-recheck-on-reload.md` (~lines 34-38) so the deferred-follow-ups list no longer describes this race as an accepted/deferred tradeoff, and notes BT-2806's other item (untested compiler-port exit path) is also resolved via a regression test.
- Doc/tracking-only change, no code modified. This is a follow-up to close the gap flagged by the Claude review bot on PR #3315 as out of scope for that PR.

## Linear

- [BT-3137](https://linear.app/beamtalk/issue/BT-3137) — this PR's tracked issue
- [BT-2806](https://linear.app/beamtalk/issue/BT-2806) — commented with resolution details; already Done
- [BT-3109](https://linear.app/beamtalk/issue/BT-3109) — the fix this doc update reflects

## Test plan

- [x] Doc-only change; no code paths affected
- [x] Verified current `beamtalk_recheck.erl` (`do_trigger_pending/5`, moduledoc) matches the updated ADR text — no `register_class/2` mutation or `after`-restore remains, overlay is passed per-request

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mti3GvPcHXnpCsrM48Hcae)_