### PR TITLE
Add cycle-detection and superclass-chain tests to beamtalk_hierarchy_docs (72% → ~94%)

### DIFF
--- a/runtime/apps/beamtalk_runtime/test/beamtalk_hierarchy_docs_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_hierarchy_docs_tests.erl
@@ -12,12 +12,12 @@ Covers all four public functions:
 
 - `metaclass_method_doc/1` — pure pattern match, all four clauses including
   the previously uncovered `<<"spawnWith:">>` clause.
-- `find_defining_class/2` — the root-class (no superclass) and
-  unregistered-superclass terminal paths that were not reachable by the
-  existing callers' integration-level tests.
+- `find_defining_class/2` — the root-class (no superclass),
+  unregistered-superclass terminal paths, and the `max_depth_exceeded`
+  cycle-detection path.
 - `find_defining_class_method/2` — same edge paths for the class-side walk.
-- `collect_flattened_methods/2` — the root-class path that terminates on
-  `superclass => none`.
+- `collect_flattened_methods/2` — the root-class path, multi-level
+  superclass inheritance chain, and the `max_depth_exceeded` cycle path.
 
 The `metaclass_method_doc/1` tests run without any runtime process.
 The hierarchy-walking tests start minimal class processes via
@@ -66,12 +66,20 @@ metaclass_method_doc_empty_binary_test() ->
 -define(GHOST_D, 'BT3087HierarchyDocsGhostD').
 -define(ROOT_E, 'BT3087HierarchyDocsRootE').
 -define(ROOT_F, 'BT3087HierarchyDocsRootF').
+%% Superclass names for inheritance-chain tests:
+-define(SUPERCLASS_H, 'BT3087HierarchyDocsSuperH').
+-define(SUBCLASS_G, 'BT3087HierarchyDocsSubG').
+%% Circular-chain classes for cycle-detection tests:
+-define(CYCLE_X, 'BT3087HierarchyDocsCycleX').
+-define(CYCLE_Y, 'BT3087HierarchyDocsCycleY').
 %% Superclass names that are deliberately never registered:
 -define(GHOST_SUPER_1, 'BT3087HierarchyDocsNeverRegistered1').
 -define(GHOST_SUPER_2, 'BT3087HierarchyDocsNeverRegistered2').
 
 hierarchy_docs_test_() ->
-    {setup, fun setup/0, fun teardown/1, fun({PidA, PidB, PidC, PidD, PidE, PidF}) ->
+    {setup, fun setup/0, fun teardown/1, fun(
+        {PidA, PidB, PidC, PidD, PidE, PidF, PidG, _PidH, PidX, _PidY}
+    ) ->
         [
             {"find_defining_class: root class (no superclass) returns own name", fun() ->
                 ?assertEqual(
@@ -111,7 +119,44 @@ hierarchy_docs_test_() ->
             {"collect_flattened_methods: root class methods tagged with defining class", fun() ->
                 Result = beamtalk_hierarchy_docs:collect_flattened_methods(?ROOT_F, PidF),
                 ?assertMatch(#{fakeMethod := {?ROOT_F, _}}, Result)
-            end}
+            end},
+            {
+                "collect_flattened_methods: superclass methods merged and tagged with defining "
+                "class",
+                fun() ->
+                    Result = beamtalk_hierarchy_docs:collect_flattened_methods(
+                        ?SUBCLASS_G, PidG
+                    ),
+                    ?assertMatch(
+                        #{
+                            ownMethod := {?SUBCLASS_G, _},
+                            inheritedMethod := {?SUPERCLASS_H, _}
+                        },
+                        Result
+                    )
+                end
+            },
+            {"find_defining_class: cycle detection returns receiver class name", fun() ->
+                ?assertEqual(
+                    ?CYCLE_X,
+                    beamtalk_hierarchy_docs:find_defining_class(PidX, undefinedSel)
+                )
+            end},
+            {"find_defining_class_method: cycle detection returns receiver class name", fun() ->
+                ?assertEqual(
+                    ?CYCLE_X,
+                    beamtalk_hierarchy_docs:find_defining_class_method(
+                        PidX, undefinedClassSel
+                    )
+                )
+            end},
+            {"collect_flattened_methods: cycle detection returns partial accumulated result",
+                fun() ->
+                    ?assertEqual(
+                        #{},
+                        beamtalk_hierarchy_docs:collect_flattened_methods(?CYCLE_X, PidX)
+                    )
+                end}
         ]
     end}.
 
@@ -128,10 +173,16 @@ setup() ->
     PidD = start_class(?GHOST_D, ?GHOST_SUPER_2, #{}, #{}),
     PidE = start_class(?ROOT_E, none, #{}, #{}),
     PidF = start_class(?ROOT_F, none, #{fakeMethod => #{arity => 0}}, #{}),
-    {PidA, PidB, PidC, PidD, PidE, PidF}.
+    %% Inheritance chain: SubG has ownMethod; its superclass SuperH has inheritedMethod.
+    PidH = start_class(?SUPERCLASS_H, none, #{inheritedMethod => #{arity => 0}}, #{}),
+    PidG = start_class(?SUBCLASS_G, ?SUPERCLASS_H, #{ownMethod => #{arity => 0}}, #{}),
+    %% Circular chain: CycleX → CycleY → CycleX → … triggers max_depth_exceeded.
+    PidX = start_class(?CYCLE_X, ?CYCLE_Y, #{}, #{}),
+    PidY = start_class(?CYCLE_Y, ?CYCLE_X, #{}, #{}),
+    {PidA, PidB, PidC, PidD, PidE, PidF, PidG, PidH, PidX, PidY}.
 
-teardown({PidA, PidB, PidC, PidD, PidE, PidF}) ->
-    lists:foreach(fun stop_class/1, [PidA, PidB, PidC, PidD, PidE, PidF]).
+teardown({PidA, PidB, PidC, PidD, PidE, PidF, PidG, PidH, PidX, PidY}) ->
+    lists:foreach(fun stop_class/1, [PidA, PidB, PidC, PidD, PidE, PidF, PidG, PidH, PidX, PidY]).
 
 start_class(Name, Superclass, InstanceMethods, ClassMethods) ->
     ClassInfo = #{

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_hierarchy_docs_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_hierarchy_docs_tests.erl
@@ -152,8 +152,8 @@ hierarchy_docs_test_() ->
             end},
             {"collect_flattened_methods: cycle detection returns partial accumulated result",
                 fun() ->
-                    ?assertEqual(
-                        #{},
+                    ?assertMatch(
+                        #{cycleMethod := {?CYCLE_X, _}},
                         beamtalk_hierarchy_docs:collect_flattened_methods(?CYCLE_X, PidX)
                     )
                 end}
@@ -177,7 +177,9 @@ setup() ->
     PidH = start_class(?SUPERCLASS_H, none, #{inheritedMethod => #{arity => 0}}, #{}),
     PidG = start_class(?SUBCLASS_G, ?SUPERCLASS_H, #{ownMethod => #{arity => 0}}, #{}),
     %% Circular chain: CycleX → CycleY → CycleX → … triggers max_depth_exceeded.
-    PidX = start_class(?CYCLE_X, ?CYCLE_Y, #{}, #{}),
+    %% CycleX carries a method so the partial accumulator on cycle is non-empty,
+    %% making the collect_flattened_methods cycle-detection assertion non-trivial.
+    PidX = start_class(?CYCLE_X, ?CYCLE_Y, #{cycleMethod => #{arity => 0}}, #{}),
     PidY = start_class(?CYCLE_Y, ?CYCLE_X, #{}, #{}),
     {PidA, PidB, PidC, PidD, PidE, PidF, PidG, PidH, PidX, PidY}.
 


### PR DESCRIPTION
## Summary

- Adds 4 new EUnit test cases to `beamtalk_hierarchy_docs_tests.erl` to cover previously untested edge paths in `beamtalk_hierarchy_docs.erl`
- Extends the fixture from a 6-tuple to a 10-tuple: adds `SuperH`, `SubG` (inheritance chain), `CycleX`, `CycleY` (circular chain) class processes
- No production code changes — test-only

## Coverage gaps closed

`beamtalk_hierarchy_docs.erl` was at **72.2% (39/54 lines)** on CI run 31531075831. The 4 new tests cover:

| Lines | Branch | New test |
|-------|--------|----------|
| 165 | `collect_flattened_methods/2` — `{next, {SuperName, SuperPid, NewAcc}}` path (registered superclass) | `collect_flattened_methods: superclass methods merged and tagged with defining class` |
| 82–88 | `find_defining_class/2` — `{max_depth_exceeded, CyclePid}` → LOG_WARNING + receiver name | `find_defining_class: cycle detection returns receiver class name` |
| 127–133 | `find_defining_class_method/2` — same cycle branch | `find_defining_class_method: cycle detection returns receiver class name` |
| 177–183 | `collect_flattened_methods/2` — `{max_depth_exceeded, {CycleName,_,PartialAcc}}` → partial map | `collect_flattened_methods: cycle detection returns partial accumulated result` |

Lines 93, 136, 186 (`erlang:error({unreachable,...})`) are explicitly documented as unreachable and are intentionally excluded.

Expected post-change coverage: **~51/54 lines ≈ 94%**.

## Cycle construction

The circular chain uses two classes: `CycleX` (superclass=`CycleY`) and `CycleY` (superclass=`CycleX`). Both are registered before any walk runs, so both `whereis_class/1` calls return a pid. With `?MAX_HIERARCHY_DEPTH = 20`, the walker reaches depth 21 and returns `{max_depth_exceeded, _}` deterministically — no timing dependency.

## Test plan

- [x] All 15 EUnit tests pass (`just test` in `runtime/`)
- [x] Pre-push hooks pass (clippy, dialyzer, erlfmt, full build)
- [x] All new class atoms use unique `BT3087HierarchyDocs`-prefixed names to avoid pg/registry collisions with other test modules

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbKq8zvavyAXWcvr3TWZ4Q)_