### PR TITLE
Pilot migration: while-direct loops emit through ThreadedIr, gated (BT-3145)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/while_loops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/while_loops.rs
@@ -10,10 +10,15 @@
 
 use super::super::document::{Document, join, leaf};
 use super::super::intrinsics::{STATEFUL_BLOCK_DISPATCH_HINT, validate_block_arity_exact};
-use super::super::{CoreErlangGenerator, Result, block_analysis};
+use super::super::threaded_ir::{
+    self, BindOp, FrameId, RenderCtx, ThreadedStmt, ThreadingMode, ValueRef, VersionPrefix,
+    VersionedVar,
+};
+use super::super::{CodeGenError, CoreErlangGenerator, Result, block_analysis};
 use super::{BodyKind, ThreadingPlan};
 use crate::ast::{Block, Expression};
 use crate::docvec;
+use std::collections::HashMap;
 
 /// Result of pre-extracting hybrid loop fields: pre-extraction docs, readonly params, mutated params.
 ///
@@ -279,6 +284,344 @@ impl CoreErlangGenerator {
         Ok(Document::Vec(docs))
     }
 
+    /// ADR 0111 Addendum 2 (BT-3145 pilot): the loop's condition body is
+    /// ordinary AST-directed expression codegen with no state-threading
+    /// content of its own (the same class of embed
+    /// `ThreadedStmt::ConditionalLoop`'s `continue_header` uses it as —
+    /// §Verifier honesty). Factored out of `generate_while_loop_direct` so
+    /// both the legacy path and `try_render_while_direct_via_threaded_ir`
+    /// call the SAME condition-codegen, never a re-derivation
+    /// (CLAUDE.md's no-duplicate-implementations rule).
+    fn generate_loop_condition_body(
+        &mut self,
+        condition: &Expression,
+    ) -> Result<Document<'static>> {
+        self.with_branch_context(|this| {
+            if let Expression::Block(cond_block) = condition {
+                // BT-3151: see the analogous check in `generate_while_loop`.
+                let analysis =
+                    crate::codegen::core_erlang::block_analysis::analyze_block(cond_block);
+                this.check_no_unsafe_class_method_self_sends(&analysis, cond_block.span)?;
+                this.generate_block_body(cond_block)
+            } else {
+                this.generate_expression(condition)
+            }
+        })
+    }
+
+    /// ADR 0111 Addendum 2 pilot (BT-3145): env-flag measurement gate for
+    /// routing `generate_while_loop_direct` through `ThreadedIr`
+    /// (lower → verify → render) instead of the legacy Document-construction
+    /// path. Off by default — this pilot's coverage is deliberately narrow
+    /// (see `while_direct_body_is_bind_representable`'s doc comment), so the
+    /// default stays the always-correct legacy path until a follow-up
+    /// closes the discovered gap and the ≤3% measurement gate is re-run
+    /// against full coverage.
+    fn threaded_ir_while_direct_enabled() -> bool {
+        std::env::var("BEAMTALK_THREADED_IR_WHILE_DIRECT").is_ok_and(|v| v == "1")
+    }
+
+    /// ADR 0111 Addendum 2 pilot (BT-3145): a conservative, purely
+    /// AST-level (zero generator side effects) check for whether `body` is
+    /// representable as a `ThreadedStmt::ConditionalLoop` `Bind` chain —
+    /// every statement must be a straight-line reassignment of a threaded
+    /// local from a "simple" RHS (`is_simple_threaded_rhs`).
+    ///
+    /// This is intentionally narrower than everything `select_direct_params`
+    /// allows through a direct-params loop body: plain-let temporaries
+    /// (non-threaded locals, `try_generate_block_local_plain_let`),
+    /// destructuring, non-assignment statements, and any RHS that could
+    /// reach `direct_params_list_op_result`'s open-chain codegen path (a
+    /// tuple-safe nested list op, `list_ops/*.rs`) are NOT yet representable
+    /// in this pilot's IR shape — `ThreadedStmt` has no "opaque non-`Bind`
+    /// body statement" node, and `ValueRef` cannot represent an open-chain
+    /// fragment (two chained `let`s) as a single `Bind`'s value. Bailing
+    /// here falls back to the unmodified legacy path, unconditionally
+    /// correct, just not migrated onto `ThreadedIr` yet.
+    ///
+    /// This is a real, additional scope boundary discovered empirically
+    /// while implementing this call site (verified against real compiled
+    /// output, the same evidentiary standard as BT-3145's original
+    /// investigation), beyond ADR 0111 Addendum 2's own Gap 1/Gap 2 —
+    /// recorded on the BT-3145 Linear issue as a named follow-up, not
+    /// silently absorbed into "done."
+    fn while_direct_body_is_bind_representable(body: &Block, plan: &ThreadingPlan) -> bool {
+        !body.body.is_empty()
+            && body.body.iter().all(|stmt| match &stmt.expression {
+                Expression::Assignment { target, value, .. } => match target.as_ref() {
+                    Expression::Identifier(id) => {
+                        plan.threaded_locals.contains(&id.name.to_string())
+                            && Self::is_simple_threaded_rhs(value)
+                    }
+                    _ => false,
+                },
+                _ => false,
+            })
+    }
+
+    /// Conservative allowlist for a threaded-local rebind's RHS shape — see
+    /// `while_direct_body_is_bind_representable`'s doc comment for why this
+    /// is deliberately narrow: default-deny for anything not explicitly
+    /// listed, including any nested `Block` anywhere in the subtree — every
+    /// list-op selector (`collect:`/`select:`/`inject:into:`/…) requires a
+    /// block-literal argument, so excluding `Block` safely excludes
+    /// `direct_params_list_op_result`'s open-chain shape too, without
+    /// needing to duplicate `list_ops/*.rs`'s selector set here.
+    fn is_simple_threaded_rhs(expr: &Expression) -> bool {
+        match expr {
+            Expression::Literal(..) | Expression::Identifier(_) => true,
+            Expression::FieldAccess { receiver, .. }
+            | Expression::Parenthesized {
+                expression: receiver,
+                ..
+            } => Self::is_simple_threaded_rhs(receiver),
+            Expression::MessageSend {
+                receiver,
+                arguments,
+                ..
+            } => {
+                Self::is_simple_threaded_rhs(receiver)
+                    && arguments.iter().all(Self::is_simple_threaded_rhs)
+            }
+            _ => false,
+        }
+    }
+
+    /// ADR 0111 Addendum 2 pilot (BT-3145): attempts to lower, verify, and
+    /// render `generate_while_loop_direct`'s condition/case-split shape
+    /// through `ThreadedIr`. Returns `Ok(None)` (zero generator mutation)
+    /// when `body` isn't representable in this pilot's narrow `Bind`-chain
+    /// shape (`while_direct_body_is_bind_representable`) or when a threaded
+    /// local's outer-scope binding has already diverged from its plain
+    /// `to_core_erlang_var` form (see the `initial_direct_args` guard below)
+    /// — the caller falls back to the unmodified legacy path unconditionally
+    /// in either case.
+    ///
+    /// Mint order mirrors `generate_while_loop_direct` exactly (ADR 0111
+    /// Addendum 2, Gap 2's ordering contract, load-bearing for
+    /// byte-identity): `CondFun` + condition first, then each body rebind
+    /// as its `Bind` is lowered (in encounter order), and the exit arm's
+    /// `ExitSA` chain LAST — lowering mints via the SAME `fresh_temp_var`
+    /// calls production makes, never gensym'd by `render`.
+    #[allow(clippy::too_many_lines)] // ThreadedIr lowering mirroring generate_while_loop_direct's own shape, ADR 0111 Addendum 2 pilot (BT-3145)
+    fn try_render_while_direct_via_threaded_ir(
+        &mut self,
+        condition: &Expression,
+        body: &Block,
+        plan: &ThreadingPlan,
+        negate: bool,
+    ) -> Result<Option<Document<'static>>> {
+        if !Self::while_direct_body_is_bind_representable(body, plan) {
+            return Ok(None);
+        }
+
+        // Pure lookups (`&self`) — safe to check before committing to any
+        // mutation. `render_loop_skeleton`'s outer-call-args rendering
+        // (shared with the bare `Threaded` shape) derives each param's
+        // OUTER reference from its plain `to_core_erlang_var` form; if the
+        // outer scope already rebound a threaded local to a different Core
+        // Erlang name (e.g. an earlier construct gensym'd it), that
+        // rendering would silently diverge from `initial_direct_args`'s real
+        // value — bail rather than risk an unbound-variable reference.
+        let initial_direct_args = plan.initial_direct_args(self);
+        if plan
+            .threaded_locals
+            .iter()
+            .zip(initial_direct_args.iter())
+            .any(|(name, arg)| *arg != CoreErlangGenerator::to_core_erlang_var(name))
+        {
+            return Ok(None);
+        }
+
+        let param_names: Vec<String> = plan
+            .threaded_locals
+            .iter()
+            .map(|v| CoreErlangGenerator::to_core_erlang_var(v))
+            .collect();
+        let frame = FrameId::new(1);
+        let param_list_doc = || {
+            join(
+                param_names.iter().map(|v| leaf::var(v.clone())),
+                &Document::Str(", "),
+            )
+        };
+
+        let cond_var = self.fresh_temp_var("CondFun"); // mint #1: CondFun, matching `while_loops.rs`'s legacy order
+
+        self.push_scope();
+        plan.generate_unpack_at_iteration_start(self);
+
+        let cond_doc = self.generate_loop_condition_body(condition)?;
+        let case_arm = if negate {
+            "<'false'> when 'true' -> "
+        } else {
+            "<'true'> when 'true' -> "
+        };
+        let continue_header = docvec![
+            "let ",
+            leaf::var(cond_var.clone()),
+            " = fun (",
+            param_list_doc(),
+            ") -> ",
+            cond_doc,
+            " in case apply ",
+            leaf::var(cond_var),
+            " (",
+            param_list_doc(),
+            ") of ",
+            case_arm,
+        ];
+
+        // Lower the body: each statement is (per eligibility) a
+        // straight-line reassignment of a threaded local — mint each
+        // rebind's fresh name in ENCOUNTER order, exactly where
+        // `generate_direct_var_update_in_loop` mints today. Wrapped in
+        // `with_branch_context` exactly like `generate_threaded_loop_body`
+        // itself is (`in_loop_body = true`, `state_version` reset to 0) —
+        // required for a rebind RHS that reads a field (`self.step`) to
+        // resolve `StateAcc` (loop context) rather than `State` (ambient
+        // outer context), confirmed against real compiled output: without
+        // this wrap, `maps:get('step', State)` diverges from legacy's
+        // `maps:get('step', StateAcc)`.
+        let mut ir_body: Vec<ThreadedStmt> = Vec::with_capacity(body.body.len());
+        self.with_branch_context(|this| -> Result<()> {
+            let mut current: HashMap<String, VersionedVar> = plan
+                .threaded_locals
+                .iter()
+                .map(|name| {
+                    (
+                        name.clone(),
+                        VersionedVar::new(VersionPrefix::Local(name.clone()), 0, frame),
+                    )
+                })
+                .collect();
+            let mut rebind_counts: HashMap<String, usize> = plan
+                .threaded_locals
+                .iter()
+                .map(|n| (n.clone(), 0))
+                .collect();
+            for stmt in &body.body {
+                let Expression::Assignment { target, value, .. } = &stmt.expression else {
+                    unreachable!(
+                        "while_direct_body_is_bind_representable guarantees every \
+                         statement is an Assignment"
+                    );
+                };
+                let Expression::Identifier(id) = target.as_ref() else {
+                    unreachable!(
+                        "while_direct_body_is_bind_representable guarantees the \
+                         target is an Identifier"
+                    );
+                };
+                let name = id.name.to_string();
+                this.direct_params_list_op_result = None;
+                let value_doc = this.expression_doc(value)?; // mints inside expression codegen, same order as legacy
+                // Defense in depth: `is_simple_threaded_rhs` excludes any RHS
+                // containing a `Block` literal (every list-op selector needs
+                // one), which should make `direct_params_list_op_result`
+                // impossible here — EXCEPT a list-op called with a block
+                // held in a *variable* (`list collect: storedBlock`) has no
+                // `Block` literal in this expression's own AST at all, so the
+                // static check cannot rule it out by construction. Verified
+                // empirically that this specific flag cannot actually fire
+                // for `generate_while_loop_direct` today — the list-op
+                // codegen functions that set it all gate on
+                // `self.in_direct_params_loop`, which only
+                // `generate_counted_stateful_loop_direct`/
+                // `generate_hybrid_loop_body` ever set `true`, never this
+                // (pure, non-hybrid) while-direct call site — but that is a
+                // property of the CURRENT `in_direct_params_loop` wiring
+                // elsewhere in this file, not something this function
+                // controls or that `is_simple_threaded_rhs` proves, so this
+                // check stays as a real guard against future coupling
+                // (e.g. a while-direct loop nested inside a construct that
+                // sets `in_direct_params_loop` ambiently). Legacy's
+                // open-chain shape for that case (`value_code` ending in an
+                // open `"... in "`, not a self-contained expression) does
+                // not fit `BindOp::Direct(ValueRef::Doc(..))`'s "closed
+                // expression" contract — wrapping it in `"let TARGET = " +
+                // value_doc + " in "` would emit invalid Core Erlang. Fail
+                // loudly with a structured internal error instead of
+                // emitting that: by this point mints have already been
+                // consumed for this (and possibly earlier) statements, so
+                // silently falling back to the legacy path here would
+                // re-mint from scratch and diverge from what legacy alone
+                // would have produced — no longer safe once lowering has
+                // started (see this function's doc comment on why
+                // eligibility is checked BEFORE any mutation, never
+                // re-checked mid-lowering).
+                if this.direct_params_list_op_result.take().is_some() {
+                    return Err(CodeGenError::Internal(format!(
+                        "ThreadedIr while-direct pilot (BT-3145): rebind of `{name}` \
+                         resolved to a list-op open-chain RHS (a block held in a \
+                         variable, not a literal) — not representable as a single \
+                         Bind value; this shape must not reach ConditionalLoop \
+                         lowering. Retry without BEAMTALK_THREADED_IR_WHILE_DIRECT=1."
+                    )));
+                }
+                let source = current.get(&name).cloned().unwrap_or_else(|| {
+                    VersionedVar::new(VersionPrefix::Local(name.clone()), 0, frame)
+                });
+                let core_var = CoreErlangGenerator::to_core_erlang_var(&name);
+                let new_var = this.fresh_temp_var(&core_var); // mint: body rebind, matches `generate_direct_var_update_in_loop`'s own order
+                this.bind_var(&name, &new_var);
+                let count = rebind_counts.entry(name.clone()).or_insert(0);
+                *count += 1;
+                let target_var = VersionedVar::new(VersionPrefix::Gensym(new_var), *count, frame);
+                ir_body.push(ThreadedStmt::Bind {
+                    target: target_var.clone(),
+                    source,
+                    op: BindOp::Direct(ValueRef::Doc(value_doc)),
+                    shadow_write: false,
+                    span: stmt.expression.span(),
+                });
+                current.insert(name, target_var);
+            }
+            Ok(())
+        })?;
+
+        // Unlike legacy, `final_args` (the recursive tail call's arguments)
+        // is NOT collected here — `render` reconstructs it from the `Bind`
+        // chain via `final_loop_arg_identities` (see `ConditionalLoop`'s doc
+        // comment for why `produces` alone cannot supply it for a `Gensym`
+        // target).
+        let exit_stateacc = plan.generate_exit_stateacc(&param_names, self); // mint: ExitSA chain, LAST — matches legacy order
+        let exit_case_arm = if negate {
+            "<'true'> when 'true' -> "
+        } else {
+            "<'false'> when 'true' -> "
+        };
+        let exit_arm = docvec![exit_case_arm, exit_stateacc, " end "];
+
+        self.pop_scope();
+
+        let produces: Vec<VersionedVar> = plan
+            .threaded_locals
+            .iter()
+            .map(|name| VersionedVar::new(VersionPrefix::Local(name.clone()), 0, frame))
+            .collect();
+
+        let node = ThreadedStmt::ConditionalLoop {
+            fn_name: "while".to_string(),
+            mode: ThreadingMode::DirectParams,
+            frame,
+            counter: None,
+            continue_header,
+            body: ir_body,
+            produces,
+            exit_arm,
+            span: body.span,
+        };
+
+        let errors = threaded_ir::verify(std::slice::from_ref(&node));
+        self.report_threaded_ir_verify_errors(&errors, "while-direct ConditionalLoop", body.span);
+
+        let mut ctx = RenderCtx::new(self);
+        let rendered = threaded_ir::render(std::slice::from_ref(&node), &mut ctx);
+
+        Ok(Some(rendered))
+    }
+
     /// BT-1275: Direct-params variant of `generate_while_loop_with_mutations`.
     ///
     /// Uses `fun (Var1, ..., VarN)` instead of `fun (StateAcc)`.
@@ -291,6 +634,13 @@ impl CoreErlangGenerator {
         plan: &ThreadingPlan,
         negate: bool,
     ) -> Result<Document<'static>> {
+        if Self::threaded_ir_while_direct_enabled()
+            && let Some(doc) =
+                self.try_render_while_direct_via_threaded_ir(condition, body, plan, negate)?
+        {
+            return Ok(doc);
+        }
+
         // Collect initial arg values from the outer scope (before push_scope).
         let initial_direct_args = plan.initial_direct_args(self);
 
@@ -334,17 +684,7 @@ impl CoreErlangGenerator {
             ") -> ",
         ]);
 
-        let cond_doc = self.with_branch_context(|this| {
-            if let Expression::Block(cond_block) = condition {
-                // BT-3151: see the analogous check in `generate_while_loop`.
-                let analysis =
-                    crate::codegen::core_erlang::block_analysis::analyze_block(cond_block);
-                this.check_no_unsafe_class_method_self_sends(&analysis, cond_block.span)?;
-                this.generate_block_body(cond_block)
-            } else {
-                this.generate_expression(condition)
-            }
-        })?;
+        let cond_doc = self.generate_loop_condition_body(condition)?;
         docs.push(cond_doc);
 
         // Apply condition with current params.
@@ -1258,6 +1598,126 @@ mod tests {
         assert!(
             code.contains("element'(1,"),
             "last-expr whileTrue: should unwrap element 1 (nil). Got:\n{code}"
+        );
+    }
+
+    // ── ADR 0111 Addendum 2 pilot (BT-3145): ThreadedIr measurement gate ──
+
+    /// Runs `codegen(src)` with `BEAMTALK_THREADED_IR_WHILE_DIRECT` forced to
+    /// the given value for the duration of the call. Mutates process-global
+    /// state (`std::env`), so callers must not assume isolation from other
+    /// concurrently-running tests — acceptable here because the flag's own
+    /// contract is "identical output when representable, an untouched
+    /// legacy passthrough otherwise" (`try_render_while_direct_via_threaded_ir`'s
+    /// doc comment), so a concurrently-running test observing the flag
+    /// toggled cannot itself produce different output because of it.
+    fn codegen_with_threaded_ir_while_direct(src: &str, enabled: bool) -> String {
+        // SAFETY: single-process test env var toggle around a single
+        // synchronous `codegen` call, restored to unset immediately after —
+        // no other thread in this process reads/writes this specific
+        // variable concurrently with a way to observe a torn value (see
+        // this fn's caller-side doc comment for why a racy toggle is
+        // tolerable here regardless).
+        unsafe {
+            if enabled {
+                std::env::set_var("BEAMTALK_THREADED_IR_WHILE_DIRECT", "1");
+            } else {
+                std::env::remove_var("BEAMTALK_THREADED_IR_WHILE_DIRECT");
+            }
+        }
+        let code = codegen(src);
+        // SAFETY: same as above — restoring the env var to unset.
+        unsafe {
+            std::env::remove_var("BEAMTALK_THREADED_IR_WHILE_DIRECT");
+        }
+        code
+    }
+
+    #[test]
+    fn threaded_ir_while_direct_single_local_byte_identical_to_legacy() {
+        let src = "Actor subclass: Ctr\n  state: n = 0\n\n  run =>\n    sum := 0\n    [sum < 10] whileTrue: [sum := sum + 1]\n    self.n := sum\n";
+        let legacy = codegen_with_threaded_ir_while_direct(src, false);
+        let via_ir = codegen_with_threaded_ir_while_direct(src, true);
+        assert_eq!(
+            legacy, via_ir,
+            "ThreadedIr-rendered while-direct output must be byte-identical \
+             to the legacy path for a single-local straight-line body"
+        );
+    }
+
+    #[test]
+    fn threaded_ir_while_direct_multi_local_byte_identical_to_legacy() {
+        let src = "Actor subclass: Ctr\n  state: n = 0\n\n  run =>\n    sum := 0\n    count := 0\n    [sum < 10] whileTrue: [sum := sum + 1. count := count + 1]\n    self.n := sum + count\n";
+        let legacy = codegen_with_threaded_ir_while_direct(src, false);
+        let via_ir = codegen_with_threaded_ir_while_direct(src, true);
+        assert_eq!(
+            legacy, via_ir,
+            "ThreadedIr-rendered while-direct output must be byte-identical \
+             to the legacy path for a multi-local straight-line body"
+        );
+    }
+
+    #[test]
+    fn threaded_ir_while_direct_negated_condition_byte_identical_to_legacy() {
+        let src = "Actor subclass: Ctr\n  state: n = 0\n\n  run =>\n    sum := 0\n    [sum >= 10] whileFalse: [sum := sum + 1]\n    self.n := sum\n";
+        let legacy = codegen_with_threaded_ir_while_direct(src, false);
+        let via_ir = codegen_with_threaded_ir_while_direct(src, true);
+        assert_eq!(
+            legacy, via_ir,
+            "ThreadedIr-rendered whileFalse: (negated) output must be \
+             byte-identical to the legacy path"
+        );
+    }
+
+    #[test]
+    fn threaded_ir_while_direct_same_local_rebound_twice_in_one_iteration_byte_identical_to_legacy()
+    {
+        // `sum` is reassigned TWICE within a single loop iteration — exercises
+        // `try_render_while_direct_via_threaded_ir`'s `current`/`rebind_counts`
+        // chaining (the second rebind's `Bind::source` must be the first
+        // rebind's own fresh `Gensym` target, not the fun's version-0 param),
+        // a code path the single/multi-local tests above (one rebind per
+        // local) don't reach.
+        let src = "Actor subclass: Ctr\n  state: n = 0\n\n  run =>\n    sum := 0\n    [sum < 10] whileTrue: [sum := sum + 1. sum := sum * 2]\n    self.n := sum\n";
+        let legacy = codegen_with_threaded_ir_while_direct(src, false);
+        let via_ir = codegen_with_threaded_ir_while_direct(src, true);
+        assert_eq!(
+            legacy, via_ir,
+            "ThreadedIr-rendered while-direct output must be byte-identical \
+             to the legacy path when the same local is rebound twice in one \
+             iteration"
+        );
+    }
+
+    #[test]
+    fn threaded_ir_while_direct_field_read_in_rhs_byte_identical_to_legacy() {
+        // A field READ (not a write) in the rebind's RHS — `select_direct_params`
+        // permits this (only WRITES/self-sends disqualify direct-params), and
+        // `is_simple_threaded_rhs` allows `FieldAccess` through, so this must
+        // still route through `ConditionalLoop` and match legacy exactly.
+        let src = "Actor subclass: Ctr\n  state: step = 1\n  state: n = 0\n\n  run =>\n    sum := 0\n    [sum < 10] whileTrue: [sum := sum + self.step]\n    self.n := sum\n";
+        let legacy = codegen_with_threaded_ir_while_direct(src, false);
+        let via_ir = codegen_with_threaded_ir_while_direct(src, true);
+        assert_eq!(
+            legacy, via_ir,
+            "ThreadedIr-rendered while-direct output must be byte-identical \
+             to the legacy path when the rebind RHS reads a field"
+        );
+    }
+
+    #[test]
+    fn threaded_ir_while_direct_falls_back_for_unrepresentable_body() {
+        // A plain-let temporary (`half`, never a threaded local) inside the
+        // loop body — outside this pilot's narrow `Bind`-chain coverage
+        // (`while_direct_body_is_bind_representable`'s doc comment) — must
+        // fall back to the legacy path untouched, not error or diverge.
+        let src = "Actor subclass: Ctr\n  state: n = 0\n\n  run =>\n    sum := 0\n    [sum < 10] whileTrue: [half := sum / 2. sum := sum + 1 + half - half]\n    self.n := sum\n";
+        let legacy = codegen_with_threaded_ir_while_direct(src, false);
+        let via_ir = codegen_with_threaded_ir_while_direct(src, true);
+        assert_eq!(
+            legacy, via_ir,
+            "an unrepresentable body must fall back to the legacy path \
+             byte-for-byte, flag on or off"
         );
     }
 }

--- a/crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs
@@ -28,12 +28,28 @@
 //! skeleton fidelity (flattened body, no letrec wrapper) — no production
 //! call site or dual-run proof needs them yet; a later migration issue
 //! extends `render` to them when it does (issue body point 3: "extend node
-//! types only where fidelity requires it"). **No production call site
-//! renders through this module yet** — `lower_and_render`, the pre-existing
-//! test-shim entry point, now delegates to [`render`] against a throwaway
-//! [`CoreErlangGenerator`], so this remains true of every caller today
-//! (BT-3145, the pilot migration, is what first points a real emission site
-//! at `render`).
+//! types only where fidelity requires it").
+//!
+//! ## Status (as of BT-3145 — see ADR 0111 Addendum 2)
+//!
+//! BT-3145 (the pilot migration) adds [`ThreadedStmt::ConditionalLoop`] (the
+//! real condition/case-split loop skeleton, Addendum 2's "Gap 1") and
+//! [`VersionPrefix::Gensym`] (a pre-minted, verbatim Core Erlang name,
+//! Addendum 2's "Gap 2"), and points the FIRST real (non-test) emission site
+//! at [`render`]: `while_loops.rs`'s `generate_while_loop_direct`, gated
+//! behind the `BEAMTALK_THREADED_IR_WHILE_DIRECT=1` env flag (off by
+//! default). Coverage is deliberately narrow — only straight-line,
+//! `Bind`-representable loop bodies (`while_loops.rs`'s
+//! `while_direct_body_is_bind_representable`) route through this module;
+//! anything else falls back to the legacy path untouched. A real
+//! implementation attempt surfaced a third, smaller-but-real gap beyond
+//! Addendum 2's own two (an opaque-RHS-value need, closed here via
+//! [`ValueRef::Doc`], plus a `BodyKind::Letrec` inter-statement whitespace
+//! quirk, confirmed against real compiled output) — recorded on the BT-3145
+//! Linear issue rather than silently folded into "done." The default stays
+//! the legacy path (this pilot's own measurement gate did not clear
+//! deleting it) — see BT-3145's Linear issue for the full evidentiary trail
+//! and the ≤3% gate's outcome.
 //!
 //! This module lands the IR types, the [`verify`] checker, and the
 //! [`lower_and_render`] test shim (BT-3129), the unified `VersionedVar`/
@@ -189,6 +205,26 @@ pub(super) enum VersionPrefix {
     /// See module docs §Deviations for why this exists beyond the ADR's
     /// three-prefix sketch.
     Local(String),
+    /// A pre-minted, verbatim Core Erlang name (e.g. `_Sum7`), ADR 0111
+    /// Addendum 2 "Gap 2" (`docs/ADR/0111-...md` §Addendum 2, "naming-scheme
+    /// mismatch"): real per-iteration loop-local rebinds go through
+    /// `fresh_temp_var` (a single module-wide gensym counter shared across
+    /// ALL codegen in the method), never through [`VersionPrefix::Local`]'s
+    /// bare-prefix-plus-sequential-version scheme (`Sum1`, `Sum2`, …) —
+    /// confirmed against real compiled output, not just source reading (the
+    /// investigation trail is on the BT-3145 Linear issue). `render_name`
+    /// returns the stored string VERBATIM, regardless of `version` — minting
+    /// happens once, at LOWERING time (via the same `fresh_temp_var` call
+    /// production already makes, in the same order), never at render time.
+    /// A render-time memoizing cache was considered and rejected (Addendum
+    /// 2, Gap 2 option 1): it defers minting to `render()`, which inverts
+    /// mint order relative to legacy whenever a construct (like
+    /// `ConditionalLoop`) builds its `exit_arm` from lowered body state —
+    /// `exit_arm`'s temps must be minted LAST, after every body rebind, and
+    /// a lazy render-time cache cannot honor that ordering. See
+    /// [`ThreadedStmt::ConditionalLoop`]'s doc comment for the full
+    /// ordering contract.
+    Gensym(String),
 }
 
 /// A version-identified Core Erlang variable, scoped to the frame that
@@ -238,6 +274,7 @@ impl VersionedVar {
                 let core_name = super::CoreErlangGenerator::to_core_erlang_var(name);
                 super::util::versioned_var(&core_name, self.version)
             }
+            VersionPrefix::Gensym(name) => name.clone(),
         }
     }
 }
@@ -263,6 +300,29 @@ impl VersionedVar {
 pub(super) struct AccParam(pub(super) String);
 
 impl AccParam {
+    pub(super) fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+}
+
+// ─── LoopCounter (ADR 0111 Addendum 2, Gap 1) ──────────────────────────────
+
+/// A counted loop's (`to:do:`/`to:by:do:`/`timesRepeat:`/`repeat`) gensym'd
+/// loop *index* fun parameter (`frame.counter`, `fresh_temp_var("loopidx")`
+/// in production, `control_flow/mod.rs`'s `CountedLoopFrame::counter`) — an
+/// extra [`ThreadedStmt::ConditionalLoop`] fun parameter that is never a
+/// `Bind` target or source, threaded instead by a raw "next value"
+/// expression (e.g. `call 'erlang':'+'(Counter, 1)`). Mirrors [`AccParam`]'s
+/// existing precedent for an unversioned, generator-allocated identity kept
+/// outside [`VersionedVar`]'s producer/consumer bookkeeping — see Addendum
+/// 2's Gap 1 evidence (`docs/ADR/0111-...md` §Addendum 2). `None` for
+/// while/`whileFalse:` loops, which have no counter; counted loops are a
+/// later call site (BT-3145 wires only `generate_while_loop_direct` first).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LoopCounter(pub(super) String);
+
+impl LoopCounter {
+    #[allow(dead_code)] // counted-loop call sites are a later migration, not this pilot
     pub(super) fn new(name: impl Into<String>) -> Self {
         Self(name.into())
     }
@@ -405,6 +465,22 @@ pub(super) enum ValueRef {
     Var(String),
     /// A literal Core Erlang fragment (e.g. `'nil'`).
     Literal(&'static str),
+    /// An opaque, pre-rendered `Document` — ordinary AST-directed
+    /// expression codegen with no state-threading content of its own,
+    /// exactly the class of embed [`ThreadedStmt::ConditionalLoop`]'s
+    /// `continue_header`/`exit_arm` already use (the `NlrCatch` precedent,
+    /// ADR 0111 Addendum 2 §Gap 1). Needed because a real loop-local rebind's
+    /// RHS is an arbitrary computed expression (e.g. `call
+    /// 'erlang':'+'(Sum, 1)` for `sum := sum + 1`), not merely a reference to
+    /// a previously-bound version — [`ValueRef::Version`]/`Var`/`Literal`
+    /// alone cannot represent it. `verify()`'s `check_use` does not (and
+    /// cannot) look inside a `Doc` value for hidden `VersionedVar`
+    /// references — same accepted §Verifier-honesty-class limitation as
+    /// `exit_arm`'s own opacity: the RHS is built by the SAME live
+    /// generator/scope resolution production already uses, so any prior
+    /// version it references resolves correctly by construction, just
+    /// unverified by this pass.
+    Doc(Document<'static>),
 }
 
 /// The mutation an individual [`ThreadedStmt::Bind`] performs. See
@@ -499,6 +575,73 @@ pub(super) enum ThreadedStmt {
         gate_slots: usize,
         targets: Vec<VersionedVar>,
         frame: FrameId,
+        span: Span,
+    },
+
+    /// A while/counted loop's condition/case-split skeleton (ADR 0111
+    /// Addendum 2, Gap 1): `letrec 'fn_name'/N = fun (Params) ->
+    /// <continue_header> <body> apply 'fn_name'/N (<final_args>) <exit_arm>
+    /// in apply 'fn_name'/N (<outer_args>)`. Unlike bare [`Threaded`](Self::Threaded)
+    /// (which has no slot for a condition or exit arm — the unconditional
+    /// tail-recursion skeleton [`Threaded`](Self::Threaded)'s `DirectParams`/`Hybrid`
+    /// modes render), this variant is the REAL shape every while/counted
+    /// loop call site emits: a condition test gates a two-arm `case`, one
+    /// arm continuing the recursion, the other exiting.
+    ///
+    /// `produces` carries each threaded local's INITIAL (`version == 0`)
+    /// identity, one per fun parameter, in the SAME order as the fun's
+    /// parameter list — exactly mirroring bare [`Threaded`](Self::Threaded)'s
+    /// existing `produces` convention (`param_list`/`outer_args` are derived
+    /// from it by construction, never independently supplied). The loop's
+    /// FINAL per-iteration values (the recursive tail call's actual
+    /// arguments) are NOT read from `produces` directly — they are
+    /// reconstructed by following each local's `Bind` chain forward through
+    /// `body` from its `produces` seed (see `render`'s
+    /// `final_loop_arg_identities` helper) — because a real rebind's target
+    /// is [`VersionPrefix::Gensym`], whose rendering does not vary with
+    /// `version`, so the "reset version to 0" trick bare `Threaded` uses to
+    /// derive `param_list`/`outer_args` from the SAME field would not recover
+    /// the fun's plain parameter name from a Gensym'd final identity.
+    ConditionalLoop {
+        /// Static per-construct function name — `"while"`, `"loop"`,
+        /// `"repeat"` — never gensym'd by `render` (ADR 0111 Addendum 2's
+        /// "loop-fn-name" finding: production never gensyms this name
+        /// either, `while_loops.rs`'s `"while"` literal /
+        /// `CountedLoopFrame::fn_name`). Caller-supplied at lowering time,
+        /// mirroring `CountedLoopFrame::fn_name`'s existing field type.
+        fn_name: String,
+        mode: ThreadingMode,
+        frame: FrameId,
+        /// Present only for counted loops (`to:do:`/`to:by:do:`/
+        /// `timesRepeat:`/`repeat`) — `None` for while/`whileFalse:`. See
+        /// [`LoopCounter`]'s doc comment.
+        counter: Option<LoopCounter>,
+        /// Opaque, AST-directed condition scrutinee + the case's chosen
+        /// continue-arm pattern, up to and including `"-> "` — e.g. `"let
+        /// CondFun = <cond> in case apply CondFun (Params) of <'true'> when
+        /// 'true' -> "`. Built by the SAME condition-codegen call production
+        /// already runs — the IR does not re-derive condition semantics.
+        /// Sound opacity: the condition body is ordinary AST-directed
+        /// expression codegen with no state-threading content of its own
+        /// (the `NlrCatch` precedent — see the ADR's §Verifier honesty).
+        continue_header: Document<'static>,
+        body: Vec<ThreadedStmt>,
+        produces: Vec<VersionedVar>,
+        /// Opaque exit arm: pattern + exit value + `"end "` — e.g.
+        /// `"<'false'> when 'true' -> {'nil', _ExitSA8} end "` (built by
+        /// `generate_exit_stateacc`). ORDERING CONSTRAINT (load-bearing for
+        /// byte-identity): must be constructed AFTER `body` is lowered — its
+        /// `ExitSA` temps share the SAME module-wide `fresh_temp_var`
+        /// counter as `body`'s rebind temps, and legacy mints body temps
+        /// first. This opacity is NOT sound on `continue_header`'s grounds —
+        /// `exit_arm` genuinely hides state-threading content (the loop
+        /// exit's `StateAcc` repack). Deliberate, named
+        /// §Verifier-honesty-class limitation for this pilot: the loop exit
+        /// repack is unverified by design (ADR 0111 Addendum 2, Gap 1 —
+        /// deferred, not rejected; a future structural model is a `Bind`
+        /// chain of `Put`s with `Gensym` targets, which this variant already
+        /// makes directly expressible).
+        exit_arm: Document<'static>,
         span: Span,
     },
 }
@@ -670,7 +813,9 @@ fn contains_class_var_nlr_catch(ir: &[ThreadedStmt]) -> bool {
                 }
             )
         }
-        ThreadedStmt::Threaded { body, .. } => contains_class_var_nlr_catch(body),
+        ThreadedStmt::Threaded { body, .. } | ThreadedStmt::ConditionalLoop { body, .. } => {
+            contains_class_var_nlr_catch(body)
+        }
         ThreadedStmt::Bind { .. }
         | ThreadedStmt::Return(..)
         | ThreadedStmt::TupleAccUnpack { .. } => false,
@@ -692,7 +837,7 @@ fn collect_producer_consumer_counts(
                 *producers.entry(target.clone()).or_insert(0) += 1;
                 *consumers.entry(source.clone()).or_insert(0) += 1;
             }
-            ThreadedStmt::Threaded { body, .. } => {
+            ThreadedStmt::Threaded { body, .. } | ThreadedStmt::ConditionalLoop { body, .. } => {
                 collect_producer_consumer_counts(body, producers, consumers);
             }
             ThreadedStmt::TupleAccUnpack { targets, .. } => {
@@ -790,7 +935,21 @@ impl VerifyWalk<'_> {
                 body,
                 produces,
                 span: _,
+            }
+            | ThreadedStmt::ConditionalLoop {
+                mode,
+                frame,
+                body,
+                produces,
+                span: _,
+                ..
             } => {
+                // ADR 0111 Addendum 2, Gap 1: `ConditionalLoop` verifies
+                // exactly like `Threaded` — push frame/mode, walk body,
+                // check_use each `produces` entry, pop. `continue_header`/
+                // `exit_arm`/`fn_name`/`counter` are opaque (or caller-
+                // supplied, non-threading) fields `verify()` does not, and
+                // is not meant to, inspect — see the variant's doc comment.
                 self.frame_stack.push(*frame);
                 self.mode_stack.push(mode.clone());
                 self.walk(body);
@@ -852,12 +1011,6 @@ impl VerifyWalk<'_> {
 /// [`RenderCtx`] threads, it never becomes a second source of truth for
 /// their values — [`RenderCtx::with_loop_context`] always reads/writes them
 /// through the wrapped generator).
-///
-/// `#[allow(dead_code)]`: BT-3154 deleted the Phase A0 measurement
-/// prototype, the entire render pipeline's last production (non-test) call
-/// site — see [`render`]'s doc comment. Exercised only by unit tests until
-/// BT-3145's pilot migration points a real emission site at [`render`].
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 struct LoopContextFlags {
     in_loop_body: bool,
@@ -884,15 +1037,10 @@ struct LoopContextFlags {
 /// (constructing a `RenderCtx` without a full generator instance); since
 /// [`CoreErlangGenerator::new`] is cheap (no I/O, pure data-structure
 /// init), [`lower_and_render`] pays that cost directly instead.
-///
-/// `#[allow(dead_code)]`: see [`LoopContextFlags`]'s doc comment — the whole
-/// render pipeline is exercised only by unit tests as of BT-3154.
-#[allow(dead_code)]
 pub(super) struct RenderCtx<'g> {
     generator: &'g mut CoreErlangGenerator,
 }
 
-#[allow(dead_code)]
 impl<'g> RenderCtx<'g> {
     pub(super) fn new(generator: &'g mut CoreErlangGenerator) -> Self {
         Self { generator }
@@ -920,9 +1068,10 @@ impl<'g> RenderCtx<'g> {
                 self.generator.in_loop_body,
                 var.version,
             ),
-            VersionPrefix::ClassVars | VersionPrefix::SelfVt | VersionPrefix::Local(_) => {
-                var.render_name()
-            }
+            VersionPrefix::ClassVars
+            | VersionPrefix::SelfVt
+            | VersionPrefix::Local(_)
+            | VersionPrefix::Gensym(_) => var.render_name(),
         }
     }
 
@@ -956,16 +1105,11 @@ impl<'g> RenderCtx<'g> {
 /// infallible, but a guard costs nothing extra and keeps the two save/
 /// restore mechanisms in this file at parity instead of one silently being
 /// weaker than the other it's explicitly modeled after).
-///
-/// `#[allow(dead_code)]`: see [`LoopContextFlags`]'s doc comment — the whole
-/// render pipeline is exercised only by unit tests as of BT-3154.
-#[allow(dead_code)]
 struct LoopContextGuard<'a, 'g> {
     ctx: &'a mut RenderCtx<'g>,
     saved: LoopContextFlags,
 }
 
-#[allow(dead_code)]
 impl<'a, 'g> LoopContextGuard<'a, 'g> {
     fn enter(ctx: &'a mut RenderCtx<'g>, flags: LoopContextFlags) -> Self {
         let saved = LoopContextFlags {
@@ -1003,12 +1147,10 @@ impl Drop for LoopContextGuard<'_, '_> {
 /// returns — nothing after an `NlrCatch` renders a second time outside the
 /// wrap.
 ///
-/// `#[allow(dead_code)]`: BT-3154 deleted the Phase A0 measurement
-/// prototype (`control_flow::while_loops`'s `BEAMTALK_THREADED_IR_WHILE`
-/// gate), this function's last production (non-test) call site — see module
-/// docs §Status. Exercised only by unit tests until BT-3145's pilot
-/// migration points a real emission site here.
-#[allow(dead_code)]
+/// Has a real (non-test) production caller as of BT-3145:
+/// `control_flow::while_loops`'s `try_render_while_direct_via_threaded_ir`,
+/// gated behind `BEAMTALK_THREADED_IR_WHILE_DIRECT=1` — see module docs
+/// §Status (BT-3145).
 pub(super) fn render(ir: &[ThreadedStmt], ctx: &mut RenderCtx) -> Document<'static> {
     let mut docs: Vec<Document<'static>> = Vec::new();
     for (i, stmt) in ir.iter().enumerate() {
@@ -1039,6 +1181,26 @@ pub(super) fn render(ir: &[ThreadedStmt], ctx: &mut RenderCtx) -> Document<'stat
                 targets,
                 ..
             } => docs.push(render_tuple_acc_unpack(param, *gate_slots, targets)),
+            ThreadedStmt::ConditionalLoop {
+                fn_name,
+                mode,
+                frame,
+                counter: _counter, // counted-loop rendering: a later migration wires a real counted-loop call site (BT-3145 pilots while-direct only)
+                continue_header,
+                body,
+                produces,
+                exit_arm,
+                span: _,
+            } => docs.push(render_conditional_loop(
+                fn_name,
+                mode,
+                *frame,
+                body,
+                produces,
+                continue_header,
+                exit_arm,
+                ctx,
+            )),
         }
     }
     Document::Vec(docs)
@@ -1048,9 +1210,13 @@ pub(super) fn render(ir: &[ThreadedStmt], ctx: &mut RenderCtx) -> Document<'stat
 /// the issue body's point 5: delegates to [`render`] against a throwaway
 /// [`CoreErlangGenerator`] (cheap — no I/O) so every existing
 /// `lower_and_render(&ir).to_pretty_string()` test call survives verbatim.
-/// BT-3154 deleted `control_flow::while_loops`'s Phase A0 measurement
-/// prototype, this function's last production (non-test) caller — see
-/// [`render`]'s doc comment.
+///
+/// `#[allow(dead_code)]`: unlike [`render`] itself (which now has a real
+/// production caller as of BT-3145 — see [`render`]'s doc comment), this
+/// shim remains test-only: `while_loops.rs`'s
+/// `try_render_while_direct_via_threaded_ir` builds its own
+/// [`RenderCtx`] directly against the live generator rather than a
+/// throwaway one, so this convenience wrapper has no production caller.
 #[allow(dead_code)]
 pub(super) fn lower_and_render(ir: &[ThreadedStmt]) -> Document<'static> {
     let mut generator = CoreErlangGenerator::new("__threaded_ir_render_shim");
@@ -1063,9 +1229,6 @@ pub(super) fn lower_and_render(ir: &[ThreadedStmt]) -> Document<'static> {
 /// [`ThreadingMode::Hybrid`] (the while-loop family modes this issue's
 /// dual-run harness proves parity for — see `render_tests` below);
 /// `TupleAcc`/`StateAcc` still flatten the body (module docs §Status).
-///
-/// `#[allow(dead_code)]`: see [`render`]'s doc comment (BT-3154).
-#[allow(dead_code)]
 fn render_threaded(
     mode: &ThreadingMode,
     frame: FrameId,
@@ -1074,17 +1237,25 @@ fn render_threaded(
     ctx: &mut RenderCtx,
 ) -> Document<'static> {
     match mode {
-        ThreadingMode::DirectParams => render_loop_letrec(frame, body, produces, ctx, None),
-        ThreadingMode::Hybrid => render_loop_letrec(
-            frame,
-            body,
-            produces,
-            ctx,
-            Some(LoopContextFlags {
-                in_loop_body: true,
-                in_hybrid_loop: true,
-            }),
-        ),
+        ThreadingMode::DirectParams => {
+            let fn_name = ctx.fresh_temp_var("Loop");
+            render_loop_skeleton(fn_name, frame, body, produces, ctx, None, None)
+        }
+        ThreadingMode::Hybrid => {
+            let fn_name = ctx.fresh_temp_var("Loop");
+            render_loop_skeleton(
+                fn_name,
+                frame,
+                body,
+                produces,
+                ctx,
+                Some(LoopContextFlags {
+                    in_loop_body: true,
+                    in_hybrid_loop: true,
+                }),
+                None,
+            )
+        }
         ThreadingMode::TupleAcc(_) | ThreadingMode::StateAcc(_) => render(body, ctx),
     }
 }
@@ -1116,23 +1287,69 @@ fn render_threaded(
 /// names — a `fun`'s parameter name never has to match its caller's
 /// argument expression).
 ///
-/// `#[allow(dead_code)]`: see [`render`]'s doc comment (BT-3154).
-#[allow(dead_code)]
-fn render_loop_letrec(
+///
+/// ADR 0111 Addendum 2, Gap 1: factored out of the pre-existing
+/// `render_loop_letrec` so the bare unconditional [`Threaded`](ThreadedStmt::Threaded)
+/// skeleton (`header_and_exit: None`) and [`ConditionalLoop`](ThreadedStmt::ConditionalLoop)'s
+/// real condition/case-split skeleton (`header_and_exit: Some((continue_header,
+/// exit_arm))`) share one implementation instead of two near-duplicates
+/// (CLAUDE.md's no-duplicate-implementations rule applies within this file,
+/// not just across the Rust/Erlang boundary).
+///
+/// `fn_name` is already resolved by the caller — the bare shape mints it via
+/// `ctx.fresh_temp_var("Loop")` (`render_threaded`, unchanged behavior);
+/// `ConditionalLoop` carries its own caller-supplied, never-gensym'd name
+/// (the variant's own doc comment: production never gensyms this name
+/// either).
+///
+/// `produces`' own (post-body) versions render as the `fun`'s declared
+/// parameters AND (for the bare shape only) the recursive self-call's
+/// arguments — both textually inside the same `fun` block as `body_doc`, so
+/// both resolve under the loop's OWN context (`render_in_loop_body`, below).
+/// The OUTER initial call is different: it is the calling scope's own
+/// reference to `produces` at version 0, so it resolves under whatever
+/// context was already ambient *before* this node — never the loop's own.
+/// For a `Local`-prefixed var these two resolutions coincide
+/// ([`VersionedVar::render_name`] names it purely from `(name, version)`,
+/// context-independent — the common case, matching how the real
+/// direct-params/hybrid generators reuse `to_core_erlang_var`-derived names
+/// on both sides, `while_loops.rs`'s `initial_direct_args`/
+/// `param_list_doc`); for a `State`-prefixed var nested inside a
+/// differently-flagged ambient loop, they do NOT (the `fun`'s formal
+/// parameter and the outer call's argument are legitimately different
+/// names — a `fun`'s parameter name never has to match its caller's
+/// argument expression).
+///
+/// For `ConditionalLoop` (`header_and_exit: Some(..)`), the recursive
+/// self-call's arguments are NOT `produces` verbatim — they are
+/// [`final_loop_arg_identities`]'s reconstruction of each local's REAL final
+/// `Bind` target (a [`VersionPrefix::Gensym`] identity production actually
+/// minted), because `produces` only ever carries each local's INITIAL
+/// (`version == 0`) identity (see the variant's doc comment for why the
+/// bare shape's "reset version to 0" trick cannot be reused the other
+/// direction for a `Gensym` prefix). The body itself also renders
+/// differently for `ConditionalLoop`: real loop bodies are `BodyKind::Letrec`
+/// (`generate_threaded_loop_body_inner`, `control_flow/mod.rs`), which
+/// inserts a literal `" "` between statements — [`render_loop_body_statements`]
+/// reproduces that; the bare shape's body is a synthetic, condition-free
+/// fixture with no such production twin, so it keeps rendering via plain
+/// [`render`].
+fn render_loop_skeleton(
+    fn_name: String,
     frame: FrameId,
     body: &[ThreadedStmt],
     produces: &[VersionedVar],
     ctx: &mut RenderCtx,
     loop_context: Option<LoopContextFlags>,
+    header_and_exit: Option<(&Document<'static>, &Document<'static>)>,
 ) -> Document<'static> {
-    let fn_name = ctx.fresh_temp_var("Loop");
     let arity = produces.len();
 
     // The OUTER initial call's arguments — this is the calling scope's own
     // reference to `produces` at version 0, so it must resolve under
-    // whatever context was already ambient *before* this `Threaded` node,
-    // never the loop's own context (that would rename a var the caller
-    // never bound under).
+    // whatever context was already ambient *before* this node, never the
+    // loop's own context (that would rename a var the caller never bound
+    // under).
     let outer_args = join(
         produces
             .iter()
@@ -1159,11 +1376,24 @@ fn render_loop_letrec(
             }),
             &Document::Str(", "),
         );
-        let body_doc = render(body, ctx);
-        let final_args = join(
-            produces.iter().map(|v| leaf::var(ctx.resolve_prefix(v))),
-            &Document::Str(", "),
-        );
+        let body_doc = if header_and_exit.is_some() {
+            render_loop_body_statements(body, ctx)
+        } else {
+            render(body, ctx)
+        };
+        let final_args = if header_and_exit.is_some() {
+            join(
+                final_loop_arg_identities(body, produces)
+                    .iter()
+                    .map(|v| leaf::var(ctx.resolve_prefix(v))),
+                &Document::Str(", "),
+            )
+        } else {
+            join(
+                produces.iter().map(|v| leaf::var(ctx.resolve_prefix(v))),
+                &Document::Str(", "),
+            )
+        };
         (param_list, body_doc, final_args)
     };
     let (param_list, body_doc, final_args) = match loop_context {
@@ -1171,24 +1401,140 @@ fn render_loop_letrec(
         None => render_in_loop_body(ctx),
     };
 
-    docvec![
-        "letrec ",
-        leaf::fname(fn_name.clone(), arity),
-        " = fun (",
-        param_list,
-        ") -> ",
-        body_doc,
-        "apply ",
-        leaf::fname(fn_name.clone(), arity),
-        " (",
-        final_args,
-        ")",
-        " in apply ",
-        leaf::fname(fn_name, arity),
-        " (",
-        outer_args,
-        ")",
-    ]
+    match header_and_exit {
+        None => docvec![
+            "letrec ",
+            leaf::fname(fn_name.clone(), arity),
+            " = fun (",
+            param_list,
+            ") -> ",
+            body_doc,
+            "apply ",
+            leaf::fname(fn_name.clone(), arity),
+            " (",
+            final_args,
+            ")",
+            " in apply ",
+            leaf::fname(fn_name, arity),
+            " (",
+            outer_args,
+            ")",
+        ],
+        Some((continue_header, exit_arm)) => docvec![
+            "letrec ",
+            leaf::fname(fn_name.clone(), arity),
+            " = fun (",
+            param_list,
+            ") -> ",
+            continue_header.clone(),
+            body_doc,
+            " apply ",
+            leaf::fname(fn_name.clone(), arity),
+            " (",
+            final_args,
+            ") ",
+            exit_arm.clone(),
+            // NOTE: no leading space here (unlike the bare-shape arm above) —
+            // `exit_arm` (e.g. `"<'false'> ... end "`) already ends with a
+            // trailing space, matching production's own `" end ",` +
+            // `"in apply "` concatenation (`while_loops.rs`'s
+            // `generate_while_loop_direct`) exactly; an extra leading space
+            // here would double it.
+            "in apply ",
+            leaf::fname(fn_name, arity),
+            " (",
+            outer_args,
+            ")",
+        ],
+    }
+}
+
+/// Renders a real (`ConditionalLoop`) loop body's statements with the
+/// literal `" "` separator `generate_threaded_loop_body_inner` inserts
+/// between statements for `BodyKind::Letrec` (`control_flow/mod.rs`) —
+/// confirmed against real compiled output (two consecutive threaded-local
+/// rebinds emit `"... in  let ..."`, a double space: the statement's own
+/// trailing `" in "` plus this separator). Each statement renders through
+/// the general [`render`] dispatch (a one-element slice), so nested shapes
+/// (a future `ConditionalLoop` body statement that isn't a bare `Bind`)
+/// stay correctly handled without this function re-deriving `render`'s own
+/// match.
+fn render_loop_body_statements(body: &[ThreadedStmt], ctx: &mut RenderCtx) -> Document<'static> {
+    let mut docs: Vec<Document<'static>> = Vec::with_capacity(body.len() * 2);
+    for (i, stmt) in body.iter().enumerate() {
+        if i > 0 {
+            docs.push(Document::Str(" "));
+        }
+        docs.push(render(std::slice::from_ref(stmt), ctx));
+    }
+    Document::Vec(docs)
+}
+
+/// Reconstructs each `produces` entry's REAL final identity by following its
+/// `Bind` chain forward through `body` (ADR 0111 Addendum 2, Gap 1 — see
+/// [`ThreadedStmt::ConditionalLoop`]'s doc comment for why this cannot be
+/// derived from `produces` alone the way the bare loop shape derives
+/// `param_list`/`outer_args` from it). `produces` seeds the search at each
+/// local's INITIAL (`version == 0`) identity; a local never rebound in
+/// `body` keeps that identity (matching legacy's `collect_final_local_args`
+/// fallback — the fun's own unchanged parameter name IS the final arg).
+/// Only scans `body`'s own top-level `Bind`s — a nested construct's `Bind`s
+/// belong to a different [`FrameId`] and can never be this loop's own
+/// rebind chain.
+fn final_loop_arg_identities(
+    body: &[ThreadedStmt],
+    produces: &[VersionedVar],
+) -> Vec<VersionedVar> {
+    produces
+        .iter()
+        .map(|seed| {
+            let mut current = seed.clone();
+            while let Some(next) = body.iter().find_map(|stmt| match stmt {
+                ThreadedStmt::Bind { source, target, .. } if *source == current => {
+                    Some(target.clone())
+                }
+                _ => None,
+            }) {
+                current = next;
+            }
+            current
+        })
+        .collect()
+}
+
+/// Full-fidelity rendering of a [`ThreadedStmt::ConditionalLoop`] node (ADR
+/// 0111 Addendum 2, Gap 1): delegates to [`render_loop_skeleton`] with the
+/// real `continue_header`/`exit_arm` pair, reusing the exact same
+/// `param_list`/`outer_args` plumbing the bare loop shape uses.
+#[allow(clippy::too_many_arguments)]
+fn render_conditional_loop(
+    fn_name: &str,
+    mode: &ThreadingMode,
+    frame: FrameId,
+    body: &[ThreadedStmt],
+    produces: &[VersionedVar],
+    continue_header: &Document<'static>,
+    exit_arm: &Document<'static>,
+    ctx: &mut RenderCtx,
+) -> Document<'static> {
+    let loop_context = match mode {
+        ThreadingMode::Hybrid => Some(LoopContextFlags {
+            in_loop_body: true,
+            in_hybrid_loop: true,
+        }),
+        ThreadingMode::DirectParams | ThreadingMode::TupleAcc(_) | ThreadingMode::StateAcc(_) => {
+            None
+        }
+    };
+    render_loop_skeleton(
+        fn_name.to_string(),
+        frame,
+        body,
+        produces,
+        ctx,
+        loop_context,
+        Some((continue_header, exit_arm)),
+    )
 }
 
 /// Skeleton-fidelity rendering of [`ThreadedStmt::TupleAccUnpack`], mirroring
@@ -1196,9 +1542,6 @@ fn render_loop_letrec(
 /// in` chain — `idx` starts at `gate_slots + 1` (1-based, past the leading
 /// gate slots) for the first target. Already full-fidelity (no generator
 /// context needed): this shape was real before BT-3144, unchanged here.
-///
-/// `#[allow(dead_code)]`: see [`render`]'s doc comment (BT-3154).
-#[allow(dead_code)]
 fn render_tuple_acc_unpack(
     param: &AccParam,
     gate_slots: usize,
@@ -1220,18 +1563,15 @@ fn render_tuple_acc_unpack(
     Document::Vec(docs)
 }
 
-/// `#[allow(dead_code)]`: see [`render`]'s doc comment (BT-3154).
-#[allow(dead_code)]
 fn render_value(value: &ValueRef, ctx: &RenderCtx) -> Document<'static> {
     match value {
         ValueRef::Version(v) => leaf::var(ctx.resolve_prefix(v)),
         ValueRef::Var(name) => leaf::var(name.clone()),
         ValueRef::Literal(lit) => Document::Str(lit),
+        ValueRef::Doc(doc) => doc.clone(),
     }
 }
 
-/// `#[allow(dead_code)]`: see [`render`]'s doc comment (BT-3154).
-#[allow(dead_code)]
 fn render_bind(
     target: &VersionedVar,
     source: &VersionedVar,
@@ -1300,9 +1640,6 @@ fn render_bind(
 /// (module docs on [`ThreadedStmt::NlrCatch`]: "the true call site
 /// `ThreadedStmt::NlrCatch` faithfully models"). Zero re-derivation, so
 /// this can never drift from production's try/catch shape.
-///
-/// `#[allow(dead_code)]`: see [`render`]'s doc comment (BT-3154).
-#[allow(dead_code)]
 fn render_nlr_catch(
     boundary: NlrBoundary,
     body_doc: Document<'static>,
@@ -1313,8 +1650,6 @@ fn render_nlr_catch(
         .wrap_body_with_nlr_catch(body_doc, &token_var, boundary)
 }
 
-/// `#[allow(dead_code)]`: see [`render`]'s doc comment (BT-3154).
-#[allow(dead_code)]
 fn render_return(value: &ValueRef, state: &VersionedVar, ctx: &RenderCtx) -> Document<'static> {
     docvec![
         "{",
@@ -1804,6 +2139,71 @@ mod tests {
             span: span(),
         }];
         assert_eq!(verify(&ir), Vec::new());
+    }
+
+    #[test]
+    fn verify_silent_on_well_formed_conditional_loop_fixture() {
+        // ADR 0111 Addendum 2, Gap 1: `verify()` treats `ConditionalLoop`
+        // exactly like `Threaded` — push frame/mode, walk body, check_use
+        // each `produces` entry, pop — no new `VerifyError` variant. Opaque
+        // fields (`continue_header`/`exit_arm`) and caller-supplied,
+        // non-threading fields (`fn_name`/`counter`) are not, and cannot be,
+        // inspected — see the variant's doc comment.
+        let frame = FrameId::new(1);
+        let sum_v0 = local("sum", 0, frame);
+        let sum_v1 = VersionedVar::new(VersionPrefix::Gensym("_Sum7".to_string()), 1, frame);
+        let ir = vec![ThreadedStmt::ConditionalLoop {
+            fn_name: "while".to_string(),
+            mode: ThreadingMode::DirectParams,
+            frame,
+            counter: None,
+            continue_header: Document::Str("<opaque condition>"),
+            body: vec![ThreadedStmt::Bind {
+                target: sum_v1,
+                source: sum_v0.clone(),
+                op: BindOp::Direct(ValueRef::Doc(Document::Str("<opaque rhs>"))),
+                shadow_write: false,
+                span: span(),
+            }],
+            produces: vec![sum_v0],
+            exit_arm: Document::Str("<opaque exit>"),
+            span: span(),
+        }];
+        assert_eq!(verify(&ir), Vec::new());
+    }
+
+    #[test]
+    fn verify_unbound_version_conditional_loop_frame_flow_matches_threaded() {
+        // ConditionalLoop's frame is pushed/popped exactly like Threaded's —
+        // a Bind referencing a version from a frame never entered is still
+        // caught.
+        let frame = FrameId::new(1);
+        let stray_frame = FrameId::new(99);
+        let ir = vec![ThreadedStmt::ConditionalLoop {
+            fn_name: "while".to_string(),
+            mode: ThreadingMode::DirectParams,
+            frame,
+            counter: None,
+            continue_header: Document::Str("<opaque condition>"),
+            body: vec![ThreadedStmt::Bind {
+                target: local("sum", 1, frame),
+                source: class_var(1, stray_frame),
+                op: BindOp::Direct(ValueRef::Doc(Document::Str("<opaque rhs>"))),
+                shadow_write: false,
+                span: span(),
+            }],
+            produces: vec![local("sum", 1, frame)],
+            exit_arm: Document::Str("<opaque exit>"),
+            span: span(),
+        }];
+        let errors = verify(&ir);
+        assert!(
+            errors.iter().any(|e| matches!(
+                e,
+                VerifyError::UnboundVersion { var, .. } if var.frame == stray_frame
+            )),
+            "expected UnboundVersion for the out-of-scope frame, got: {errors:?}"
+        );
     }
 
     // ── UnboundVersion ───────────────────────────────────────────────────
@@ -2960,175 +3360,357 @@ mod tests {
     // legacy call site.
 
     #[test]
-    fn dual_run_direct_params_letrec_byte_parity() {
-        // "Legacy" side: hand-authored letrec skeleton for a two-local
-        // direct-params loop, written independently of `render_loop_letrec`.
-        let mut legacy_gen = CoreErlangGenerator::new("dual_run_direct_params");
-        let fn_name = legacy_gen.fresh_temp_var("Loop");
-        let params = vec![leaf::var("Sum"), leaf::var("Count")];
-        let param_list = join(params.clone(), &Document::Str(", "));
+    #[allow(clippy::too_many_lines)] // hand-authored dual-run fixture mirroring generate_while_loop_direct's real shape, ADR 0111 Addendum 2
+    fn dual_run_conditional_loop_direct_params_byte_parity() {
+        // ADR 0111 Addendum 2, Gap 1's own closing instruction: hand-author
+        // the REAL condition/case-split shape `generate_while_loop_direct`
+        // actually emits (`while_loops.rs:287-406`) — not the condition-free
+        // skeleton this test checked pre-Addendum-2 — proving `render()`'s
+        // `ConditionalLoop` arm reproduces production's real output
+        // byte-for-byte, closing the exact honesty gap this module's own
+        // §Status doc names ("no single production function today emits
+        // only the letrec skeleton these tests check").
+        //
+        // Condition/RHS bodies are deliberately trivial, mint-free fragments
+        // (not real binop codegen, which mints its own internal temps and is
+        // separately tested elsewhere) — this test's job is proving the
+        // SKELETON and the GENSYM'D NAMING match, not re-verifying
+        // expression codegen. Both concerns (Gap 1's shape, Gap 2's naming)
+        // are exercised together: `CondFun`/`Sum`-rebind/`ExitSA` are all
+        // minted via the SAME `fresh_temp_var` calls production makes, IN
+        // THE SAME ORDER (condition first, then the body's rebind, then the
+        // exit arm's `ExitSA` chain LAST) — an inverted order would still
+        // pass this assertion by accident only if both sides inverted
+        // identically, which is exactly why `legacy_gen`/`render_gen` mint
+        // independently, on separately-seeded generators, rather than
+        // sharing one generator's counter.
+        let mut legacy_gen = CoreErlangGenerator::new("dual_run_conditional_loop_direct");
+        let cond_var = legacy_gen.fresh_temp_var("CondFun"); // mint #1: CondFun, matching `while_loops.rs:310`
+        let cond_doc = docvec![
+            "call 'erlang':'<'(",
+            leaf::var("Sum"),
+            ", ",
+            leaf::int_lit(10),
+            ")",
+        ];
+        let continue_header = docvec![
+            "let ",
+            leaf::var(cond_var.clone()),
+            " = fun (",
+            leaf::var("Sum"),
+            ") -> ",
+            cond_doc,
+            " in case apply ",
+            leaf::var(cond_var),
+            " (",
+            leaf::var("Sum"),
+            ") of ",
+            "<'true'> when 'true' -> ",
+        ];
+        let sum_rebind = legacy_gen.fresh_temp_var("Sum"); // mint #2: body rebind, matching `generate_direct_var_update_in_loop`
         let body = docvec![
             "let ",
-            leaf::var("Sum1"),
-            " = ",
+            leaf::var(sum_rebind.clone()),
+            " = call 'erlang':'+'(",
             leaf::var("Sum"),
-            " in ",
-            "let ",
-            leaf::var("Count1"),
-            " = ",
-            leaf::var("Count"),
-            " in ",
+            ", ",
+            leaf::int_lit(1),
+            ") in ",
         ];
-        let final_args = join(
-            vec![leaf::var("Sum1"), leaf::var("Count1")],
-            &Document::Str(", "),
-        );
+        let exit_sa = legacy_gen.fresh_temp_var("ExitSA"); // mint #3: exit arm, LAST — matching `generate_exit_stateacc`
+        let exit_arm = docvec![
+            "<'false'> when 'true' -> let ",
+            leaf::var(exit_sa.clone()),
+            " = call 'maps':'put'(",
+            leaf::atom("__local__sum"),
+            ", ",
+            leaf::var("Sum"),
+            ", State) in {'nil', ",
+            leaf::var(exit_sa),
+            "} end ",
+        ];
         let legacy_doc = docvec![
             "letrec ",
-            leaf::fname(fn_name.clone(), 2),
+            leaf::fname("while", 1),
             " = fun (",
-            param_list,
+            leaf::var("Sum"),
             ") -> ",
+            continue_header,
             body,
-            "apply ",
-            leaf::fname(fn_name.clone(), 2),
+            " apply ",
+            leaf::fname("while", 1),
             " (",
-            final_args,
-            ")",
-            " in apply ",
-            leaf::fname(fn_name, 2),
+            leaf::var(sum_rebind),
+            ") ",
+            exit_arm,
+            "in apply ",
+            leaf::fname("while", 1),
             " (",
-            join(params, &Document::Str(", ")),
+            leaf::var("Sum"),
             ")",
         ]
         .to_pretty_string();
 
-        // `render(lower(..))` side: the equivalent `ThreadedIr` fixture, on
-        // a freshly-constructed generator seeded identically to
-        // `legacy_gen` (same module name, so `fresh_temp_var`'s counter
-        // starts at the same place).
+        // `render(..)` side: a real `ConditionalLoop` node, built on a
+        // separately-constructed but identically-seeded generator — the
+        // opaque `continue_header`/`exit_arm` fields and the body's `Bind`
+        // are minted via the SAME calls, in the SAME order, mirroring
+        // exactly how the lowering pass would build them (Addendum 2's
+        // ordering contract: condition, then body rebinds, then exit_arm
+        // LAST).
+        let mut render_gen = CoreErlangGenerator::new("dual_run_conditional_loop_direct");
+        let ir_cond_var = render_gen.fresh_temp_var("CondFun");
+        let ir_cond_doc = docvec![
+            "call 'erlang':'<'(",
+            leaf::var("Sum"),
+            ", ",
+            leaf::int_lit(10),
+            ")",
+        ];
+        let ir_continue_header = docvec![
+            "let ",
+            leaf::var(ir_cond_var.clone()),
+            " = fun (",
+            leaf::var("Sum"),
+            ") -> ",
+            ir_cond_doc,
+            " in case apply ",
+            leaf::var(ir_cond_var),
+            " (",
+            leaf::var("Sum"),
+            ") of ",
+            "<'true'> when 'true' -> ",
+        ];
         let frame = FrameId::new(1);
-        let ir = vec![ThreadedStmt::Threaded {
-            mode: ThreadingMode::DirectParams,
-            frame,
-            body: vec![
-                ThreadedStmt::Bind {
-                    target: local("sum", 1, frame),
-                    source: local("sum", 0, frame),
-                    op: BindOp::Direct(ValueRef::Version(local("sum", 0, frame))),
-                    shadow_write: false,
-                    span: span(),
-                },
-                ThreadedStmt::Bind {
-                    target: local("count", 1, frame),
-                    source: local("count", 0, frame),
-                    op: BindOp::Direct(ValueRef::Version(local("count", 0, frame))),
-                    shadow_write: false,
-                    span: span(),
-                },
-            ],
-            produces: vec![local("sum", 1, frame), local("count", 1, frame)],
+        let sum_v0 = local("sum", 0, frame);
+        let ir_sum_rebind = render_gen.fresh_temp_var("Sum");
+        let sum_v1 = VersionedVar::new(VersionPrefix::Gensym(ir_sum_rebind), 1, frame);
+        let value_doc = docvec![
+            "call 'erlang':'+'(",
+            leaf::var("Sum"),
+            ", ",
+            leaf::int_lit(1),
+            ")",
+        ];
+        let ir_body = vec![ThreadedStmt::Bind {
+            target: sum_v1,
+            source: sum_v0.clone(),
+            op: BindOp::Direct(ValueRef::Doc(value_doc)),
+            shadow_write: false,
             span: span(),
         }];
-        let mut render_gen = CoreErlangGenerator::new("dual_run_direct_params");
+        let ir_exit_sa = render_gen.fresh_temp_var("ExitSA");
+        let ir_exit_arm = docvec![
+            "<'false'> when 'true' -> let ",
+            leaf::var(ir_exit_sa.clone()),
+            " = call 'maps':'put'(",
+            leaf::atom("__local__sum"),
+            ", ",
+            leaf::var("Sum"),
+            ", State) in {'nil', ",
+            leaf::var(ir_exit_sa),
+            "} end ",
+        ];
+        let ir = vec![ThreadedStmt::ConditionalLoop {
+            fn_name: "while".to_string(),
+            mode: ThreadingMode::DirectParams,
+            frame,
+            counter: None,
+            continue_header: ir_continue_header,
+            body: ir_body,
+            produces: vec![sum_v0],
+            exit_arm: ir_exit_arm,
+            span: span(),
+        }];
         let mut ctx = RenderCtx::new(&mut render_gen);
         let rendered_doc = render(&ir, &mut ctx).to_pretty_string();
 
         assert_eq!(
             rendered_doc, legacy_doc,
-            "render(lower(..)) must reproduce the hand-authored direct-params \
-             letrec byte-for-byte"
+            "render(..)'s ConditionalLoop arm must reproduce the real \
+             direct-params while-loop condition/case-split shape byte-for-byte"
         );
     }
 
     #[test]
-    fn dual_run_hybrid_letrec_state_prefix_matches_live_generator() {
-        // "Legacy" side: hand-authored letrec skeleton for a hybrid loop
-        // whose body also mutates a `State`-prefixed var (e.g. a nested
-        // construct's field mutation running inside the hybrid loop body) —
-        // its rendered name is resolved through the REAL production
-        // accessors `current_state_var`/`next_state_var` under hybrid loop
-        // context, not a hand-copy of their logic, so this proves
+    #[allow(clippy::too_many_lines)] // hand-authored dual-run fixture mirroring generate_while_loop_hybrid's real shape, ADR 0111 Addendum 2
+    fn dual_run_conditional_loop_hybrid_state_prefix_matches_live_generator() {
+        // Hybrid-mode counterpart of the direct-params test above: proves
+        // BOTH that `ConditionalLoop`'s real condition/case-split shape
+        // renders correctly under Hybrid loop context, AND (mirroring the
+        // pre-Addendum-2 test this replaces) that a `State`-prefixed `Bind`
+        // nested in the body (e.g. a nested construct's field mutation
+        // running inside the hybrid loop body) resolves through the REAL
+        // production accessors `current_state_var`/`next_state_var` under
+        // hybrid loop context — not a hand-copy of their logic — so
         // `RenderCtx::resolve_prefix` (via the shared `render_state_prefix`
         // helper both paths call) matches live generator behavior
-        // bit-for-bit.
-        let mut legacy_gen = CoreErlangGenerator::new("dual_run_hybrid");
-        let fn_name = legacy_gen.fresh_temp_var("Loop");
-        let entry_param = leaf::var("Sum");
+        // bit-for-bit even when interleaved with the new condition/exit
+        // scaffolding.
+        let mut legacy_gen = CoreErlangGenerator::new("dual_run_conditional_loop_hybrid");
+        let cond_var = legacy_gen.fresh_temp_var("CondFun");
         legacy_gen.in_hybrid_loop = true;
         legacy_gen.in_loop_body = true;
-        let source_name = legacy_gen.current_state_var();
-        let target_name = legacy_gen.next_state_var();
-        legacy_gen.in_hybrid_loop = false;
-        legacy_gen.in_loop_body = false;
+        let cond_doc = docvec![
+            "call 'erlang':'<'(",
+            leaf::var("Sum"),
+            ", ",
+            leaf::int_lit(10),
+            ")"
+        ];
+        let continue_header = docvec![
+            "let ",
+            leaf::var(cond_var.clone()),
+            " = fun (",
+            leaf::var("Sum"),
+            ") -> ",
+            cond_doc,
+            " in case apply ",
+            leaf::var(cond_var),
+            " (",
+            leaf::var("Sum"),
+            ") of ",
+            "<'true'> when 'true' -> ",
+        ];
+        let sum_rebind = legacy_gen.fresh_temp_var("Sum");
+        let state_source_name = legacy_gen.current_state_var();
+        let state_target_name = legacy_gen.next_state_var();
         let body = docvec![
             "let ",
-            leaf::var("Sum1"),
-            " = ",
+            leaf::var(sum_rebind.clone()),
+            " = call 'erlang':'+'(",
             leaf::var("Sum"),
-            " in ",
+            ", ",
+            leaf::int_lit(1),
+            ") in ",
+            " ", // BodyKind::Letrec's inter-statement separator (generate_threaded_loop_body_inner)
             "let ",
-            leaf::var(target_name),
+            leaf::var(state_target_name),
             " = ",
-            leaf::var(source_name),
+            leaf::var(state_source_name),
             " in ",
         ];
-        let final_args = join(vec![leaf::var("Sum1")], &Document::Str(", "));
+        legacy_gen.in_hybrid_loop = false;
+        legacy_gen.in_loop_body = false;
+        let exit_sa = legacy_gen.fresh_temp_var("ExitSA");
+        let exit_arm = docvec![
+            "<'false'> when 'true' -> let ",
+            leaf::var(exit_sa.clone()),
+            " = call 'maps':'put'(",
+            leaf::atom("__local__sum"),
+            ", ",
+            leaf::var("Sum"),
+            ", State) in {'nil', ",
+            leaf::var(exit_sa),
+            "} end ",
+        ];
         let legacy_doc = docvec![
             "letrec ",
-            leaf::fname(fn_name.clone(), 1),
+            leaf::fname("while", 1),
             " = fun (",
-            entry_param.clone(),
+            leaf::var("Sum"),
             ") -> ",
+            continue_header,
             body,
-            "apply ",
-            leaf::fname(fn_name.clone(), 1),
+            " apply ",
+            leaf::fname("while", 1),
             " (",
-            final_args,
-            ")",
-            " in apply ",
-            leaf::fname(fn_name, 1),
+            leaf::var(sum_rebind),
+            ") ",
+            exit_arm,
+            "in apply ",
+            leaf::fname("while", 1),
             " (",
-            entry_param,
+            leaf::var("Sum"),
             ")",
         ]
         .to_pretty_string();
 
+        let mut render_gen = CoreErlangGenerator::new("dual_run_conditional_loop_hybrid");
+        let ir_cond_var = render_gen.fresh_temp_var("CondFun");
+        let ir_cond_doc = docvec![
+            "call 'erlang':'<'(",
+            leaf::var("Sum"),
+            ", ",
+            leaf::int_lit(10),
+            ")"
+        ];
+        let ir_continue_header = docvec![
+            "let ",
+            leaf::var(ir_cond_var.clone()),
+            " = fun (",
+            leaf::var("Sum"),
+            ") -> ",
+            ir_cond_doc,
+            " in case apply ",
+            leaf::var(ir_cond_var),
+            " (",
+            leaf::var("Sum"),
+            ") of ",
+            "<'true'> when 'true' -> ",
+        ];
         let frame = FrameId::new(1);
-        let ir = vec![ThreadedStmt::Threaded {
+        let sum_v0 = local("sum", 0, frame);
+        let ir_sum_rebind = render_gen.fresh_temp_var("Sum");
+        let sum_v1 = VersionedVar::new(VersionPrefix::Gensym(ir_sum_rebind), 1, frame);
+        let value_doc = docvec![
+            "call 'erlang':'+'(",
+            leaf::var("Sum"),
+            ", ",
+            leaf::int_lit(1),
+            ")",
+        ];
+        let ir_body = vec![
+            ThreadedStmt::Bind {
+                target: sum_v1,
+                source: sum_v0.clone(),
+                op: BindOp::Direct(ValueRef::Doc(value_doc)),
+                shadow_write: false,
+                span: span(),
+            },
+            ThreadedStmt::Bind {
+                target: VersionedVar::new(VersionPrefix::State, 1, frame),
+                source: VersionedVar::new(VersionPrefix::State, 0, frame),
+                op: BindOp::Direct(ValueRef::Version(VersionedVar::new(
+                    VersionPrefix::State,
+                    0,
+                    frame,
+                ))),
+                shadow_write: false,
+                span: span(),
+            },
+        ];
+        let ir_exit_sa = render_gen.fresh_temp_var("ExitSA");
+        let ir_exit_arm = docvec![
+            "<'false'> when 'true' -> let ",
+            leaf::var(ir_exit_sa.clone()),
+            " = call 'maps':'put'(",
+            leaf::atom("__local__sum"),
+            ", ",
+            leaf::var("Sum"),
+            ", State) in {'nil', ",
+            leaf::var(ir_exit_sa),
+            "} end ",
+        ];
+        let ir = vec![ThreadedStmt::ConditionalLoop {
+            fn_name: "while".to_string(),
             mode: ThreadingMode::Hybrid,
             frame,
-            body: vec![
-                ThreadedStmt::Bind {
-                    target: local("sum", 1, frame),
-                    source: local("sum", 0, frame),
-                    op: BindOp::Direct(ValueRef::Version(local("sum", 0, frame))),
-                    shadow_write: false,
-                    span: span(),
-                },
-                ThreadedStmt::Bind {
-                    target: VersionedVar::new(VersionPrefix::State, 1, frame),
-                    source: VersionedVar::new(VersionPrefix::State, 0, frame),
-                    op: BindOp::Direct(ValueRef::Version(VersionedVar::new(
-                        VersionPrefix::State,
-                        0,
-                        frame,
-                    ))),
-                    shadow_write: false,
-                    span: span(),
-                },
-            ],
-            produces: vec![local("sum", 1, frame)],
+            counter: None,
+            continue_header: ir_continue_header,
+            body: ir_body,
+            produces: vec![sum_v0],
+            exit_arm: ir_exit_arm,
             span: span(),
         }];
-        let mut render_gen = CoreErlangGenerator::new("dual_run_hybrid");
         let mut ctx = RenderCtx::new(&mut render_gen);
         let rendered_doc = render(&ir, &mut ctx).to_pretty_string();
 
         assert_eq!(
             rendered_doc, legacy_doc,
-            "render(lower(..)) must reproduce the hand-authored hybrid letrec \
-             byte-for-byte, including the loop-context-aware State prefix"
+            "render(..)'s ConditionalLoop arm must reproduce the real hybrid \
+             while-loop condition/case-split shape byte-for-byte, including \
+             the loop-context-aware State prefix"
         );
     }
 

--- a/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
+++ b/docs/ADR/0111-lowered-ir-verifier-for-state-threading.md
@@ -744,6 +744,88 @@ codebase, and smaller than the phase's own size estimate.
    existing measurement flag, and re-run the ≤3% gate (§Measurement gate,
    restated) against real construct-and-render cost for the first time.
 
+## Addendum 3 (2026-08-11): BT-3145 re-attempt — what actually shipped, a third discovered gap, and the measurement outcome
+
+BT-3145 implemented Addendum 2's design in full: `ThreadedStmt::ConditionalLoop`
+(Gap 1), `VersionPrefix::Gensym` (Gap 2), `render_loop_letrec` refactored
+into a shared `render_loop_skeleton` behind both the bare `Threaded` shape
+and `ConditionalLoop`, and the three `dual_run_*` tests rewritten to
+hand-author the real condition/case-split shape and mint via a real,
+identically-seeded `fresh_temp_var` generator — all exactly as specified,
+with zero deviation from the reviewed design's field shapes.
+
+**A real implementation attempt at wiring `generate_while_loop_direct`
+surfaced two small, closely-related mechanical gaps Addendum 2's design
+didn't anticipate** (verified against real compiled output, same standard
+as the original investigation and Addendum 2 itself):
+
+- **`ValueRef` had no way to carry an arbitrary computed RHS.** A real
+  rebind's value is not a bare version reference — `sum := sum + 1`'s RHS is
+  `call 'erlang':'+'(Sum, 1)`, ordinary AST-directed expression codegen.
+  Closed by adding `ValueRef::Doc(Document<'static>)`, the same class of
+  opaque embed `continue_header`/`exit_arm` already use, with the identical
+  §Verifier-honesty justification.
+- **`BodyKind::Letrec` inserts a literal `" "` between body statements**
+  (`generate_threaded_loop_body_inner`, confirmed by compiling a two-rebind
+  loop and finding `"... in  let ..."` — a genuine double space) that
+  neither `render()` nor the pre-Addendum-2 dual-run fixtures reproduced.
+  Closed via `render_loop_body_statements`, scoped to `ConditionalLoop`
+  bodies only (the bare `Threaded` shape's body was never a real production
+  shape, so it correctly never needed this).
+
+Both were small (one new `ValueRef` variant, one small rendering helper) and
+are implemented, tested (including dedicated dual-run byte-parity tests),
+and landed — not deferred.
+
+**A third, larger, genuinely-deferred gap: full loop-body coverage.**
+Modeling *every* shape `select_direct_params` allows through a direct-params
+loop body — plain-let temporaries for non-threaded locals
+(`try_generate_block_local_plain_let`), destructuring, and the
+`direct_params_list_op_result` open-chain shape a nested tuple-safe list op
+produces — needs either a new "opaque non-`Bind` body statement"
+`ThreadedStmt` variant or a materially different body model. This is exactly
+the "third, materially larger gap" this ADR's own Addendum 2 named as the
+point to re-open the descope question, rather than force it through under
+this issue's already-spent budget. BT-3145 does not attempt it: the pilot's
+`while_direct_body_is_bind_representable` conservatively routes only
+straight-line, `Bind`-representable bodies (every statement a reassignment
+of a threaded local, no plain-let temporaries, no nested control flow, no
+list-op RHS) through `ConditionalLoop`; anything else falls back to the
+unmodified legacy path, unconditionally correct. See the BT-3145 Linear
+issue for the follow-up recommendation.
+
+**Measurement gate: inconclusive in this environment, gate not cleared.**
+`beamtalk build-stdlib` (the real stdlib corpus, `just build-stdlib`),
+4 runs each with the flag off vs on, cold `ebin/` each time:
+
+| | wall-clock (s) | user CPU (s) |
+|---|---|---|
+| flag off (mean of 4) | 12.44 | 14.79 |
+| flag on (mean of 4) | 15.30 (18.57 outlier included) / 14.21 (excluded) | 15.18 |
+| Δ | +14–23% wall-clock | +2.6% user CPU |
+
+Wall-clock and CPU-time deltas disagree by an order of magnitude, and the
+wall-clock samples include one clear outlier (18.57s vs. 13–15s for the
+other three) — this machine's shared/virtualized environment does not give
+a clean enough signal to confidently say the gate passes OR fails at a
+precise number. What is clear: overhead is not obviously near zero, and the
+covered subset (straight-line bodies) is a small fraction of the full
+stdlib's while-loop population, so the ≤3% gate is **not affirmatively
+cleared** — this is the ADR's own pre-planned "over threshold → stop, do not
+flip the default" outcome (§Measurement gate), reached here honestly rather
+than rounded away.
+
+**Outcome:** the default stays the legacy path. `BEAMTALK_THREADED_IR_WHILE_DIRECT=1`
+exists as an opt-in, fully-tested (byte-identical on every covered shape)
+path for future measurement once full body coverage closes gap three, but
+is not flipped, and the legacy code is not deleted — both explicitly
+conditional on the ≤3% gate per BT-3145's own acceptance criteria, and
+neither condition holds today. This is not a failure to fix at all costs;
+it is the pre-planned, acceptable descope path this ADR names, reached only
+after landing real, tested, reviewed infrastructure (the two Addendum-2
+gaps, both now closed) rather than stopping at the investigation stage a
+second time.
+
 ## Context
 
 ### Problem statement

--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -201,6 +201,21 @@ narrow that corpus down: `just test-stdlib <file>` / `just test-bunit
 <file>` against the specific fixture, then `dbg!` the `ThreadedIr` fragment
 at the failing construct's emission site.
 
+**`ConditionalLoop` — the first real (non-test) emission-input call site
+(BT-3145, ADR 0111 Addendum 2/3).** Every other construct in this table is
+still verification-only: `ThreadedIr` is built as a side-channel fixture and
+checked, but `Document` emission happens separately, directly from AST +
+generator state (ADR 0111's own Addendum, "delivered vs. designed"). As of
+BT-3145, `while_loops.rs`'s `generate_while_loop_direct` — gated behind
+`BEAMTALK_THREADED_IR_WHILE_DIRECT=1`, off by default — is the first call
+site where the `ThreadedStmt` built (a `ConditionalLoop` node) IS the
+`Document` returned: `verify()` runs on the real fragment, and `render()`'s
+output is what the caller emits, not a discarded side-channel check. Only
+straight-line loop bodies (every statement a reassignment of a threaded
+local — see `while_direct_body_is_bind_representable`'s doc comment) route
+through this path; anything else silently falls back to the pre-existing
+AST-directed emission, unconditionally correct either way.
+
 ## Runtime/REPL Debugging
 
 ```bash


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-3145

## Summary

Implements ADR 0111 Addendum 2's design in full and wires the first real (non-test) `ThreadedIr` emission-input call site.

- `ThreadedStmt::ConditionalLoop` (Gap 1: condition/case-split loop skeleton) and `VersionPrefix::Gensym` (Gap 2: pre-minted, verbatim Core Erlang names) — exactly as specified in Addendum 2.
- `render_loop_letrec` refactored into a shared `render_loop_skeleton` behind both the bare `Threaded` shape and `ConditionalLoop` (no duplicate implementation).
- The three `dual_run_*` byte-parity tests rewritten to hand-author the real condition/case-split shape and mint via a real, identically-seeded generator, plus two new `verify()`-level `ConditionalLoop` tests.
- `while_loops.rs`'s `generate_while_loop_direct` now lowers, verifies, and renders through `ThreadedIr` for straight-line, `Bind`-representable bodies (every statement a reassignment of a threaded local), gated behind `BEAMTALK_THREADED_IR_WHILE_DIRECT=1` (**off by default**). Anything else falls back to the unmodified legacy path unconditionally — zero behavior change for existing users.

### A real third gap, discovered and closed

Wiring the real call site surfaced two small, closely-related gaps beyond Addendum 2's own two — verified against real compiled output, same standard as the original BT-3145 investigation:

- **`ValueRef::Doc(Document<'static>)`** — a real rebind's RHS is an arbitrary computed expression (`call 'erlang':'+'(Sum, 1)`), not a bare version reference. Same opacity class as `continue_header`/`exit_arm`.
- **`render_loop_body_statements`** — `BodyKind::Letrec` inserts a literal `" "` between body statements (confirmed by compiling a two-rebind loop and finding a genuine double space), which neither `render()` nor the pre-existing dual-run fixtures reproduced.

Both are implemented and tested (dedicated byte-parity tests prove exact production-output equality, including a same-local-rebound-twice case).

### What's deferred, and why

Full loop-body coverage — plain-let temporaries for non-threaded locals, destructuring, nested control flow, and the `direct_params_list_op_result` open-chain shape a stored-block-variable list-op call produces — needs a materially different body model (a new "opaque non-`Bind` body statement" IR node, at minimum). This is the "third, materially larger gap" ADR 0111's own Addendum 2 names as the point to re-open the descope question rather than force it through. `while_direct_body_is_bind_representable` conservatively routes only the narrow, provably-safe subset; a defense-in-depth check makes any unforeseen hole in that static analysis fail loudly (a structured internal error) rather than emit invalid Core Erlang.

### Measurement gate

`beamtalk build-stdlib`, 4 runs each, cold `ebin/` each time: wall-clock overhead ranged 14–23% (one clear outlier included), user CPU overhead ~2.6% — the two metrics disagree by an order of magnitude in this shared/virtualized environment, so the ≤3% gate is not affirmatively cleared. Per ADR 0111's own pre-planned "over threshold → stop, do not flip the default" path, the default stays the legacy path and the legacy code is not deleted. Full detail, including the measurement table, is recorded as ADR 0111 Addendum 3.

## Test plan

- [x] `cargo test -p beamtalk-core --lib` — 5676 passed, 0 failed
- [x] `just clippy` / `cargo fmt --check` — clean
- [x] `just test-stdlib` — 233/233 passed
- [x] `just test-bunit` — 3216/3218 passed, 0 failed
- [x] `just verify-threaded-ir` — no invariant violations
- [x] `just test-repl-protocol` — 3/3 passed
- [x] New byte-identity tests (flag on vs off) for single-local, multi-local, negated condition, field-read RHS, and same-local-rebound-twice bodies — all byte-identical to legacy
- [x] Fallback test proving an unrepresentable body (plain-let temp) still matches legacy byte-for-byte with the flag on

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6yh2Ngzg29ipiiNxWbGCP)_