### PR TITLE
test: tighten loose wildcard assertion for file delete in ffi_result_conversion

### DIFF
--- a/tests/repl-protocol/cases/ffi_result_conversion.btscript
+++ b/tests/repl-protocol/cases/ffi_result_conversion.btscript
@@ -121,4 +121,4 @@ fromTupleResult isError
 // ===========================================================================
 
 Erlang file delete: _btTmpFile
-// => _
+// => Result ok: nil


### PR DESCRIPTION
## Summary

- Tightens the `Erlang file delete:` cleanup assertion in `ffi_result_conversion.btscript` from `// => _` to `// => Result ok: nil`

## Detail

`ffi_result_conversion.btscript` is the E2E gate for automatic `ok`/`error` tuple → `Result` conversion at the FFI boundary (BT-1868, ADR 0076). The file's own header documents that the proxy converts bare `ok` atoms to `Result ok: nil`, and the same file already uses tight `// => Result ok: nil` for `file:write_file:with:` (lines 23 and 59). The `file:delete/1` call in the cleanup block used `// => _` despite the return being fully deterministic via the same proxy path.

The change is a one-line tightening: no logic changed, no new coverage added.

## Test plan

- [x] `just test-repl-protocol` passes with the tighter assertion in place (verified locally — 3 passed, 0 failed)

---
_Generated by [Claude Code](https://claude.ai/code/session_013BBVdDSgeLEbW2WUQ9c6gD)_