### PR TITLE
Tighten actor_timeout.btscript cleanup assertions from wildcard to ok

### DIFF
--- a/tests/repl-protocol/cases/actor_timeout.btscript
+++ b/tests/repl-protocol/cases/actor_timeout.btscript
@@ -55,13 +55,13 @@ infProxy slowGet: 50
 // ===========================================================================
 
 slow stop
-// => _
+// => ok
 
 proxy stop
-// => _
+// => ok
 
 shortProxy stop
-// => _
+// => ok
 
 infProxy stop
-// => _
+// => ok


### PR DESCRIPTION
## Summary

The CLEANUP section of `tests/repl-protocol/cases/actor_timeout.btscript` used `// => _` wildcards for four `stop` calls. These are deterministic: `Actor.stop` is `sealed` in `stdlib/src/Actor.bt` and documented to return `#ok`.

**What changed:** 4 `// => _` → `// => ok` in the CLEANUP section, covering:
- `slow stop` — `SlowE2EActor`, a plain `Actor subclass`  
- `proxy stop`, `shortProxy stop`, `infProxy stop` — `TimeoutProxy`, a `typed Actor subclass` that does not override `stop` (it's `sealed`; DNU only fires for unknown messages)

**Why these wildcards are safe to tighten:**
- `Actor.stop` is declared `sealed stop -> Symbol => @intrinsic "actorStop"` — cannot be overridden by any subclass
- The Actor docstring example explicitly shows `counter stop   // => ok`
- `workspace_actors.btscript` and `named-actors.btscript` already assert `stop // => ok` for plain Actor subclasses; supervisors return `nil` but none of the actors here are supervisors
- All 3 REPL protocol tests pass with this change

**Smell addressed:** Placeholder `// => _` assertions where the actual value is deterministic and known. Now the test will catch any future regression where `Actor.stop` stops returning `ok` for these actor types.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PE8VsCrJhRpFrerYp2MreB)_