### PR TITLE
docs(codegen): fix stale/misleading comments in ThreadedIr post-migration

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/control_flow/exception_handling.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/control_flow/exception_handling.rs
@@ -996,11 +996,14 @@ impl CoreErlangGenerator {
     /// through `render_loop_body_statements` (that function separates every
     /// *raw* `ThreadedStmt` entry, which would inject a spurious extra
     /// space inside any shape that itself decomposes into more than one
-    /// entry, e.g. E1's Statement+Bind pair — breaking byte-identity).
+    /// entry, e.g. E1's Statement+Bind pair — a real double-space bug, not
+    /// a cosmetic one).
     /// `verify_and_render_branch_arm`'s plain `render()` has no separator
     /// of its own, so the manually-inserted space is the only one that
-    /// ends up in the output, at exactly the position the legacy
-    /// `if i > 0 { docs.push(" ") }` loop put it.
+    /// ends up in the output, at exactly the position this same
+    /// `if i > 0 { docs.push(" ") }` loop below has always put it — this
+    /// is the loop's own IR-producing form, not a match against some
+    /// other, deleted implementation.
     #[allow(clippy::too_many_lines)]
     fn generate_exception_body_with_threading_inner(
         &mut self,

--- a/crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/threaded_ir.rs
@@ -275,12 +275,12 @@
 //! (`mod.rs`), the same way BT-3164 deleted
 //! `wrap_class_method_body_with_nlr_catch`. `wrap_body_with_nlr_catch`
 //! itself remains live: [`render`]'s `NlrCatch` arm (this module) still
-//! calls it directly to build the real try/catch scaffolding. Deleting the
+//! calls it directly to build the real try/catch scaffolding. The
 //! now-unused rendering-only wrappers these three call sites left behind
 //! (`generate_method_definition_body_with_reply`, `generate_method_body_with_reply`,
 //! and their shared `generate_body_exprs_with_reply` helper — all in
-//! `gen_server/methods.rs`, all with zero remaining callers once the
-//! migration landed) mirrors how BT-3164 renamed away
+//! `gen_server/methods.rs`) were deleted once they had zero remaining
+//! callers, the same way BT-3164 renamed away
 //! `generate_class_method_body` rather than leaving a dead rendering path
 //! beside the lowering one.
 //!
@@ -454,8 +454,11 @@
 //! at each source-statement boundary and renders the whole arm through
 //! plain [`render`] (the same no-separator function `conditionals.rs` uses)
 //! — the manually-placed `Statement`s supply the only separators that end
-//! up in the output, at exactly the positions the legacy `if i > 0 {
-//! docs.push(" ") }` loop put them.
+//! up in the output, at exactly the positions this same per-statement
+//! `if i > 0 { ... }` loop has always put them (it is not a deleted
+//! predecessor being matched — the loop is still live, unchanged in
+//! shape, just now pushing an IR node instead of a `Document` fragment
+//! directly; see `exception_handling.rs`'s own copy of this loop).
 //!
 //! `control_flow/mod.rs`'s `check_branch_frame_linearity` and this file's
 //! `verify_branch_frame_linearity` — the scalar-synthesis scaffolding these
@@ -3892,17 +3895,6 @@ mod tests {
         let rendered = lower_and_render(&ir).to_pretty_string();
         assert_eq!(rendered, "let N1 = call 'erlang':'element'(3, AccSt0) in ");
     }
-
-    // `verify_branch_frame_linearity` (BT-3134) and its coverage above were
-    // deleted by BT-3165 (ADR 0111 Addendum 5) once
-    // `exception_handling.rs`'s `on:do:`/`ensure:` — its last two production
-    // callers via `check_branch_frame_linearity` — moved to real per-arm
-    // `ThreadedIr` (`verify_and_render_branch_arm`, `conditionals.rs`). The
-    // regression coverage proving `NonLinearVersion`/`UnboundVersion` are
-    // live against real exception-arm IR now lives in
-    // `exception_handling.rs`'s own test module, mirroring
-    // `conditionals.rs`'s `test_bt3146_*_detected_via_production_lowering_types`
-    // pattern.
 
     // ── construct_and_verify_class_var_bind (BT-3135/BT-3148, ADR 0110
     // contract) ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Zero-risk doc/comment fixes found during a post-ADR-0111 cleanup review of the ThreadedIr migration (full review, not yet all filed — see BT-3179/BT-3180/BT-3181/BT-3182 for the substantive follow-ups this review also surfaced).

- Delete a tombstone comment (`threaded_ir.rs`) narrating `verify_branch_frame_linearity`'s BT-3165 deletion — pure historical narration with no bearing on the surrounding code, better left to `git log`/`git blame`.
- Reword `threaded_ir.rs`'s `wrap_body_with_nlr_catch` status paragraph: it described the deletion of `generate_method_definition_body_with_reply` et al. as if mirroring a future action ("mirrors how BT-3164..."), when the deletion already happened — confirmed via grep that none of the three functions exist anywhere in the crate.
- Reword the "legacy `if i > 0 { docs.push(" ") }` loop" phrasing in both `threaded_ir.rs` and its `exception_handling.rs` twin. That loop is not a deleted predecessor being byte-matched — it's the same loop, still live today, just now pushing an IR node instead of a `Document` fragment directly (BT-3165 relocated it, didn't replace it). The old wording invited readers to go looking for a separate legacy implementation that never had a distinct existence to delete.

No behavior change — doc comments only, no `Document`/render path touched.

## Test plan

- [x] `cargo check -p beamtalk-core --lib` — clean compile
- [x] `cargo test -p beamtalk-core --lib threaded_ir::` — 67 passed, 0 failed
- [x] Full pre-push lint suite (clippy, Rust fmt, Erlang/Dialyzer, JS/Biome, Elixir, Beamtalk fmt) — all passed

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_015rcqxrkWKK42do7ZNcDC77)_