### PR TITLE
refactor: extract duplicate html_escape into commands/util

### DIFF
--- a/crates/beamtalk-cli/src/commands/doc/renderer.rs
+++ b/crates/beamtalk-cli/src/commands/doc/renderer.rs
@@ -16,13 +16,10 @@ use super::extractor::{ClassInfo, MethodInfo};
 use super::highlighter::highlight_beamtalk;
 use super::layout::{page_footer, page_header, write_hierarchy_tree};
 
-/// Escape HTML special characters.
-pub(super) fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-}
+// Re-export the shared implementation so `doc/highlighter.rs`, `doc/layout.rs`,
+// `doc/site.rs`, and tests in `doc/mod.rs` can still reach it via
+// `use super::renderer::html_escape` without any changes to those call sites.
+pub(super) use crate::commands::util::html_escape;
 
 /// Convert a class name to a link if the class exists in the docs.
 pub(super) fn class_link(name: &str, classes: &HashMap<String, &ClassInfo>) -> String {

--- a/crates/beamtalk-cli/src/commands/registry/renderer.rs
+++ b/crates/beamtalk-cli/src/commands/registry/renderer.rs
@@ -15,17 +15,7 @@ use crate::commands::deps::registry::{RegistryEntry, RegistryRelease, compare_ve
 
 use super::layout::{page_footer, page_header};
 
-/// Escape HTML special characters.
-///
-/// Index entries are third-party data (published by any package author, not
-/// validated beyond TOML syntax), so every field is escaped before it lands
-/// in generated HTML.
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-}
+use crate::commands::util::html_escape;
 
 /// The dependency snippet for a `(name, version)` pair, matching the bare
 /// registry-string `[dependencies]` format `beamtalk.toml` accepts (BT-2978):

--- a/crates/beamtalk-cli/src/commands/util.rs
+++ b/crates/beamtalk-cli/src/commands/util.rs
@@ -13,6 +13,19 @@ use sha2::{Digest, Sha256};
 use std::fs;
 use std::time::SystemTime;
 
+/// Escape HTML special characters.
+///
+/// Shared by `commands/doc` and `commands/registry` — both render third-party
+/// or user-supplied text into HTML and must escape the same four characters.
+/// Centralised here (the shared-helpers leaf) so the two renderer modules
+/// import a single definition rather than each carrying a private copy.
+pub(crate) fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
 /// Build the BEAM module name for a user-code file stem (`bt@<normalised-stem>`).
 ///
 /// ADR 0016: all user-code modules use the `bt@` prefix. The stem is normalised


### PR DESCRIPTION
## Summary

`html_escape` was implemented twice, byte-for-byte identically, in two sibling renderer modules:

- `crates/beamtalk-cli/src/commands/doc/renderer.rs:20` — `pub(super) fn html_escape`
- `crates/beamtalk-cli/src/commands/registry/renderer.rs:23` — `fn html_escape`

Both modules render user/third-party text into HTML and escape the same four characters (`&`, `<`, `>`, `"`). This violates CLAUDE.md § "No duplicate implementations" and `architecture-principles.md` §6 (Shared-Leaf-Module Pattern): `commands/util` is already the shared-helpers leaf for this crate, and both sibling subdirectories can reach it.

## Changes

- **`commands/util.rs`** — Add `pub(crate) fn html_escape` with the shared implementation and a doc comment explaining why it lives here.
- **`commands/doc/renderer.rs`** — Replace the function body with `pub(super) use crate::commands::util::html_escape;`. The `pub(super)` re-export preserves all existing `use super::renderer::html_escape` imports in `doc/highlighter.rs`, `doc/layout.rs`, `doc/site.rs`, and the `doc/mod.rs` tests — no changes to those files needed.
- **`commands/registry/renderer.rs`** — Replace the function body with `use crate::commands::util::html_escape;`.

Net change: 18 lines added, 18 lines removed. No behaviour change.

## Test plan

- [ ] `cargo build -p beamtalk-cli` — clean build
- [ ] `cargo test -p beamtalk-cli --lib` — all 147 tests pass
- [ ] `cargo clippy -p beamtalk-cli` — no warnings
- [ ] `just fmt` — no format changes
- [ ] Pre-push hooks (clippy, dialyzer, Erlang formatting, Beamtalk formatting) — all green ✅

## Notes

The code review surfaced a pre-existing issue in the adjacent `class_link` function: its `if`-branch (when the class exists in the map) interpolates `name` raw into the `href` and link text without escaping. In practice this is safe because Beamtalk class names are identifiers (no `"`, `<`, `>`, or `&` can appear), but the asymmetry with the `else` branch is a latent inconsistency. Not fixed here to keep this diff scoped to the extraction; a follow-up issue should address it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01We6RqDdLLSievsSmNcyzvh)_