### PR TITLE
test: pin file-op return values in workspace_flush_roundtrip.btscript

### DIFF
--- a/tests/repl-protocol/cases/workspace_flush_roundtrip.btscript
+++ b/tests/repl-protocol/cases/workspace_flush_roundtrip.btscript
@@ -143,7 +143,7 @@ _flushDir := _tmpDir ++ "/bt_e2e_flush_" ++ (Erlang erlang) unique_integer asStr
 // => _
 
 (Erlang file) make_dir: _flushDir
-// => _
+// => Result ok: nil
 
 _flushPath := _flushDir ++ "/RoundTripCounter.bt"
 // => _
@@ -417,13 +417,13 @@ Erlang maps get: #flushed with: _emptyKindsFlush
 // ===========================================================================
 
 (Erlang file) delete: _flushPath
-// => _
+// => Result ok: nil
 
 (Erlang file) delete: _newClassPath
-// => _
+// => Result ok: nil
 
 (Erlang file) del_dir: _flushDir
-// => _
+// => Result ok: nil
 
 Workspace changes clear
 // => _


### PR DESCRIPTION
## Summary

- Replaces 4 `// => _` wildcard assertions with `// => Result ok: nil` on Erlang file-operation calls in `workspace_flush_roundtrip.btscript`
- Affected calls: `(Erlang file) make_dir:`, `(Erlang file) delete:` (×2), `(Erlang file) del_dir:`
- All four return bare `ok` from Erlang, which the FFI proxy auto-converts to `Result ok: nil` — confirmed by the already-pinned assertion in `ffi_result_conversion.btscript`

## Why

Wildcard assertions on these calls silently pass even if the file operations fail (e.g., permission error creating the temp dir, or `del_dir` failing because a prior step left files behind). Pinning to the correct return value catches those failures immediately with a clear mismatch message.

## Test plan

- [x] `just test-repl-protocol` — all 3 tests pass (86s), including `e2e_language_tests` which runs `workspace_flush_roundtrip.btscript`

Closes #3390

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bcabsg7NSy7128ZyVtebqR)_