### PR TITLE
codegen: migrate remaining Actor-boundary NLR call sites to real NlrCatch prepend (BT-3171)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/actor_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/actor_codegen.rs
@@ -548,30 +548,33 @@ impl CoreErlangGenerator {
                 None
             };
 
-            // Generate method body with reply tuple (reuse existing codegen)
-            // BT-1482: Capture result so we can clean up NLR token and scope
-            // unconditionally, then propagate error afterwards.
-            let method_body_result = self.generate_method_definition_body_with_reply(method);
+            // Lower the method body (reuse existing codegen). BT-1482: Capture
+            // result so we can clean up NLR token and scope unconditionally,
+            // then propagate error afterwards.
+            let lowered = self.lower_method_definition_body_with_reply(method);
 
             self.set_current_nlr_token(None);
 
             // If codegen failed, pop scope before propagating the error.
-            let method_body_doc = match method_body_result {
-                Ok(doc) => doc,
+            let stmts = match lowered {
+                Ok(stmts) => stmts,
                 Err(e) => {
                     self.pop_scope();
                     return Err(e);
                 }
             };
 
-            // BT-761/BT-764: Sealed methods are standalone functions (not inside case arms),
-            // so the try/catch can be placed directly at function level (no letrec needed).
-            // BT-774: Compose at Document level without intermediate string rendering.
-            let method_body_doc = if let Some(ref token_var) = nlr_token_var {
-                self.wrap_actor_body_with_nlr_catch(method_body_doc, token_var, false)
-            } else {
-                method_body_doc
-            };
+            // BT-3171 (ADR 0111 Addendum 4/6): prepend a real `NlrCatch` stmt
+            // and verify+render once, instead of rendering the body then
+            // wrapping the `Document`. BT-761/BT-764: Sealed methods are
+            // standalone functions (not inside case arms), so the try/catch
+            // can be placed directly at function level (no letrec needed).
+            let span = method
+                .body
+                .first()
+                .map_or_else(|| method.span, |s| s.expression.span());
+            let method_body_doc =
+                self.prepend_nlr_catch_and_render(stmts, nlr_token_var.as_deref(), span, false);
 
             // BT-940: Annotate the `fun` expression (not just the body) with source line.
             // Annotating the body would create invalid `( ( e -| [...] ) -| [...] )` when the

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/basic_ops.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/list_ops/basic_ops.rs
@@ -131,7 +131,7 @@ impl CoreErlangGenerator {
                 ]
             } else {
                 // BT-1276: Re-pack updated locals into StateAcc so the outer method-body
-                // threading (`maps:get` in `generate_method_body_with_reply`) can extract them.
+                // threading (`maps:get` in `lower_body_exprs_with_reply`) can extract them.
                 let (repack_doc, stateacc) = plan.append_repack_stateacc_doc(self);
                 docvec![
                     " in let ",

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/dispatch.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/dispatch.rs
@@ -342,8 +342,8 @@ impl CoreErlangGenerator {
             None
         };
 
-        let body_doc = match self.generate_method_body_with_reply(block) {
-            Ok(doc) => doc,
+        let stmts = match self.lower_method_body_with_reply(block) {
+            Ok(stmts) => stmts,
             Err(e) => {
                 self.set_current_nlr_token(None);
                 self.pop_scope();
@@ -352,13 +352,16 @@ impl CoreErlangGenerator {
         };
         self.set_current_nlr_token(None);
 
-        // BT-761/BT-764: Wrap body in letrec function with try/catch via shared helper.
-        // BT-774: Compose at Document level without intermediate string rendering.
-        let body_doc = if let Some(ref token_var) = nlr_token_var {
-            self.wrap_actor_body_with_nlr_catch(body_doc, token_var, true)
-        } else {
-            body_doc
-        };
+        // BT-3171 (ADR 0111 Addendum 4/6): prepend a real `NlrCatch` stmt and
+        // verify+render once, instead of rendering the body then wrapping the
+        // `Document`. BT-761/BT-764: the body sits inside a `case` arm, so it
+        // still needs the letrec function frame when NLR is present.
+        let span = block
+            .body
+            .first()
+            .map_or_else(|| block.span, |s| s.expression.span());
+        let body_doc =
+            self.prepend_nlr_catch_and_render(stmts, nlr_token_var.as_deref(), span, true);
 
         let clause_doc = Self::build_dispatch_clause(name, &param_vars, body_doc);
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/extensions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/extensions.rs
@@ -339,11 +339,11 @@ impl CoreErlangGenerator {
             None
         };
 
-        let body_result = self.generate_method_definition_body_with_reply(method);
+        let lowered = self.lower_method_definition_body_with_reply(method);
         self.set_current_nlr_token(None);
 
-        let body_doc = match body_result {
-            Ok(doc) => doc,
+        let stmts = match lowered {
+            Ok(stmts) => stmts,
             Err(e) => {
                 self.pop_scope();
                 self.context = prev_context;
@@ -351,11 +351,16 @@ impl CoreErlangGenerator {
             }
         };
 
-        let body_doc = if let Some(ref token_var) = nlr_token_var {
-            self.wrap_actor_body_with_nlr_catch(body_doc, token_var, false)
-        } else {
-            body_doc
-        };
+        // BT-3171 (ADR 0111 Addendum 4/6): prepend a real `NlrCatch` stmt and
+        // verify+render once, instead of rendering the body then wrapping the
+        // `Document`. Extension funs are standalone functions (not inside
+        // case arms), so no letrec is needed.
+        let span = method
+            .body
+            .first()
+            .map_or_else(|| method.span, |s| s.expression.span());
+        let body_doc =
+            self.prepend_nlr_catch_and_render(stmts, nlr_token_var.as_deref(), span, false);
 
         self.pop_scope();
         self.context = prev_context;

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -372,27 +372,17 @@ impl CoreErlangGenerator {
         Ok(result_doc)
     }
 
-    /// Generates a method definition body wrapped in a reply tuple.
-    ///
-    /// For `MethodDefinition` nodes with explicit body expressions.
-    /// Delegates to [`Self::generate_body_exprs_with_reply`].
-    pub(in crate::codegen::core_erlang) fn generate_method_definition_body_with_reply(
-        &mut self,
-        method: &MethodDefinition,
-    ) -> Result<Document<'static>> {
-        let body = super::super::util::collect_body_exprs(&method.body);
-        self.generate_body_exprs_with_reply(&body, true)
-    }
-
-    /// BT-3148 (ADR 0111 Addendum 4 task 2): lowering-only counterpart of
-    /// [`Self::generate_method_definition_body_with_reply`], returning the
-    /// raw `Vec<ThreadedStmt>` instead of rendering it. Used by
-    /// [`Self::generate_method_dispatch`], which needs the IR itself so it
-    /// can prepend a real `NlrCatch` stmt (token already minted, in
+    /// BT-3148 (ADR 0111 Addendum 4 task 2): lowering-only counterpart of the
+    /// old `generate_method_definition_body_with_reply` (deleted BT-3171 once
+    /// its last caller migrated off it), returning the raw `Vec<ThreadedStmt>`
+    /// instead of rendering it. Used by [`Self::generate_method_dispatch`]
+    /// and, since BT-3171, the other Actor-boundary NLR call sites (sealed
+    /// methods, actor extension funs), all of which need the IR itself so
+    /// they can prepend a real `NlrCatch` stmt (token already minted, in
     /// production's real mint position) before the single `verify()` +
     /// `render()` pass — rather than rendering the body first and wrapping
     /// the resulting `Document` afterward.
-    fn lower_method_definition_body_with_reply(
+    pub(in crate::codegen::core_erlang) fn lower_method_definition_body_with_reply(
         &mut self,
         method: &MethodDefinition,
     ) -> Result<Vec<threaded_ir::ThreadedStmt>> {
@@ -425,14 +415,41 @@ impl CoreErlangGenerator {
             .map_or_else(|| method.span, |s| s.expression.span());
         let lowered = self.lower_method_definition_body_with_reply(method);
         self.set_current_nlr_token(None);
-        let mut stmts = lowered?;
+        let stmts = lowered?;
 
-        if let Some(ref token_var) = nlr_token_var {
+        // Case-arm context (dispatch clause): always needs the letrec frame
+        // when NLR is present — see `prepend_nlr_catch_and_render`'s doc.
+        Ok(self.prepend_nlr_catch_and_render(stmts, nlr_token_var.as_deref(), span, true))
+    }
+
+    /// BT-3171 (ADR 0111 Addendum 4/6): shared tail step for every
+    /// Actor-boundary NLR call site — prepends a real `ThreadedStmt::NlrCatch`
+    /// (when `nlr_token_var` is `Some`; the token is already minted, in
+    /// production's real mint position, by the caller) to an already-lowered
+    /// method body, then verifies and renders the whole sequence in one pass.
+    /// Replaces the old two-step "render body, then
+    /// `wrap_actor_body_with_nlr_catch` the rendered `Document`" shape.
+    ///
+    /// `needs_letrec` mirrors `wrap_actor_body_with_nlr_catch`'s own
+    /// parameter of the same name: `true` when the try/catch would otherwise
+    /// nest inside a `case` arm (dispatch clauses — BEAM validator
+    /// `ambiguous_catch_try_state`), `false` for standalone functions (sealed
+    /// methods, extension funs) that don't need the extra function frame. No
+    /// letrec is emitted when `nlr_token_var` is `None` regardless of
+    /// `needs_letrec` — there is no try/catch to isolate.
+    pub(in crate::codegen::core_erlang) fn prepend_nlr_catch_and_render(
+        &mut self,
+        mut stmts: Vec<threaded_ir::ThreadedStmt>,
+        nlr_token_var: Option<&str>,
+        span: Span,
+        needs_letrec: bool,
+    ) -> Document<'static> {
+        if let Some(token_var) = nlr_token_var {
             stmts.insert(
                 0,
                 threaded_ir::ThreadedStmt::NlrCatch {
                     boundary: super::super::NlrBoundary::ActorReply,
-                    token: threaded_ir::TokenId::new(token_var.clone()),
+                    token: threaded_ir::TokenId::new(token_var.to_string()),
                     frame: threaded_ir::FrameId::ROOT,
                     span,
                 },
@@ -447,7 +464,7 @@ impl CoreErlangGenerator {
         // already produced the try/catch itself; the letrec is a Document-level
         // wrapper around that, unchanged from `wrap_actor_body_with_nlr_catch`'s
         // own `needs_letrec` shape.
-        Ok(if nlr_token_var.is_some() {
+        if needs_letrec && nlr_token_var.is_some() {
             docvec![
                 "letrec '__nlr_body'/0 = fun () ->\n",
                 rendered_body,
@@ -456,19 +473,23 @@ impl CoreErlangGenerator {
             ]
         } else {
             rendered_body
-        })
+        }
     }
 
-    /// Generates a block-based method body with state threading and reply tuple.
-    ///
-    /// For methods using block syntax with implicit returns.
-    /// Delegates to [`Self::generate_body_exprs_with_reply`].
-    pub(in crate::codegen::core_erlang) fn generate_method_body_with_reply(
+    /// BT-3171 (ADR 0111 Addendum 4/6): lowering-only counterpart of the old
+    /// `generate_method_body_with_reply` (deleted BT-3171 once its last
+    /// caller migrated off it), returning the raw `Vec<ThreadedStmt>` instead
+    /// of rendering it — the Block-based sibling of
+    /// [`Self::lower_method_definition_body_with_reply`]. Used by
+    /// `generate_legacy_method_clause` (top-level `name := [block]`
+    /// workspace bindings), which needs the IR itself so it can prepend a
+    /// real `NlrCatch` stmt before the single verify+render pass.
+    pub(in crate::codegen::core_erlang) fn lower_method_body_with_reply(
         &mut self,
         block: &Block,
-    ) -> Result<Document<'static>> {
+    ) -> Result<Vec<threaded_ir::ThreadedStmt>> {
         let body = super::super::util::collect_body_exprs(&block.body);
-        self.generate_body_exprs_with_reply(&body, false)
+        self.lower_body_exprs_with_reply(&body, false)
     }
 
     // ── BT-1422: Unified method body state-threading ──────────────────
@@ -876,27 +897,6 @@ impl CoreErlangGenerator {
         }
 
         BodyExprKind::Pure
-    }
-
-    /// Unified method body code generation with state threading and reply tuple.
-    ///
-    /// Both `generate_method_definition_body_with_reply` (for `MethodDefinition`)
-    /// and `generate_method_body_with_reply` (for `Block`) delegate here.
-    ///
-    /// BT-3148 (ADR 0111 Addendum 4): thin wrapper over
-    /// [`Self::lower_body_exprs_with_reply`] (one real `Vec<ThreadedStmt>`
-    /// per body) + [`Self::verify_and_render_body_stmts`] (one `verify()`
-    /// call, one [`threaded_ir::render`] call). Callers that need the IR
-    /// itself — `generate_method_dispatch`'s NLR wrap — call the lowering
-    /// step directly.
-    fn generate_body_exprs_with_reply(
-        &mut self,
-        body: &[&Expression],
-        supports_early_return: bool,
-    ) -> Result<Document<'static>> {
-        let span = body.first().map_or_else(Span::default, |e| e.span());
-        let stmts = self.lower_body_exprs_with_reply(body, supports_early_return)?;
-        Ok(self.verify_and_render_body_stmts(&stmts, span))
     }
 
     /// BT-3148: verifies a lowered method-body IR once (via

--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -139,7 +139,7 @@ pub(crate) fn extract_package_from_module_name(module_name: &str) -> Option<Stri
 
 /// Classification of how a method body expression should be handled for
 /// state threading.  Produced by [`CoreErlangGenerator::classify_body_expr`]
-/// and consumed by the unified [`CoreErlangGenerator::generate_body_exprs_with_reply`]
+/// and consumed by the unified [`CoreErlangGenerator::lower_body_exprs_with_reply`]
 /// and [`CoreErlangGenerator::generate_conditional_branch_inline`].
 pub(in crate::codegen::core_erlang) enum BodyExprKind {
     /// `^ value` — early return from method.
@@ -281,7 +281,7 @@ impl CoreErlangGenerator {
         // BT-851: Populate tier2_block_params for this method from pre-scanned info
         self.tier2_block_params.clear();
         // BT-2797: Reset the same-method local-var tracking. The real
-        // (re-)population happens inside generate_body_exprs_with_reply via
+        // (re-)population happens inside lower_body_exprs_with_reply via
         // prescan_tier2_local_vars — this clear here is belt-and-suspenders
         // for the case where a caller inspects the field between the clear
         // and the body being generated.
@@ -513,7 +513,7 @@ impl CoreErlangGenerator {
     /// that would otherwise qualify as safe. A nested block literal compiles
     /// through a completely separate path
     /// (`generate_block_body_slice`/`BlockExprKind` in `expressions.rs`, not
-    /// `generate_body_exprs_with_reply`/`BodyExprKind` here) that has no
+    /// `lower_body_exprs_with_reply`/`BodyExprKind` here) that has no
     /// Tier2-tuple-unpacking logic and never resets `tier2_local_vars` for
     /// its own body — so a "safe-looking" `value:` call on a promoted var
     /// found inside a nested block either leaks an unpacked

--- a/crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/intrinsics.rs
@@ -2479,7 +2479,7 @@ impl CoreErlangGenerator {
                         // Avoids sync_send(self()) → gen_server:call(self(), ...) → deadlock.
                         //
                         // BT-1324: Method-body-level state threading is handled by
-                        // generate_method_body_with_reply via is_self_field_at_put/
+                        // lower_body_exprs_with_reply via is_self_field_at_put/
                         // generate_self_field_at_put_open, which intercepts before
                         // expression_doc is called. This intrinsic path is a
                         // deadlock-avoidance fallback for contexts where method-body

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -1058,10 +1058,11 @@ pub(crate) enum CodeGenContext {
 ///
 /// Allocated by [`CoreErlangGenerator::alloc_nlr_catch_vars`] and consumed by the
 /// single boundary-parameterised wrapper [`CoreErlangGenerator::wrap_body_with_nlr_catch`]
-/// (via [`CoreErlangGenerator::wrap_actor_body_with_nlr_catch`]; the class-method
-/// boundary variant, `wrap_class_method_body_with_nlr_catch`, was deleted by BT-3164
-/// once its sole caller — `generate_class_method_fun_from_block` — migrated to
-/// prepending a real `ThreadedStmt::NlrCatch` instead) and by
+/// (the class-method boundary variant, `wrap_class_method_body_with_nlr_catch`, was
+/// deleted by BT-3164 once its sole caller — `generate_class_method_fun_from_block` —
+/// migrated to prepending a real `ThreadedStmt::NlrCatch` instead; the Actor boundary
+/// variant, `wrap_actor_body_with_nlr_catch`, was deleted the same way by BT-3171 once
+/// its last of 3 remaining callers migrated) and by
 /// [`CoreErlangGenerator::wrap_value_type_body_with_nlr_catch`].
 #[allow(clippy::struct_field_names)]
 struct NlrCatchVars {
@@ -2961,38 +2962,6 @@ impl CoreErlangGenerator {
             val_var: self.fresh_temp_var("NlrVal"),
             state_var: self.fresh_temp_var("NlrState"),
             ot_pair_var: self.fresh_temp_var("OtherPair"),
-        }
-    }
-
-    /// BT-764: Wraps an actor method body with NLR (non-local return) try/catch.
-    ///
-    /// Actor NLR uses a 4-element throw tuple `{$bt_nlr, Token, Value, State}` and
-    /// catches it to produce `{reply, Value, State}`.
-    ///
-    /// When `needs_letrec` is true, the body is wrapped in a `letrec` function to
-    /// create a separate function frame, avoiding BEAM validator
-    /// `ambiguous_catch_try_state` errors in case arms. When false (sealed methods),
-    /// the try/catch is emitted directly.
-    ///
-    /// BT-774: Accepts and returns `Document` instead of `String` to avoid
-    /// intermediate string rendering.
-    pub(super) fn wrap_actor_body_with_nlr_catch(
-        &mut self,
-        body_doc: Document<'static>,
-        token_var: &str,
-        needs_letrec: bool,
-    ) -> Document<'static> {
-        let try_catch = self.wrap_body_with_nlr_catch(body_doc, token_var, NlrBoundary::ActorReply);
-
-        if needs_letrec {
-            docvec![
-                "letrec '__nlr_body'/0 = fun () ->\n",
-                try_catch,
-                "\n",
-                "in apply '__nlr_body'/0 ()",
-            ]
-        } else {
-            try_catch
         }
     }
 

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -1746,7 +1746,7 @@ pub(crate) struct CoreErlangGenerator {
     /// block literal has captured-local or field mutations, *and* every later
     /// reference to `var` in the same body is a safe `value`/`value:`/etc.
     /// call (proven by `prescan_tier2_local_vars`, which runs once at the top
-    /// of `generate_body_exprs_with_reply` before classification starts).
+    /// of `lower_body_exprs_with_reply` before classification starts).
     /// `value:` / `value:value:` calls on a variable in this set use the
     /// stateful Tier 2 protocol: `apply _Fun(Args..., State) → {Result, NewState}`.
     /// A block whose safety can't be proven (returned, passed elsewhere,

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -2047,7 +2047,7 @@ fn test_bt2797_local_tier2_block_invoked_inside_nested_do_block_is_still_compile
     // must NOT be treated as a safe use, even though it looks identical to a
     // safe top-level `value:` call. A nested block compiles through a
     // completely separate path (`generate_block_body_slice`/`BlockExprKind`,
-    // not `generate_body_exprs_with_reply`/`BodyExprKind`) that has no
+    // not `lower_body_exprs_with_reply`/`BodyExprKind`) that has no
     // Tier2-tuple-unpacking logic and never resets `tier2_local_vars` for its
     // own body — so wrongly promoting `blk` here would either leak an
     // unpacked `{Result, NewState}` tuple as the inner block's return value,

--- a/crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs
@@ -243,6 +243,52 @@
 //! the vt-conditional family's own permanent ADR-documented exception to
 //! this migration) — audited, not applicable.
 //!
+//! ## Status (as of BT-3171 — the remaining Actor-boundary call sites)
+//!
+//! BT-3171 migrates the 3 Actor-boundary call sites the BT-3164 audit above
+//! named as real, well-understood follow-up: `gen_server/dispatch.rs`'s
+//! `generate_legacy_method_clause`, `gen_server/extensions.rs`'s
+//! `generate_actor_extension_fun`, and `actor_codegen.rs`'s sealed-method
+//! generator. Each now lowers its body (via
+//! `gen_server/methods.rs::lower_method_definition_body_with_reply` — widened
+//! from `gen_server::methods`-private to `pub(in
+//! crate::codegen::core_erlang)`, mirroring `generate_method_dispatch`'s own
+//! caller — or the new Block-based sibling `lower_method_body_with_reply`,
+//! for `dispatch.rs`'s Block-shaped legacy clause), prepends a real
+//! `ThreadedStmt::NlrCatch` when NLR was detected, and runs the whole
+//! sequence through the SAME `verify_and_render_body_stmts` call — replacing
+//! the "render body, then `wrap_actor_body_with_nlr_catch` the rendered
+//! `Document`" shape. The three call sites' shared tail (prepend + verify +
+//! render + the `needs_letrec`-gated `letrec` wrapper) is itself extracted
+//! once as `gen_server/methods.rs::prepend_nlr_catch_and_render`, reused by
+//! `generate_method_dispatch`'s own (BT-3148) NLR call site too rather than
+//! left duplicated inline.
+//!
+//! As the BT-3164 audit noted, none of these three carry the ADR 0110
+//! `ShadowWriteMissing` joint-visibility gap that migration closed for class
+//! methods — they are all `State`-prefix (Actor) bodies, and that check only
+//! fires for `VersionPrefix::ClassVars` `Bind`s — so this migration is
+//! architectural consistency cleanup, not a verification-gap closure.
+//!
+//! With all Actor- and class-method-boundary callers migrated,
+//! `wrap_actor_body_with_nlr_catch` had no callers left and was deleted
+//! (`mod.rs`), the same way BT-3164 deleted
+//! `wrap_class_method_body_with_nlr_catch`. `wrap_body_with_nlr_catch`
+//! itself remains live: [`render`]'s `NlrCatch` arm (this module) still
+//! calls it directly to build the real try/catch scaffolding. Deleting the
+//! now-unused rendering-only wrappers these three call sites left behind
+//! (`generate_method_definition_body_with_reply`, `generate_method_body_with_reply`,
+//! and their shared `generate_body_exprs_with_reply` helper — all in
+//! `gen_server/methods.rs`, all with zero remaining callers once the
+//! migration landed) mirrors how BT-3164 renamed away
+//! `generate_class_method_body` rather than leaving a dead rendering path
+//! beside the lowering one.
+//!
+//! `gen_server/extensions.rs`'s OTHER NLR-wrap call site
+//! (`generate_value_extension_fun`, `wrap_value_type_body_with_nlr_catch`)
+//! remains explicitly out of scope, per the BT-3164 audit above — it is not
+//! the same shape at all.
+//!
 //! This module lands the IR types, the [`verify`] checker, and the
 //! [`lower_and_render`] test shim (BT-3129), the unified `VersionedVar`/
 //! `VersionCounter` production path (BT-3131). BT-3132 originally added a


### PR DESCRIPTION
## Summary

Closes [BT-3171](https://linear.app/beamtalk/issue/BT-3171/migrate-remaining-actor-boundary-wrap-actor-body-with-nlr-catch-call).

Migrates the 3 remaining `wrap_actor_body_with_nlr_catch` call sites the [BT-3164](https://linear.app/beamtalk/issue/BT-3164) audit found still wrapping an already-rendered `Document` instead of prepending a real `ThreadedStmt::NlrCatch`:

- `actor_codegen.rs`'s `generate_sealed_method_functions_doc` (sealed Actor methods)
- `gen_server/dispatch.rs`'s `generate_legacy_method_clause` (top-level `name := [block]` workspace bindings)
- `gen_server/extensions.rs`'s `generate_actor_extension_fun`

Each now lowers its body, prepends a real `ThreadedStmt::NlrCatch` (token minted before lowering, matching production's real mint order), and runs the whole sequence through a single `verify_and_render_body_stmts` call — mirroring the pattern BT-3148/BT-3164 already established for `generate_method_dispatch`/`generate_class_method_functions`.

## Changes

- `lower_method_definition_body_with_reply` widened from `gen_server::methods`-private to `pub(in crate::codegen::core_erlang)`.
- New Block-based sibling `lower_method_body_with_reply` added for `dispatch.rs`'s Block-shaped legacy clause.
- The shared prepend-NlrCatch + verify + render + `needs_letrec`-gated `letrec` tail is extracted once as `prepend_nlr_catch_and_render`, reused by `generate_actor_method_body_with_nlr`'s own (BT-3148) call site too rather than left duplicated inline.
- With every Actor/class-method NLR call site now migrated, `wrap_actor_body_with_nlr_catch` has no callers left and is deleted — mirroring how BT-3164 deleted `wrap_class_method_body_with_nlr_catch`. `wrap_body_with_nlr_catch` remains live: `threaded_ir.rs`'s `NlrCatch` render arm still calls it directly.
- The now-dead rendering-only wrappers these three call sites left behind (`generate_method_definition_body_with_reply`, `generate_method_body_with_reply`, and their shared `generate_body_exprs_with_reply` helper) are deleted too, since they had zero remaining callers once the migration landed.
- Added a "Status (as of BT-3171)" section to `threaded_ir.rs`'s module doc, following this file's established per-migration status-log convention.

None of these three call sites carry the ADR 0110 `ShadowWriteMissing` joint-visibility gap BT-3164 closed for class methods (that check only fires for `VersionPrefix::ClassVars` `Bind`s, and these are all Actor/`State`-prefix bodies) — this migration is architectural consistency cleanup, not a verification-gap closure. `gen_server/extensions.rs`'s other NLR-wrap call site (`generate_value_extension_fun`, `wrap_value_type_body_with_nlr_catch`) is explicitly out of scope, per ADR 0111's permanent exception for the vt-conditional family.

## Test plan

- [x] `cargo build -p beamtalk-core` — clean, no warnings (confirms no dead code left behind)
- [x] `cargo test -p test-package-compiler` — 478 passed, byte-identical snapshot corpus
- [x] `just verify-threaded-ir` — no invariant violations across stdlib + bootstrap-test corpus
- [x] `just test` — Rust, stdlib, BUnit, runtime, and metamorphic suites all pass
- [x] `just ci-changed` — build/clippy/fmt/lint/corpus/surface-drift all pass
- [x] Pre-push hooks (clippy, Dialyzer, Erlang/Elixir/JS formatting) all pass

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABjvyJBpsmh7pAFMzp7TPh)_