### PR TITLE
Relax stdlib refusal in remove_method for removeSelector: (BT-3184)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_eval.erl
@@ -54,7 +54,11 @@ module loading to beamtalk_repl_loader (BT-863).
 
 %% ADR 0082 revert completeness (BT-2663/BT-2665) — remove a live method (the
 %% *add* revert case) and remove a live class (new-class revert, BT-2664).
--export([remove_method/3, remove_class/1]).
+%% ADR 0112 Phase 1 (BT-3184) — remove_method/4 adds an explicit stdlib policy
+%% so the future `removeSelector:` primitive can reach stdlib classes through
+%% this SAME function rather than a forked copy; remove_method/3 keeps the
+%% revert-of-an-add caller's unchanged refuse-stdlib default.
+-export([remove_method/3, remove_method/4, remove_class/1]).
 
 %% BT-2531 — workspace binding-mutation announcement with an explicit session id.
 %% Called from `beamtalk_repl_shell` for the clear / pending put/remove paths,
@@ -906,16 +910,51 @@ Remove a live method from a class (BT-2663/BT-2665 *add* revert case).
 `Side` (`instance | class`) selects which side's method to drop. Recompiles the
 class without the method and hot-reloads it; the live image is unchanged on error.
 Returns `{ok, ClassNameBin}` or `{error, Reason}`. Refuses stdlib classes (their
-methods are read-only in the workspace).
+methods are read-only in the workspace) — equivalent to
+`remove_method/4` with `refuse_stdlib`, the policy every caller of this arity
+gets (currently just the revert-of-an-add path, which has no legitimate
+"revert" of a patch that was never flushable in the first place).
 """.
 -spec remove_method(binary(), atom() | binary(), instance | class) ->
     {ok, binary()} | {error, term()}.
 remove_method(ClassNameBin, Selector, Side) ->
+    remove_method(ClassNameBin, Selector, Side, refuse_stdlib).
+
+-doc """
+Remove a live method from a class, with an explicit stdlib policy (ADR 0112
+Phase 1, BT-3184).
+
+Same removal mechanism as `remove_method/3` (recompiles the class without the
+method and hot-reloads it; the live image is unchanged on error), but the
+stdlib gate is now conditional on `StdlibPolicy`:
+
+- `refuse_stdlib` — reject a stdlib class up front with
+  `stdlib_method_read_only_error/2`, matching `remove_method/3`'s behavior
+  (the revert-of-an-add caller keeps this: there is no legitimate "revert" of
+  a patch that was never flushable).
+- `allow_stdlib` — skip the gate and let the removal reach stdlib classes too,
+  matching `compile:source:`'s existing flushability rule (ADR 0082) rather
+  than `removeFromSystem`'s hard block. For the future `removeSelector:`
+  primitive (ADR 0112 Phase 2), which must install in memory even on stdlib
+  classes — flushability, not refusal, is enforced later at the ChangeLog
+  layer, not here.
+
+One shared code path for both policies (CLAUDE.md's no-duplicate-
+implementations rule) — only the gate decision forks. `StdlibPolicy` is
+matched exhaustively (`refuse_stdlib` / `allow_stdlib` only) rather than via a
+catch-all `_` clause, so an unrecognised policy atom fails loudly
+(`case_clause`) instead of silently falling through to the permissive path.
+""".
+-spec remove_method(binary(), atom() | binary(), instance | class, refuse_stdlib | allow_stdlib) ->
+    {ok, binary()} | {error, term()}.
+remove_method(ClassNameBin, Selector, Side, StdlibPolicy) ->
     SelectorBin = beamtalk_repl_protocol:to_binary(Selector),
-    case stdlib_class_module(ClassNameBin) of
-        {ok, _Module} ->
+    case {StdlibPolicy, stdlib_class_module(ClassNameBin)} of
+        {refuse_stdlib, {ok, _Module}} ->
             {error, stdlib_method_read_only_error(ClassNameBin, SelectorBin)};
-        none ->
+        {allow_stdlib, _} ->
+            beamtalk_repl_loader:remove_method(ClassNameBin, SelectorBin, Side);
+        {refuse_stdlib, none} ->
             beamtalk_repl_loader:remove_method(ClassNameBin, SelectorBin, Side)
     end.
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_revert_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_revert_tests.erl
@@ -11,6 +11,12 @@ End-to-end tests for the ChangeLog revert completeness set (ADR 0082):
   - BT-2665: reverting a *class-side* method works symmetrically with instance
     side — a modify re-installs the prior class-side body; an add removes it.
 
+Also covers the stdlib policy `beamtalk_repl_eval:remove_method/3,4` gates on
+(ADR 0112 Phase 1, BT-3184): `remove_method/3` (the revert-of-an-add path
+above) keeps refusing stdlib classes, while `remove_method/4` with
+`allow_stdlib` reaches them — the mechanism the future `removeSelector:`
+primitive (ADR 0112 Phase 2) will drive.
+
 These boot the full stack (compiler port + runtime + workspace_meta + changelog)
 against an isolated, in-project temp tree so the live install / remove and the
 flushable-with-prev-source recording paths run for real, then drive revert
@@ -36,7 +42,10 @@ revert_e2e_test_() ->
             fun revert_modified_instance_method_restores_prior_body/1,
             fun revert_added_class_side_method_removes_it/1,
             fun revert_modified_class_side_method_restores_prior_body/1,
-            fun revert_new_class_removes_the_class/1
+            fun revert_new_class_removes_the_class/1,
+            fun remove_method_default_still_refuses_stdlib/1,
+            fun remove_method_allow_stdlib_removes_from_a_stdlib_class/1,
+            fun remove_method_unknown_policy_fails_closed/1
         ]}}.
 
 %% Start the heavy, node-global apps once for the whole suite (the compiler port
@@ -214,6 +223,65 @@ revert_new_class_removes_the_class(#{tmp := Tmp, unique := U}) ->
     ].
 
 %%====================================================================
+%% BT-3184 — remove_method/3,4 stdlib policy (ADR 0112 Phase 1)
+%%====================================================================
+
+%% remove_method/3 (the arity the revert-of-an-add path above uses) must keep
+%% refusing stdlib classes exactly as before this issue — a real, already-
+%% loaded stdlib class (ErlangModule) is used directly since this path never
+%% reaches the recompile step, so nothing about the live class is mutated.
+remove_method_default_still_refuses_stdlib(_) ->
+    ?assert(beamtalk_runtime_api:whereis_class('ErlangModule') =/= undefined),
+    Result3 = beamtalk_repl_eval:remove_method(
+        <<"ErlangModule">>, <<"doesNotUnderstand:args:">>, instance
+    ),
+    Result4Refuse = beamtalk_repl_eval:remove_method(
+        <<"ErlangModule">>, <<"doesNotUnderstand:args:">>, instance, refuse_stdlib
+    ),
+    [
+        ?_assertMatch({error, #beamtalk_error{kind = runtime_error}}, Result3),
+        ?_assertMatch({error, #beamtalk_error{kind = runtime_error}}, Result4Refuse)
+    ].
+
+%% remove_method/4 with `allow_stdlib` must reach a stdlib class instead of
+%% refusing it up front. Defines a throwaway class under a `stdlib/src/`
+%% subdirectory of the isolated temp tree (real file, `reload_class_file`-
+%% loaded — see `define_stdlib_class/3`) so `is_stdlib_path/1`'s path check
+%% genuinely classifies it stdlib-mode, giving it a real `bt@stdlib@...`
+%% module name — the exact condition `stdlib_class_module/1` checks for. This
+%% never touches a real production stdlib class.
+remove_method_allow_stdlib_removes_from_a_stdlib_class(#{tmp := Tmp, unique := U}) ->
+    ClassName = list_to_binary("Bt3184StdlibProbe" ++ U),
+    {ok, Pid} = define_stdlib_class(
+        Tmp, ClassName, ["  class keep => 1\n", "  class probe => 2\n"]
+    ),
+    AfterAdd = beamtalk_runtime_api:local_class_methods(Pid),
+    Result = beamtalk_repl_eval:remove_method(ClassName, <<"probe">>, class, allow_stdlib),
+    AfterRemove = beamtalk_runtime_api:local_class_methods(Pid),
+    [
+        ?_assert(lists:member(probe, AfterAdd)),
+        ?_assertMatch({ok, _}, Result),
+        ?_assertNot(lists:member(probe, AfterRemove)),
+        %% The pre-existing method is untouched.
+        ?_assert(lists:member(keep, AfterRemove))
+    ].
+
+%% An unrecognised `StdlibPolicy` atom must fail loudly (no matching case
+%% clause) rather than silently falling through to the permissive
+%% `allow_stdlib` path — guards against a future caller's typo reaching a real
+%% stdlib class unintentionally.
+remove_method_unknown_policy_fails_closed(_) ->
+    ?assert(beamtalk_runtime_api:whereis_class('ErlangModule') =/= undefined),
+    [
+        ?_assertError(
+            {case_clause, _},
+            beamtalk_repl_eval:remove_method(
+                <<"ErlangModule">>, <<"doesNotUnderstand:args:">>, instance, bogus_policy
+            )
+        )
+    ].
+
+%%====================================================================
 %% Helpers
 %%====================================================================
 
@@ -230,6 +298,26 @@ define_project_class(Tmp, ClassNameBin, Methods) ->
     {ok, _ClassNames} = beamtalk_repl_loader:reload_class_file(Path),
     %% Record the class source in workspace_meta so live patches resolve their
     %% span (the stateful REPL load path does this; the stateless reload does not).
+    ok = beamtalk_workspace_meta:set_class_source(ClassNameBin, binary_to_list(Source)),
+    ClassAtom = binary_to_atom(ClassNameBin, utf8),
+    Pid = wait_for_class(ClassAtom, 50),
+    {ok, Pid}.
+
+%% Like define_project_class/3, but writes the file under a `stdlib/src/`
+%% subdirectory of the temp tree instead of directly in it. `is_stdlib_path/1`
+%% (`beamtalk_repl_loader`) matches on the `/stdlib/src/` path substring alone,
+%% so this drives the real compiler through its stdlib-mode branch and yields
+%% a genuine `bt@stdlib@...` module name (BT-3184) — without writing anything
+%% into the real `stdlib/src/` tree or touching a real stdlib class.
+define_stdlib_class(Tmp, ClassNameBin, Methods) ->
+    Dir = filename:join([Tmp, "stdlib", "src"]),
+    ok = filelib:ensure_path(Dir),
+    Path = filename:join(Dir, binary_to_list(ClassNameBin) ++ ".bt"),
+    Source = iolist_to_binary([
+        <<"Object subclass: ">>, ClassNameBin, <<"\n">>, Methods
+    ]),
+    ok = file:write_file(Path, Source),
+    {ok, _ClassNames} = beamtalk_repl_loader:reload_class_file(Path),
     ok = beamtalk_workspace_meta:set_class_source(ClassNameBin, binary_to_list(Source)),
     ClassAtom = binary_to_atom(ClassNameBin, utf8),
     Pid = wait_for_class(ClassAtom, 50),


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-3184

Part of ADR 0112 (`docs/ADR/0112-method-level-removal-language-primitive.md`), Phase 1 of 5 (Foundation).

`beamtalk_repl_eval:remove_method/3` — the existing method-removal mechanism ADR 0082's `revert:`-of-an-add case (BT-2663/BT-2665) already provides — refused stdlib classes outright. That refusal was correct for `revert:` (there's no legitimate "revert" of a patch that was never flushable), but contradicts ADR 0112's decision for the future `removeSelector:` primitive: it must install in memory even on stdlib classes, matching `compile:source:`'s existing flushability rule (ADR 0082) rather than `removeFromSystem`'s hard block.

## Changes

- `beamtalk_repl_eval:remove_method/4` adds an explicit `refuse_stdlib | allow_stdlib` policy parameter. `remove_method/3` is now a thin wrapper defaulting to `refuse_stdlib`, so the existing revert-of-an-add caller (`beamtalk_workspace_interface_primitives.erl`) is unaffected — one shared function, not a forked copy, per CLAUDE.md's no-duplicate-implementations rule.
- The policy match is exhaustive (no catch-all `_` clause) so an unrecognised policy atom fails loudly (`case_clause`) instead of silently falling through to the permissive path — found and fixed during self-review.
- New EUnit coverage in `beamtalk_workspace_revert_tests.erl`:
  - the relaxed (`allow_stdlib`) path actually removes a method from a genuine stdlib-mode class (compiled via a real `stdlib/src/`-pathed temp file, never touching production stdlib source)
  - the default 3-arity form still refuses a real stdlib class (`ErlangModule`)
  - an unknown policy atom raises `case_clause`

## Out of scope (Phase 2, separate issue)

- The new `classRemoveSelector`/`classRemoveSelectorIfAbsent` primitives that will call this relaxed function.
- Extension-method removal (`beamtalk_extensions:unregister/2`) — separate issue.

## Test plan

- [x] `just ci-changed` — build, lint (dialyzer + dialyzer-specs + fmt), full `just test` (stdlib/BUnit/runtime/metamorphic), corpus check, surface-drift check, integration/MCP/REPL-protocol/parity tests — all green, run twice (before and after the fail-closed fix)
- [x] New EUnit tests cover both stdlib policies and the fail-closed unknown-policy case
- [x] Existing revert/BT-2663/BT-2665 tests unaffected (same fixture, all still pass)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CeTtDi5ua6oSuVrkEMvCCM)_