### PR TITLE
refactor: extract format_selector_list helper in validation.rs

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs
@@ -86,11 +86,7 @@ impl TypeChecker {
                 }
             }
         }
-        all_missing
-            .iter()
-            .map(|s| format!("'{s}'"))
-            .collect::<Vec<_>>()
-            .join(", ")
+        Self::format_selector_list(&all_missing)
     }
 
     /// Check a class-side message send (e.g., `Counter spawn`, `Object new`).
@@ -3057,11 +3053,7 @@ impl TypeChecker {
                 match protocol_registry.check_conformance(class_name, base_protocol, hierarchy) {
                     Ok(()) => {} // Conforms — no warning
                     Err(missing) => {
-                        let missing_list = missing
-                            .iter()
-                            .map(|s| format!("'{s}'"))
-                            .collect::<Vec<_>>()
-                            .join(", ");
+                        let missing_list = Self::format_selector_list(&missing);
                         self.diagnostics.push(
                             Diagnostic::warning(
                                 format!(
@@ -3215,11 +3207,7 @@ impl TypeChecker {
         match protocol_registry.check_class_side_conformance(class_name, base_protocol, hierarchy) {
             Ok(()) => {} // Class side conforms — no warning
             Err(missing) => {
-                let missing_list = missing
-                    .iter()
-                    .map(|s| format!("'{s}'"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
+                let missing_list = Self::format_selector_list(&missing);
                 self.diagnostics.push(
                     Diagnostic::warning(
                         format!("{class_name} class does not conform to protocol {base_protocol}"),
@@ -3333,11 +3321,7 @@ impl TypeChecker {
                         Ok(()) => {} // Conforms — no warning
                         Err(missing) => {
                             let param_name = param_names.get(i).map_or("?", |p| p.as_str());
-                            let missing_list = missing
-                                .iter()
-                                .map(|s| format!("'{s}'"))
-                                .collect::<Vec<_>>()
-                                .join(", ");
+                            let missing_list = Self::format_selector_list(&missing);
                             self.diagnostics.push(
                                 Diagnostic::warning(
                                     format!(
@@ -3418,5 +3402,15 @@ impl TypeChecker {
                 | InferredType::Intersection { .. } => {}
             }
         }
+    }
+
+    /// Format a slice of selector names as a comma-separated list of
+    /// single-quoted atoms for use in diagnostic hint strings.
+    fn format_selector_list(selectors: &[EcoString]) -> String {
+        selectors
+            .iter()
+            .map(|s| format!("'{s}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 }


### PR DESCRIPTION
## Summary

Four call sites in `TypeChecker` (in `validation.rs`) repeated the identical expression:

```rust
.iter()
.map(|s| format!("'{s}'"))
.collect::<Vec<_>>()
.join(", ")
```

to format a list of missing protocol selector names for diagnostic hint strings. This extracts a single private helper method so the rule lives in one place.

**Locations consolidated:**
- `TypeChecker::collect_missing_protocol_methods` (line 89) — union conformance
- Instance-side protocol conformance check (line ~3060)
- Class-side protocol conformance check (line ~3218)
- Generic type-argument bound conformance check (line ~3336)

**Change:** One new private method `format_selector_list(&[EcoString]) -> String` replaces four identical inline chains. No semantic change — the output for any input is identical.

## Files modified

- `crates/beamtalk-core/src/semantic_analysis/type_checker/validation.rs`

## Verification

- `just ci` passed locally (8,235+ Rust tests, 3,228 BUnit tests, Dialyzer, all parity suites).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVqMJyQ1FvixJdHFr5qYQi)_