### PR TITLE
refactor(codegen): extract duplicated instantiation_error docvec in value_type_codegen

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -840,7 +840,13 @@ impl CoreErlangGenerator {
 
         Ok(docvec![
             function_head,
-            nest(INDENT, docvec![line(), Self::instantiation_error_expr(class_name, selector, &hint)]),
+            nest(
+                INDENT,
+                docvec![
+                    line(),
+                    Self::instantiation_error_expr(class_name, selector, &hint)
+                ]
+            ),
             "\n",
             "\n",
         ])
@@ -874,7 +880,13 @@ impl CoreErlangGenerator {
 
         docvec![
             function_head,
-            nest(INDENT, docvec![line(), Self::instantiation_error_expr(class_name, selector, &hint)]),
+            nest(
+                INDENT,
+                docvec![
+                    line(),
+                    Self::instantiation_error_expr(class_name, selector, &hint)
+                ]
+            ),
             "\n",
             "\n",
         ]

--- a/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/value_type_codegen.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 use std::fmt::Write as FmtWrite;
 
 use super::control_flow::ThreadingPlan;
-use super::document::{Document, concat, join, leaf};
+use super::document::{Document, INDENT, concat, join, leaf, line, nest};
 use super::intrinsics::validate_block_arity_exact;
 use super::spec_codegen;
 use super::util::ClassIdentity;
@@ -840,17 +840,8 @@ impl CoreErlangGenerator {
 
         Ok(docvec![
             function_head,
+            nest(INDENT, docvec![line(), Self::instantiation_error_expr(class_name, selector, &hint)]),
             "\n",
-            "    let Error0 = call 'beamtalk_error':'new'('instantiation_error', ",
-            leaf::atom(class_name.to_string()),
-            ") in\n",
-            "    let Error1 = call 'beamtalk_error':'with_selector'(Error0, ",
-            leaf::atom(selector.to_string()),
-            ") in\n",
-            "    let Error2 = call 'beamtalk_error':'with_hint'(Error1, ",
-            leaf::binary_lit(&hint),
-            ") in\n",
-            "    call 'beamtalk_error':'raise'(Error2)\n",
             "\n",
         ])
     }
@@ -883,17 +874,8 @@ impl CoreErlangGenerator {
 
         docvec![
             function_head,
+            nest(INDENT, docvec![line(), Self::instantiation_error_expr(class_name, selector, &hint)]),
             "\n",
-            "    let Error0 = call 'beamtalk_error':'new'('instantiation_error', ",
-            leaf::atom(class_name.to_string()),
-            ") in\n",
-            "    let Error1 = call 'beamtalk_error':'with_selector'(Error0, ",
-            leaf::atom(selector.to_string()),
-            ") in\n",
-            "    let Error2 = call 'beamtalk_error':'with_hint'(Error1, ",
-            leaf::binary_lit(&hint),
-            ") in\n",
-            "    call 'beamtalk_error':'raise'(Error2)\n",
             "\n",
         ]
     }


### PR DESCRIPTION
## Summary

`generate_primitive_new_error` and `generate_native_new_error` in `value_type_codegen.rs` each inlined an identical 9-element `docvec!` to emit the `instantiation_error` let-chain. The shared helper `instantiation_error_expr` (already `pub(in crate::codegen::core_erlang)`) in `gen_server/spawn.rs` encapsulates exactly this pattern.

- Replace both inline `docvec!` blocks with `nest(INDENT, docvec[line(), Self::instantiation_error_expr(...)])`, preserving the two-trailing-newline convention used by all sibling functions in `value_type_codegen.rs`
- Add `INDENT`, `line`, `nest` to the existing `document::` import
- No behaviour change — rendered Core Erlang output is byte-identical

Net change: −18 lines (3 inserted, 21 deleted across the two commits; second commit is a rustfmt reflow of the new `nest()` calls).

## Test plan

- [x] `cargo test -p beamtalk-core` — 5686 passed, 0 failed
- [x] `just clippy` — passes
- [x] `cargo fmt --check` — passes (formatted in second commit)
- [x] Pre-push hook (lint-rust, clippy, fmt, dialyzer, build, stdlib build) — all green

---
_Generated by [Claude Code](https://claude.ai/code/session_015rhtqVbP72JVw3E9kGhAAX)_