### PR TITLE
Reject class-var-mutating self-sends in unthreaded blocks (BT-3151)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/block_analysis.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/block_analysis.rs
@@ -8,4 +8,6 @@
 //! Re-exports from `semantic_analysis::block_facts`. The analysis logic
 //! now lives in the semantic analysis layer (BT-1288).
 
-pub use crate::semantic_analysis::block_facts::{BlockMutationAnalysis, analyze_block};
+pub use crate::semantic_analysis::block_facts::{
+    BlockMutationAnalysis, analyze_block, compute_class_var_mutating_selectors,
+};

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/enumeration_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/enumeration_ops.rs
@@ -206,6 +206,11 @@ impl CoreErlangGenerator {
             return Ok(None);
         }
         if !self.enumeration_block_needs_threading(user_block) {
+            // BT-3151: falling through to `Collection.bt`'s own self-hosted
+            // `eachWithIndex:` (built on `do:`) — a same-process, in-process
+            // call, same as the other list-op call sites. See
+            // `check_bare_list_op_block_self_sends`'s doc comment.
+            self.check_bare_list_op_block_self_sends(block_arg)?;
             return Ok(None);
         }
 
@@ -257,6 +262,12 @@ impl CoreErlangGenerator {
         if !self.enumeration_block_needs_threading(element_block)
             && !self.enumeration_block_needs_threading(separator_block)
         {
+            // BT-3151: falling through to `Collection.bt`'s own self-hosted
+            // `do:separatedBy:` (built on `inject:into:`) — same-process,
+            // in-process call. See `check_bare_list_op_block_self_sends`'s
+            // doc comment.
+            self.check_bare_list_op_block_self_sends(element_arg)?;
+            self.check_bare_list_op_block_self_sends(separator_arg)?;
             return Ok(None);
         }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/filter_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/filter_ops.rs
@@ -56,6 +56,11 @@ impl CoreErlangGenerator {
 
         // list reject: is opposite of filter - we need to negate the predicate
         // BT-416: Add runtime is_list guard for non-list receivers
+        // BT-3151: see the analogous check in `generate_simple_list_op`.
+        if let Some(block) = Self::extract_block_literal(body) {
+            let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(block);
+            self.check_no_unsafe_class_method_self_sends(&analysis, block.span)?;
+        }
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/filter_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/filter_ops.rs
@@ -56,11 +56,8 @@ impl CoreErlangGenerator {
 
         // list reject: is opposite of filter - we need to negate the predicate
         // BT-416: Add runtime is_list guard for non-list receivers
-        // BT-3151: see the analogous check in `generate_simple_list_op`.
-        if let Some(block) = Self::extract_block_literal(body) {
-            let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(block);
-            self.check_no_unsafe_class_method_self_sends(&analysis, block.span)?;
-        }
+        // BT-3151: see `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(body)?;
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/mod.rs
@@ -87,6 +87,26 @@ impl CoreErlangGenerator {
         None
     }
 
+    /// BT-3151 review follow-up: checks a bare (no-mutation-threading) list-op
+    /// block body for a class-var-mutating self-send. Call this after
+    /// `block_needs_mutation_threading` returns `None`, before falling
+    /// through to a plain/BIF dispatch that compiles the block via
+    /// `generate_block` (or `expression_doc`/`generate_erlang_interop_wrapper`
+    /// on top of it) — that fallback has no way to thread a classState
+    /// mutation back to the class method that owns it. See
+    /// `check_no_unsafe_class_method_self_sends`'s doc comment for the full
+    /// rationale.
+    pub(in crate::codegen::core_erlang) fn check_bare_list_op_block_self_sends(
+        &self,
+        body: &Expression,
+    ) -> Result<()> {
+        if let Some(block) = Self::extract_block_literal(body) {
+            let analysis = block_analysis::analyze_block(block);
+            self.check_no_unsafe_class_method_self_sends(&analysis, block.span)?;
+        }
+        Ok(())
+    }
+
     pub(in crate::codegen::core_erlang) fn generate_simple_list_op(
         &mut self,
         receiver: &Expression,
@@ -101,6 +121,13 @@ impl CoreErlangGenerator {
             _ => operation,
         };
 
+        // BT-3151: `do:`/`collect:`/`select:` all route through here — a
+        // same-class mutating self-send inside a bare block has no way to
+        // thread its class-var mutation back (this always runs in-process,
+        // never a genuine cross-class gen_server call). See
+        // `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(body)?;
+
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");
@@ -110,13 +137,6 @@ impl CoreErlangGenerator {
         // Mutations inside the block are dropped (Erlang cannot propagate NewStateAcc).
         // BT-855 follow-up: Also unwrap parenthesized block literals (e.g. `([:x | ...])`).
         let body_code = if let Some(block) = Self::extract_block_literal(body) {
-            // BT-3151: `do:`/`collect:`/`select:` all route through here — a
-            // same-class mutating self-send inside this block has no way to
-            // thread its class-var mutation back (this always runs in-process,
-            // never a genuine cross-class gen_server call). See
-            // `check_no_unsafe_class_method_self_sends`'s doc comment.
-            let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(block);
-            self.check_no_unsafe_class_method_self_sends(&analysis, block.span)?;
             let (wrapped_doc, is_stateful) = self.generate_erlang_interop_wrapper(block)?;
             if is_stateful {
                 self.warn_stateful_block_at_erlang_boundary(

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/mod.rs
@@ -110,6 +110,13 @@ impl CoreErlangGenerator {
         // Mutations inside the block are dropped (Erlang cannot propagate NewStateAcc).
         // BT-855 follow-up: Also unwrap parenthesized block literals (e.g. `([:x | ...])`).
         let body_code = if let Some(block) = Self::extract_block_literal(body) {
+            // BT-3151: `do:`/`collect:`/`select:` all route through here — a
+            // same-class mutating self-send inside this block has no way to
+            // thread its class-var mutation back (this always runs in-process,
+            // never a genuine cross-class gen_server call). See
+            // `check_no_unsafe_class_method_self_sends`'s doc comment.
+            let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(block);
+            self.check_no_unsafe_class_method_self_sends(&analysis, block.span)?;
             let (wrapped_doc, is_stateful) = self.generate_erlang_interop_wrapper(block)?;
             if is_stateful {
                 self.warn_stateful_block_at_erlang_boundary(

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/search_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/search_ops.rs
@@ -353,6 +353,11 @@ impl CoreErlangGenerator {
         }
 
         // No mutations: fall through to BIF call (beamtalk_list:detect/2)
+        // BT-3151: see the analogous check in `generate_simple_list_op`.
+        if let Some(block) = Self::extract_block_literal(body) {
+            let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(block);
+            self.check_no_unsafe_class_method_self_sends(&analysis, block.span)?;
+        }
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/search_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/search_ops.rs
@@ -65,6 +65,8 @@ impl CoreErlangGenerator {
         }
 
         // No mutations: fall through to simple BIF call (lists:any/2)
+        // BT-3151: see `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(body)?;
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");
@@ -112,6 +114,8 @@ impl CoreErlangGenerator {
         }
 
         // No mutations: fall through to simple BIF call (lists:all/2)
+        // BT-3151: see `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(body)?;
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");
@@ -353,11 +357,8 @@ impl CoreErlangGenerator {
         }
 
         // No mutations: fall through to BIF call (beamtalk_list:detect/2)
-        // BT-3151: see the analogous check in `generate_simple_list_op`.
-        if let Some(block) = Self::extract_block_literal(body) {
-            let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(block);
-            self.check_no_unsafe_class_method_self_sends(&analysis, block.span)?;
-        }
+        // BT-3151: see `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(body)?;
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");
@@ -427,6 +428,10 @@ impl CoreErlangGenerator {
         predicate: &Expression,
         if_none: &Expression,
     ) -> Result<Document<'static>> {
+        // BT-3151: both blocks reach `generate_block` via `expression_doc`
+        // below — see `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(predicate)?;
+        self.check_bare_list_op_block_self_sends(if_none)?;
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let pred_var = self.fresh_temp_var("temp");

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/search_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/search_ops.rs
@@ -508,6 +508,11 @@ impl CoreErlangGenerator {
         let acc_state_var = self.fresh_temp_var("AccSt");
 
         // Compile the ifNone block upfront.
+        // BT-3151 review follow-up: `if_none` is compiled as an ordinary
+        // block via `expression_doc` → `generate_block`, independently of
+        // `body`'s own (accepted, documented) fold-threading gap — see
+        // `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(if_none)?;
         let none_code = self.expression_doc(if_none)?;
 
         if plan.use_tuple_acc {

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/transform_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/transform_ops.rs
@@ -534,6 +534,13 @@ impl CoreErlangGenerator {
         // Generate the foldl fun: for literal blocks, compile body with swapped
         // parameter order; for non-literal, use runtime arg-swap wrapper.
         let foldl_fun_doc = if let Expression::Block(body_block) = body {
+            // BT-3151: this pure-block fast path calls `generate_block_body`
+            // directly below, bypassing `generate_block`'s own self-send
+            // check — so it needs the same guard here. See
+            // `check_no_unsafe_class_method_self_sends`'s doc comment.
+            let analysis = crate::codegen::core_erlang::block_analysis::analyze_block(body_block);
+            self.check_no_unsafe_class_method_self_sends(&analysis, body_block.span)?;
+
             // Literal block: compile directly with foldl parameter order (Elem, Acc).
             // Block params: [0] = acc, [1] = elem (Beamtalk convention)
             // Foldl fun params: (Elem, Acc) (Erlang convention)

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/transform_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/transform_ops.rs
@@ -36,6 +36,8 @@ impl CoreErlangGenerator {
         }
 
         // No mutations: use lists:filter + erlang:length
+        // BT-3151: see `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(body)?;
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");
@@ -264,6 +266,8 @@ impl CoreErlangGenerator {
         }
 
         // No mutations: use lists:flatmap
+        // BT-3151: see `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(body)?;
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");
@@ -828,6 +832,8 @@ impl CoreErlangGenerator {
         }
 
         // No mutations: use lists:takewhile
+        // BT-3151: see `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(body)?;
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");
@@ -1081,6 +1087,8 @@ impl CoreErlangGenerator {
         }
 
         // No mutations: use lists:dropwhile
+        // BT-3151: see `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(body)?;
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");
@@ -1330,6 +1338,8 @@ impl CoreErlangGenerator {
         }
 
         // No mutations: use beamtalk_list:partition
+        // BT-3151: see `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(body)?;
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");
@@ -1631,6 +1641,8 @@ impl CoreErlangGenerator {
         }
 
         // No mutations: use beamtalk_list:group_by
+        // BT-3151: see `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(body)?;
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");
@@ -1880,6 +1892,8 @@ impl CoreErlangGenerator {
         }
 
         // No mutations: use beamtalk_list:sort_with
+        // BT-3151: see `check_bare_list_op_block_self_sends`'s doc comment.
+        self.check_bare_list_op_block_self_sends(body)?;
         let list_var = self.fresh_temp_var("temp");
         let recv_code = self.expression_doc(receiver)?;
         let body_var = self.fresh_temp_var("temp");

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/while_loops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/while_loops.rs
@@ -226,6 +226,12 @@ impl CoreErlangGenerator {
         // Generate condition inside branch context
         let cond_doc = self.with_branch_context(|this| {
             if let Expression::Block(cond_block) = condition {
+                // BT-3151: this condition block bypasses `generate_block`'s own
+                // self-send check by calling `generate_block_body` directly —
+                // see `check_no_unsafe_class_method_self_sends`'s doc comment.
+                let analysis =
+                    crate::codegen::core_erlang::block_analysis::analyze_block(cond_block);
+                this.check_no_unsafe_class_method_self_sends(&analysis, cond_block.span)?;
                 this.generate_block_body(cond_block)
             } else {
                 this.generate_expression(condition)
@@ -277,6 +283,7 @@ impl CoreErlangGenerator {
     ///
     /// Uses `fun (Var1, ..., VarN)` instead of `fun (StateAcc)`.
     /// The `StateAcc` map is rebuilt only once in the false (exit) arm.
+    #[allow(clippy::too_many_lines)] // direct-params state-threading codegen, BT-1275
     fn generate_while_loop_direct(
         &mut self,
         condition: &Expression,
@@ -352,6 +359,10 @@ impl CoreErlangGenerator {
 
         let cond_doc = self.with_branch_context(|this| {
             if let Expression::Block(cond_block) = condition {
+                // BT-3151: see the analogous check in `generate_while_loop`.
+                let analysis =
+                    crate::codegen::core_erlang::block_analysis::analyze_block(cond_block);
+                this.check_no_unsafe_class_method_self_sends(&analysis, cond_block.span)?;
                 this.generate_block_body(cond_block)
             } else {
                 this.generate_expression(condition)
@@ -647,7 +658,11 @@ impl CoreErlangGenerator {
             let prev_hybrid = this.in_hybrid_loop;
             this.in_hybrid_loop = true;
             let result = if let Expression::Block(cond_block) = condition {
-                this.generate_block_body(cond_block)
+                // BT-3151: see the analogous check in `generate_while_loop`.
+                let analysis =
+                    crate::codegen::core_erlang::block_analysis::analyze_block(cond_block);
+                this.check_no_unsafe_class_method_self_sends(&analysis, cond_block.span)
+                    .and_then(|()| this.generate_block_body(cond_block))
             } else {
                 this.generate_expression(condition)
             };

--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -1106,6 +1106,16 @@ impl CoreErlangGenerator {
                         arg_parts.push(Document::Str(", "));
                     }
                     if let Some(block) = Self::extract_block_literal(arg) {
+                        // BT-3151 review follow-up: a block crossing the Erlang
+                        // interop boundary here goes through
+                        // `generate_erlang_interop_wrapper` → `generate_block`,
+                        // the same same-process, in-process closure mechanism as
+                        // a `select:`/`do:` argument — see
+                        // `check_no_unsafe_class_method_self_sends`'s doc
+                        // comment.
+                        let analysis =
+                            crate::codegen::core_erlang::block_analysis::analyze_block(block);
+                        self.check_no_unsafe_class_method_self_sends(&analysis, block.span)?;
                         let (wrapped_doc, is_stateful) =
                             self.generate_erlang_interop_wrapper(block)?;
                         if is_stateful {

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -892,18 +892,25 @@ impl CoreErlangGenerator {
     /// this guard introduces). `generate_block` has no way to tell those apart
     /// from its own call site. Instead, called individually from each
     /// call site *confirmed* unsafe (same-process, in-process self-send,
-    /// mutation empirically lost): `generate_simple_list_op`
-    /// (`do:`/`collect:`/`select:`), `generate_list_reject`,
-    /// `generate_list_detect`, `generate_list_inject`'s BT-1327 pure-block
-    /// fast path (which also bypasses `generate_block` — calls
-    /// `generate_block_body` directly to avoid wrapper overhead), a
-    /// `whileTrue:`/`whileFalse:` condition block, a bare (no local-var
-    /// mutation) `timesRepeat:`/`to:do:`/`to:by:do:` body that falls through
-    /// to the stdlib's own `Integer`/value-type loop implementation, and a
-    /// block argument crossing the Erlang interop boundary in a direct
-    /// `(Erlang mod) fn: arg` call (`generate_direct_erlang_call`'s keyword
-    /// branch, `dispatch_codegen.rs`) — same `generate_erlang_interop_wrapper`
-    /// → `generate_block` mechanism as the list-op call sites above.
+    /// mutation empirically lost). Most list-op call sites share this via
+    /// `check_bare_list_op_block_self_sends` (`control_flow/list_ops/mod.rs`)
+    /// — `do:`/`collect:`/`select:`/`reject:`/`detect:`/`detect:ifNone:`/
+    /// `anySatisfy:`/`allSatisfy:`/`count:`/`flatMap:`/`takeWhile:`/
+    /// `dropWhile:`/`partition:`/`groupBy:`/`sort:`, plus the
+    /// `eachWithIndex:`/`do:separatedBy:` desugar fallbacks
+    /// (`enumeration_ops.rs`) — every one a bare, no-mutation-threading
+    /// block that falls through to a plain/BIF dispatch. Called directly
+    /// (not through that shared helper) at three shapes it doesn't cover:
+    /// `generate_list_inject`'s BT-1327 pure-block fast path (bypasses
+    /// `generate_block` entirely — calls `generate_block_body` directly to
+    /// avoid wrapper overhead), a `whileTrue:`/`whileFalse:` condition
+    /// block, a bare `timesRepeat:`/`to:do:`/`to:by:do:` body that falls
+    /// through to the stdlib's own `Integer`/value-type loop implementation,
+    /// and a block argument crossing the Erlang interop boundary in a
+    /// direct `(Erlang mod) fn: arg` call (`generate_direct_erlang_call`'s
+    /// keyword branch, `dispatch_codegen.rs`) — same
+    /// `generate_erlang_interop_wrapper` → `generate_block` mechanism as
+    /// the list-op call sites above.
     pub(super) fn check_no_unsafe_class_method_self_sends(
         &self,
         analysis: &crate::codegen::core_erlang::block_analysis::BlockMutationAnalysis,

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -888,8 +888,8 @@ impl CoreErlangGenerator {
     /// not the lossy in-process direct-call optimization — see ADR 0110
     /// BT-3039 / `shadow_cross_class_owner.bt`) or merely unproven (an
     /// `ifTrue:`/`ifFalse:` block reached via generic dynamic dispatch is a
-    /// long-documented ADR 0110 "known limitation", not something this
-    /// guard introduces). `generate_block` has no way to tell those apart
+    /// long-documented ADR 0110 "known limitation" (BT-1550), not something
+    /// this guard introduces). `generate_block` has no way to tell those apart
     /// from its own call site. Instead, called individually from each
     /// call site *confirmed* unsafe (same-process, in-process self-send,
     /// mutation empirically lost): `generate_simple_list_op`
@@ -897,9 +897,13 @@ impl CoreErlangGenerator {
     /// `generate_list_detect`, `generate_list_inject`'s BT-1327 pure-block
     /// fast path (which also bypasses `generate_block` — calls
     /// `generate_block_body` directly to avoid wrapper overhead), a
-    /// `whileTrue:`/`whileFalse:` condition block, and a bare (no local-var
+    /// `whileTrue:`/`whileFalse:` condition block, a bare (no local-var
     /// mutation) `timesRepeat:`/`to:do:`/`to:by:do:` body that falls through
-    /// to the stdlib's own `Integer`/value-type loop implementation.
+    /// to the stdlib's own `Integer`/value-type loop implementation, and a
+    /// block argument crossing the Erlang interop boundary in a direct
+    /// `(Erlang mod) fn: arg` call (`generate_direct_erlang_call`'s keyword
+    /// branch, `dispatch_codegen.rs`) — same `generate_erlang_interop_wrapper`
+    /// → `generate_block` mechanism as the list-op call sites above.
     pub(super) fn check_no_unsafe_class_method_self_sends(
         &self,
         analysis: &crate::codegen::core_erlang::block_analysis::BlockMutationAnalysis,

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -864,6 +864,73 @@ impl CoreErlangGenerator {
         None
     }
 
+    /// BT-3151: Rejects a same-class self-send inside a block whose target
+    /// selector isn't provably free of class-variable mutation (see
+    /// `ClassMethodSelfSendInUnthreadedBlock`'s doc comment for the full
+    /// rationale) — such a block has no way to thread a classState mutation
+    /// back to the class method that owns it, silently losing it otherwise.
+    ///
+    /// Scoped to class-method context only (this is a classState concern,
+    /// not an actor-state one), and gated on the class actually declaring
+    /// class variables: with none, there is no classState a self-send could
+    /// possibly lose, so the conservative "not defined locally" fallback
+    /// below (which can't see inherited methods — e.g. `Actor`'s
+    /// `spawnWith:` called from a native Actor subclass with no
+    /// `classState:` of its own, like `Subprocess`) would otherwise reject
+    /// sends to safe inherited methods it has no way to prove safe. See
+    /// `class_var_names`.
+    ///
+    /// Deliberately NOT called from `generate_block` itself — that function
+    /// is the universal block-to-closure compiler, reached from contexts
+    /// that are safe (a block passed to a *different* class's class-side
+    /// method always runs in that class's own `gen_server` process, so a
+    /// same-class self-send inside it is genuine cross-process messaging,
+    /// not the lossy in-process direct-call optimization — see ADR 0110
+    /// BT-3039 / `shadow_cross_class_owner.bt`) or merely unproven (an
+    /// `ifTrue:`/`ifFalse:` block reached via generic dynamic dispatch is a
+    /// long-documented ADR 0110 "known limitation", not something this
+    /// guard introduces). `generate_block` has no way to tell those apart
+    /// from its own call site. Instead, called individually from each
+    /// call site *confirmed* unsafe (same-process, in-process self-send,
+    /// mutation empirically lost): `generate_simple_list_op`
+    /// (`do:`/`collect:`/`select:`), `generate_list_reject`,
+    /// `generate_list_detect`, `generate_list_inject`'s BT-1327 pure-block
+    /// fast path (which also bypasses `generate_block` — calls
+    /// `generate_block_body` directly to avoid wrapper overhead), a
+    /// `whileTrue:`/`whileFalse:` condition block, and a bare (no local-var
+    /// mutation) `timesRepeat:`/`to:do:`/`to:by:do:` body that falls through
+    /// to the stdlib's own `Integer`/value-type loop implementation.
+    pub(super) fn check_no_unsafe_class_method_self_sends(
+        &self,
+        analysis: &crate::codegen::core_erlang::block_analysis::BlockMutationAnalysis,
+        span: crate::source_analysis::Span,
+    ) -> Result<()> {
+        if !self.in_class_method() || self.class_var_names().is_empty() {
+            return Ok(());
+        }
+        let mut unsafe_selectors: Vec<&String> = analysis
+            .self_send_selectors
+            .iter()
+            .filter(|sel| {
+                self.class_var_mutating_selectors().contains(sel.as_str())
+                    || !self.class_method_selectors().contains(sel.as_str())
+            })
+            .collect();
+        if let Some(selector) = {
+            unsafe_selectors.sort_unstable();
+            unsafe_selectors.into_iter().next()
+        } {
+            return Err(CodeGenError::ClassMethodSelfSendInUnthreadedBlock {
+                selector: selector.clone(),
+                location: self.span_to_line(span).map_or_else(
+                    || format!("offset {}", span.start()),
+                    |line| format!("line {line}"),
+                ),
+            });
+        }
+        Ok(())
+    }
+
     /// Generates code for a block (closure).
     ///
     /// BT-852: Automatically selects Tier 1 (plain) or Tier 2 (stateful) codegen
@@ -911,6 +978,29 @@ impl CoreErlangGenerator {
                 )
             })?;
         }
+
+        // BT-3151: deliberately NOT calling `check_no_unsafe_class_method_self_sends`
+        // here — `generate_block` is the universal block-to-closure compiler,
+        // reached both from genuinely unsafe bare-block call sites (a
+        // `select:`/`do:`/`inject:into:` argument, a `whileTrue:` condition —
+        // all same-process, in-process self-send contexts where the mutation
+        // is provably lost) AND from contexts that are safe or cannot be
+        // proven unsafe here: an `ifTrue:`/`ifFalse:` block reached via
+        // generic dynamic dispatch (a long-documented ADR 0110 "known
+        // limitation", not newly introduced by this guard), and a block
+        // passed to a message send whose receiver may be a *different*
+        // class's class-side method — which always executes in that class's
+        // own gen_server process (`docs/beamtalk-language-features.md` §
+        // Passing Blocks Through Class Methods), so a same-class self-send
+        // inside it is genuine cross-process messaging, not the in-process
+        // direct-call optimization, and correctly commits (confirmed by the
+        // pre-existing, passing `shadow_cross_class_owner.bt` fixture/
+        // `testCrossClassMutationDoesNotCorruptForeignProcessShadow`, ADR
+        // 0110 BT-3039). `generate_block` has no way to distinguish these
+        // from its own call site, so the check instead lives at each
+        // specific, individually-verified-unsafe call site: see
+        // `check_no_unsafe_class_method_self_sends`'s doc comment for the
+        // full list.
 
         let captured_mutations = Self::captured_mutations_from_analysis(&analysis);
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -2915,6 +2915,17 @@ impl CoreErlangGenerator {
             .map(|m| m.selector.name().to_string())
             .collect();
 
+        // BT-3151: Populate the class-var-mutating selector set (transitive
+        // closure over same-class self-sends) — see
+        // `compute_class_var_mutating_selectors`'s doc comment. Depends on
+        // `class_var_names` above, so must run after it; independent of
+        // `class_method_selectors` above (recomputes its own local view).
+        *self.class_var_mutating_selectors_mut() =
+            crate::codegen::core_erlang::block_analysis::compute_class_var_mutating_selectors(
+                class,
+                self.class_var_names(),
+            );
+
         // BT-996: Populate auto-generated keyword constructor selector for Value subclass: classes.
         // This allows `ClassName slot: value` inside a class method to route to the correct
         // class-side constructor instead of falling through to the instance-side getter.

--- a/crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs
@@ -530,6 +530,11 @@ impl CoreErlangGenerator {
                 let doc = self.generate_times_repeat_with_mutations(receiver, body_block)?;
                 return Ok(Some(doc));
             }
+            // BT-3151: falling through to the stdlib's own tail-recursive
+            // `Integer>>timesRepeat:` — a same-process, in-process call, same
+            // as `select:`/`do:`. See
+            // `check_no_unsafe_class_method_self_sends`'s doc comment.
+            self.check_no_unsafe_class_method_self_sends(&analysis, body_block.span)?;
         }
         Ok(None)
     }
@@ -565,6 +570,8 @@ impl CoreErlangGenerator {
                     self.generate_to_do_with_mutations(receiver, &arguments[0], body_block)?;
                 return Ok(Some(doc));
             }
+            // BT-3151: see the analogous check in `try_generate_times_repeat`.
+            self.check_no_unsafe_class_method_self_sends(&analysis, body_block.span)?;
         }
         Ok(None)
     }
@@ -604,6 +611,8 @@ impl CoreErlangGenerator {
                 )?;
                 return Ok(Some(doc));
             }
+            // BT-3151: see the analogous check in `try_generate_times_repeat`.
+            self.check_no_unsafe_class_method_self_sends(&analysis, body_block.span)?;
         }
         Ok(None)
     }

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -237,6 +237,46 @@ pub enum CodeGenError {
         location: String,
     },
 
+    /// BT-3151: A self-send to a same-class class method, inside a block that
+    /// compiles through `generate_block`'s generic "plain fun"/Tier 2 fallback
+    /// (`select:`/`collect:`/`do:`/etc. arguments, a block stored in a local var
+    /// then invoked, or any other bare/passed block) in a class method — the
+    /// sibling gap BT-3150 left open (see that error's doc comment and ADR
+    /// 0110's BT-3150 amendment): unlike a `Letrec`/`FoldlDo` threaded loop
+    /// body, this shape has no legitimate "unconditionally discard the
+    /// self-send's return value" reading to justify rejecting *every*
+    /// self-send here the way BT-3150 does — `select:`/`collect:`/etc. bodies
+    /// routinely and correctly use a self-send's return value (confirmed by a
+    /// real stdlib fixture, `stdlib/test/fixtures/class_method_block.bt`,
+    /// BT-2350), so a blanket rejection would break real code exactly as it
+    /// did when first tried for BT-3150's own `Foldl*` widening attempt.
+    ///
+    /// Resolved instead with `block_analysis::compute_class_var_mutating_selectors`:
+    /// a same-class self-send is only rejected here when its target selector is
+    /// *not provably free* of class-variable mutation — it (or something it
+    /// calls, transitively) writes a class variable directly, or it isn't a
+    /// locally defined class method at all (inherited/unresolvable, where
+    /// purity can't be checked — conservatively assumed unsafe, the same
+    /// "can't know statically" call BT-3150 makes). A self-send to a provably
+    /// pure class method (the common case — `self double:`-style helpers)
+    /// keeps compiling.
+    #[error(
+        "Cannot send '{selector}' to self inside this block at {location}: this self-send \
+             cannot be proven free of class-variable mutation ('{selector}' either writes a \
+             class variable itself, calls another method that might, or isn't defined locally \
+             in this class where that could be checked) — and unlike a threaded loop body, this \
+             block has no way to thread such a mutation back to the class method that owns it.\n\n\
+             Fix: Call '{selector}' directly from the class method's own body instead of from \
+             inside this block, or extract whatever the block needs into a helper method \
+             that's provably free of class-variable mutation."
+    )]
+    ClassMethodSelfSendInUnthreadedBlock {
+        /// The selector being self-sent.
+        selector: String,
+        /// Source location.
+        location: String,
+    },
+
     /// BT-3140: A class-var assignment (`self.field := ...`) inside a loop, conditional,
     /// exception handler, or list-op body (or any other context reached via
     /// `generate_field_assignment_open`) in a class method.
@@ -1252,6 +1292,14 @@ pub(super) struct ClassContext {
     /// BT-412: Selector names of class methods in the current class.
     /// Used to route self-sends to class method functions vs module exports.
     pub class_method_selectors: std::collections::HashSet<String>,
+    /// BT-3151: Selector names of class methods (in the current class) that are
+    /// known or suspected to mutate a class variable, directly or transitively
+    /// — see `block_analysis::compute_class_var_mutating_selectors`. Used to
+    /// let a self-send to a provably pure class method compile inside a bare,
+    /// unthreaded block (`select:`/`collect:`/`do:`/etc.) while rejecting one
+    /// that may mutate class state there, where BT-3150's `Letrec`-only guard
+    /// doesn't reach.
+    pub class_var_mutating_selectors: std::collections::HashSet<String>,
     /// BT-412/BT-3131: State version counter for class variable threading.
     ///
     /// Not `pub` (unlike this struct's other fields) — [`VersionCounter`] is
@@ -1301,6 +1349,7 @@ pub(super) struct SavedClassMethodCtx {
     in_class_method: bool,
     class_var_names: std::collections::HashSet<String>,
     class_method_selectors: std::collections::HashSet<String>,
+    class_var_mutating_selectors: std::collections::HashSet<String>,
     class_var_version: usize,
     class_var_mutated: bool,
     class_slot_constructor_selector: Option<String>,
@@ -1314,6 +1363,7 @@ impl ClassContext {
             class_identity: None,
             class_var_names: std::collections::HashSet::new(),
             class_method_selectors: std::collections::HashSet::new(),
+            class_var_mutating_selectors: std::collections::HashSet::new(),
             class_var_version: VersionCounter::new(),
             class_var_mutated: false,
             class_module_index: std::collections::HashMap::new(),
@@ -1814,6 +1864,22 @@ impl CoreErlangGenerator {
         &mut self.class_context_mut().class_method_selectors
     }
 
+    /// BT-3151: Returns a reference to the class-var-mutating selectors set.
+    pub(super) fn class_var_mutating_selectors(&self) -> &std::collections::HashSet<String> {
+        static EMPTY: std::sync::LazyLock<std::collections::HashSet<String>> =
+            std::sync::LazyLock::new(std::collections::HashSet::new);
+        self.class_context
+            .as_ref()
+            .map_or(&*EMPTY, |ctx| &ctx.class_var_mutating_selectors)
+    }
+
+    /// BT-3151: Returns a mutable reference to the class-var-mutating selectors set.
+    pub(super) fn class_var_mutating_selectors_mut(
+        &mut self,
+    ) -> &mut std::collections::HashSet<String> {
+        &mut self.class_context_mut().class_var_mutating_selectors
+    }
+
     /// Returns the class variable version counter.
     pub(super) fn class_var_version(&self) -> usize {
         self.class_context
@@ -1931,6 +1997,7 @@ impl CoreErlangGenerator {
             in_class_method: self.in_class_method(),
             class_var_names: self.class_var_names().clone(),
             class_method_selectors: self.class_method_selectors().clone(),
+            class_var_mutating_selectors: self.class_var_mutating_selectors().clone(),
             class_var_version: self.class_var_version(),
             class_var_mutated: self.class_var_mutated(),
             class_slot_constructor_selector: self.class_slot_constructor_selector().cloned(),
@@ -1945,6 +2012,16 @@ impl CoreErlangGenerator {
         // threading across such self-sends rides on the open scope that
         // `emit_class_var_result_unwrap` always produces, not on this set.
         self.class_method_selectors_mut().clear();
+        // BT-3151: also cleared, for the same reason plus one more — an empty
+        // `class_method_selectors` already makes `generate_block`'s bare-block
+        // self-send check treat every self-send here as unresolvable (so
+        // conservatively unsafe) regardless of this set's contents, since a
+        // programmatic `ClassBuilder` cascade has no static `ClassDefinition`
+        // to run `compute_class_var_mutating_selectors` over in the first
+        // place. Clearing just avoids leaking the enclosing class's own
+        // mutating-selector set into an unrelated builder class's selector
+        // namespace.
+        self.class_var_mutating_selectors_mut().clear();
         self.set_class_var_version(0);
         self.set_class_var_mutated(false);
         self.set_class_slot_constructor_selector(None);
@@ -1959,6 +2036,7 @@ impl CoreErlangGenerator {
             self.set_in_class_method(saved.in_class_method);
             *self.class_var_names_mut() = saved.class_var_names;
             *self.class_method_selectors_mut() = saved.class_method_selectors;
+            *self.class_var_mutating_selectors_mut() = saved.class_var_mutating_selectors;
             self.set_class_var_version(saved.class_var_version);
             self.set_class_var_mutated(saved.class_var_mutated);
             self.set_class_slot_constructor_selector(saved.class_slot_constructor_selector);

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -4110,6 +4110,59 @@ fn test_class_method_self_send_in_erlang_interop_block_is_compile_error() {
 }
 
 #[test]
+fn test_class_method_self_send_in_any_satisfy_block_is_compile_error() {
+    // BT-3151 review follow-up: `anySatisfy:`/`allSatisfy:` (and every other
+    // sibling list-op in `control_flow/list_ops/` with the same
+    // `block_needs_mutation_threading`-gated "fall through to a bare/BIF
+    // call" shape — `detect:ifNone:`, `count:`, `flatMap:`, `takeWhile:`,
+    // `dropWhile:`, `partition:`, `groupBy:`, `sort:`, plus the
+    // `eachWithIndex:`/`do:separatedBy:` desugar fallbacks) were left
+    // unguarded by this PR's first push even though they're structurally
+    // identical to `select:`/`do:`/`collect:`. Now share the guard via
+    // `check_bare_list_op_block_self_sends`. This pins the exact repro from
+    // the review comment.
+    let src = "Value subclass: DriverAnySatisfy\n  classState: runs = 0\n  class check: x => self.runs := self.runs + 1. x > 0\n  class positives: aList =>\n    aList anySatisfy: [:x | self check: x]";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@driveranysatisfy").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(CodeGenError::ClassMethodSelfSendInUnthreadedBlock { .. })
+        ),
+        "A mutating self-send inside an anySatisfy: block must be caught by \
+         BT-3151's guard, matching every other bare-block list-op call site. \
+         Got: {result:?}"
+    );
+}
+
+#[test]
+fn test_class_method_self_send_in_sort_block_is_compile_error() {
+    // BT-3151 review follow-up: pins `sort:` (a 2-arg comparator block) as
+    // another sibling covered by `check_bare_list_op_block_self_sends` — see
+    // `test_class_method_self_send_in_any_satisfy_block_is_compile_error`'s
+    // comment for the full list.
+    let src = "Value subclass: DriverSort\n  classState: runs = 0\n  class check: x => self.runs := self.runs + 1. x\n  class sorted: aList =>\n    aList sort: [:a :b | (self check: a) < (self check: b)]";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@driversort").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(CodeGenError::ClassMethodSelfSendInUnthreadedBlock { .. })
+        ),
+        "A mutating self-send inside a sort: comparator block must be caught by \
+         BT-3151's guard. Got: {result:?}"
+    );
+}
+
+#[test]
 fn test_class_method_self_send_in_pure_inject_into_block_is_compile_error() {
     // BT-3151 follow-up: `generate_list_inject`'s BT-1327 pure-block fast
     // path calls `generate_block_body` directly (to emit an inline

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -3833,6 +3833,12 @@ fn test_bare_class_method_self_send_in_times_repeat_body_skips_loop_threading() 
     // reaching `generate_threaded_loop_body`/the BT-3150 gap at all. Pinned
     // here as the boundary of this fix's scope, mirroring BT-3140's analogous
     // bare-field-write contrast test.
+    //
+    // BT-3151: that "ordinary block" path is exactly `generate_block`'s
+    // generic fallback, which is where BT-3151's own guard lives — so this
+    // bare, mutation-losing self-send is now a compile error instead of
+    // silently compiling. Updated from `result.is_ok()` (BT-3150-era) to
+    // match.
     let src = "Value subclass: Driver4\n  classState: runs = 0\n  class bump => self.runs := self.runs + 1\n  class countedRun: n =>\n    n timesRepeat: [\n      self bump\n      self bump\n    ]\n    nil";
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _diags) = crate::source_analysis::parse(tokens);
@@ -3841,9 +3847,13 @@ fn test_bare_class_method_self_send_in_times_repeat_body_skips_loop_threading() 
         CodegenOptions::new("bt@driver4").with_workspace_mode(true),
     );
     assert!(
-        result.is_ok(),
-        "A timesRepeat: body with only self-sends (no local var) should not reach \
-         the threaded-loop codegen path at all. Got: {result:?}"
+        matches!(
+            result,
+            Err(CodeGenError::ClassMethodSelfSendInUnthreadedBlock { .. })
+        ),
+        "A timesRepeat: body with only self-sends (no local var) skips the \
+         threaded-loop codegen path, but the mutating self-send must now be \
+         caught by BT-3151's unthreaded-block guard. Got: {result:?}"
     );
 }
 
@@ -3851,10 +3861,17 @@ fn test_bare_class_method_self_send_in_times_repeat_body_skips_loop_threading() 
 fn test_class_method_self_send_after_loop_still_compiles() {
     // BT-3150 (contrast case): the workaround recommended by
     // `ClassMethodSelfSendInThreadedLoopBody`'s error message — accumulate a
-    // local count inside the loop, then self-send the required number of
-    // times after the loop (a top-frame self-send per call, the already-
-    // proven ADR 0110/BT-412 shape) — must keep compiling.
-    let src = "Value subclass: Driver8\n  classState: runs = 0\n  class bump => self.runs := self.runs + 1\n  class countedRun: aBlock over: aList =>\n    i := 1\n    count := 0\n    [i <= aList size] whileTrue: [\n      count := count + 1\n      aBlock value: (aList at: i)\n      i := i + 1\n    ]\n    count timesRepeat: [self bump]\n    nil";
+    // local count inside the loop, then make the self-send once after the
+    // loop, at the class method's own top frame (the already-proven ADR
+    // 0110/BT-412 shape) — must keep compiling.
+    //
+    // BT-3151: this is deliberately a single top-frame self-send, not
+    // `count timesRepeat: [self bump]` — repeating the self-send N times
+    // still requires wrapping it in a block, which is exactly the shape
+    // BT-3151's guard now (correctly) rejects. See
+    // `test_bare_class_method_self_send_in_times_repeat_body_skips_loop_threading`
+    // for that case.
+    let src = "Value subclass: Driver8\n  classState: runs = 0\n  class bump => self.runs := self.runs + 1\n  class countedRun: aBlock over: aList =>\n    i := 1\n    count := 0\n    [i <= aList size] whileTrue: [\n      count := count + 1\n      aBlock value: (aList at: i)\n      i := i + 1\n    ]\n    self bump\n    nil";
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _diags) = crate::source_analysis::parse(tokens);
     let result = generate_module(
@@ -3971,17 +3988,14 @@ fn test_bare_class_method_self_send_in_select_body_skips_loop_threading() {
     // mutation never needs state threading — mirroring
     // `test_bare_class_method_self_send_in_times_repeat_body_skips_loop_threading`
     // for `Letrec`, it compiles as an ordinary block (never reaching
-    // `generate_threaded_loop_body`). NOTE: this does NOT mean it's
-    // runtime-safe — confirmed empirically that this shape also silently
-    // loses the class-var mutation (`runs` stayed 0), the same way a bare
-    // class-var *field* write in a stored/passed block is caught by the
-    // pre-existing `FieldAssignmentInUnsupportedBlock`/`validate_stored_closure`
-    // guard (BT-1346/BT-2792) — except that guard only walks a block's field
-    // writes, not self-sends, so this self-send variant currently slips
-    // through uncaught. Tracked as a follow-up (BT-3151) rather than fixed
-    // here: it's a different code path (block-mutation analysis in
-    // `block_analysis.rs`, not `generate_threaded_loop_body_inner`) than the
-    // one this PR's guard covers.
+    // `generate_threaded_loop_body`), routing instead through
+    // `generate_block`'s generic fallback.
+    //
+    // BT-3151: this is the exact repro from that issue — confirmed
+    // empirically (before the fix) that this shape silently loses the
+    // class-var mutation (`runs` stayed 0). Now caught at compile time by
+    // BT-3151's guard in `generate_block`. Updated from `result.is_ok()`
+    // (BT-3150-era, when this was still a documented open gap) to match.
     let src = "Value subclass: DriverSelect\n  classState: runs = 0\n  class check: x => self.runs := self.runs + 1. x > 0\n  class positives: aList =>\n    aList select: [:x | self check: x]";
     let tokens = crate::source_analysis::lex_with_eof(src);
     let (module, _diags) = crate::source_analysis::parse(tokens);
@@ -3990,9 +4004,105 @@ fn test_bare_class_method_self_send_in_select_body_skips_loop_threading() {
         CodegenOptions::new("bt@driverselect").with_workspace_mode(true),
     );
     assert!(
+        matches!(
+            result,
+            Err(CodeGenError::ClassMethodSelfSendInUnthreadedBlock { .. })
+        ),
+        "A select: body with only a class-method self-send (no local var) skips the \
+         threaded-loop codegen path, but the mutating self-send must now be caught \
+         by BT-3151's unthreaded-block guard. Got: {result:?}"
+    );
+}
+
+#[test]
+fn test_class_method_self_send_in_block_compiles_when_class_has_no_class_vars() {
+    // BT-3151 follow-up: BT-3151's unthreaded-block guard can't see a
+    // self-send's target selector when it isn't locally defined on the
+    // current class (e.g. inherited from a superclass in a different file —
+    // `compute_class_var_mutating_selectors` only has this class's own
+    // `class_methods` to analyze), so it conservatively treats any such
+    // self-send as unsafe. That conservatism is unsound as a blanket rule:
+    // `stdlib/src/Subprocess.bt` self-sends `spawnWith:` (inherited from
+    // `Actor`, `stdlib/src/Actor.bt`) from inside a `tryDo:` block, and
+    // `just build` failed on it once this guard landed.
+    //
+    // The fix: gate the whole check on the class actually declaring class
+    // variables (`class_var_names`). With none, there is no classState a
+    // self-send could possibly lose — an inherited method's body is fixed
+    // at the *superclass's* compile time and can only reference class vars
+    // declared there or above, never ones a subclass adds later. This class
+    // has no `classState:`, so a self-send to `spawnWith:` — not locally
+    // defined here, standing in for the real inherited-from-`Actor` case —
+    // must still compile inside a bare `select:` block, hitting exactly the
+    // "isn't defined locally in this class" conservative-fallback branch
+    // this guard would otherwise trip.
+    let src = "Value subclass: NoClassVarsDriver\n  class doubled: aList =>\n    aList select: [:x | self spawnWith: x]";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@noclassvarsdriver").with_workspace_mode(true),
+    );
+    assert!(
         result.is_ok(),
-        "A select: body with only a class-method self-send (no local var) should not \
-         reach the threaded-loop codegen path at all. Got: {result:?}"
+        "A self-send inside a bare block must not be rejected when the enclosing \
+         class has no class variables at all — there is no classState mutation to \
+         lose. Got: {result:?}"
+    );
+}
+
+#[test]
+fn test_class_method_self_send_in_pure_inject_into_block_is_compile_error() {
+    // BT-3151 follow-up: `generate_list_inject`'s BT-1327 pure-block fast
+    // path calls `generate_block_body` directly (to emit an inline
+    // `lists:foldl` with zero wrapper overhead), bypassing
+    // `generate_block`'s own BT-3151 self-send check entirely. Before this
+    // was wired up (`check_no_unsafe_class_method_self_sends`, called from
+    // `generate_list_inject` too), this didn't just silently lose the
+    // mutation — it crashed erlc with malformed Core Erlang (`unbound
+    // variable 'ClassVars1'`), confirmed empirically. Must now be a clean
+    // compile-time error, matching every other bare-block call site.
+    let src = "Value subclass: DriverInject\n  classState: runs = 0\n  class check: x => self.runs := self.runs + 1. x\n  class sumChecked: aList =>\n    aList inject: 0 into: [:acc :x | acc + (self check: x)]";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@driverinject").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(CodeGenError::ClassMethodSelfSendInUnthreadedBlock { .. })
+        ),
+        "A mutating self-send inside inject:into:'s pure-block fast path must be \
+         caught by BT-3151's guard, not reach codegen and crash erlc. Got: {result:?}"
+    );
+}
+
+#[test]
+fn test_class_method_self_send_in_while_condition_block_is_compile_error() {
+    // BT-3151 follow-up: a `whileTrue:`/`whileFalse:` loop's *condition*
+    // block is structurally the same kind of bare, unthreaded block as a
+    // `select:`/`inject:into:` argument — `generate_while_loop` (and its
+    // direct-params/hybrid-params variants) calls `generate_block_body` on
+    // the condition directly, bypassing `generate_block`'s check the same
+    // way `generate_list_inject`'s fast path did. A mutating self-send in
+    // the condition silently loses its mutation on every iteration; must be
+    // a compile-time error instead.
+    let src = "Value subclass: DriverCond\n  classState: runs = 0\n  class shouldContinue: n => self.runs := self.runs + 1. self.runs < n\n  class run: n =>\n    i := 0\n    [self shouldContinue: n] whileTrue: [i := i + 1]\n    i";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@drivercond").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(CodeGenError::ClassMethodSelfSendInUnthreadedBlock { .. })
+        ),
+        "A mutating self-send inside a whileTrue: condition block must be caught by \
+         BT-3151's guard. Got: {result:?}"
     );
 }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -4052,6 +4052,64 @@ fn test_class_method_self_send_in_block_compiles_when_class_has_no_class_vars() 
 }
 
 #[test]
+fn test_class_method_mutating_self_send_as_second_cascade_message_in_block_is_compile_error() {
+    // BT-3151 review follow-up: a cascade's 2nd+ message is sent to the same
+    // shared receiver as the first (cascade semantics evaluate the receiver
+    // once), but `analyze_expression`'s `Expression::Cascade` arm only ever
+    // checked later messages for `is_self_field_value_send` — it never
+    // recorded a self-send to `self_send_selectors`/`has_self_sends` for
+    // them, unlike the `MessageSend` arm's handling of the cascade's first
+    // message (folded into `receiver` by the parser). A mutating self-send
+    // hidden behind an earlier *pure* cascade message inside a bare block
+    // (`self pureLog: x; check: x`) was therefore invisible to
+    // `check_no_unsafe_class_method_self_sends`, silently compiling and
+    // losing the mutation — reproducing the exact bug this guard exists to
+    // close, just one cascade message later.
+    let src = "Value subclass: DriverCascade\n  classState: runs = 0\n  class pureLog: x => x\n  class check: x => self.runs := self.runs + 1. x > 0\n  class positives: aList =>\n    aList select: [:x | self pureLog: x; check: x]";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@drivercascade").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(CodeGenError::ClassMethodSelfSendInUnthreadedBlock { .. })
+        ),
+        "A mutating self-send as the 2nd+ message of a cascade inside a bare block \
+         must be caught by BT-3151's guard just like a standalone self-send. \
+         Got: {result:?}"
+    );
+}
+
+#[test]
+fn test_class_method_self_send_in_erlang_interop_block_is_compile_error() {
+    // BT-3151 review follow-up: a block argument crossing the Erlang interop
+    // boundary in a direct `(Erlang mod) fn: arg` call
+    // (`generate_direct_erlang_call`'s keyword branch, `dispatch_codegen.rs`)
+    // routes through the same `generate_erlang_interop_wrapper` →
+    // `generate_block` mechanism as a `select:`/`do:` argument — same
+    // process, same lossy in-process self-send optimization. Must be caught
+    // the same way.
+    let src = "Value subclass: DriverErlangInterop\n  classState: runs = 0\n  class bump => self.runs := self.runs + 1\n  class run: aList =>\n    (Erlang lists) foreach: [:x | self bump] over: aList\n    self.runs";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@drivererlanginterop").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(CodeGenError::ClassMethodSelfSendInUnthreadedBlock { .. })
+        ),
+        "A mutating self-send inside a block crossing the Erlang interop boundary \
+         must be caught by BT-3151's guard. Got: {result:?}"
+    );
+}
+
+#[test]
 fn test_class_method_self_send_in_pure_inject_into_block_is_compile_error() {
     // BT-3151 follow-up: `generate_list_inject`'s BT-1327 pure-block fast
     // path calls `generate_block_body` directly (to emit an inline

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -4163,6 +4163,81 @@ fn test_class_method_self_send_in_sort_block_is_compile_error() {
 }
 
 #[test]
+fn test_class_method_self_send_in_each_with_index_block_is_compile_error() {
+    // BT-3151 review follow-up: `eachWithIndex:` desugars to `inject:into:`
+    // (`try_generate_each_with_index`, `enumeration_ops.rs`) only when the
+    // user block needs mutation threading; a bare self-send-only block falls
+    // through to `Collection.bt`'s own self-hosted `eachWithIndex:` — a
+    // same-process, in-process call, same as every other list-op call site.
+    let src = "Value subclass: DriverEachWithIndex\n  classState: runs = 0\n  class check: x => self.runs := self.runs + 1. x\n  class run: aList =>\n    aList eachWithIndex: [:item :i | self check: item]";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@drivereachwithindex").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(CodeGenError::ClassMethodSelfSendInUnthreadedBlock { .. })
+        ),
+        "A mutating self-send inside an eachWithIndex: block must be caught by \
+         BT-3151's guard. Got: {result:?}"
+    );
+}
+
+#[test]
+fn test_class_method_self_send_in_do_separated_by_block_is_compile_error() {
+    // BT-3151 review follow-up: `do:separatedBy:`'s desugar
+    // (`try_generate_do_separated_by`, `enumeration_ops.rs`) has the same
+    // bare-block fallthrough shape as `eachWithIndex:` above — checks both
+    // the element and separator blocks.
+    let src = "Value subclass: DriverDoSeparatedBy\n  classState: runs = 0\n  class check: x => self.runs := self.runs + 1. x\n  class run: aList =>\n    aList do: [:x | x] separatedBy: [self check: 0]";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@driverdoseparatedby").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(CodeGenError::ClassMethodSelfSendInUnthreadedBlock { .. })
+        ),
+        "A mutating self-send inside a do:separatedBy: separator block must be caught \
+         by BT-3151's guard. Got: {result:?}"
+    );
+}
+
+#[test]
+fn test_class_method_self_send_in_detect_if_none_block_alongside_mutating_predicate_is_compile_error()
+ {
+    // BT-3151 review follow-up: when `detect:ifNone:`'s predicate needs
+    // mutation threading (a co-occurring local-var mutation), execution
+    // routes through `generate_list_detect_if_none_with_mutations`, which
+    // compiles `if_none` independently via `expression_doc` →
+    // `generate_block` — a bare, unthreaded block regardless of what the
+    // predicate does. A mutating self-send hidden only in `if_none` (not
+    // the predicate) must still be caught.
+    let src = "Value subclass: DriverDetectIfNone\n  classState: runs = 0\n  class check: x => self.runs := self.runs + 1. x\n  class run: aList =>\n    seen := 0\n    aList detect: [:x | seen := seen + 1. x > 1000] ifNone: [self check: 0]";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@driverdetectifnone").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(CodeGenError::ClassMethodSelfSendInUnthreadedBlock { .. })
+        ),
+        "A mutating self-send inside detect:ifNone:'s ifNone block must be caught by \
+         BT-3151's guard even when the predicate needs mutation threading. \
+         Got: {result:?}"
+    );
+}
+
+#[test]
 fn test_class_method_self_send_in_pure_inject_into_block_is_compile_error() {
     // BT-3151 follow-up: `generate_list_inject`'s BT-1327 pure-block fast
     // path calls `generate_block_body` directly (to emit an inline

--- a/crates/beamtalk-core/src/semantic_analysis/block_facts.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/block_facts.rs
@@ -416,6 +416,20 @@ fn analyze_expression(
                 if is_self_field_value_send(cascade_receiver, &msg.selector) {
                     analysis.has_field_value_call = true;
                 }
+                // BT-3151 review follow-up: a cascade's 2nd+ message is sent to
+                // the same shared receiver as the first (see the comment above),
+                // so a self-send there needs the same `self_send_selectors`
+                // recording the `MessageSend` arm does for the first message —
+                // otherwise a mutating self-send hidden behind an earlier pure
+                // cascade message (`self pureLog: x; check: x`) is invisible to
+                // `check_no_unsafe_class_method_self_sends` and to
+                // `compute_class_var_mutating_selectors`'s purity closure.
+                if is_self_reference(cascade_receiver) {
+                    analysis.has_self_sends = true;
+                    analysis
+                        .self_send_selectors
+                        .insert(msg.selector.name().to_string());
+                }
                 for arg in &msg.arguments {
                     analyze_expression(arg, analysis, ctx);
                 }

--- a/crates/beamtalk-core/src/semantic_analysis/block_facts.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/block_facts.rs
@@ -9,7 +9,10 @@
 //! read/written, enabling proper state threading in tail-recursive loops.
 
 use crate::ast::well_known::WellKnownSelector;
-use crate::ast::{Block, Expression, MessageSelector};
+use crate::ast::{
+    Block, ClassDefinition, Expression, ExpressionStatement, MessageSelector, MethodKind,
+    ParameterDefinition,
+};
 use std::collections::HashSet;
 
 /// Analysis results for a block's variable and field usage.
@@ -27,6 +30,11 @@ pub struct BlockMutationAnalysis {
     pub field_writes: HashSet<String>,
     /// BT-245: Whether the block contains self-sends (which may mutate actor state).
     pub has_self_sends: bool,
+    /// BT-3151: Selectors sent to `self` anywhere in the block, including inside
+    /// nested blocks (e.g. a `do:`/`collect:` argument) — unlike `has_self_sends`,
+    /// tracked by name so a caller can distinguish a self-send to a provably
+    /// non-mutating class method from one that is (or might be) mutating.
+    pub self_send_selectors: HashSet<String>,
     /// BT-2807: Whether the block contains a `self.field value(:...)` send — invoking
     /// a block stored in a field. The stored block's body isn't visible here (it may
     /// be assigned anywhere), so this is conservative: any such call is treated as a
@@ -65,19 +73,112 @@ impl BlockMutationAnalysis {
 
 /// Analyzes a block to detect variable and field mutations.
 pub fn analyze_block(block: &Block) -> BlockMutationAnalysis {
-    let mut analysis = BlockMutationAnalysis::new();
     let mut ctx = AnalysisContext::new();
-
-    // Block parameters are local bindings
     for param in &block.parameters {
         ctx.local_bindings.insert(param.name.to_string());
     }
+    analyze_statements(&block.body, &mut ctx)
+}
 
-    // Analyze all expressions in the block body
-    for stmt in &block.body {
-        analyze_expression(&stmt.expression, &mut analysis, &mut ctx);
+/// BT-3151: Analyzes a method body (top-level statements, not wrapped in a
+/// `Block`) the same way [`analyze_block`] analyzes a block body — used by
+/// the class-var-mutating-selector purity check (`compute_class_var_mutating_selectors`)
+/// to inspect each class method's own body directly, since `MethodDefinition`
+/// isn't a `Block`.
+pub fn analyze_method_body(
+    parameters: &[ParameterDefinition],
+    body: &[ExpressionStatement],
+) -> BlockMutationAnalysis {
+    let mut ctx = AnalysisContext::new();
+    for param in parameters {
+        ctx.local_bindings.insert(param.name.name.to_string());
+    }
+    analyze_statements(body, &mut ctx)
+}
+
+/// BT-3151: Computes the set of this class's own class-method selectors that
+/// are *known or suspected* to mutate a class variable — directly (`self.cv
+/// := ...` for `cv` in `class_var_names`) or transitively (a self-send,
+/// anywhere in the method body including inside nested blocks, to another
+/// selector already in this set).
+///
+/// A self-send to a selector NOT defined in this class's own `class_methods`
+/// (inherited from a superclass, or otherwise unresolvable at this class's
+/// compile time) is conservatively treated as mutating too — the same "can't
+/// know statically, so assume the worst" call BT-3150 makes for self-sends in
+/// threaded loop bodies. This keeps the analysis sound without needing
+/// cross-class information codegen doesn't have at this point: a self-send is
+/// only ever excluded from the mutating set when its target is a *locally
+/// defined* method that this same pass has proven pure.
+///
+/// Used to let a self-send to a provably pure class method (the common case —
+/// see `stdlib/test/fixtures/class_method_block.bt`'s `self double:`-style
+/// helpers) keep compiling in a bare, unthreaded block passed to
+/// `select:`/`collect:`/`do:`/etc., while rejecting one whose target may
+/// mutate class state, where BT-3150's `Letrec`-only guard doesn't reach.
+#[allow(clippy::implicit_hasher)] // concrete HashSet (matches ClassContext::class_var_names) is simpler for callers
+pub fn compute_class_var_mutating_selectors(
+    class: &ClassDefinition,
+    class_var_names: &HashSet<String>,
+) -> HashSet<String> {
+    let methods: Vec<(String, BlockMutationAnalysis)> = class
+        .class_methods
+        .iter()
+        .filter(|m| m.kind == MethodKind::Primary)
+        .map(|m| {
+            (
+                m.selector.name().to_string(),
+                analyze_method_body(&m.parameters, &m.body),
+            )
+        })
+        .collect();
+    let local_selectors: HashSet<&str> = methods.iter().map(|(sel, _)| sel.as_str()).collect();
+
+    let mut mutating: HashSet<String> = methods
+        .iter()
+        .filter(|(_, analysis)| {
+            analysis
+                .field_writes
+                .iter()
+                .any(|f| class_var_names.contains(f))
+        })
+        .map(|(sel, _)| sel.clone())
+        .collect();
+
+    // Fixed-point closure over self-sends: a method becomes "mutating" if it
+    // self-sends a selector already known to mutate, or one this class
+    // doesn't itself define (unresolvable — assume the worst).
+    loop {
+        let mut changed = false;
+        for (sel, analysis) in &methods {
+            if mutating.contains(sel) {
+                continue;
+            }
+            let calls_unsafe = analysis.self_send_selectors.iter().any(|called| {
+                mutating.contains(called) || !local_selectors.contains(called.as_str())
+            });
+            if calls_unsafe {
+                mutating.insert(sel.clone());
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
     }
 
+    mutating
+}
+
+/// Shared statement-list walker behind [`analyze_block`] and [`analyze_method_body`].
+fn analyze_statements(
+    body: &[ExpressionStatement],
+    ctx: &mut AnalysisContext,
+) -> BlockMutationAnalysis {
+    let mut analysis = BlockMutationAnalysis::new();
+    for stmt in body {
+        analyze_expression(&stmt.expression, &mut analysis, ctx);
+    }
     analysis
 }
 
@@ -181,6 +282,10 @@ fn analyze_expression(
             // BT-245: Detect self-sends (may mutate actor state)
             if is_self_reference(receiver) {
                 analysis.has_self_sends = true;
+                // BT-3151: record the selector too (see `self_send_selectors` doc).
+                analysis
+                    .self_send_selectors
+                    .insert(selector.name().to_string());
             }
             // BT-2807: Detect `self.field value(:...)` — invoking a block stored in a
             // field. The field may hold a Tier 2 (state-mutating) block, so this is
@@ -224,6 +329,9 @@ fn analyze_expression(
                         if nested.has_self_sends {
                             analysis.has_self_sends = true;
                         }
+                        analysis
+                            .self_send_selectors
+                            .extend(nested.self_send_selectors.iter().cloned());
                         if nested.has_field_value_call {
                             analysis.has_field_value_call = true;
                         }
@@ -260,6 +368,18 @@ fn analyze_expression(
             if nested_analysis.has_field_value_call {
                 analysis.has_field_value_call = true;
             }
+            // BT-3151: propagate self-sends the same way — a self-send inside a
+            // block passed to select:/collect:/do:/etc. (this is exactly that
+            // shape: a `Block` argument that isn't an inline-conditional
+            // selector, handled above) is itself a potential mutation source,
+            // and callers like `analyze_method_body`'s purity check need to see
+            // it at any nesting depth, not just at this block's own top level.
+            if nested_analysis.has_self_sends {
+                analysis.has_self_sends = true;
+            }
+            analysis
+                .self_send_selectors
+                .extend(nested_analysis.self_send_selectors.iter().cloned());
         }
 
         Expression::Return { value, .. } => {


### PR DESCRIPTION
## Summary

BT-3150 fixed a compiler crash for a class-var-mutating self-send inside a `whileTrue:`/`timesRepeat:` loop *body*, but deliberately left open (and filed as BT-3151) the identical mutation-loss bug for a self-send inside a bare block passed to `select:`/`collect:`/`do:`/`reject:`/`detect:`/`inject:into:`, a loop *condition*, or a bare `timesRepeat:`/`to:do:`/`to:by:do:` body. None of those contexts can thread a `ClassVars` update back to the class method that owns it, so the mutation was silently lost. `inject:into:`'s pure-block fast path was worse: it didn't just lose the mutation, it crashed erlc with malformed Core Erlang (`unbound variable 'ClassVars1'`).

## Changes

- `compute_class_var_mutating_selectors` (`semantic_analysis/block_facts.rs`) — a transitive-closure purity analysis over a class's own class methods, computing which selectors provably mutate a class variable (directly, or via a self-send to another mutating selector). A self-send to a selector not locally defined on the class is conservatively treated as mutating too, since only same-class self-sends to a *locally defined* selector are statically known to be non-polymorphic.
- A new `CodeGenError::ClassMethodSelfSendInUnthreadedBlock` and a shared guard, `check_no_unsafe_class_method_self_sends`, wired into every call site confirmed unsafe by testing: `select:`/`collect:`/`do:` (`generate_simple_list_op`), `reject:`, `detect:`, `inject:into:`'s BT-1327 pure-block fast path, a `whileTrue:`/`whileFalse:` condition block, and a bare (no local-var mutation) `timesRepeat:`/`to:do:`/`to:by:do:` body.
- The guard is gated on the class actually declaring class variables — with none, there's no classState mutation to lose, so the conservative "not locally defined" fallback doesn't wrongly reject a safe inherited method (e.g. `Subprocess.bt` self-sending `Actor`'s `spawnWith:`, which broke the stdlib build the first time this guard landed).
- Deliberately **not** applied to `generate_block`'s generic fallback: running the guard against the full stdlib build and BUnit suite surfaced two shapes that must stay uncaught — an `ifTrue:`/`ifFalse:` block reached via generic dynamic dispatch (a pre-existing, ADR 0110-documented "known limitation", not something this PR should newly reject) and a block handed to a *different* class's class-side method, which always runs in that class's own `gen_server` process — a same-class self-send there is genuine cross-process messaging, not the lossy in-process optimization, and already correctly commits (confirmed by the existing `shadow_cross_class_owner.bt` fixture, ADR 0110 BT-3039).

## Test plan

- [x] `cargo test -p beamtalk-core --lib` — 5665 passed, 0 failed
- [x] `just clippy` / `cargo fmt --check`
- [x] `just build` — full stdlib rebuild (109 modules)
- [x] `just test-bunit` — 3218 tests, 0 failed
- [x] `just test-stdlib` — 233 tests, 0 failed
- [x] New regression tests added/updated in `crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs`, each verified to fail without its corresponding fix (toggled off and re-run)
- [x] Manually confirmed the original BT-3151 repro, plus `detect:`/`reject:`/`inject:into:`/loop-condition/bare-`timesRepeat:` variants, now fail at compile time with a clear error instead of silently losing the mutation or crashing erlc

Closes BT-3151.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiVpfyPyDC2qUDcRQjbwvh)_