### PR TITLE
fix(stdlib): close dead owners' file handles off the registry process BT-3050

### DIFF
--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_file_handle_registry.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_file_handle_registry.erl
@@ -32,11 +32,20 @@ calling `register/2`:
 
 Registering a handle against a pid owner arms a monitor on that owner the
 first time it appears; further handles from the same owner share it. When
-the owner dies, every handle still registered under it is closed (via
-`beamtalk_file_handle:close_handle/1`, already idempotent) and dropped from
-the registry. `unregister/1` (called from `beamtalk_file_handle:close/1` on
+the owner dies, every handle still registered under it is dropped from the
+registry and closed (via `beamtalk_file_handle:close_handle/1`, already
+idempotent). `unregister/1` (called from `beamtalk_file_handle:close/1` on
 every close, whatever opened the handle) removes a handle immediately, so a
 closed handle never lingers and a later owner death can never double-close it.
+
+The bookkeeping half of that reclamation is synchronous — the dead owner's
+handles are gone from `open_handles/0` the moment the `'DOWN'` is handled —
+but the `file:close/1` calls themselves are handed to a transient process
+(BT-3050). Each close is a round-trip to that handle's `file_io_server`, and
+`register/2`, `unregister/1` and `open_handles/0` are all calls to *this*
+process; doing the closes inline would block the registry's mailbox — and so
+every concurrent `File open:mode:` / `close` / `openHandles` node-wide — until
+one dying owner's descriptors finished closing. See `handle_owner_down/3`.
 
 This is a supervised `one_for_one` worker (`beamtalk_runtime_sup`, alongside
 `beamtalk_object_watch` — the same monitor-owner/react-to-'DOWN' shape); if it
@@ -297,28 +306,54 @@ demonitor_owner(Owner, Monitors) ->
         Monitors
     ).
 
+%% Reclaim a dead owner's handles: drop the bookkeeping here and now, close the
+%% descriptors elsewhere. `file:close/1` on a non-raw descriptor is a
+%% round-trip to that handle's `file_io_server` process, so closing inline
+%% would hold this gen_server's mailbox — blocking every concurrent register /
+%% unregister / open_handles call node-wide — for as long as one dying owner's
+%% descriptors take, and indefinitely for a wedged one (BT-3050).
 -spec handle_owner_down(reference(), pid(), #state{}) -> #state{}.
 handle_owner_down(MonRef, Owner, State) ->
     #state{handles = Handles, by_owner = ByOwner, monitors = Monitors} = State,
     Keys = maps:keys(maps:get(Owner, ByOwner, #{})),
-    lists:foreach(fun(Key) -> close_owned_handle(Key, Handles) end, Keys),
+    close_owned_handles_async(owned_handles(Keys, Handles)),
     State#state{
         handles = maps:without(Keys, Handles),
         by_owner = maps:remove(Owner, ByOwner),
         monitors = maps:remove(MonRef, Monitors)
     }.
 
--spec close_owned_handle(handle_key(), map()) -> ok.
-close_owned_handle(Key, Handles) ->
-    case maps:find(Key, Handles) of
-        {ok, {Handle, _Owner}} ->
-            %% close_handle/1 is idempotent (atomics exchange) and does not
-            %% raise on I/O failure — best-effort reclamation on owner death.
-            catch beamtalk_file_handle:close_handle(Handle),
-            ok;
-        error ->
-            ok
-    end.
+-spec owned_handles([handle_key()], map()) -> [beamtalk_file_handle:t()].
+owned_handles(Keys, Handles) ->
+    lists:filtermap(
+        fun(Key) ->
+            case maps:find(Key, Handles) of
+                {ok, {Handle, _Owner}} -> {true, Handle};
+                error -> false
+            end
+        end,
+        Keys
+    ).
+
+%% One transient, unlinked process per dying owner — unlinked so a wedged
+%% descriptor can never take the registry down with it, and per-owner so one
+%% owner's stuck close does not delay another's reclamation. The handles are
+%% already out of the registry's state by the time this runs, so nothing else
+%% will reach for them; a concurrent explicit `close` is harmless because
+%% `close_handle/1` claims its atomics cell exactly once.
+-spec close_owned_handles_async([beamtalk_file_handle:t()]) -> ok.
+close_owned_handles_async([]) ->
+    ok;
+close_owned_handles_async(Handles) ->
+    _ = spawn(fun() -> lists:foreach(fun close_owned_handle/1, Handles) end),
+    ok.
+
+-spec close_owned_handle(beamtalk_file_handle:t()) -> ok.
+close_owned_handle(Handle) ->
+    %% close_handle/1 is idempotent (atomics exchange) and does not
+    %% raise on I/O failure — best-effort reclamation on owner death.
+    catch beamtalk_file_handle:close_handle(Handle),
+    ok.
 
 -spec do_open_handles(#state{}) -> [{binary(), beamtalk_file_handle:mode(), owner()}].
 do_open_handles(#state{handles = Handles}) ->

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_file_handle_registry_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_file_handle_registry_tests.erl
@@ -17,7 +17,10 @@ Covers the acceptance criteria:
 * `unregister/1` removes a handle immediately, so a closed handle does not
   linger in `open_handles/0` and a later owner `'DOWN'` cannot double-close it;
 * handles sharing an owner share a single monitor, torn down only once the
-  last of them is gone.
+  last of them is gone;
+* owner-death reclamation does not block the registry's mailbox (BT-3050) —
+  an unrelated `register`/`open_handles` is still answered while one owner's
+  `file:close/1` is stuck.
 """.
 
 -include_lib("eunit/include/eunit.hrl").
@@ -71,12 +74,52 @@ wait_dead(Pid) ->
             wait_dead(Pid)
     end.
 
+%% A descriptor stand-in that never answers a close request. `file:close/1` on
+%% a pid sends the request and then waits for either a `{file_reply, ...}` or
+%% the descriptor process's death, so a handle wrapping this pid makes
+%% reclamation hang until `release_wedged_fd/1`.
+spawn_wedged_fd() ->
+    spawn(fun() ->
+        receive
+            release -> ok
+        end
+    end).
+
+release_wedged_fd(Fd) ->
+    Fd ! release,
+    wait_dead(Fd).
+
 %% Block until the registry has processed all calls up to this point (calls
 %% are handled in order, so a further sync call flushes prior ones — and
 %% 'DOWN' messages are handled by the same serialised mailbox).
 sync(_) ->
     _ = sys:get_state(beamtalk_file_handle_registry),
     ok.
+
+%% Poll `Pred` until it holds, then return ok; assert (and so fail the test) if
+%% it never does. Owner-death reclamation is only half-synchronous since
+%% BT-3050: `sync/1` proves the registry has dropped its own bookkeeping, but
+%% the descriptor is closed by a transient process shortly afterwards, so
+%% "is the handle shut?" has to be polled rather than assumed.
+wait_until(Pred) ->
+    wait_until(Pred, 400).
+
+wait_until(Pred, 0) ->
+    ?assert(Pred());
+wait_until(Pred, Attempts) ->
+    case Pred() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(5),
+            wait_until(Pred, Attempts - 1)
+    end.
+
+closed(Handle) ->
+    fun() -> not beamtalk_file_handle:is_open(Handle) end.
+
+unlisted(Path) ->
+    fun() -> not has_entry(Path, beamtalk_file_handle_registry:open_handles()) end.
 
 has_entry(Path, Handles) ->
     lists:any(fun({P, _Mode, _Owner}) -> P =:= Path end, Handles).
@@ -98,9 +141,53 @@ owned_handle_closed_and_removed_on_owner_death_test_() ->
             stop_dummy(Owner),
             ok = sync(ok),
 
-            ?assertNot(beamtalk_file_handle:is_open(Handle)),
+            %% Bookkeeping is dropped synchronously with the 'DOWN'; the close
+            %% itself lands a moment later, off the registry process (BT-3050).
             ?assertNot(has_entry(PathBin, beamtalk_file_handle_registry:open_handles())),
+            ok = wait_until(closed(Handle)),
             delete_temp(TmpPath)
+        end)
+    end}.
+
+registry_stays_responsive_while_owner_close_is_in_flight_test_() ->
+    %% BT-3050: owner-death reclamation must not run `file:close/1` inside the
+    %% registry's own handle_info. One owner's handle wraps a descriptor
+    %% stand-in that never answers a close, so its reclamation is stuck for as
+    %% long as the test wants it to be; meanwhile an unrelated register/
+    %% open_handles must still be answered. Both assertions below use a bounded
+    %% timeout, so the inline-close implementation this replaces fails them
+    %% (gen_server:call exits on timeout) rather than merely running slowly.
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        ?_test(begin
+            Registry = whereis(beamtalk_file_handle_registry),
+            Owner = spawn_dummy(),
+            WedgedFd = spawn_wedged_fd(),
+            WedgedPath = list_to_binary(temp_path("beamtalk_file_handle_registry_wedged")),
+            Wedged = beamtalk_file_handle:new(WedgedFd, write, WedgedPath),
+            ok = beamtalk_file_handle_registry:register(Wedged, Owner),
+
+            stop_dummy(Owner),
+            %% The registry drops its own bookkeeping synchronously, so the
+            %% wedged handle disappearing proves the 'DOWN' was handled...
+            ok = wait_until(unlisted(WedgedPath)),
+            %% ...while its close is genuinely still in flight and stuck.
+            ?assert(is_process_alive(WedgedFd)),
+
+            {Other, OtherPath} = open_handle(),
+            OtherPathBin = list_to_binary(OtherPath),
+            ?assertEqual(ok, gen_server:call(Registry, {register, Other, undefined}, 1000)),
+            ?assert(has_entry(OtherPathBin, gen_server:call(Registry, open_handles, 1000))),
+
+            %% Releasing the stand-in lets the stuck close/1 return and the
+            %% reclaimer finish on its own. (The handle already reads closed:
+            %% close_handle/1 claims its atomics cell before calling
+            %% file:close/1, which is what makes the close idempotent.)
+            release_wedged_fd(WedgedFd),
+            ?assertNot(beamtalk_file_handle:is_open(Wedged)),
+
+            ok = beamtalk_file_handle:close_handle(Other),
+            ok = beamtalk_file_handle_registry:unregister(Other),
+            delete_temp(OtherPath)
         end)
     end}.
 
@@ -171,7 +258,7 @@ shared_owner_monitor_survives_until_last_handle_gone_test_() ->
             stop_dummy(Owner),
             ok = sync(ok),
 
-            ?assertNot(beamtalk_file_handle:is_open(H2)),
+            ok = wait_until(closed(H2)),
             Handles = beamtalk_file_handle_registry:open_handles(),
             ?assertNot(has_entry(list_to_binary(P1), Handles)),
             ?assertNot(has_entry(list_to_binary(P2), Handles)),
@@ -282,7 +369,7 @@ multiple_owners_monitor_demonitored_independently_test_() ->
             %% H2 must still be reclaimed when Owner2 dies (its monitor was kept).
             stop_dummy(Owner2),
             ok = sync(ok),
-            ?assertNot(beamtalk_file_handle:is_open(H2)),
+            ok = wait_until(closed(H2)),
             ?assertNot(
                 has_entry(
                     list_to_binary(P2),


### PR DESCRIPTION
## Problem

`beamtalk_file_handle_registry:handle_owner_down/3` closed every outstanding handle of a dead owner **synchronously, inline**, in the registry's own `handle_info({'DOWN', ...})` clause. Each `file:close/1` on a non-raw descriptor is a round-trip to that handle's `file_io_server` process, and `register/2`, `unregister/1` and `open_handles/0` are all `gen_server:call`s to that *same* registry process — so one owner's teardown blocked the registry's mailbox, and therefore every concurrent `File open:mode:` / `close` / `openHandles` call node-wide, until all of that owner's closes finished. For a wedged descriptor, indefinitely.

Since `open:mode:` runs inside the long-lived `File` class gen_server (deliberately not call-site lowered), the stall was felt by every caller of `File`, not just the dying owner's session/actor.

## Change

Reclamation is now split in two:

* **Bookkeeping stays synchronous** — the dead owner's handles are removed from `handles` / `by_owner` / `monitors` while handling the `'DOWN'`, so they are observably gone from `File openHandles` immediately.
* **The `file:close/1` calls are handed to a transient process** — one unlinked process per dying owner. Unlinked so a wedged descriptor can never take the registry down with it; per-owner so one stuck close does not delay another owner's reclamation. The handles are already out of the registry's state by the time it runs, and a concurrent explicit `close` is harmless because `close_handle/1` claims its atomics cell exactly once.

Behaviour is otherwise preserved: the dead owner's handles are still closed, still removed, and `close`/`unregister` still prevent any double-close.

## Tests

New `registry_stays_responsive_while_owner_close_is_in_flight_test_` registers a handle wrapping a descriptor stand-in that never answers a close request (`file:close/1` on a pid waits for a `{file_reply, ...}` or the descriptor's death), kills its owner, then asserts an unrelated `register` and `open_handles` are both answered within a bounded 1s call. Verified this test wedges the registry outright under the old implementation (the run aborts with 11 tests cancelled) and passes with the fix.

The three existing owner-death tests now poll for the descriptor close via a `wait_until/1` helper rather than assuming it has landed by the time the registry has processed the `'DOWN'`; their registry-state assertions remain synchronous.

`just ci-changed` passes (build, clippy, fmt, Rust + stdlib + BUnit + runtime + metamorphic tests, corpus check, surface-drift check); `just dialyzer` clean.

Closes BT-3050.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lpk7sFewQxfoTLiZw3qsWg)_