### PR TITLE
test: add gen_server protocol edge-case tests for beamtalk_file_handle_registry

### DIFF
--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_file_handle_registry_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_file_handle_registry_tests.erl
@@ -211,3 +211,95 @@ malformed_handle_calls_are_safe_test_() ->
             ?assertNot(has_entry(<<"anything">>, beamtalk_file_handle_registry:open_handles()))
         end)
     end}.
+
+open_handles_no_server_is_safe_test() ->
+    %% Complements no_server_calls_are_safe_test/0: that test covers register/2
+    %% and unregister/1 when the server is absent; this one covers open_handles/0.
+    %% After gen_server:stop the registered name is gone (stop is synchronous);
+    %% open_handles/0 must return [] rather than raise.
+    case whereis(beamtalk_file_handle_registry) of
+        undefined -> ok;
+        Pid -> gen_server:stop(Pid)
+    end,
+    ?assertEqual([], beamtalk_file_handle_registry:open_handles()).
+
+unknown_call_returns_error_unknown_request_test_() ->
+    %% handle_call/3 has a catch-all clause that replies {error, unknown_request}
+    %% for any message not matching the three known selectors. Verify it without
+    %% crashing the server.
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        ?_test(begin
+            Pid = whereis(beamtalk_file_handle_registry),
+            ?assertMatch(
+                {error, unknown_request},
+                gen_server:call(Pid, totally_unknown_message)
+            ),
+            %% Registry is still alive after the unknown call.
+            ?assertEqual(ok, sync(ok))
+        end)
+    end}.
+
+unknown_cast_is_safe_test_() ->
+    %% handle_cast/2 catch-all: an unexpected cast must not crash the server.
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        ?_test(begin
+            gen_server:cast(beamtalk_file_handle_registry, totally_unknown_cast),
+            ?assertEqual(ok, sync(ok))
+        end)
+    end}.
+
+unknown_handle_info_is_safe_test_() ->
+    %% handle_info/2 catch-all: an unexpected message sent directly to the
+    %% process must not crash the server.
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        ?_test(begin
+            beamtalk_file_handle_registry ! totally_unknown_info,
+            ?assertEqual(ok, sync(ok))
+        end)
+    end}.
+
+multiple_owners_monitor_demonitored_independently_test_() ->
+    %% When two different owners each hold a handle, closing and unregistering
+    %% one owner's handle must demonitor that owner WITHOUT removing the other
+    %% owner's monitor.  This exercises the `(_Ref, _P) -> true` keep-branch
+    %% inside `demonitor_owner/2`'s `maps:filter` — only reached when the
+    %% monitors map contains entries for more than one distinct owner pid.
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        ?_test(begin
+            Owner1 = spawn_dummy(),
+            Owner2 = spawn_dummy(),
+            {H1, P1} = open_handle(),
+            {H2, P2} = open_handle(),
+            ok = beamtalk_file_handle_registry:register(H1, Owner1),
+            ok = beamtalk_file_handle_registry:register(H2, Owner2),
+
+            %% Explicitly close and unregister H1 (not via Owner1's death).
+            %% This must demonitor Owner1 while leaving Owner2's monitor intact.
+            ok = beamtalk_file_handle:close_handle(H1),
+            ok = beamtalk_file_handle_registry:unregister(H1),
+            ok = sync(ok),
+
+            %% H2 must still be reclaimed when Owner2 dies (its monitor was kept).
+            stop_dummy(Owner2),
+            ok = sync(ok),
+            ?assertNot(beamtalk_file_handle:is_open(H2)),
+            ?assertNot(
+                has_entry(
+                    list_to_binary(P2),
+                    beamtalk_file_handle_registry:open_handles()
+                )
+            ),
+
+            %% Owner1 is still alive but holds no handles — let it exit cleanly.
+            stop_dummy(Owner1),
+            ok = sync(ok),
+            ?assertNot(
+                has_entry(
+                    list_to_binary(P1),
+                    beamtalk_file_handle_registry:open_handles()
+                )
+            ),
+            delete_temp(P1),
+            delete_temp(P2)
+        end)
+    end}.


### PR DESCRIPTION
## Summary

Adds 5 targeted EUnit tests to `beamtalk_file_handle_registry_tests.erl`, covering previously-uncovered gen_server protocol branches measured at **79.5% line coverage (58/73)** in the 2026-08-13 CI run (artifact `coverage-reports`, run `31750149684`).

Expected improvement: **79.5% → ~87.7% (64/73 lines)**.

## Coverage gaps closed

| Test | Source line | What it covers |
|---|---|---|
| `open_handles_no_server_is_safe_test` | 163 | `open_handles/0` returns `[]` when `whereis/1` → `undefined` |
| `unknown_call_returns_error_unknown_request_test_` | 187 | `handle_call/3` catch-all replies `{error, unknown_request}` |
| `unknown_cast_is_safe_test_` | 190 | `handle_cast/2` catch-all no-ops without crashing |
| `unknown_handle_info_is_safe_test_` | 195 | `handle_info/2` catch-all no-ops without crashing |
| `multiple_owners_monitor_demonitored_independently_test_` | 295 | `demonitor_owner/2` `maps:filter` keep-branch — only reached when the monitors map contains refs for more than one distinct owner |

The `multiple_owners` test also verifies the behavioural invariant: explicitly closing one owner's handle must not disturb the other owner's monitor, confirmed by asserting the second handle is reclaimed when that owner dies.

## What was not changed

- No source files modified — test-only diff.
- Remaining uncovered lines (`exit:_` catch paths, abnormal `terminate/2`) require either a crashed-during-call server or OTP release-handler machinery to reach deterministically; per `testing-strategy.md`'s "genuinely unreachable" note these are out of scope.
- No BUnit/bootstrap tests added (the gap is in an Erlang EUnit module, not a Beamtalk language feature).

## Test run

```
rebar3 eunit --module=beamtalk_file_handle_registry_tests
# 11 tests, 0 failures  (6 existing + 5 new)

rebar3 eunit --app=beamtalk_stdlib
# 1755 tests, 0 failures, 3 cancelled  (+5 vs 1750 baseline on main)
```

Pre-existing CLI integration failures (`cli_test::test_passes_for_passing_suite`, `cli_doctor::doctor_passes_against_real_workspace_runtime`) confirmed pre-existing on main before this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Katy7EnYuqtTEDoDE7dwUv)_