### PR TITLE
fix(ci): bump nightly workflow timeouts to stop chronic cancellations

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -155,7 +155,9 @@ jobs:
     if: needs.check-activity.outputs.has_commits == 'true'
     # Pin to 2022: erlef/setup-beam@v1 doesn't support windows-2025 yet
     runs-on: windows-2022
-    timeout-minutes: 45
+    # Observed runtime is consistently 42-45min against a full suite run,
+    # leaving no margin under a 45min budget — bumped to give headroom.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -239,7 +241,9 @@ jobs:
     needs: check-activity
     if: needs.check-activity.outputs.has_commits == 'true'
     runs-on: macos-15-intel
-    timeout-minutes: 30
+    # Observed runtime is consistently 28-33min (dist build + smoke test on
+    # the slower Intel runner) against a 30min budget — bumped to give margin.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Summary

Nightly builds have been chronically failing to publish: 13 of the last 19 scheduled `Nightly` workflow runs were cancelled instead of completing.

Root cause: `publish-nightly` requires all of `macos`, `macos-x86_64`, `windows`, and `linux` to succeed. Two of those jobs have been running right up against (or over) their `timeout-minutes` budget as build/test time grew, causing GitHub Actions to cancel them mid-run:

- `macos-x86_64` (macos-15-intel runner): `timeout-minutes: 30`, but "Build and install distribution" + "Smoke test" alone consistently take 28–33 minutes.
- `windows` (windows-2022 runner): `timeout-minutes: 45`, but the full suite consistently takes 42–45 minutes.

Whenever either job hits its timeout and gets cancelled, `publish-nightly` is skipped entirely — no release, no artifacts — even though every other platform succeeded.

## Changes

- `macos-x86_64`: `timeout-minutes` 30 → 45
- `windows`: `timeout-minutes` 45 → 60

## Test plan

- [x] Reviewed workflow run history via GitHub Actions API to confirm the timeout/cancellation pattern across the last two weeks
- [ ] Next scheduled nightly run (or a manual `workflow_dispatch`) completes and publishes the `nightly` release without cancellations

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxendLvqUmvxY747nh3NzS)_