### PR TITLE
Migrate class-var Bind producers to emission-input ThreadedIr (BT-3148)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/dispatch_codegen.rs
@@ -460,24 +460,63 @@ impl CoreErlangGenerator {
     ) -> Document<'static> {
         let call_result = self.fresh_temp_var("CMR");
         let cv = self.current_class_var();
-        let new_cv = self.next_class_var();
+        // BT-3148: the version numbers driving both verify() and the real
+        // Bind rendered below — captured before minting, matching the old
+        // `cv`/`new_cv` name-capture ordering exactly (fresh_temp_var call
+        // order for CV/MR/PCV below is unaffected: `class_var_version`
+        // mints from an entirely separate counter).
+        let source_version = self.class_var_version();
         let inner_cv = self.fresh_temp_var("CV");
-        // BT-3135 (ADR 0111 Phase D): construct + verify this Bind's
-        // ThreadedIr shape. This site never itself needs the ADR 0110
-        // shadow write — it rebinds `ClassVarsN` from an inherited
-        // self-dispatched call's own `class_var_result` return, and that
-        // call runs in this same class's gen_server process, so any
-        // mutation it made was already shadow-written by the *callee's own*
-        // `generate_field_assignment` under the identical `ClassSelf`-tagged
-        // key (see `verify_class_var_bind`'s doc comment / ADR 0110
-        // §Runtime change). `at_method_top_frame: false` is not a claim
-        // about this rebind's real nesting — it deliberately exempts this
-        // Bind from the check unconditionally, since it never carries a
-        // shadow-write obligation of its own regardless of block_depth.
-        let rebind_errors = super::threaded_ir::verify_class_var_bind(
-            super::threaded_ir::BindOp::Direct(super::threaded_ir::ValueRef::Var(inner_cv.clone())),
+        let inner_res = self.fresh_temp_var("MR");
+        let plain_cv = self.fresh_temp_var("PCV");
+
+        // The class-var rebind's opaque RHS (ADR 0111 Addendum 2 "Gap 1"'s
+        // `ValueRef::Doc` precedent): a `case` expression selecting the
+        // inherited self-dispatch call's own returned class vars when
+        // present, falling back to the current `ClassVars` otherwise — not
+        // representable by a bare `ValueRef::Var`/`Version`/`Literal`.
+        let class_var_case_doc = docvec![
+            "case ",
+            leaf::var(call_result.clone()),
+            " of <{'class_var_result', ",
+            leaf::var(inner_res),
+            ", ",
+            leaf::var(inner_cv.clone()),
+            "}> when 'true' -> ",
+            leaf::var(inner_cv.clone()),
+            " <",
+            leaf::var(plain_cv),
+            "> when 'true' -> ",
+            leaf::var(cv),
+            " end",
+        ];
+
+        self.next_class_var();
+        let target_version = self.class_var_version();
+
+        // BT-3135 (ADR 0111 Phase D) / BT-3148: construct, verify, and
+        // render this Bind through the real `threaded_ir` pipeline — no
+        // second, hand-rolled `Document` reconstructs it. This site never
+        // itself needs the ADR 0110 shadow write — it rebinds `ClassVarsN`
+        // from an inherited self-dispatched call's own `class_var_result`
+        // return, and that call runs in this same class's gen_server
+        // process, so any mutation it made was already shadow-written by
+        // the *callee's own* `generate_field_assignment` under the
+        // identical `ClassSelf`-tagged key (see
+        // `threaded_ir::construct_and_verify_class_var_bind`'s doc comment
+        // / ADR 0110 §Runtime change). `at_method_top_frame: false` is not
+        // a claim about this rebind's real nesting — it deliberately
+        // exempts this Bind from the shadow-write check unconditionally,
+        // since it never carries a shadow-write obligation of its own
+        // regardless of block_depth.
+        let (bind, rebind_errors) = super::threaded_ir::construct_and_verify_class_var_bind(
+            super::threaded_ir::BindOp::Direct(super::threaded_ir::ValueRef::Doc(
+                class_var_case_doc,
+            )),
             false,
             false,
+            source_version,
+            target_version,
             crate::source_analysis::Span::default(),
         );
         self.report_threaded_ir_verify_errors(
@@ -485,8 +524,11 @@ impl CoreErlangGenerator {
             "class-var rebind from inherited self-dispatch result",
             crate::source_analysis::Span::default(),
         );
-        let inner_res = self.fresh_temp_var("MR");
-        let plain_cv = self.fresh_temp_var("PCV");
+        let bind_doc = {
+            let mut ctx = super::threaded_ir::RenderCtx::new(self);
+            super::threaded_ir::render(std::slice::from_ref(&bind), &mut ctx)
+        };
+
         let result = self.fresh_temp_var("Unwrapped");
         let wrapped_res = self.fresh_temp_var("WR");
         let plain_res = self.fresh_temp_var("PR");
@@ -497,21 +539,9 @@ impl CoreErlangGenerator {
             leaf::var(call_result.clone()),
             " = ",
             call_doc,
-            " in let ",
-            leaf::var(new_cv),
-            " = case ",
-            leaf::var(call_result.clone()),
-            " of <{'class_var_result', ",
-            leaf::var(inner_res),
-            ", ",
-            leaf::var(inner_cv.clone()),
-            "}> when 'true' -> ",
-            leaf::var(inner_cv),
-            " <",
-            leaf::var(plain_cv),
-            "> when 'true' -> ",
-            leaf::var(cv),
-            " end in let ",
+            " in ",
+            bind_doc,
+            "let ",
             leaf::var(result.clone()),
             " = case ",
             leaf::var(call_result),

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -651,9 +651,13 @@ impl CoreErlangGenerator {
             });
         }
         let val_var = self.fresh_temp_var("Val");
-        let current_cv = self.current_class_var();
+        // BT-3148: the version numbers driving both the verify() call and
+        // the real Bind rendered below — captured before/after minting,
+        // exactly as `current_cv`/`new_cv`'s names used to be by hand.
+        let source_version = self.class_var_version();
         let val_doc = self.expression_doc(value)?;
-        let new_cv = self.next_class_var();
+        self.next_class_var();
+        let target_version = self.class_var_version();
         // ADR 0110 (BT-3032/BT-3037): shadow write-through so a foreign
         // NLR (`^` belonging to another method's frame) relayed out of
         // this class method does not lose the mutation —
@@ -687,86 +691,47 @@ impl CoreErlangGenerator {
         // that shape. That gap is now a compile-time error
         // (`CodeGenError::ClassVarAssignmentInThreadedBody`) rather than a
         // silent runtime no-op — see ADR 0110's BT-3140 amendment.
+        //
+        // BT-3148 (ADR 0111 Phase D completion): this Bind is now
+        // constructed, verified, and rendered through the SAME
+        // `threaded_ir::ThreadedStmt::Bind` a `while_loops.rs`-style caller
+        // would — `threaded_ir::render`'s `BindOp::Put` arm is the only
+        // place the ADR 0110 shadow write is constructed (see
+        // `threaded_ir::construct_and_verify_class_var_bind`'s doc
+        // comment); no second, hand-rolled `Document` reconstructs it.
         let shadow_write = self.block_depth == 0;
-        self.check_class_var_shadow_write_invariant(
-            field_name,
-            &val_var,
+        let (bind, verify_errors) = super::threaded_ir::construct_and_verify_class_var_bind(
+            super::threaded_ir::BindOp::Put {
+                field: field_name.to_string(),
+                value: super::threaded_ir::ValueRef::Var(val_var.clone()),
+                class_tag: super::threaded_ir::ValueRef::Var("ClassSelf".to_string()),
+            },
             shadow_write,
+            shadow_write, // at_method_top_frame == block_depth == 0, same value
+            source_version,
+            target_version,
             value.span(),
         );
-        let shadow_doc = if shadow_write {
-            docvec![
-                "let _ = call 'erlang':'put'({",
-                leaf::atom("$bt_class_vars_shadow"),
-                ", call 'erlang':'element'(2, ",
-                leaf::var("ClassSelf"),
-                ")}, ",
-                leaf::var(new_cv.clone()),
-                ") in ",
-            ]
-        } else {
-            Document::Str("")
+        self.report_threaded_ir_verify_errors(
+            &verify_errors,
+            "class-var mutation missing ADR 0110 shadow write",
+            value.span(),
+        );
+        let bind_doc = {
+            let mut ctx = super::threaded_ir::RenderCtx::new(self);
+            super::threaded_ir::render(std::slice::from_ref(&bind), &mut ctx)
         };
         let doc = docvec![
             "let ",
             leaf::var(val_var.clone()),
             " = ",
             val_doc,
-            " in let ",
-            leaf::var(new_cv.clone()),
-            " = call 'maps':'put'(",
-            leaf::atom(field_name.to_string()),
-            ", ",
-            leaf::var(val_var.clone()),
-            ", ",
-            leaf::var(current_cv),
-            ") in ",
-            shadow_doc,
+            " in ",
+            bind_doc,
         ];
         // Store result var name for callers that need to reference it
         self.last_open_scope_result = Some(OpenScopeResult::Value(val_var));
         Ok(doc)
-    }
-
-    /// BT-3135 (ADR 0111 Phase D): construct + verify the just-emitted class-var
-    /// `Bind`'s `ThreadedIr` shape — the ADR 0110 `ShadowWriteMissing` contract
-    /// check, against exactly what `generate_field_assignment`'s class-var
-    /// branch is about to emit.
-    ///
-    /// `at_method_top_frame` is re-derived from `self.block_depth` here
-    /// (the same live field `shadow_write`'s caller just read), independently
-    /// of whatever `shadow_write` value was actually computed — **not**
-    /// `self.current_nlr_token().is_some()`. The latter would silently exempt
-    /// the ADR 0110 repro shape itself: a class method that mutates a class
-    /// var and then invokes a *caller-supplied* block containing no literal
-    /// `^` of its own gets no local NLR try/catch (`current_nlr_token()` is
-    /// `None` throughout its body) — the shadow write still matters there
-    /// because the relay is caught one layer out, unconditionally, by
-    /// `apply_class_method_fun/6`. See `threaded_ir::verify_class_var_bind`'s
-    /// doc comment for the full reasoning.
-    fn check_class_var_shadow_write_invariant(
-        &mut self,
-        field_name: &str,
-        val_var: &str,
-        shadow_write: bool,
-        span: crate::source_analysis::Span,
-    ) {
-        let at_method_top_frame = self.block_depth == 0;
-        let shadow_bind_errors = super::threaded_ir::verify_class_var_bind(
-            super::threaded_ir::BindOp::Put {
-                field: field_name.to_string(),
-                value: super::threaded_ir::ValueRef::Var(val_var.to_string()),
-                class_tag: super::threaded_ir::ValueRef::Var("ClassSelf".to_string()),
-            },
-            shadow_write,
-            at_method_top_frame,
-            span,
-        );
-        self.report_threaded_ir_verify_errors(
-            &shadow_bind_errors,
-            "class-var mutation missing ADR 0110 shadow write",
-            span,
-        );
     }
 
     /// BT-3139 (ADR 0111 coverage extension): construct + verify the

--- a/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/expressions.rs
@@ -707,7 +707,7 @@ impl CoreErlangGenerator {
                 class_tag: super::threaded_ir::ValueRef::Var("ClassSelf".to_string()),
             },
             shadow_write,
-            shadow_write, // at_method_top_frame == block_depth == 0, same value
+            self.block_depth == 0, // independently re-derived per ADR 0111 §Verifier honesty — must not reuse `shadow_write`
             source_version,
             target_version,
             value.span(),

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -2802,10 +2802,11 @@ impl CoreErlangGenerator {
         // `threaded_ir::ThreadedStmt::NlrCatch`) — every NLR try/catch this
         // generator ever emits (Actor/ClassMethod/ValueType alike) is built
         // here; its `boundary` shape is also what
-        // `threaded_ir::verify_class_var_bind`'s `at_method_top_frame`
-        // fixtures reconstruct at the class-var Bind-emission sites
-        // (`expressions.rs`, `dispatch_codegen.rs`) for the ADR 0110
-        // ShadowWriteMissing contract. No standalone `verify()` call here: a
+        // `threaded_ir::construct_and_verify_class_var_bind`'s
+        // `at_method_top_frame` fixtures reconstruct at the class-var
+        // Bind-emission sites (`expressions.rs`, `dispatch_codegen.rs`) for
+        // the ADR 0110 ShadowWriteMissing contract. No standalone
+        // `verify()` call here: a
         // lone `NlrCatch` with no `Bind` can never trigger any
         // `VerifyError` (`walk_stmt` treats it as a no-op), so constructing
         // one on every NLR-catch wrap — a hot path — would pay a real

--- a/crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs
@@ -51,6 +51,51 @@
 //! deleting it) — see BT-3145's Linear issue for the full evidentiary trail
 //! and the ≤3% gate's outcome.
 //!
+//! ## Status (as of BT-3148 — partial: class-var Bind producers only)
+//!
+//! BT-3148 ("the deepest slice") targeted four sub-tasks: (1) unify
+//! `gen_server/methods.rs`'s upfront `classify_body_expr` routing
+//! classification with `threaded_expr.rs`'s downstream recheck into one IR
+//! construction, deleting the `verify_routing_invariant` debug-assert
+//! replacements; (2) give `wrap_body_with_nlr_catch` a production `NlrCatch`
+//! node instead of the deliberately-IR-free side channel it still is
+//! (`mod.rs`, doc comment on [`super::CoreErlangGenerator::wrap_body_with_nlr_catch`]);
+//! (3) the two class-var `Bind` producer sites
+//! (`expressions.rs::generate_field_assignment`,
+//! `dispatch_codegen.rs::emit_class_var_result_unwrap`) emit through real
+//! [`ThreadedStmt::Bind`] nodes rendered by [`render`], not a hand-rolled
+//! `Document` that mirrors it; (4) `threaded_expr.rs`'s `ThreadingBoundary`
+//! adapter absorbed into or replaced by the IR path.
+//!
+//! **Only (3) landed.** [`construct_and_verify_class_var_bind`] replaces the
+//! deleted `verify_class_var_bind` fixture-mirror: both class-var Bind
+//! producer sites now construct a real `Bind` carrying the actual
+//! `source_version`/`target_version` read off the live generator counter,
+//! verify it, and render it through [`render`] — [`render_bind`]'s
+//! `BindOp::Put` arm is the only place the ADR 0110 shadow write is
+//! constructed in either the verification path or the emitted `Document`.
+//! The existing `invoke_class_method/7` cross-boundary conformance fixture
+//! (`tests/class_var_shadow_contract.rs`) and the full
+//! `compiles_through_erlc`/snapshot-corpus suite pin that this produces
+//! byte-identical output to the hand-rolled `Document` it replaces.
+//!
+//! **(1), (2), (4) were investigated and NOT attempted** — closing them
+//! requires a real method-body-wide IR (every ordinary AST-directed
+//! statement — message sends, dispatch, Tier 2 calls, `EarlyReturn`, the
+//! other ~15 `BodyExprKind` variants `gen_server/methods.rs` classifies —
+//! embeddable in a straight-line `Vec<ThreadedStmt>` alongside `Bind`, so
+//! `wrap_body_with_nlr_catch`'s `body_doc` can become a real `NlrCatch`'s
+//! *rest-of-slice* body the way [`render`]'s `NlrCatch` arm already expects
+//! production callers to supply it). That is architecturally a peer of
+//! BT-3145's `ConditionalLoop`/`Gensym`/`ValueRef::Doc` gaps (Addendum 2),
+//! not a variant of the class-var Bind shape (3) closed — a full
+//! `Threaded`/`Bind` sequence can already represent state-only bodies, but
+//! `gen_server` method bodies are NOT state-only; ordinary control-flow-free
+//! statements have no IR representation today. Closing it is scoped as a
+//! design-detour follow-up (mirroring BT-3145's BT-3153 ADR-amendment
+//! pattern), not attempted inline here — see the BT-3148 Linear issue for
+//! the full investigation trail and source citations.
+//!
 //! This module lands the IR types, the [`verify`] checker, and the
 //! [`lower_and_render`] test shim (BT-3129), the unified `VersionedVar`/
 //! `VersionCounter` production path (BT-3131). BT-3132 originally added a
@@ -1873,25 +1918,43 @@ pub(super) fn verify_routing_invariant(routed: bool, span: Span) -> Vec<VerifyEr
     }
 }
 
-// ─── Class-var Bind construction (BT-3135, ADR 0110 contract) ─────────────
+// ─── Class-var Bind construction (BT-3135/BT-3148, ADR 0110 contract) ─────
 
-/// Builds a minimal `ThreadedIr` fixture for a single class-var version
-/// `Bind`, exactly as actually emitted by one of the two producer sites
-/// named in ADR 0111 §Phase D: `expressions.rs::generate_field_assignment`'s
-/// class-var branch (a [`BindOp::Put`] field mutation, `shadow_write` set
-/// from the real `block_depth == 0` gate) or
-/// `dispatch_codegen.rs::emit_class_var_result_unwrap` (a [`BindOp::Direct`]
-/// rebind from an inherited self-dispatched call's returned
-/// `class_var_result` tuple — never itself a shadow-write producer, since
-/// self-dispatch runs in the same class `gen_server` process and any mutation
-/// it reflects was already shadow-written by the *callee's own*
+/// Constructs the single class-var version `Bind` a production emission site
+/// is about to render, and verifies it against a synthetic ADR 0110
+/// NLR-relay marker — the two producer sites named in ADR 0111 §Phase D:
+/// `expressions.rs::generate_field_assignment`'s class-var branch (a
+/// [`BindOp::Put`] field mutation, `shadow_write` set from the real
+/// `block_depth == 0` gate) and `dispatch_codegen.rs::emit_class_var_result_unwrap`
+/// (a [`BindOp::Direct`] rebind from an inherited self-dispatched call's
+/// returned `class_var_result` tuple — never itself a shadow-write producer,
+/// since self-dispatch runs in the same class `gen_server` process and any
+/// mutation it reflects was already shadow-written by the *callee's own*
 /// `generate_field_assignment` call under the same `ClassSelf`-tagged key;
 /// see ADR 0110 §Runtime change's "no per-nesting-level save/restore is
 /// needed" reasoning).
 ///
-/// `at_method_top_frame` selects the `Bind`'s (and the always-included
-/// `NlrCatch { has_class_vars: true }` marker's) `FrameId`: [`FrameId::ROOT`]
-/// when `true`, a nested [`FrameId`] otherwise — mirroring
+/// **BT-3148**: unlike the deleted `verify_class_var_bind` (which verified a
+/// hardcoded `0 -> 1` step, disconnected from the version actually in play —
+/// both call sites rendered their real `current_class_var()`/`next_class_var()`
+/// names by hand, and separately passed an always-`0->1` fixture here purely
+/// to run the shadow-write check), the [`ThreadedStmt::Bind`] returned here
+/// carries the REAL `source_version`/`target_version` already read off the
+/// live generator counter and IS what [`render`] renders — there is no
+/// second, independently-reconstructed shape. `1..=source_version` backfills
+/// a dummy `Bind` chain so [`VerifyWalk::check_use`]'s frame-flow rule
+/// doesn't spuriously fail `UnboundVersion` for a mutation past a method's
+/// first (the same technique [`verify_simple_bind`] uses).
+///
+/// The synthetic `NlrCatch { has_class_vars: true }` marker is still
+/// unconditionally included in the *verified* fixture (not in the returned
+/// `Bind`, which callers render alone) — an isolated per-call-site
+/// verification cannot observe whether THIS method's body really contains a
+/// foreign-NLR-relay-capable boundary, so it assumes one, same as the
+/// deleted fixture did (ADR 0111 §Verifier honesty).
+///
+/// `at_method_top_frame` selects the `Bind`'s (and the marker's) `FrameId`:
+/// [`FrameId::ROOT`] when `true`, a nested [`FrameId`] otherwise — mirroring
 /// [`VerifyError::ShadowWriteMissing`]'s own `target.frame == FrameId::ROOT`
 /// gate. **This is deliberately NOT `self.current_nlr_token().is_some()`**
 /// (whether *this* method's own body happens to contain a literal `^` inside
@@ -1913,39 +1976,85 @@ pub(super) fn verify_routing_invariant(routed: bool, span: Span) -> Vec<VerifyEr
 /// gate 1:1 (ADR 0111 §Verifier honesty: comparing the generator against
 /// itself is silent when both are consistently wrong).
 ///
-/// The `dispatch_codegen.rs` rebind site passes `false` unconditionally —
-/// not a claim about its real block-depth, but a deliberate exemption: that
+/// The `dispatch_codegen.rs` rebind site passes `false`/`false` unconditionally
+/// — not a claim about its real block-depth, but a deliberate exemption: that
 /// `Bind` structurally never carries its own shadow-write obligation
 /// regardless of nesting (see its own call-site comment), so it is modeled
 /// as never sitting at the frame this check inspects.
-pub(super) fn verify_class_var_bind(
+pub(super) fn construct_and_verify_class_var_bind(
     op: BindOp,
     shadow_write: bool,
     at_method_top_frame: bool,
+    source_version: usize,
+    target_version: usize,
     span: Span,
-) -> Vec<VerifyError> {
+) -> (ThreadedStmt, Vec<VerifyError>) {
     let frame = if at_method_top_frame {
         FrameId::ROOT
     } else {
         FrameId::new(1)
     };
-    verify(&[
-        ThreadedStmt::Bind {
-            target: VersionedVar::new(VersionPrefix::ClassVars, 1, frame),
-            source: VersionedVar::new(VersionPrefix::ClassVars, 0, frame),
-            op,
-            shadow_write,
+    let mut body = Vec::with_capacity(source_version + 1);
+    for v in 1..=source_version {
+        body.push(ThreadedStmt::Bind {
+            target: VersionedVar::new(VersionPrefix::ClassVars, v, frame),
+            source: VersionedVar::new(VersionPrefix::ClassVars, v - 1, frame),
+            op: BindOp::Direct(ValueRef::Literal("'_'")),
+            // `shadow_write: true` here is a backfill-scaffolding
+            // assumption, not a claim about the earlier mutation's real
+            // shape (this fixture never inspects it): only the LAST Bind
+            // below — the one this call site is actually about to
+            // render — is what `ShadowWriteMissing` is checking. Backfilling
+            // `false` would spuriously flag every earlier synthetic step at
+            // `FrameId::ROOT`, since `has_class_vars_nlr` is unconditionally
+            // true here (the synthetic marker below).
+            shadow_write: true,
             span,
+        });
+    }
+    let bind = ThreadedStmt::Bind {
+        target: VersionedVar::new(VersionPrefix::ClassVars, target_version, frame),
+        source: VersionedVar::new(VersionPrefix::ClassVars, source_version, frame),
+        op,
+        shadow_write,
+        span,
+    };
+    body.push(bind.clone());
+    let marker = ThreadedStmt::NlrCatch {
+        boundary: NlrBoundary::ClassMethod {
+            has_class_vars: true,
         },
-        ThreadedStmt::NlrCatch {
-            boundary: NlrBoundary::ClassMethod {
-                has_class_vars: true,
+        token: TokenId::new(0),
+        frame,
+        span,
+    };
+    // `verify()` seeds its frame stack with just `[FrameId::ROOT]` (module
+    // docs on `FrameId`) — when `frame == FrameId::ROOT` (`at_method_top_frame`),
+    // `body`'s Binds are already reachable at the top level with no wrapper.
+    // Otherwise `frame` must be PUSHED via a `Threaded` node, or
+    // `VerifyWalk::check_use`'s frame-flow rule can never find a backfilled
+    // version `>0` at that frame (a bare top-level `Bind`/`NlrCatch` never
+    // pushes anything) — this is exactly the gap that produced a spurious
+    // `UnboundVersion` before BT-3148 added real backfill history here (a
+    // nested class-var rebind is always `at_method_top_frame: false`, so it
+    // always took this branch once `source_version > 0`).
+    let fixture: Vec<ThreadedStmt> = if at_method_top_frame {
+        let mut f = body;
+        f.push(marker);
+        f
+    } else {
+        vec![
+            ThreadedStmt::Threaded {
+                mode: ThreadingMode::StateAcc(StateAccFallbackReason::None),
+                frame,
+                body,
+                produces: Vec::new(),
+                span,
             },
-            token: TokenId::new(0),
-            frame,
-            span,
-        },
-    ])
+            marker,
+        ]
+    };
+    (bind, verify(&fixture))
 }
 
 // ─── Simple version-bind construction (BT-3139) ────────────────────────────
@@ -1955,16 +2064,20 @@ pub(super) fn verify_class_var_bind(
 /// numbers already read off the live generator counter at the call site
 /// (BT-3139: `generate_field_assignment`'s value-type and instance-actor
 /// branches, `expressions.rs` around lines 634/664 — the two sibling
-/// branches of the class-var branch [`verify_class_var_bind`] already
-/// covers, BT-3135). Reused for both prefixes instead of copy-pasting
-/// [`verify_class_var_bind`]'s body three times (CLAUDE.md's
-/// no-duplicate-implementations rule).
+/// branches of the class-var branch [`construct_and_verify_class_var_bind`]
+/// already covers, BT-3135/BT-3148). Reused for both prefixes instead of
+/// copy-pasting [`construct_and_verify_class_var_bind`]'s body three times
+/// (CLAUDE.md's no-duplicate-implementations rule).
 ///
-/// Unlike [`verify_class_var_bind`] (which always checks a fixed `0 -> 1`
-/// step, since its only interesting invariant is `ShadowWriteMissing`, not
-/// version linearity — see its own doc comment), this helper is handed the
-/// *actual* version numbers, which may already be arbitrarily large after
-/// earlier mutations in the same method. [`VerifyWalk::check_use`]'s
+/// Like [`construct_and_verify_class_var_bind`] (BT-3148 onward, both are
+/// handed the real version numbers already read off the live generator
+/// counter and share its `1..=source_version` backfill technique), but
+/// without that function's class-var-specific `ShadowWriteMissing`
+/// machinery (the synthetic `NlrCatch` marker, `at_method_top_frame`'s
+/// `FrameId` selection) — `Self{N}`/`State{N}` mutations never carry that
+/// ADR 0110 obligation. This helper is handed the *actual* version numbers,
+/// which may already be arbitrarily large after earlier mutations in the
+/// same method. [`VerifyWalk::check_use`]'s
 /// frame-flow rule requires every version `>0` referenced as a `Bind`'s
 /// source to have a producing `Bind` visible on the frame stack — so without
 /// backfilling that history, every mutation past a method's first would
@@ -3135,7 +3248,8 @@ mod tests {
         );
     }
 
-    // ── verify_class_var_bind (BT-3135, ADR 0110 contract) ───────────────
+    // ── construct_and_verify_class_var_bind (BT-3135/BT-3148, ADR 0110
+    // contract) ─────────────────────────────────────────────────────────
     // Pins the production replacement/extension covering the two Bind-
     // emission sites named in ADR 0111 §Phase D:
     // `expressions.rs::generate_field_assignment` (Put) and
@@ -3150,20 +3264,31 @@ mod tests {
     }
 
     #[test]
-    fn verify_class_var_bind_put_silent_with_shadow_write() {
+    fn construct_and_verify_class_var_bind_put_silent_with_shadow_write() {
         // generate_field_assignment's real post-ADR-0110 shape: block_depth
-        // == 0 (shadow_write: true).
+        // == 0 (shadow_write: true), first mutation in the method
+        // (source_version: 0, target_version: 1).
+        let (bind, errors) =
+            construct_and_verify_class_var_bind(put_op(), true, true, 0, 1, span());
+        assert_eq!(errors, Vec::new());
         assert_eq!(
-            verify_class_var_bind(put_op(), true, true, span()),
-            Vec::new()
+            bind,
+            ThreadedStmt::Bind {
+                target: VersionedVar::new(VersionPrefix::ClassVars, 1, FrameId::ROOT),
+                source: VersionedVar::new(VersionPrefix::ClassVars, 0, FrameId::ROOT),
+                op: put_op(),
+                shadow_write: true,
+                span: span(),
+            },
+            "the returned Bind must be the exact node a caller renders — no second shape"
         );
     }
 
     #[test]
-    fn verify_class_var_bind_put_fires_when_shadow_write_missing_at_top_frame() {
+    fn construct_and_verify_class_var_bind_put_fires_when_shadow_write_missing_at_top_frame() {
         // The regression this exists to catch: block_depth == 0 (a top-frame
         // mutation) but the shadow write was forgotten.
-        let errors = verify_class_var_bind(put_op(), false, true, span());
+        let (_, errors) = construct_and_verify_class_var_bind(put_op(), false, true, 0, 1, span());
         assert_eq!(
             errors,
             vec![VerifyError::ShadowWriteMissing {
@@ -3175,7 +3300,8 @@ mod tests {
     }
 
     #[test]
-    fn verify_class_var_bind_put_fires_even_without_a_local_nlr_catch_in_this_method() {
+    fn construct_and_verify_class_var_bind_put_fires_even_without_a_local_nlr_catch_in_this_method()
+    {
         // Pins the exact ADR 0110 repro shape, not just the ADR's abbreviated
         // worked example: `CollectionDriver countedRun:over:` mutates a class
         // var, then invokes a *caller-supplied* block (`aBlock value: x`)
@@ -3188,7 +3314,7 @@ mod tests {
         // NEVER by whether this method happens to have its own NLR catch:
         // gating on the latter (an earlier version of this helper's bug)
         // would silently exempt this exact shape from the check.
-        let errors = verify_class_var_bind(put_op(), false, true, span());
+        let (_, errors) = construct_and_verify_class_var_bind(put_op(), false, true, 0, 1, span());
         assert!(
             errors
                 .iter()
@@ -3198,25 +3324,73 @@ mod tests {
     }
 
     #[test]
-    fn verify_class_var_bind_put_silent_below_top_frame() {
+    fn construct_and_verify_class_var_bind_put_silent_below_top_frame() {
         // A class-var mutation inside a nested block (block_depth > 0) is
         // legitimately shadow_write: false — already discarded on normal
         // return (BT-1550), not a regression. Matches
         // `verify_shadow_write_missing_silent_below_top_frame`.
-        assert_eq!(
-            verify_class_var_bind(put_op(), false, false, span()),
-            Vec::new()
-        );
+        let (_, errors) = construct_and_verify_class_var_bind(put_op(), false, false, 0, 1, span());
+        assert_eq!(errors, Vec::new());
     }
 
     #[test]
-    fn verify_class_var_bind_direct_rebind_silent_never_requires_shadow_write() {
+    fn construct_and_verify_class_var_bind_direct_rebind_silent_never_requires_shadow_write() {
         // dispatch_codegen.rs's inherited-self-dispatch rebind: never itself
         // a shadow-write producer (the callee's own Bind already wrote it
         // under the same ClassSelf-tagged key) — its call site always passes
         // at_method_top_frame: false, so this stays silent unconditionally.
         let op = BindOp::Direct(ValueRef::Var("_CV0".to_string()));
-        assert_eq!(verify_class_var_bind(op, false, false, span()), Vec::new());
+        let (_, errors) = construct_and_verify_class_var_bind(op, false, false, 0, 1, span());
+        assert_eq!(errors, Vec::new());
+    }
+
+    #[test]
+    fn construct_and_verify_class_var_bind_direct_rebind_silent_with_a_nonzero_source_version() {
+        // Regression for a real BT-3148 bug caught by this migration's own
+        // tests: `at_method_top_frame: false` selects a non-`ROOT` `FrameId`,
+        // which `verify()`'s frame stack (seeded as `[FrameId::ROOT]` only)
+        // cannot see without an explicit `Threaded` wrapper — a nested
+        // class-var rebind (`emit_class_var_result_unwrap`) is ALWAYS
+        // `at_method_top_frame: false`, and its `source_version` is the real,
+        // possibly-nonzero `class_var_version()` (e.g. an earlier top-frame
+        // mutation already minted `ClassVars1` before this nested rebind
+        // runs) — this must stay silent, not spuriously report
+        // `UnboundVersion` for the backfilled version.
+        let op = BindOp::Direct(ValueRef::Var("_CV3".to_string()));
+        let (bind, errors) = construct_and_verify_class_var_bind(op, false, false, 2, 3, span());
+        assert_eq!(errors, Vec::new(), "got: {errors:?}");
+        assert_eq!(
+            bind,
+            ThreadedStmt::Bind {
+                target: VersionedVar::new(VersionPrefix::ClassVars, 3, FrameId::new(1)),
+                source: VersionedVar::new(VersionPrefix::ClassVars, 2, FrameId::new(1)),
+                op: BindOp::Direct(ValueRef::Var("_CV3".to_string())),
+                shadow_write: false,
+                span: span(),
+            }
+        );
+    }
+
+    #[test]
+    fn construct_and_verify_class_var_bind_uses_the_real_version_numbers_not_a_fixed_0_to_1_step() {
+        // BT-3148: the whole point of the migration off the deleted
+        // `verify_class_var_bind` — a mutation later in the method (source
+        // version 3, minted to 4) must be silent, not spuriously flagged,
+        // and the returned Bind must carry those exact versions (never the
+        // old fixture's hardcoded 0 -> 1).
+        let (bind, errors) =
+            construct_and_verify_class_var_bind(put_op(), true, true, 3, 4, span());
+        assert_eq!(errors, Vec::new(), "got: {errors:?}");
+        assert_eq!(
+            bind,
+            ThreadedStmt::Bind {
+                target: VersionedVar::new(VersionPrefix::ClassVars, 4, FrameId::ROOT),
+                source: VersionedVar::new(VersionPrefix::ClassVars, 3, FrameId::ROOT),
+                op: put_op(),
+                shadow_write: true,
+                span: span(),
+            }
+        );
     }
 
     // ── verify_simple_bind (BT-3139) ──────────────────────────────────────
@@ -3244,7 +3418,8 @@ mod tests {
     fn verify_simple_bind_silent_after_several_prior_mutations() {
         // A later mutation in the same method (source_version > 0) must not
         // spuriously fire UnboundVersion — the whole point of this helper's
-        // backfill chain over `verify_class_var_bind`'s fixed `0 -> 1`.
+        // (and, as of BT-3148, `construct_and_verify_class_var_bind`'s)
+        // backfill chain.
         assert_eq!(
             verify_simple_bind(VersionPrefix::SelfVt, 4, 5, span()),
             Vec::new()

--- a/crates/beamtalk-examples/corpus.json
+++ b/crates/beamtalk-examples/corpus.json
@@ -104,6 +104,33 @@
       "title": "Passing Blocks Through Class Methods (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
+        "LoopCounter",
+        "Object",
+        "assign",
+        "assignment",
+        "beamtalk-language-features",
+        "countUpTo:",
+        "extends",
+        "field",
+        "inherit",
+        "inheritance",
+        "instance variable",
+        "member",
+        "mutate",
+        "mutation",
+        "object",
+        "property",
+        "set",
+        "subclassing"
+      ],
+      "source": "Object subclass: LoopCounter\n  classState: runs = 0\n\n  // Rejected: class-var mutation alongside a local mutation inside a loop body\n  class countUpTo: n =>\n    i := 0.\n    [i < n] whileTrue: [\n      self.runs := self.runs + 1.    // compile error — mutation can't thread back\n      i := i + 1\n    ].\n    self.runs\n\n  // Correct: accumulate locally, mutate once after the loop\n  class countUpTo: n =>\n    i := 0.\n    count := self.runs.\n    [i < n] whileTrue: [\n      count := count + 1.\n      i := i + 1\n    ].\n    self.runs := count",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-106",
+      "title": "Passing Blocks Through Class Methods (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
         "Batch",
         "Collection",
         "beamtalk-language-features",
@@ -129,7 +156,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-106",
+      "id": "docs-beamtalk-language-features-block-107",
       "title": "Actor-to-Actor Coordination (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -139,7 +166,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-107",
+      "id": "docs-beamtalk-language-features-block-108",
       "title": "Actor-to-Actor Coordination (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -149,7 +176,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-108",
+      "id": "docs-beamtalk-language-features-block-109",
       "title": "Defining a Server (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -196,7 +223,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-110",
+      "id": "docs-beamtalk-language-features-block-111",
       "title": "Timer Lifecycle (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -236,7 +263,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-112",
+      "id": "docs-beamtalk-language-features-block-113",
       "title": "Static Supervisor (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -257,7 +284,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-113",
+      "id": "docs-beamtalk-language-features-block-114",
       "title": "Static Supervisor (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -275,7 +302,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-114",
+      "id": "docs-beamtalk-language-features-block-115",
       "title": "Class-Side Configuration Defaults (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -298,7 +325,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-115",
+      "id": "docs-beamtalk-language-features-block-116",
       "title": "Actor Supervision Policy (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -323,7 +350,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-118",
+      "id": "docs-beamtalk-language-features-block-119",
       "title": "SupervisionSpec — Per-Child Overrides (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -365,7 +392,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-120",
+      "id": "docs-beamtalk-language-features-block-121",
       "title": "Dynamic Supervisor (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -391,7 +418,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-122",
+      "id": "docs-beamtalk-language-features-block-123",
       "title": "Nested Supervisors (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -409,7 +436,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-123",
+      "id": "docs-beamtalk-language-features-block-124",
       "title": "Call-site patterns (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -424,7 +451,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-125",
+      "id": "docs-beamtalk-language-features-block-126",
       "title": "Call-site patterns (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -443,7 +470,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-126",
+      "id": "docs-beamtalk-language-features-block-127",
       "title": "Actor Named Registration (ADR 0079) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -466,7 +493,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-127",
+      "id": "docs-beamtalk-language-features-block-128",
       "title": "Introspecting the Live Supervision Tree (ADR 0092) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -501,7 +528,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-128",
+      "id": "docs-beamtalk-language-features-block-129",
       "title": "Introspecting the Live Supervision Tree (ADR 0092) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -516,19 +543,6 @@
         "supervision"
       ],
       "source": "node pid               // => a Pid | nil   (nil for a child mid-restart)\nnode registeredName    // => Symbol | nil\nnode kind              // => #beamtalkSupervisor | #beamtalkActor\n                       //    | #otpSupervisor | #otpProcess | #restarting\nnode behaviourClass    // => Class | nil   (nil for foreign OTP processes)\nnode childCount        // => Integer       (live children; supervisors only)\nnode strategy          // => Symbol | nil  (#oneForOne … ; supervisors only)\nnode restartIntensity  // => Dictionary | nil  (configured #{#maxRestarts, #window})\nnode children          // => List(SupervisionNode)\nnode parent            // => SupervisionNode | nil\nnode isSupervisor      // => Boolean\nnode isBeamtalk        // => Boolean\nnode status            // => Dictionary | nil   (LAZY — see below)",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-129",
-      "title": "Introspecting the Live Supervision Tree (ADR 0092) (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features",
-        "exception",
-        "raise",
-        "throw"
-      ],
-      "source": "ProcessNavigation system tree size                 // everything, incl. infra\n(ProcessNavigation from: aSup) unwrap tree         // a rooted subtree\n(ProcessNavigation from: aStoppedSup)              // => Result error: (beamtalk_error stale_handle)",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -558,7 +572,20 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-131",
+      "id": "docs-beamtalk-language-features-block-130",
+      "title": "Introspecting the Live Supervision Tree (ADR 0092) (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "beamtalk-language-features",
+        "exception",
+        "raise",
+        "throw"
+      ],
+      "source": "ProcessNavigation system tree size                 // everything, incl. infra\n(ProcessNavigation from: aSup) unwrap tree         // a rooted subtree\n(ProcessNavigation from: aStoppedSup)              // => Result error: (beamtalk_error stale_handle)",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-132",
       "title": "Before named registration (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -586,7 +613,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-132",
+      "id": "docs-beamtalk-language-features-block-133",
       "title": "After named registration (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -608,7 +635,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-133",
+      "id": "docs-beamtalk-language-features-block-134",
       "title": "Proxy Semantics (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -629,7 +656,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-134",
+      "id": "docs-beamtalk-language-features-block-135",
       "title": "Match Expression (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -647,7 +674,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-135",
+      "id": "docs-beamtalk-language-features-block-136",
       "title": "Match Expression (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -660,26 +687,13 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-136",
+      "id": "docs-beamtalk-language-features-block-137",
       "title": "Match Expression (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
         "beamtalk-language-features"
       ],
       "source": "// direction :: #north | #south | #east | #west\ndirection match: [\n  #north -> 0;\n  #south -> 180;\n  #east  -> 90\n]\n// ⚠ Warning: non-exhaustive match: `#west` is not handled (residual type: `#west`)",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-137",
-      "title": "Match Expression (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features",
-        "exception",
-        "raise",
-        "throw"
-      ],
-      "source": "// direction :: #north | #south | #east | #west\n\n// Compile error: matchExhaustive: proves this is NOT exhaustive\ndirection matchExhaustive: [\n  #north -> 0;\n  #south -> 180;\n  #east  -> 90\n]\n// ⛔ Error: non-exhaustive matchExhaustive: `#west` is not handled (residual type: `#west`)\n\n// Fine: all four members covered — silent, no diagnostic\ndirection matchExhaustive: [\n  #north -> 0;\n  #south -> 180;\n  #east  -> 90;\n  #west  -> 270\n]\n\n// Fine: an unguarded wildcard is still full coverage\ndirection matchExhaustive: [\n  #north -> 0;\n  _      -> -1\n]",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -692,22 +706,20 @@
         "raise",
         "throw"
       ],
-      "source": "x matchExhaustive: [#ok -> 1; _ -> 0]\n// ⛔ Error: cannot verify `matchExhaustive:` is exhaustive — scrutinee type\n//    `Dynamic` is not a closed union of symbol singletons, `nil`, or\n//    concrete leaf classes",
+      "source": "// direction :: #north | #south | #east | #west\n\n// Compile error: matchExhaustive: proves this is NOT exhaustive\ndirection matchExhaustive: [\n  #north -> 0;\n  #south -> 180;\n  #east  -> 90\n]\n// ⛔ Error: non-exhaustive matchExhaustive: `#west` is not handled (residual type: `#west`)\n\n// Fine: all four members covered — silent, no diagnostic\ndirection matchExhaustive: [\n  #north -> 0;\n  #south -> 180;\n  #east  -> 90;\n  #west  -> 270\n]\n\n// Fine: an unguarded wildcard is still full coverage\ndirection matchExhaustive: [\n  #north -> 0;\n  _      -> -1\n]",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
       "id": "docs-beamtalk-language-features-block-139",
-      "title": "Destructuring in Match Arms (beamtalk-language-features)",
+      "title": "Match Expression (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
-        "assign",
-        "assignment",
         "beamtalk-language-features",
-        "mutate",
-        "mutation",
-        "set"
+        "exception",
+        "raise",
+        "throw"
       ],
-      "source": "// Variable captures the matched value\n42 match: [x -> x + 1]\n// => 43\n\n// Variable binding with guard\n10 match: [x when: [x > 100] -> \"big\"; x when: [x > 5] -> \"medium\"; _ -> \"small\"]\n// => \"medium\"\n\n// Tuple destructuring in match arms\nt := Erlang erlang list_to_tuple: #(#ok, 42)\nt match: [{#ok, v} -> v; {#error, _} -> 0]\n// => 42",
+      "source": "x matchExhaustive: [#ok -> 1; _ -> 0]\n// ⛔ Error: cannot verify `matchExhaustive:` is exhaustive — scrutinee type\n//    `Dynamic` is not a closed union of symbol singletons, `nil`, or\n//    concrete leaf classes",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -727,6 +739,21 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-140",
+      "title": "Destructuring in Match Arms (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "assign",
+        "assignment",
+        "beamtalk-language-features",
+        "mutate",
+        "mutation",
+        "set"
+      ],
+      "source": "// Variable captures the matched value\n42 match: [x -> x + 1]\n// => 43\n\n// Variable binding with guard\n10 match: [x when: [x > 100] -> \"big\"; x when: [x > 5] -> \"medium\"; _ -> \"small\"]\n// => \"medium\"\n\n// Tuple destructuring in match arms\nt := Erlang erlang list_to_tuple: #(#ok, 42)\nt match: [{#ok, v} -> v; {#error, _} -> 0]\n// => 42",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-141",
       "title": "Rest Patterns in Destructuring (BT-1251) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -741,7 +768,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-141",
+      "id": "docs-beamtalk-language-features-block-142",
       "title": "Live Patching (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -777,7 +804,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-142",
+      "id": "docs-beamtalk-language-features-block-143",
       "title": "Live Patching (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -798,7 +825,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-146",
+      "id": "docs-beamtalk-language-features-block-147",
       "title": "External-edit conflict — patch, edit on disk, flush (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -833,7 +860,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-152",
+      "id": "docs-beamtalk-language-features-block-153",
       "title": "Live Re-Checking on Reload (ADR 0105) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -846,7 +873,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-153",
+      "id": "docs-beamtalk-language-features-block-154",
       "title": "Extension Methods (Open Classes) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -860,7 +887,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-154",
+      "id": "docs-beamtalk-language-features-block-155",
       "title": "Type annotations on extensions (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -881,7 +908,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-155",
+      "id": "docs-beamtalk-language-features-block-156",
       "title": "Cross-file extensions (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -898,7 +925,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-156",
+      "id": "docs-beamtalk-language-features-block-157",
       "title": "Beamtalk — System reflection (BeamtalkInterface) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -908,7 +935,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-157",
+      "id": "docs-beamtalk-language-features-block-158",
       "title": "Workspace — Project operations (WorkspaceInterface) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -923,7 +950,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-158",
+      "id": "docs-beamtalk-language-features-block-159",
       "title": "Class-based reload via Behaviour >> reload (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -933,29 +960,6 @@
         "throw"
       ],
       "source": "Counter sourceFile\n// => \"examples/counter.bt\"\n\nCounter reload\n// => Counter  (recompiled and hot-swapped)\n\nInteger sourceFile\n// => nil  (stdlib built-in, no source file)\n\nInteger reload\n// => Error: Integer has no source file — stdlib classes cannot be reloaded",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-159",
-      "title": "SystemNavigation — Cross-class code queries (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "assign",
-        "assignment",
-        "async",
-        "beamtalk-language-features",
-        "concurrent",
-        "gen_server",
-        "genserver",
-        "mutate",
-        "mutation",
-        "process",
-        "set",
-        "string conversion",
-        "toString",
-        "to_string"
-      ],
-      "source": "nav := SystemNavigation default\n\nnav implementorsOf: #printString\n// => [Object, Integer, String, ...]\n\nnav sendersOf: #increment\n// => [#{#class => CounterTest, #selector => #testIncrement, #line => 12}, ...]\n\nnav referencesTo: Counter\n// => [#{#class => CounterTest, #selector => #setUp, #line => 5}, ...]\n\nnav methodsMatching: (Regex from: \"printString\") unwrap\n// => [#{#class => Object, #selector => #printString}, ...]\n\nnav selectorsMatching: \"print\"\n// => [#printString, #printOn:, ...]\n\nnav messagesSentBy: (Counter >> #increment)\n// => [#{#selector => #+, #line => 2}, ...]\n\nnav announcementsSentBy: PriceTracker\n// => [PriceChanged, ...]  (distinct Announcement subclasses PriceTracker emits)\n\nnav announcementSitesSentBy: PriceTracker\n// => [#{#class => PriceTracker, #selector => #notify, #line => 4, #announcementClass => PriceChanged}, ...]\n\nnav unimplementedSelectors\n// => []  (empty = no typos in the loaded registry)\n\nnav unusedSelectors\n// => [#{#class => MyLib, #selector => #helperNoOneCalls}, ...]\n\nnav actorClasses\n// => [Actor, ClassBuilder, MyActor, ...]\n\nnav dnuHandlers\n// => [ErlangModule, ProtoObject, TimeoutProxy, ...]\n\nnav extendersOf: String\n// => [Package(my_lib v1.0.0), ...]\n\nnav extensionsBy: (Package named: \"my_lib\")\n// => [#{#class => String, #selector => #asJson}, ...]\n\nnav classesInPackage: #stdlib\n// => [Actor, Array, ...]\n\nnav subclassesOf: Number in: #stdlib\n// => [Float, Integer]\n\nnav fieldReadersOf: #value in: Counter\n// => [#{#class => Counter, #selector => #getValue, #line => 5}, ...]\n\nnav fieldWritersOf: #value in: Counter\n// => [#{#class => Counter, #selector => #increment, #line => 3}, ...]\n\nnav ffiSitesFor: \"lists:reverse\"\n// => [#{#class => MyList, #selector => #reversed, #line => 7}, ...]",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -980,6 +984,29 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-160",
+      "title": "SystemNavigation — Cross-class code queries (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "assign",
+        "assignment",
+        "async",
+        "beamtalk-language-features",
+        "concurrent",
+        "gen_server",
+        "genserver",
+        "mutate",
+        "mutation",
+        "process",
+        "set",
+        "string conversion",
+        "toString",
+        "to_string"
+      ],
+      "source": "nav := SystemNavigation default\n\nnav implementorsOf: #printString\n// => [Object, Integer, String, ...]\n\nnav sendersOf: #increment\n// => [#{#class => CounterTest, #selector => #testIncrement, #line => 12}, ...]\n\nnav referencesTo: Counter\n// => [#{#class => CounterTest, #selector => #setUp, #line => 5}, ...]\n\nnav methodsMatching: (Regex from: \"printString\") unwrap\n// => [#{#class => Object, #selector => #printString}, ...]\n\nnav selectorsMatching: \"print\"\n// => [#printString, #printOn:, ...]\n\nnav messagesSentBy: (Counter >> #increment)\n// => [#{#selector => #+, #line => 2}, ...]\n\nnav announcementsSentBy: PriceTracker\n// => [PriceChanged, ...]  (distinct Announcement subclasses PriceTracker emits)\n\nnav announcementSitesSentBy: PriceTracker\n// => [#{#class => PriceTracker, #selector => #notify, #line => 4, #announcementClass => PriceChanged}, ...]\n\nnav unimplementedSelectors\n// => []  (empty = no typos in the loaded registry)\n\nnav unusedSelectors\n// => [#{#class => MyLib, #selector => #helperNoOneCalls}, ...]\n\nnav actorClasses\n// => [Actor, ClassBuilder, MyActor, ...]\n\nnav dnuHandlers\n// => [ErlangModule, ProtoObject, TimeoutProxy, ...]\n\nnav extendersOf: String\n// => [Package(my_lib v1.0.0), ...]\n\nnav extensionsBy: (Package named: \"my_lib\")\n// => [#{#class => String, #selector => #asJson}, ...]\n\nnav classesInPackage: #stdlib\n// => [Actor, Array, ...]\n\nnav subclassesOf: Number in: #stdlib\n// => [Float, Integer]\n\nnav fieldReadersOf: #value in: Counter\n// => [#{#class => Counter, #selector => #getValue, #line => 5}, ...]\n\nnav fieldWritersOf: #value in: Counter\n// => [#{#class => Counter, #selector => #increment, #line => 3}, ...]\n\nnav ffiSitesFor: \"lists:reverse\"\n// => [#{#class => MyList, #selector => #reversed, #line => 7}, ...]",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-161",
       "title": "Session — a first-class session value (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -997,7 +1024,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-162",
+      "id": "docs-beamtalk-language-features-block-163",
       "title": "BindingsView — a live, write-through Dictionary view (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1007,7 +1034,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-164",
+      "id": "docs-beamtalk-language-features-block-165",
       "title": "Cross-session access (read-only) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1031,7 +1058,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-165",
+      "id": "docs-beamtalk-language-features-block-166",
       "title": "Tracing Lifecycle (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1041,7 +1068,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-166",
+      "id": "docs-beamtalk-language-features-block-167",
       "title": "Aggregate Stats (Always-On) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1056,7 +1083,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-167",
+      "id": "docs-beamtalk-language-features-block-168",
       "title": "Trace Event Queries (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1074,7 +1101,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-168",
+      "id": "docs-beamtalk-language-features-block-169",
       "title": "Analysis Methods (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1089,7 +1116,17 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-169",
+      "id": "docs-beamtalk-language-features-block-17",
+      "title": "Message Sends (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "beamtalk-language-features"
+      ],
+      "source": "// Unary message\ncounter increment\n\n// Binary message (standard math precedence: 2 + 3 * 4 = 14)\n2 + 3 * 4\n\n// Keyword message\ndict at: #name put: \"hello\"\n\n// Cascade - multiple messages to same receiver\nTranscript show: \"Hello\"; cr; show: \"World\"",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-170",
       "title": "Live Health (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1104,17 +1141,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-17",
-      "title": "Message Sends (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features"
-      ],
-      "source": "// Unary message\ncounter increment\n\n// Binary message (standard math precedence: 2 + 3 * 4 = 14)\n2 + 3 * 4\n\n// Keyword message\ndict at: #name put: \"hello\"\n\n// Cascade - multiple messages to same receiver\nTranscript show: \"Hello\"; cr; show: \"World\"",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-170",
+      "id": "docs-beamtalk-language-features-block-171",
       "title": "Configuration (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1124,7 +1151,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-171",
+      "id": "docs-beamtalk-language-features-block-172",
       "title": "Typical Workflow (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1144,7 +1171,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-172",
+      "id": "docs-beamtalk-language-features-block-173",
       "title": "Events — subclass Announcement (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1173,7 +1200,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-173",
+      "id": "docs-beamtalk-language-features-block-174",
       "title": "Announcer — a per-instance dispatcher (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1204,7 +1231,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-175",
+      "id": "docs-beamtalk-language-features-block-176",
       "title": "Synchronous vs asynchronous (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1223,7 +1250,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-176",
+      "id": "docs-beamtalk-language-features-block-177",
       "title": "MRO matching — subscribe to a superclass (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1251,7 +1278,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-177",
+      "id": "docs-beamtalk-language-features-block-178",
       "title": "SystemAnnouncer — watch the runtime live (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1269,16 +1296,6 @@
         "process"
       ],
       "source": "SystemAnnouncer current when: ActorSpawned do: [:e |\n  Transcript showLine: e actorClass asString\n]\nCounter spawn    // the subscription fires: prints \"Counter\"",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-179",
-      "title": "Introspection — the third navigation sibling (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features"
-      ],
-      "source": "a subscriptions          // => a List of SubscriptionNode snapshots\na subscribersOf: PriceChanged   // => subscriptions to exactly PriceChanged\na subscriptionCount      // => total live subscriptions on the bus",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -1316,6 +1333,16 @@
       "title": "Introspection — the third navigation sibling (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
+        "beamtalk-language-features"
+      ],
+      "source": "a subscriptions          // => a List of SubscriptionNode snapshots\na subscribersOf: PriceChanged   // => subscriptions to exactly PriceChanged\na subscriptionCount      // => total live subscriptions on the bus",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-181",
+      "title": "Introspection — the third navigation sibling (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
         "async",
         "beamtalk-language-features",
         "concurrent",
@@ -1327,7 +1354,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-181",
+      "id": "docs-beamtalk-language-features-block-182",
       "title": "Introspection — the third navigation sibling (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1342,7 +1369,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-184",
+      "id": "docs-beamtalk-language-features-block-185",
       "title": "Protected stdlib class names (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1363,7 +1390,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-185",
+      "id": "docs-beamtalk-language-features-block-186",
       "title": "Protected stdlib class names (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1399,7 +1426,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-190",
+      "id": "docs-beamtalk-language-features-block-191",
       "title": "Binary — Byte-Level Data (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1420,7 +1447,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-191",
+      "id": "docs-beamtalk-language-features-block-192",
       "title": "Binary vs String at Runtime (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1438,7 +1465,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-193",
+      "id": "docs-beamtalk-language-features-block-194",
       "title": "Accessing an Empty Collection (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1448,7 +1475,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-196",
+      "id": "docs-beamtalk-language-features-block-197",
       "title": "Accessing an Empty Collection (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1467,23 +1494,13 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-197",
+      "id": "docs-beamtalk-language-features-block-198",
       "title": "Accessing an Empty Collection (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
         "beamtalk-language-features"
       ],
       "source": "#() rest                   // => #()\n#() take: 3                // => #()\n#() drop: 3                // => #()\n#() sum                    // => 0 (identity element, unlike max/min)",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-199",
-      "title": "Accessing an Empty Collection (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features"
-      ],
-      "source": "(1 to: 10) at: 1     // => 1\n(1 to: 10) at: 11    // raises index_out_of_bounds\n(1 to: 0) at: 1       // raises index_out_of_bounds (not empty_collection)",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -1512,7 +1529,17 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-201",
+      "id": "docs-beamtalk-language-features-block-200",
+      "title": "Accessing an Empty Collection (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "beamtalk-language-features"
+      ],
+      "source": "(1 to: 10) at: 1     // => 1\n(1 to: 10) at: 11    // raises index_out_of_bounds\n(1 to: 0) at: 1       // raises index_out_of_bounds (not empty_collection)",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-202",
       "title": "Lookups That Find Nothing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1525,7 +1552,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-202",
+      "id": "docs-beamtalk-language-features-block-203",
       "title": "Lookups That Find Nothing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1535,7 +1562,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-203",
+      "id": "docs-beamtalk-language-features-block-204",
       "title": "Interval — Arithmetic Sequences (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1551,7 +1578,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-204",
+      "id": "docs-beamtalk-language-features-block-205",
       "title": "Bag(E) — Multisets (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1575,7 +1602,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-205",
+      "id": "docs-beamtalk-language-features-block-206",
       "title": "Constructors (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1594,7 +1621,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-206",
+      "id": "docs-beamtalk-language-features-block-207",
       "title": "Lazy Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1615,7 +1642,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-207",
+      "id": "docs-beamtalk-language-features-block-208",
       "title": "Terminal Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1628,7 +1655,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-208",
+      "id": "docs-beamtalk-language-features-block-209",
       "title": "printString — Pipeline Inspection (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1641,19 +1668,6 @@
         "where"
       ],
       "source": "(Stream from: 1) printString\n// => Stream(from: 1)\n\n(Stream on: #(1, 2, 3)) printString\n// => Stream(on: [...])\n\n((Stream from: 1) select: [:n | n isEven]) printString\n// => Stream(from: 1) | select: [...]",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-209",
-      "title": "Eager vs Lazy — The Boundary (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features",
-        "filter",
-        "filtering",
-        "where"
-      ],
-      "source": "// Eager — List methods return a List immediately\n#(1, 2, 3, 4, 5) select: [:n | n > 2]\n// => [3,4,5]  (a List)\n\n// Lazy — stream methods return a Stream (unevaluated)\n(#(1, 2, 3, 4, 5) stream) select: [:n | n > 2]\n// => Stream  (unevaluated — call asList or take: to materialize)",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -1678,6 +1692,19 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-210",
+      "title": "Eager vs Lazy — The Boundary (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "beamtalk-language-features",
+        "filter",
+        "filtering",
+        "where"
+      ],
+      "source": "// Eager — List methods return a List immediately\n#(1, 2, 3, 4, 5) select: [:n | n > 2]\n// => [3,4,5]  (a List)\n\n// Lazy — stream methods return a Stream (unevaluated)\n(#(1, 2, 3, 4, 5) stream) select: [:n | n > 2]\n// => Stream  (unevaluated — call asList or take: to materialize)",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-211",
       "title": "File Streaming (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1696,7 +1723,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-211",
+      "id": "docs-beamtalk-language-features-block-212",
       "title": "File I/O and Directory Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1706,7 +1733,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-212",
+      "id": "docs-beamtalk-language-features-block-213",
       "title": "Incremental File I/O — FileHandle (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1727,7 +1754,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-213",
+      "id": "docs-beamtalk-language-features-block-214",
       "title": "Incremental File I/O — FileHandle (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1746,7 +1773,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-215",
+      "id": "docs-beamtalk-language-features-block-216",
       "title": "Side-Effect Timing ⚠️ (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1764,7 +1791,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-216",
+      "id": "docs-beamtalk-language-features-block-217",
       "title": "Diagnostic Suppression (@expect) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1779,7 +1806,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-217",
+      "id": "docs-beamtalk-language-features-block-218",
       "title": "Diagnostic Suppression (@expect) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1789,7 +1816,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-218",
+      "id": "docs-beamtalk-language-features-block-219",
       "title": "Diagnostic Suppression (@expect) (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1822,7 +1849,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-221",
+      "id": "docs-beamtalk-language-features-block-222",
       "title": "Creating a Table (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1845,7 +1872,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-222",
+      "id": "docs-beamtalk-language-features-block-223",
       "title": "Reading and Writing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1855,7 +1882,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-223",
+      "id": "docs-beamtalk-language-features-block-224",
       "title": "Other Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1865,7 +1892,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-224",
+      "id": "docs-beamtalk-language-features-block-225",
       "title": "Cross-Actor Sharing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1888,7 +1915,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-226",
+      "id": "docs-beamtalk-language-features-block-227",
       "title": "Enqueueing and Dequeueing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1903,26 +1930,13 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-227",
+      "id": "docs-beamtalk-language-features-block-228",
       "title": "Other Operations (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
         "beamtalk-language-features"
       ],
       "source": "q peek                        // => front element without removing (raises empty_queue if empty)\nq isEmpty                     // => true or false\nq size                        // => number of elements (O(n))",
-      "explanation": "Code example from docs/beamtalk-language-features.md"
-    },
-    {
-      "id": "docs-beamtalk-language-features-block-229",
-      "title": "Atomic Operations (beamtalk-language-features)",
-      "category": "language-reference",
-      "tags": [
-        "beamtalk-language-features",
-        "constructor",
-        "create",
-        "instantiate"
-      ],
-      "source": "c increment                    // atomically add 1, return new value\nc incrementBy: 5               // atomically add N, return new value\nc decrement                    // atomically subtract 1, return new value\nc decrementBy: 3               // atomically subtract N, return new value\nc value                        // instantaneous read; may observe a stale value under concurrent updates or reset\nc reset                        // set to 0, return nil (not atomic with concurrent increments/decrements)\nc delete                       // destroy the backing ETS table",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
@@ -1952,6 +1966,19 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-230",
+      "title": "Atomic Operations (beamtalk-language-features)",
+      "category": "language-reference",
+      "tags": [
+        "beamtalk-language-features",
+        "constructor",
+        "create",
+        "instantiate"
+      ],
+      "source": "c increment                    // atomically add 1, return new value\nc incrementBy: 5               // atomically add N, return new value\nc decrement                    // atomically subtract 1, return new value\nc decrementBy: 3               // atomically subtract N, return new value\nc value                        // instantaneous read; may observe a stale value under concurrent updates or reset\nc reset                        // set to 0, return nil (not atomic with concurrent increments/decrements)\nc delete                       // destroy the backing ETS table",
+      "explanation": "Code example from docs/beamtalk-language-features.md"
+    },
+    {
+      "id": "docs-beamtalk-language-features-block-231",
       "title": "Cross-Actor Sharing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1974,7 +2001,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-231",
+      "id": "docs-beamtalk-language-features-block-232",
       "title": "TestCase — BUnit Testing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -1997,7 +2024,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-232",
+      "id": "docs-beamtalk-language-features-block-233",
       "title": "TestCase — BUnit Testing (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2020,7 +2047,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-233",
+      "id": "docs-beamtalk-language-features-block-234",
       "title": "Suite-Level Setup — setUpOnce / tearDownOnce (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
@@ -2051,7 +2078,7 @@
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {
-      "id": "docs-beamtalk-language-features-block-234",
+      "id": "docs-beamtalk-language-features-block-235",
       "title": "Parallel Test Execution (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-3148

Part of epic [BT-3141](https://linear.app/beamtalk/issue/BT-3141) (ADR 0111 completion). This PR delivers **task 3 of BT-3148's 4-part scope** — the two class-var `Bind` producer sites now construct, verify, and render through a real `threaded_ir::ThreadedStmt::Bind` node instead of a hand-rolled `Document` that mirrored it:

- `expressions.rs::generate_class_var_field_assignment` (the `BindOp::Put` mutation)
- `dispatch_codegen.rs::emit_class_var_result_unwrap` (the `BindOp::Direct` rebind, using the `ValueRef::Doc` opaque-RHS precedent BT-3145 introduced, since this rebind's RHS is a `case` expression)

`threaded_ir::verify_class_var_bind` (the fixture-mirror wrapper) is deleted, replaced by `construct_and_verify_class_var_bind`, which builds the *actual* Bind — real `source_version`/`target_version` read off the live generator counter, not the old hardcoded `0 -> 1` step — and renders it via `threaded_ir::render`. `render_bind`'s `BindOp::Put` arm is now the only place the ADR 0110 shadow write is constructed, for both the verified fixture and the emitted `Document`.

## Bug found and fixed during this migration's own review

The new backfill-based verification (needed once real, possibly-nonzero version numbers replaced the old fixed `0->1` step) initially produced a spurious `UnboundVersion` for any nested class-var rebind following an earlier top-frame mutation, because `verify()`'s frame stack starts as `[FrameId::ROOT]` only — a non-ROOT frame must be pushed via a `Threaded` wrapper, which the old always-`0->1` fixture never needed. Caught by the existing `test_class_method_self_send_in_block_local_assignment` test, fixed, and pinned with a new regression test.

## Scope note — tasks 1, 2, 4 not attempted

Investigated `gen_server/methods.rs`'s routing (`classify_body_expr`/`verify_routing_invariant`), `wrap_body_with_nlr_catch`, and `threaded_expr.rs`'s `ThreadingBoundary`. All three are blocked on the same architectural gap: `classify_body_expr`'s `BodyExprKind` has ~18 variants, most of which are ordinary AST-directed statements (message sends, dispatch, Tier 2 calls) with no `ThreadedIr` representation today. Closing this needs a general opaque statement-level IR node — the same shape of gap BT-3145 hit, which needed its own adversarially-reviewed design detour (BT-3153) before landing. Split out as [BT-3156](https://linear.app/beamtalk/issue/BT-3156) (needs-spec), blocked by this issue, now also blocking BT-3149's close-out.

## Verification

- `just test`: 5667 Rust + 3216 BUnit + 233 stdlib + 5653+1807 runtime EUnit + 520 metamorphic — all green (pre-existing counts, zero failures)
- `class_var_shadow_contract.rs`'s `invoke_class_method/7` ADR 0110 cross-boundary conformance fixture — unchanged, passing
- `just clippy` / `just check-corpus` / `just check-surface-drift` / `just check-generated-builtins` — all green
- Snapshot corpus byte-identical (the only diff is pre-existing, unrelated `docs/beamtalk-language-features.md` drift from a prior "daily docs refresh" commit, regenerated here)

## Test plan

- [x] `just test` (full suite)
- [x] `just clippy`
- [x] `just fmt-check`
- [x] `just check-corpus`
- [x] `just check-surface-drift` / `just check-generated-builtins`
- [x] `class_var_shadow_contract` conformance fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6yh2Ngzg29ipiiNxWbGCP

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6yh2Ngzg29ipiiNxWbGCP)_