### PR TITLE
fix: reject class-var mutation lost across nested loops (BT-3172)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -1416,6 +1416,22 @@ pub(super) enum BodyKind {
     FoldlSort,
 }
 
+/// BT-3172: which family a [`Self::nested_loop_or_fold_body`] match belongs
+/// to — `ThreadingPlan::threads_class_vars` uses a genuinely different
+/// formula for each (see that field's doc comment), so
+/// [`Self::nested_loop_lost_class_var_mutation`] must apply the matching
+/// one rather than a single one-size-fits-all check.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum NestedLoopShape {
+    /// `whileTrue:`/`whileFalse:`/`timesRepeat:`/`to:do:`/`to:by:do:` — the
+    /// `BodyKind::Letrec` shapes, gated by the narrow, top-level-only
+    /// `loop_body_threads_class_vars`.
+    Letrec,
+    /// `do:`/`collect:`/`select:`/... — the `BodyKind::Foldl*` shapes,
+    /// gated by the recursive, Actor-excluded `has_self_sends` formula.
+    Foldl,
+}
+
 // ─── CountedLoopFrame ─────────────────────────────────────────────────────────
 
 /// Describes the loop-type-specific structure of a counted (`letrec`-based) loop.
@@ -1659,7 +1675,7 @@ impl CoreErlangGenerator {
     /// diagnostic) — so this predicate exists purely to reject the shape,
     /// not to make it work.
     pub(super) fn nested_loop_lost_class_var_mutation(&self, expr: &Expression) -> Option<String> {
-        let body = Self::nested_loop_or_fold_body(expr)?;
+        let (body, shape) = Self::nested_loop_or_fold_body(expr)?;
         if let Some(mutating_stmt) = self.find_class_var_mutating_stmt(body) {
             if Self::is_field_assignment(mutating_stmt)
                 && self.is_class_var_assignment(mutating_stmt)
@@ -1673,14 +1689,34 @@ impl CoreErlangGenerator {
                 return Some(format!("'self {}'", selector.name()));
             }
         }
-        if self.in_class_method() {
+        // BT-3172 review: the recursive self-send fallback must match
+        // `ThreadingPlan::new_impl`'s OWN per-shape gate exactly, not apply
+        // uniformly to both shapes. `Letrec`'s real gate
+        // (`loop_body_threads_class_vars`, already checked above) is
+        // deliberately top-level-only — recursing into a conditional
+        // buried inside a `Letrec` body is EXACTLY the shape that predicate
+        // was narrowed to exclude (the `class_var_subexpr.bt`
+        // `tickInLoopConditional` regression), and it's also the shape
+        // `class_var_subexpr_test.bt`'s `testTickInLoopConditionalCompilesAndRuns`
+        // pins as already-accepted, out-of-scope, silently-non-threading
+        // behavior (BT-2308) at a single loop level — rejecting only the
+        // nested-loop variant of that exact same shape would be an
+        // inconsistent, surprising new restriction this predicate has no
+        // business introducing. Only `Foldl*`'s own real gate
+        // (`!Actor && in_class_method() && body_analysis.has_self_sends`)
+        // is genuinely recursive, so the fallback below applies only when
+        // `shape` is `Foldl` — matching `context` too.
+        if matches!(shape, NestedLoopShape::Foldl)
+            && !matches!(self.context, CodeGenContext::Actor)
+            && self.in_class_method()
+        {
             let analysis = block_analysis::analyze_block(body);
-            // BT-3172 review: `self_send_selectors` is a `HashSet` (default
-            // `RandomState`) — pick the lexicographically-smallest selector
-            // so the diagnostic text is reproducible across runs for
-            // identical source, rather than depending on hash-iteration
-            // order. Which selector is named doesn't affect the
-            // accept/reject decision, only the message.
+            // `self_send_selectors` is a `HashSet` (default `RandomState`) —
+            // pick the lexicographically-smallest selector so the
+            // diagnostic text is reproducible across runs for identical
+            // source, rather than depending on hash-iteration order. Which
+            // selector is named doesn't affect the accept/reject decision,
+            // only the message.
             if let Some(selector) = analysis.self_send_selectors.iter().min() {
                 return Some(format!("'self {selector}'"));
             }
@@ -1688,14 +1724,15 @@ impl CoreErlangGenerator {
         None
     }
 
-    /// Extracts the body block of `expr` if it is a nested loop/fold send —
-    /// the `BodyKind::Letrec` shapes (`whileTrue:`/`whileFalse:`/
-    /// `timesRepeat:`/`to:do:`/`to:by:do:`, see this module's `//!` doc
-    /// comment) or the `BodyKind::Foldl*` shapes (`do:`/`collect:`/
-    /// `select:`/`reject:`/`anySatisfy:`/`allSatisfy:`/`inject:into:`/
-    /// `detect:`/`count:`/`takeWhile:`/`dropWhile:`/`partition:`/
-    /// `groupBy:`). Unlike the analogous local-variable cross-scope-mutation
-    /// analysis in [`Self::list_op_needs_stateacc_fallback`]/
+    /// Extracts the body block of `expr`, and which family it belongs to,
+    /// if it is a nested loop/fold send — the `BodyKind::Letrec` shapes
+    /// (`whileTrue:`/`whileFalse:`/`timesRepeat:`/`to:do:`/`to:by:do:`, see
+    /// this module's `//!` doc comment) or the `BodyKind::Foldl*` shapes
+    /// (`do:`/`collect:`/`select:`/`reject:`/`anySatisfy:`/`allSatisfy:`/
+    /// `inject:into:`/`detect:`/`count:`/`takeWhile:`/`dropWhile:`/
+    /// `partition:`/`groupBy:`). Unlike the analogous local-variable
+    /// cross-scope-mutation analysis in
+    /// [`Self::list_op_needs_stateacc_fallback`]/
     /// [`Self::collect_list_op_cross_scope_mutations`] (which safely omit
     /// the predicate-based shapes — a narrower, unrelated optimization
     /// concern), this list must cover every `Foldl*` `BodyKind`: per
@@ -1707,8 +1744,12 @@ impl CoreErlangGenerator {
     /// vulnerable to this predicate's silent-loss/`erlc`-crash bug as one
     /// nested inside `do:`. `detect:ifNone:` is intentionally excluded: its
     /// second (`ifNone:`) block argument is a separate, not-yet-analyzed
-    /// risk surface this predicate doesn't attempt to cover.
-    fn nested_loop_or_fold_body(expr: &Expression) -> Option<&crate::ast::Block> {
+    /// risk surface this predicate doesn't attempt to cover. The returned
+    /// [`NestedLoopShape`] tells [`Self::nested_loop_lost_class_var_mutation`]
+    /// which of `ThreadingPlan`'s two `threads_class_vars` gates applies.
+    fn nested_loop_or_fold_body(
+        expr: &Expression,
+    ) -> Option<(&crate::ast::Block, NestedLoopShape)> {
         use crate::ast::MessageSelector;
         let Expression::MessageSend {
             selector: MessageSelector::Keyword(parts),
@@ -1720,22 +1761,31 @@ impl CoreErlangGenerator {
         };
         let sel: String = parts.iter().map(|p| p.keyword.as_str()).collect();
         match sel.as_str() {
-            "whileTrue:" | "whileFalse:" | "do:" | "collect:" | "select:" | "reject:"
-            | "anySatisfy:" | "allSatisfy:" | "detect:" | "count:" | "takeWhile:"
-            | "dropWhile:" | "partition:" | "groupBy:" => match arguments.first() {
-                Some(Expression::Block(block)) => Some(block),
+            "whileTrue:" | "whileFalse:" => match arguments.first() {
+                Some(Expression::Block(block)) => Some((block, NestedLoopShape::Letrec)),
                 _ => None,
             },
+            "do:" | "collect:" | "select:" | "reject:" | "anySatisfy:" | "allSatisfy:"
+            | "detect:" | "count:" | "takeWhile:" | "dropWhile:" | "partition:" | "groupBy:" => {
+                match arguments.first() {
+                    Some(Expression::Block(block)) => Some((block, NestedLoopShape::Foldl)),
+                    _ => None,
+                }
+            }
             "timesRepeat:" => match arguments.last() {
-                Some(Expression::Block(block)) => Some(block),
+                Some(Expression::Block(block)) => Some((block, NestedLoopShape::Letrec)),
                 _ => None,
             },
-            "to:do:" | "inject:into:" if arguments.len() == 2 => match &arguments[1] {
-                Expression::Block(block) => Some(block),
+            "to:do:" if arguments.len() == 2 => match &arguments[1] {
+                Expression::Block(block) => Some((block, NestedLoopShape::Letrec)),
+                _ => None,
+            },
+            "inject:into:" if arguments.len() == 2 => match &arguments[1] {
+                Expression::Block(block) => Some((block, NestedLoopShape::Foldl)),
                 _ => None,
             },
             "to:by:do:" if arguments.len() == 3 => match &arguments[2] {
-                Expression::Block(block) => Some(block),
+                Expression::Block(block) => Some((block, NestedLoopShape::Letrec)),
                 _ => None,
             },
             _ => None,

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -1675,7 +1675,13 @@ impl CoreErlangGenerator {
         }
         if self.in_class_method() {
             let analysis = block_analysis::analyze_block(body);
-            if let Some(selector) = analysis.self_send_selectors.iter().next() {
+            // BT-3172 review: `self_send_selectors` is a `HashSet` (default
+            // `RandomState`) — pick the lexicographically-smallest selector
+            // so the diagnostic text is reproducible across runs for
+            // identical source, rather than depending on hash-iteration
+            // order. Which selector is named doesn't affect the
+            // accept/reject decision, only the message.
+            if let Some(selector) = analysis.self_send_selectors.iter().min() {
                 return Some(format!("'self {selector}'"));
             }
         }
@@ -1685,14 +1691,23 @@ impl CoreErlangGenerator {
     /// Extracts the body block of `expr` if it is a nested loop/fold send —
     /// the `BodyKind::Letrec` shapes (`whileTrue:`/`whileFalse:`/
     /// `timesRepeat:`/`to:do:`/`to:by:do:`, see this module's `//!` doc
-    /// comment) or the most common `BodyKind::Foldl*` shapes (`do:`/
-    /// `collect:`/`select:`/`reject:`/`anySatisfy:`/`allSatisfy:`/
-    /// `inject:into:` — the same set [`Self::list_op_needs_stateacc_fallback`]/
-    /// [`Self::collect_list_op_cross_scope_mutations`] special-case for the
-    /// analogous local-variable cross-scope-mutation analysis; the less
-    /// common predicate-based fold shapes — `detect:`/`count:`/
-    /// `takeWhile:`/... — are out of scope here for the same reason they're
-    /// out of scope there).
+    /// comment) or the `BodyKind::Foldl*` shapes (`do:`/`collect:`/
+    /// `select:`/`reject:`/`anySatisfy:`/`allSatisfy:`/`inject:into:`/
+    /// `detect:`/`count:`/`takeWhile:`/`dropWhile:`/`partition:`/
+    /// `groupBy:`). Unlike the analogous local-variable cross-scope-mutation
+    /// analysis in [`Self::list_op_needs_stateacc_fallback`]/
+    /// [`Self::collect_list_op_cross_scope_mutations`] (which safely omit
+    /// the predicate-based shapes — a narrower, unrelated optimization
+    /// concern), this list must cover every `Foldl*` `BodyKind`: per
+    /// `ThreadingPlan::new_impl`'s `else` branch (~line 607), ALL of them —
+    /// not just `do:`/`collect:`/etc. — share the exact same
+    /// `threads_class_vars` gate (`!Actor && in_class_method() &&
+    /// body_analysis.has_self_sends`) and the same `{ClassVars, tail}` wrap,
+    /// so a class-var self-send nested inside e.g. `detect:` is exactly as
+    /// vulnerable to this predicate's silent-loss/`erlc`-crash bug as one
+    /// nested inside `do:`. `detect:ifNone:` is intentionally excluded: its
+    /// second (`ifNone:`) block argument is a separate, not-yet-analyzed
+    /// risk surface this predicate doesn't attempt to cover.
     fn nested_loop_or_fold_body(expr: &Expression) -> Option<&crate::ast::Block> {
         use crate::ast::MessageSelector;
         let Expression::MessageSend {
@@ -1706,7 +1721,8 @@ impl CoreErlangGenerator {
         let sel: String = parts.iter().map(|p| p.keyword.as_str()).collect();
         match sel.as_str() {
             "whileTrue:" | "whileFalse:" | "do:" | "collect:" | "select:" | "reject:"
-            | "anySatisfy:" | "allSatisfy:" => match arguments.first() {
+            | "anySatisfy:" | "allSatisfy:" | "detect:" | "count:" | "takeWhile:"
+            | "dropWhile:" | "partition:" | "groupBy:" => match arguments.first() {
                 Some(Expression::Block(block)) => Some(block),
                 _ => None,
             },

--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/mod.rs
@@ -1574,36 +1574,156 @@ impl CoreErlangGenerator {
     /// tuple-shape decision can never independently drift out of sync
     /// (CLAUDE.md's no-duplicate-implementations rule).
     pub(super) fn loop_body_threads_class_vars(&self, body: &crate::ast::Block) -> bool {
+        self.find_class_var_mutating_stmt(body).is_some()
+    }
+
+    /// Shared predicate behind [`Self::loop_body_threads_class_vars`] and
+    /// [`Self::nested_loop_lost_class_var_mutation`] (BT-3172) — returns the
+    /// first top-level statement of `body` that is a bare class-var
+    /// assignment or class-method self-send, or `None` if there isn't one.
+    ///
+    /// Deliberately narrower than `block_analysis::analyze_block`'s own
+    /// (recursive) `field_writes`/`has_self_sends` — those also count a
+    /// class-var write or self-send NESTED inside a conditional, a binary
+    /// op, or any other sub-expression position, which is exactly right
+    /// for THEIR job (deciding whether the body needs `StateAcc` fallback
+    /// at all) but wrong for this one: `generate_threaded_loop_body_inner`
+    /// only ever threads `ClassVars` through the loop's tail call for a
+    /// BARE, top-level class-var-assignment or class-method-self-send
+    /// STATEMENT (the two shapes it has real Bind-construction branches
+    /// for) — never for one buried inside a larger expression, whose own
+    /// `ClassVarsN` rebind is scoped to that expression's own nested
+    /// `let`, not threaded out to the loop body's own statement sequence.
+    /// Confirmed by a real regression while validating this issue: a
+    /// pre-existing, previously-compiling fixture
+    /// (`class_var_subexpr.bt`'s `tickInLoopConditional`, a self-send
+    /// nested inside a `to:do:` body's `ifTrue:` *condition*) started
+    /// emitting `unbound variable 'ClassVars1'` once this predicate used
+    /// the recursive analysis — the self-send's own internally-minted
+    /// rebind was correctly scoped to its own conditional's nested `let`,
+    /// but this predicate's resulting extra loop-level `ClassVars` fun
+    /// parameter/tail-call argument then referenced that same
+    /// already-out-of-scope name.
+    fn find_class_var_mutating_stmt<'a>(
+        &self,
+        body: &'a crate::ast::Block,
+    ) -> Option<&'a Expression> {
         if !self.in_class_method() {
-            return false;
+            return None;
         }
-        // Deliberately narrower than `block_analysis::analyze_block`'s own
-        // (recursive) `field_writes`/`has_self_sends` — those also count a
-        // class-var write or self-send NESTED inside a conditional, a binary
-        // op, or any other sub-expression position, which is exactly right
-        // for THEIR job (deciding whether the body needs `StateAcc` fallback
-        // at all) but wrong for this one: `generate_threaded_loop_body_inner`
-        // only ever threads `ClassVars` through the loop's tail call for a
-        // BARE, top-level class-var-assignment or class-method-self-send
-        // STATEMENT (the two shapes it has real Bind-construction branches
-        // for) — never for one buried inside a larger expression, whose own
-        // `ClassVarsN` rebind is scoped to that expression's own nested
-        // `let`, not threaded out to the loop body's own statement sequence.
-        // Confirmed by a real regression while validating this issue: a
-        // pre-existing, previously-compiling fixture
-        // (`class_var_subexpr.bt`'s `tickInLoopConditional`, a self-send
-        // nested inside a `to:do:` body's `ifTrue:` *condition*) started
-        // emitting `unbound variable 'ClassVars1'` once this predicate used
-        // the recursive analysis — the self-send's own internally-minted
-        // rebind was correctly scoped to its own conditional's nested `let`,
-        // but this predicate's resulting extra loop-level `ClassVars` fun
-        // parameter/tail-call argument then referenced that same
-        // already-out-of-scope name.
         let filtered_body = super::util::collect_body_exprs(&body.body);
-        filtered_body.iter().any(|expr| {
+        filtered_body.into_iter().find(|expr| {
             (Self::is_field_assignment(expr) && self.is_class_var_assignment(expr))
                 || self.is_class_method_self_send(expr)
         })
+    }
+
+    /// BT-3172: if `expr` is itself a nested `Letrec`- or `Foldl*`-shaped
+    /// loop (per [`Self::nested_loop_or_fold_body`]) whose own body would
+    /// thread a `ClassVars` mutation through its own recursive tail call or
+    /// fold accumulator, returns a short description of that mutation for
+    /// use in [`CodeGenError::ClassVarMutationLostAcrossNestedLoop`]'s
+    /// message. Returns `None` for anything else, including a nested
+    /// loop/fold whose own body has no class-var mutation to lose in the
+    /// first place.
+    ///
+    /// Two independent triggers, matching each shape's own real threading
+    /// gate:
+    /// * [`Self::loop_body_threads_class_vars`] — a BARE, top-level
+    ///   class-var field write or class-method self-send (the `Letrec`
+    ///   gate, `ThreadingPlan::threads_class_vars`'s `allow_direct_params`
+    ///   branch).
+    /// * `block_analysis::analyze_block(body).has_self_sends` — ANY
+    ///   same-class self-send anywhere in the body, however deeply nested
+    ///   in a conditional or another block (the `Foldl*` gate, that same
+    ///   field's `else` branch) — deliberately recursive here, unlike the
+    ///   first trigger, because that IS how `Foldl*`'s own
+    ///   `ThreadingPlan::new_impl` decides `threads_class_vars`. A bare
+    ///   class-var field write inside a `Foldl*` body needs no matching
+    ///   trigger here: `generate_field_assignment_open` never threads one
+    ///   regardless of nesting (`loop_threads_class_vars` stays scoped to
+    ///   `BodyKind::Letrec`), so it is already unconditionally rejected by
+    ///   `reject_class_var_field_assignment` at any depth.
+    ///
+    /// This is a detection-only predicate, deliberately separate from
+    /// `ThreadingPlan::threads_class_vars`, which stays scoped to the OUTER
+    /// body's own top-level statements (see that field's doc comment)
+    /// rather than being extended to also thread the inner construct's
+    /// `ClassVars` value through — no code path currently unpacks a nested
+    /// loop/fold's `ClassVars` tuple element back into an enclosing body
+    /// (confirmed empirically for the `Foldl*`-in-`Foldl*` shape: the
+    /// nested fold's own `next_class_var()` mint permanently advances the
+    /// generator's single, unscoped class-var-name counter even though the
+    /// resulting name is never surfaced to the enclosing body, producing an
+    /// `erlc` "unbound variable" compile crash rather than a clean
+    /// diagnostic) — so this predicate exists purely to reject the shape,
+    /// not to make it work.
+    pub(super) fn nested_loop_lost_class_var_mutation(&self, expr: &Expression) -> Option<String> {
+        let body = Self::nested_loop_or_fold_body(expr)?;
+        if let Some(mutating_stmt) = self.find_class_var_mutating_stmt(body) {
+            if Self::is_field_assignment(mutating_stmt)
+                && self.is_class_var_assignment(mutating_stmt)
+            {
+                if let Expression::Assignment { target, .. } = mutating_stmt {
+                    if let Expression::FieldAccess { field, .. } = target.as_ref() {
+                        return Some(format!("class variable '{}'", field.name));
+                    }
+                }
+            } else if let Expression::MessageSend { selector, .. } = mutating_stmt {
+                return Some(format!("'self {}'", selector.name()));
+            }
+        }
+        if self.in_class_method() {
+            let analysis = block_analysis::analyze_block(body);
+            if let Some(selector) = analysis.self_send_selectors.iter().next() {
+                return Some(format!("'self {selector}'"));
+            }
+        }
+        None
+    }
+
+    /// Extracts the body block of `expr` if it is a nested loop/fold send —
+    /// the `BodyKind::Letrec` shapes (`whileTrue:`/`whileFalse:`/
+    /// `timesRepeat:`/`to:do:`/`to:by:do:`, see this module's `//!` doc
+    /// comment) or the most common `BodyKind::Foldl*` shapes (`do:`/
+    /// `collect:`/`select:`/`reject:`/`anySatisfy:`/`allSatisfy:`/
+    /// `inject:into:` — the same set [`Self::list_op_needs_stateacc_fallback`]/
+    /// [`Self::collect_list_op_cross_scope_mutations`] special-case for the
+    /// analogous local-variable cross-scope-mutation analysis; the less
+    /// common predicate-based fold shapes — `detect:`/`count:`/
+    /// `takeWhile:`/... — are out of scope here for the same reason they're
+    /// out of scope there).
+    fn nested_loop_or_fold_body(expr: &Expression) -> Option<&crate::ast::Block> {
+        use crate::ast::MessageSelector;
+        let Expression::MessageSend {
+            selector: MessageSelector::Keyword(parts),
+            arguments,
+            ..
+        } = expr.unwrap_parens()
+        else {
+            return None;
+        };
+        let sel: String = parts.iter().map(|p| p.keyword.as_str()).collect();
+        match sel.as_str() {
+            "whileTrue:" | "whileFalse:" | "do:" | "collect:" | "select:" | "reject:"
+            | "anySatisfy:" | "allSatisfy:" => match arguments.first() {
+                Some(Expression::Block(block)) => Some(block),
+                _ => None,
+            },
+            "timesRepeat:" => match arguments.last() {
+                Some(Expression::Block(block)) => Some(block),
+                _ => None,
+            },
+            "to:do:" | "inject:into:" if arguments.len() == 2 => match &arguments[1] {
+                Expression::Block(block) => Some(block),
+                _ => None,
+            },
+            "to:by:do:" if arguments.len() == 3 => match &arguments[2] {
+                Expression::Block(block) => Some(block),
+                _ => None,
+            },
+            _ => None,
+        }
     }
 
     /// BT-1343: Emits a diagnostic for synchronous self-send detected in a loop body.
@@ -1733,6 +1853,42 @@ impl CoreErlangGenerator {
 
         for (i, expr) in filtered_body.iter().enumerate() {
             let is_last = i == filtered_body.len() - 1;
+
+            // BT-3172: `expr` is a top-level statement of THIS loop/fold's
+            // own body — if it's itself a nested loop/fold whose own body
+            // threads a `ClassVars` mutation, no downstream branch (this
+            // function's own field-assignment/self-send/tier2/local-var/
+            // destructure/control-flow-has-mutations dispatch above
+            // `emit_non_assign_expr`'s generic fallback, direct-params, the
+            // `is_last`/`element(2)` unpacks, or `push_discarded_stmt`'s
+            // open-scope tracking) unpacks that nested construct's
+            // `ClassVars` value, so the mutation would be silently lost or
+            // (for a nested `Foldl*`, confirmed empirically) crash `erlc`
+            // with an unbound-variable error — regardless of which branch
+            // below would otherwise handle `expr`, `is_last`, or
+            // `plan.threads_class_vars`. Checked once here, at the very top
+            // of the per-statement loop (ahead of every dispatch branch,
+            // not just `emit_non_assign_expr`'s fallback) because a nested
+            // `do:`/`collect:`/etc. statement is classified
+            // `DispatchKind::ControlFlow` (`is_state_threading_keyword_selector`
+            // includes the `Foldl*` selectors, not just conditionals) and so
+            // is actually intercepted by the `control_flow_has_mutations`
+            // branch below, never reaching `emit_non_assign_expr` at all —
+            // confirmed empirically when this check lived only there and
+            // silently failed to catch the `Foldl*`-in-`Foldl*` repro.
+            // Reject rather than emit code that's silently wrong or
+            // malformed — see `CodeGenError::ClassVarMutationLostAcrossNestedLoop`'s
+            // doc comment.
+            if let Some(mutation) = self.nested_loop_lost_class_var_mutation(expr) {
+                let location = self.span_to_line(expr.span()).map_or_else(
+                    || format!("offset {}", expr.span().start()),
+                    |line| format!("line {line}"),
+                );
+                return Err(CodeGenError::ClassVarMutationLostAcrossNestedLoop {
+                    mutation,
+                    location,
+                });
+            }
 
             // Letrec body uses a space separator between statements.
             if i > 0 && matches!(kind, BodyKind::Letrec) {
@@ -2934,6 +3090,13 @@ impl CoreErlangGenerator {
         pred_var: Option<&String>,
         plan: &ThreadingPlan,
     ) -> Result<()> {
+        // BT-3172: the nested-loop/fold `ClassVars`-loss check runs once, at
+        // the top of `generate_threaded_loop_body_inner`'s per-statement
+        // loop — ahead of every dispatch branch, not just this function's
+        // own fallback — since a nested `do:`/`collect:`/etc. statement is
+        // classified `DispatchKind::ControlFlow` and is actually intercepted
+        // by that loop's `control_flow_has_mutations` branch before ever
+        // reaching here. See that check's own comment for why.
         match kind {
             BodyKind::Letrec => {
                 if self.in_direct_params_loop {

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -334,6 +334,67 @@ pub enum CodeGenError {
         location: String,
     },
 
+    /// BT-3172 (BT-3168 follow-up): a `Letrec`- or `Foldl*`-shaped loop
+    /// (`whileTrue:`/`whileFalse:`/`timesRepeat:`/`to:do:`/`to:by:do:`/
+    /// `do:`/`collect:`/`select:`/`reject:`/`anySatisfy:`/`allSatisfy:`/
+    /// `inject:into:`) nested inside another such loop — in any
+    /// Letrec/Letrec, Foldl*/Foldl*, or mixed combination — where the INNER
+    /// loop's own body would thread a `ClassVars` mutation through its own
+    /// recursive tail call or fold accumulator, but the OUTER loop's own
+    /// top-level statements don't independently trigger `ClassVars`
+    /// threading (see `nested_loop_lost_class_var_mutation`'s doc comment
+    /// for the exact per-shape trigger).
+    ///
+    /// For a `Letrec`-in-`Letrec` nesting, the failure mode is silent data
+    /// loss: no code path in `generate_threaded_loop_body_inner`/
+    /// `emit_non_assign_expr` unpacks a nested loop's `ClassVars` tuple
+    /// element back into the outer loop (only `StateAcc`, via the
+    /// BT-478/BT-483 last-statement `element(2)` unpack), so the mutation is
+    /// silently discarded once the inner loop's own branch exits
+    /// (`with_branch_context`'s `class_var_version` restore has nothing to
+    /// hand off to). For a nesting involving `Foldl*`, the failure mode is
+    /// worse — confirmed empirically to be an `erlc` "unbound variable"
+    /// compile crash instead: the inner construct's own `next_class_var()`
+    /// mint permanently advances the generator's single, unscoped
+    /// class-var-name counter, but the resulting name is only ever bound
+    /// inside the inner construct's own (already-exited) closure, not the
+    /// enclosing scope the outer loop's own `ClassVars` wrap then tries to
+    /// reference it from.
+    ///
+    /// Extending `ClassVars` threading to propagate through nested loop
+    /// levels is tracked as a real design follow-up (needs its own
+    /// frame/accumulator design, comparable in scope to ADR 0111 Addendum 9)
+    /// — not attempted here, per BT-3172's own risk assessment (this
+    /// predicate/generator pair already absorbed two reverted
+    /// over-broad-detection attempts during BT-3168's own development).
+    #[error(
+        "Cannot mutate {mutation} inside a loop nested inside another loop, at {location}.\n\n\
+             The inner loop's own mutation would be threaded correctly on its own, but the outer \
+             loop (whileTrue:/whileFalse:/timesRepeat:/to:do:/to:by:do:/do:/collect:/select:/\
+             reject:/anySatisfy:/allSatisfy:/inject:into:) has no class-variable mutation of its \
+             own to carry it back out — so it is silently discarded, or fails to compile, once \
+             the inner loop finishes.\n\n\
+             Fix: Accumulate into a local variable across both loops, then mutate the class variable \
+             once after the outer loop finishes:\n\
+             \x20 // Instead of:\n\
+             \x20 [i < n] whileTrue: [\n\
+             \x20   [j < n] whileTrue: [self.runs := self.runs + 1. j := j + 1].\n\
+             \x20   i := i + 1].\n\
+             \x20 \n\
+             \x20 // Write:\n\
+             \x20 delta := 0.\n\
+             \x20 [i < n] whileTrue: [\n\
+             \x20   [j < n] whileTrue: [delta := delta + 1. j := j + 1].\n\
+             \x20   i := i + 1].\n\
+             \x20 self.runs := self.runs + delta."
+    )]
+    ClassVarMutationLostAcrossNestedLoop {
+        /// Description of the inner loop's mutation (e.g. "class variable 'runs'" or "'self bump'").
+        mutation: String,
+        /// Source location.
+        location: String,
+    },
+
     /// Field assignment in a block that can't thread state back — whether the block is
     /// assigned to a variable, passed as an argument, or returned (BT-2792).
     #[error(

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -372,8 +372,9 @@ pub enum CodeGenError {
         "Cannot mutate {mutation} inside a loop nested inside another loop, at {location}.\n\n\
              The inner loop's own mutation would be threaded correctly on its own, but the outer \
              loop (whileTrue:/whileFalse:/timesRepeat:/to:do:/to:by:do:/do:/collect:/select:/\
-             reject:/anySatisfy:/allSatisfy:/inject:into:) has no class-variable mutation of its \
-             own to carry it back out — so it is silently discarded, or fails to compile, once \
+             reject:/anySatisfy:/allSatisfy:/inject:into:/detect:/count:/takeWhile:/dropWhile:/\
+             partition:/groupBy:) has no class-variable mutation of its own to carry it back out \
+             — so it is silently discarded, or fails to compile, once \
              the inner loop finishes.\n\n\
              Fix: Accumulate into a local variable across both loops, then mutate the class variable \
              once after the outer loop finishes:\n\

--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -337,7 +337,8 @@ pub enum CodeGenError {
     /// BT-3172 (BT-3168 follow-up): a `Letrec`- or `Foldl*`-shaped loop
     /// (`whileTrue:`/`whileFalse:`/`timesRepeat:`/`to:do:`/`to:by:do:`/
     /// `do:`/`collect:`/`select:`/`reject:`/`anySatisfy:`/`allSatisfy:`/
-    /// `inject:into:`) nested inside another such loop — in any
+    /// `inject:into:`/`detect:`/`count:`/`takeWhile:`/`dropWhile:`/
+    /// `partition:`/`groupBy:`) nested inside another such loop — in any
     /// Letrec/Letrec, Foldl*/Foldl*, or mixed combination — where the INNER
     /// loop's own body would thread a `ClassVars` mutation through its own
     /// recursive tail call or fold accumulator, but the OUTER loop's own

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -4494,6 +4494,93 @@ fn test_class_var_mutation_before_loop_still_emits_shadow_write() {
 }
 
 #[test]
+fn test_nested_letrec_direct_field_mutation_in_inner_loop_is_compile_error() {
+    // BT-3172 (BT-3168 follow-up): a `Letrec` loop nested inside another
+    // `Letrec` loop, where the INNER loop directly mutates a class var, but
+    // the OUTER loop's own top-level statements (`j := 0`, the inner
+    // `whileTrue:` send, `i := i + 1`) have no bare class-var mutation of
+    // their own — so `loop_body_threads_class_vars` correctly returns
+    // `false` for the outer loop (per its own narrow, top-level-only
+    // design), meaning the outer loop's fun/tail call never threads
+    // `ClassVars` at all. Before this fix, this compiled successfully but
+    // silently discarded every inner-loop mutation (confirmed empirically:
+    // both the method's own return and a later fresh read of the class var
+    // returned `0` instead of `9` for `nestedBump: 3`). Now rejected at
+    // compile time instead — see
+    // `CodeGenError::ClassVarMutationLostAcrossNestedLoop`'s doc comment.
+    let src = "Object subclass: NestedLoopShadowCounter\n  classState: runs = 0\n\n  class nestedBump: n =>\n    i := 0\n    [i < n] whileTrue: [\n      j := 0\n      [j < n] whileTrue: [\n        self.runs := self.runs + 1\n        j := j + 1\n      ]\n      i := i + 1\n    ]\n    self.runs";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@nestedloopshadowcounter").with_workspace_mode(true),
+    );
+    match result {
+        Err(CodeGenError::ClassVarMutationLostAcrossNestedLoop { mutation, .. }) => {
+            assert_eq!(mutation, "class variable 'runs'");
+        }
+        other => panic!(
+            "Expected ClassVarMutationLostAcrossNestedLoop for a class-var write inside a \
+             loop nested inside another loop. Got: {other:?}"
+        ),
+    }
+}
+
+#[test]
+fn test_nested_letrec_self_send_mutation_in_inner_loop_is_compile_error() {
+    // BT-3172: the same gap via a same-class self-send (BT-3150's shape)
+    // inside the inner loop instead of a direct field write — the inner
+    // loop's own `loop_body_threads_class_vars` matches `is_class_method_self_send`,
+    // not `is_class_var_assignment`, but the outer loop's discard is
+    // identical either way.
+    let src = "Object subclass: NestedLoopSelfSendCounter\n  classState: runs = 0\n\n  class bump => self.runs := self.runs + 1\n\n  class nestedBumpViaSelfSend: n =>\n    i := 0\n    [i < n] whileTrue: [\n      j := 0\n      [j < n] whileTrue: [\n        self bump\n        j := j + 1\n      ]\n      i := i + 1\n    ]\n    self.runs";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@nestedloopselfsendcounter").with_workspace_mode(true),
+    );
+    match result {
+        Err(CodeGenError::ClassVarMutationLostAcrossNestedLoop { mutation, .. }) => {
+            assert_eq!(mutation, "'self bump'");
+        }
+        other => panic!(
+            "Expected ClassVarMutationLostAcrossNestedLoop for a self-send inside a loop \
+             nested inside another loop. Got: {other:?}"
+        ),
+    }
+}
+
+#[test]
+fn test_nested_timesrepeat_class_var_mutation_in_inner_loop_is_compile_error() {
+    // BT-3172: the same gap via `timesRepeat:`/`to:do:` nesting, not just
+    // `whileTrue:` — `nested_letrec_loop_body` must recognize all four
+    // Letrec-shaped loop selectors, not just `whileTrue:`/`whileFalse:`. The
+    // outer body needs its own co-occurring local-variable mutation
+    // (`seen := seen + 1`) so the OUTER `timesRepeat:` itself reaches
+    // `generate_threaded_loop_body` (mirroring `bumpTimes:` in
+    // `loop_class_var_mutation.bt`) instead of being caught earlier, for an
+    // unrelated reason, by the generic `FieldAssignmentInUnsupportedBlock`
+    // block-validator guard that a bare-class-var-only body (no co-occurring
+    // local mutation) hits regardless of nesting.
+    let src = "Object subclass: NestedCountedLoopCounter\n  classState: runs = 0\n\n  class nestedBumpTimes: n =>\n    seen := 0\n    n timesRepeat: [\n      n timesRepeat: [\n        self.runs := self.runs + 1\n      ]\n      seen := seen + 1\n    ]\n    self.runs";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@nestedcountedloopcounter").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(CodeGenError::ClassVarMutationLostAcrossNestedLoop { .. })
+        ),
+        "Expected ClassVarMutationLostAcrossNestedLoop for a class-var write inside a \
+         timesRepeat: nested inside another timesRepeat:. Got: {result:?}"
+    );
+}
+
+#[test]
 fn test_instance_field_mutation_does_not_emit_shadow_write() {
     // ADR 0110: the shadow write is scoped to class-var mutations in class
     // methods — ordinary actor state threading must not gain a pdict write.
@@ -7279,4 +7366,100 @@ fn test_self_extension_not_registered_via_beamtalk_extensions() {
         "self-extension (Counter >> in the same module as Counter) must NOT emit \
          beamtalk_extensions:register. Got:\n{code}"
     );
+}
+
+#[test]
+fn test_nested_foldl_self_send_in_inner_do_is_compile_error() {
+    // BT-3172 audit (acceptance criteria bullet 3): the same silent-loss gap
+    // reachable via `Foldl*`-in-`Foldl*` nesting (`do:`-in-`do:`), not just
+    // `Letrec`-in-`Letrec`. Confirmed empirically to be WORSE than silent
+    // loss before this fix: the outer `do:`'s own `plan.threads_class_vars`
+    // comes back `true` (Foldl's gate is `body_analysis.has_self_sends`,
+    // which — unlike `loop_body_threads_class_vars` — recurses into the
+    // nested `do:`'s own block and finds `self bump`), so the outer fold
+    // expects to build its own `{ClassVars, StateAcc}` accumulator wrap —
+    // but the inner `do:`'s own `next_class_var()` mint (from
+    // `ThreadingPlan::foldl_call_doc`) permanently advances the generator's
+    // single, unscoped class-var-name counter without that name ever being
+    // surfaced back to the outer scope, so the outer wrap references a name
+    // that was only ever bound inside the inner `do:`'s own (already
+    // exited) fold closure — an `erlc` "unbound variable" compile crash,
+    // not silent data loss, but broken all the same. Rejected at compile
+    // time instead — see `CodeGenError::ClassVarMutationLostAcrossNestedLoop`'s
+    // doc comment.
+    let src = "Value subclass: NestedFoldClassVarMutation\n  classState: runs = 0\n\n  class bump => self.runs := self.runs + 1\n\n  class nestedDo: aList =>\n    outerSeen := 0\n    aList\n      do: [:x |\n        total := 0\n        aList\n          do: [:y |\n            self bump\n            total := total + 1\n          ]\n        outerSeen := outerSeen + 1\n      ]\n    self.runs";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@nestedfoldclassvarmutation").with_workspace_mode(true),
+    );
+    match result {
+        Err(CodeGenError::ClassVarMutationLostAcrossNestedLoop { mutation, .. }) => {
+            assert_eq!(mutation, "'self bump'");
+        }
+        other => panic!(
+            "Expected ClassVarMutationLostAcrossNestedLoop for a self-send inside a do: \
+             nested inside another do:. Got: {other:?}"
+        ),
+    }
+}
+
+#[test]
+fn test_mixed_letrec_nested_in_foldl_is_compile_error() {
+    // BT-3172 audit (acceptance criteria bullet 3): mixed nesting — a
+    // `Letrec` (`whileTrue:`) loop with a direct class-var field write,
+    // nested inside a `Foldl*` (`do:`) body — hits the same gap. The inner
+    // `whileTrue:`'s own `ThreadingPlan::threads_class_vars` (Letrec's
+    // narrow, top-level-only `loop_body_threads_class_vars` gate) is `true`
+    // for its own bare `self.runs := self.runs + 1`, but nothing in the
+    // outer `Foldl*` machinery (which only knows how to unpack its OWN
+    // `{ClassVars, StateAcc}` accumulator shape, not a nested `Letrec`
+    // loop's extra tail-call `ClassVars` fun parameter) surfaces that
+    // mutation back out.
+    let src = "Object subclass: MixedLetrecFoldCounter\n  classState: runs = 0\n\n  class bump => self.runs := self.runs + 1\n\n  class mixedBumpUpTo: n =>\n    seen := 0\n    #(1) do: [:x |\n      i := 0\n      [i < n] whileTrue: [\n        self.runs := self.runs + 1\n        i := i + 1\n      ]\n      seen := seen + 1\n    ]\n    self.runs";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@mixedletrecfoldcounter").with_workspace_mode(true),
+    );
+    match result {
+        Err(CodeGenError::ClassVarMutationLostAcrossNestedLoop { mutation, .. }) => {
+            assert_eq!(mutation, "class variable 'runs'");
+        }
+        other => panic!(
+            "Expected ClassVarMutationLostAcrossNestedLoop for a whileTrue: (with a direct \
+             class-var write) nested inside a do:. Got: {other:?}"
+        ),
+    }
+}
+
+#[test]
+fn test_mixed_foldl_nested_in_letrec_is_compile_error() {
+    // BT-3172 audit (acceptance criteria bullet 3): the reverse mixed
+    // nesting — a `Foldl*` (`do:`) body with a direct class-var field
+    // write, nested inside a `Letrec` (`whileTrue:`) loop. The inner `do:`
+    // never reaches Foldl's own `ClassVars` threading at all here (a bare
+    // field write inside a `Foldl*` body is unconditionally rejected by
+    // `reject_class_var_field_assignment` regardless of nesting — see
+    // `nested_loop_lost_class_var_mutation`'s doc comment), so this pins
+    // that the OUTER `Letrec`'s own top-level dispatch catches the shape
+    // before ever generating the inner `do:` at all.
+    let src = "Value subclass: MixedFoldLetrecCounter\n  classState: runs = 0\n\n  class mixedBumpAll: aList =>\n    outerSeen := 0\n    [outerSeen < 2] whileTrue: [\n      aList do: [:x |\n        self.runs := self.runs + 1\n      ]\n      outerSeen := outerSeen + 1\n    ]\n    self.runs";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@mixedfoldletreccounter").with_workspace_mode(true),
+    );
+    match result {
+        Err(CodeGenError::ClassVarMutationLostAcrossNestedLoop { mutation, .. }) => {
+            assert_eq!(mutation, "class variable 'runs'");
+        }
+        other => panic!(
+            "Expected ClassVarMutationLostAcrossNestedLoop for a do: (with a direct class-var \
+             write) nested inside a whileTrue:. Got: {other:?}"
+        ),
+    }
 }

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -7406,6 +7406,36 @@ fn test_nested_foldl_self_send_in_inner_do_is_compile_error() {
 }
 
 #[test]
+fn test_nested_detect_self_send_in_inner_detect_is_compile_error() {
+    // BT-3172 review follow-up: `nested_loop_or_fold_body` must also cover
+    // the predicate-based `Foldl*` shapes (`detect:`/`count:`/`takeWhile:`/
+    // `dropWhile:`/`partition:`/`groupBy:`), not just `do:`/`collect:`/
+    // `select:`/`reject:`/`anySatisfy:`/`allSatisfy:`/`inject:into:` —
+    // `ThreadingPlan::new_impl`'s `threads_class_vars` gate
+    // (`!Actor && in_class_method() && body_analysis.has_self_sends`)
+    // applies uniformly to every non-`Letrec` `BodyKind`, so a class-var
+    // self-send nested inside `detect:`, itself nested inside another
+    // `detect:`, is exactly as vulnerable to the silent-loss/`erlc`-crash
+    // bug as the `do:`-in-`do:` shape pinned above.
+    let src = "Value subclass: NestedDetectClassVarMutation\n  classState: runs = 0\n\n  class bump => self.runs := self.runs + 1\n\n  class nestedDetect: aList =>\n    outerSeen := 0\n    aList\n      detect: [:x |\n        total := 0\n        aList\n          detect: [:y |\n            self bump\n            total := total + 1\n            true\n          ]\n        outerSeen := outerSeen + 1\n        true\n      ]\n    self.runs";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@nesteddetectclassvarmutation").with_workspace_mode(true),
+    );
+    match result {
+        Err(CodeGenError::ClassVarMutationLostAcrossNestedLoop { mutation, .. }) => {
+            assert_eq!(mutation, "'self bump'");
+        }
+        other => panic!(
+            "Expected ClassVarMutationLostAcrossNestedLoop for a self-send inside a detect: \
+             nested inside another detect:. Got: {other:?}"
+        ),
+    }
+}
+
+#[test]
 fn test_mixed_letrec_nested_in_foldl_is_compile_error() {
     // BT-3172 audit (acceptance criteria bullet 3): mixed nesting — a
     // `Letrec` (`whileTrue:`) loop with a direct class-var field write,

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -7406,6 +7406,70 @@ fn test_nested_foldl_self_send_in_inner_do_is_compile_error() {
 }
 
 #[test]
+fn test_nested_letrec_self_send_buried_in_conditional_compiles() {
+    // BT-3172 review follow-up: a same-class self-send buried inside an
+    // `ifTrue:` conditional (NOT a bare top-level statement) within an
+    // inner `whileTrue:` that's itself nested inside an outer `whileTrue:`
+    // must NOT be rejected. `Letrec`'s own real `threads_class_vars` gate
+    // (`loop_body_threads_class_vars`) is narrowly top-level-only by
+    // design — recursing into a conditional buried inside a `Letrec` body
+    // is exactly the shape that predicate was narrowed to exclude (the
+    // `class_var_subexpr.bt` `tickInLoopConditional` regression documented
+    // on `loop_body_threads_class_vars` itself), and it's also the shape
+    // `class_var_subexpr_test.bt`'s
+    // `testTickInLoopConditionalCompilesAndRuns` already pins as
+    // accepted, silently-non-threading behavior at a single loop level
+    // (BT-2308, out of BT-3172's scope). The inner loop was never going to
+    // attempt `ClassVars` threading for this self-send in the first place,
+    // so nothing is "lost" here for the outer loop to fail to recover —
+    // rejecting only the nested-loop variant of this exact same shape
+    // would be an inconsistent new restriction. Mirrors
+    // `tickInLoopConditional` one loop level deeper.
+    let src = "Object subclass: NestedCondSelfSend\n  classState: runs = 0\n\n  class bump => self.runs := self.runs + 1\n\n  class run: n =>\n    j := 0\n    [j < n] whileTrue: [\n      i := 0\n      [i < n] whileTrue: [\n        (i >= 0) ifTrue: [self bump]\n        i := i + 1\n      ]\n      j := j + 1\n    ]\n    self.runs";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@nestedcondselfsend").with_workspace_mode(true),
+    );
+    result.unwrap_or_else(|e| {
+        panic!(
+            "A self-send buried inside a conditional (not a bare top-level statement) \
+             inside a Letrec loop nested inside another Letrec loop must not be rejected \
+             by ClassVarMutationLostAcrossNestedLoop — Letrec's own real threading gate \
+             never attempts to thread it in the first place. Got: {e:?}"
+        )
+    });
+}
+
+#[test]
+fn test_nested_foldl_self_send_buried_in_conditional_is_compile_error() {
+    // BT-3172 review follow-up (contrast case): the same "self-send buried
+    // in a conditional, not a bare top-level statement" shape as the
+    // Letrec test above, but inside a `Foldl*` (`do:`) body instead —
+    // `Foldl*`'s own real `threads_class_vars` gate
+    // (`!Actor && in_class_method() && body_analysis.has_self_sends`) IS
+    // genuinely recursive (unlike Letrec's), so this shape must still be
+    // rejected when nested inside another loop.
+    let src = "Value subclass: NestedFoldCondSelfSend\n  classState: runs = 0\n\n  class bump => self.runs := self.runs + 1\n\n  class nestedDo: aList =>\n    outerSeen := 0\n    aList\n      do: [:x |\n        total := 0\n        aList\n          do: [:y |\n            (y >= 0) ifTrue: [self bump]\n            total := total + 1\n          ]\n        outerSeen := outerSeen + 1\n      ]\n    self.runs";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let result = generate_module(
+        &module,
+        CodegenOptions::new("bt@nestedfoldcondselfsend").with_workspace_mode(true),
+    );
+    assert!(
+        matches!(
+            result,
+            Err(CodeGenError::ClassVarMutationLostAcrossNestedLoop { .. })
+        ),
+        "Expected ClassVarMutationLostAcrossNestedLoop for a self-send buried in a \
+         conditional inside a do: nested inside another do: — Foldl*'s own real \
+         threading gate is recursive, unlike Letrec's. Got: {result:?}"
+    );
+}
+
+#[test]
 fn test_nested_detect_self_send_in_inner_detect_is_compile_error() {
     // BT-3172 review follow-up: `nested_loop_or_fold_body` must also cover
     // the predicate-based `Foldl*` shapes (`detect:`/`count:`/`takeWhile:`/


### PR DESCRIPTION
## Summary

BT-3172 is a BT-3168 follow-up: a `Letrec` loop (`whileTrue:`/`whileFalse:`/`timesRepeat:`/`to:do:`/`to:by:do:`) or `Foldl*` body (`do:`/`collect:`/`select:`/`reject:`/`anySatisfy:`/`allSatisfy:`/`inject:into:`) nested inside another such construct, where the *inner* one mutates a class var, was not covered by BT-3168's `loop_body_threads_class_vars` predicate — which deliberately inspects a loop's own top-level statements only (a narrowing that itself fixed a real regression during BT-3168's development).

- **Letrec-in-Letrec**: compiles successfully but **silently discards** every inner-loop mutation (confirmed empirically — `nestedBump: 3` returned `0` instead of `9`, and a later fresh read of the class var also returned `0`).
- **Any nesting involving `Foldl*`** (Foldl-in-Foldl, or mixed Letrec/Foldl nesting): confirmed empirically to be *worse* than silent loss — `erlc` crashes with an "unbound variable" error. The outer construct's `next_class_var()` name-minting is a single, unscoped counter; a nested construct's own mint permanently advances it without the resulting name ever being surfaced to the enclosing scope.

This PR implements the "reject at compile time" option from the issue's decision point (rather than extending `ClassVars` threading through nested loop levels, which needs its own frame/accumulator design comparable to ADR 0111 Addendum 9, and which this exact predicate/generator pair has already absorbed two reverted over-broad-detection attempts trying to get right) — restoring BT-3168-era safety for exactly the shape its own narrowing left uncovered.

## Changes

- Added `CodeGenError::ClassVarMutationLostAcrossNestedLoop`, a clear diagnostic with a fix suggestion (accumulate into a local across both loops, then mutate the class var once after the outer loop finishes).
- Added `nested_loop_lost_class_var_mutation`/`nested_loop_or_fold_body` in `control_flow/mod.rs`: detects a top-level statement that is itself a nested `Letrec`- or `Foldl*`-shaped loop whose own body would thread a `ClassVars` mutation (via the existing narrow `loop_body_threads_class_vars` check, or — matching `Foldl*`'s own real gate — a recursive same-class self-send anywhere in the body).
- Refactored `loop_body_threads_class_vars` to share its top-level-statement scan with the new predicate via `find_class_var_mutating_stmt`, per the project's no-duplicate-implementations rule.
- Wired the check once, at the top of `generate_threaded_loop_body_inner`'s per-statement loop (not just `emit_non_assign_expr`'s fallback) — a nested `do:`/`collect:`/etc. statement is classified `DispatchKind::ControlFlow` and is intercepted earlier, before reaching `emit_non_assign_expr` at all.

## Test plan

- [x] `test_nested_letrec_direct_field_mutation_in_inner_loop_is_compile_error` — the issue's own `nestedBump:` repro (Letrec-in-Letrec, direct field write).
- [x] `test_nested_letrec_self_send_mutation_in_inner_loop_is_compile_error` — same shape via a same-class self-send.
- [x] `test_nested_timesrepeat_class_var_mutation_in_inner_loop_is_compile_error` — `timesRepeat:`-in-`timesRepeat:`, and the last-statement position (not just non-last).
- [x] `test_nested_foldl_self_send_in_inner_do_is_compile_error` — `do:`-in-`do:` (acceptance criteria bullet 3 audit).
- [x] `test_mixed_letrec_nested_in_foldl_is_compile_error` / `test_mixed_foldl_nested_in_letrec_is_compile_error` — mixed nesting (acceptance criteria bullet 3 audit).
- [x] `just test` — full Rust/stdlib/BUnit/runtime/metamorphic suite green (5679 Rust tests, 3250 BUnit tests, 5663+1807 Erlang runtime tests, 520 metamorphic assertions).
- [x] `just ci-changed` — build, clippy, fmt, corpus, surface-drift all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMi38UaBwkgFotDYPbb2CR)_