### PR TITLE
refactor(cli): extract normalize_path to shared path_util module

### DIFF
--- a/crates/beamtalk-cli/src/commands/deps/path.rs
+++ b/crates/beamtalk-cli/src/commands/deps/path.rs
@@ -12,6 +12,7 @@
 //! - Detects circular dependencies
 //! - Returns ebin paths for BEAM code path setup
 
+use beamtalk_cli::path_util::normalize_path;
 use beamtalk_core::compilation::DependencySource;
 use camino::{Utf8Path, Utf8PathBuf};
 use miette::{Context, IntoDiagnostic, Result};
@@ -279,50 +280,6 @@ pub(crate) fn canonicalize_dep_path(
 
     // Normalize the path by resolving `.` and `..` components
     normalize_path(&joined)
-}
-
-/// Normalize a path by resolving `.` and `..` components without filesystem access.
-///
-/// Unlike `std::fs::canonicalize`, this does not require the path to exist and
-/// does not resolve symlinks.
-fn normalize_path(path: &Utf8Path) -> Utf8PathBuf {
-    use camino::Utf8Component;
-
-    let mut components = Vec::new();
-    for component in path.components() {
-        match component {
-            Utf8Component::CurDir => {
-                // Skip `.`
-            }
-            Utf8Component::ParentDir => match components.last().copied() {
-                // Already at the filesystem root — an extra `..` is a no-op
-                // rather than something to pop or accumulate (BT-2836 review
-                // finding: popping `RootDir` here would turn `/foo/../..`
-                // into `.` instead of `/`).
-                Some(Utf8Component::RootDir) => {}
-                // Nothing to pop yet, or a run of leading `..`s in a
-                // relative path — accumulate.
-                None | Some(Utf8Component::ParentDir) => components.push(component),
-                // A real component precedes it — cancel the two out.
-                Some(_) => {
-                    components.pop();
-                }
-            },
-            _ => {
-                components.push(component);
-            }
-        }
-    }
-
-    if components.is_empty() {
-        return Utf8PathBuf::from(".");
-    }
-
-    let mut result = Utf8PathBuf::new();
-    for component in components {
-        result.push(component.as_str());
-    }
-    result
 }
 
 /// Compile a dependency and return a `ResolvedDependency`.
@@ -715,36 +672,6 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
-
-    #[test]
-    fn test_normalize_path_resolves_parent() {
-        let path = Utf8PathBuf::from("/home/user/project/../dep");
-        assert_eq!(normalize_path(&path), Utf8PathBuf::from("/home/user/dep"));
-    }
-
-    #[test]
-    fn test_normalize_path_resolves_dot() {
-        let path = Utf8PathBuf::from("/home/user/./project");
-        assert_eq!(
-            normalize_path(&path),
-            Utf8PathBuf::from("/home/user/project")
-        );
-    }
-
-    #[test]
-    fn test_normalize_path_multiple_parents() {
-        let path = Utf8PathBuf::from("/home/user/project/../../dep");
-        assert_eq!(normalize_path(&path), Utf8PathBuf::from("/home/dep"));
-    }
-
-    #[test]
-    fn test_normalize_path_parent_at_root() {
-        // A `..` chain that consumes every real component and then hits
-        // root must not pop `RootDir` itself — `/foo/../..` is still `/`,
-        // not `.` (BT-2836 review finding).
-        let path = Utf8PathBuf::from("/foo/../..");
-        assert_eq!(normalize_path(&path), Utf8PathBuf::from("/"));
-    }
 
     #[test]
     fn test_canonicalize_dep_path() {

--- a/crates/beamtalk-cli/src/dependency_classes.rs
+++ b/crates/beamtalk-cli/src/dependency_classes.rs
@@ -57,11 +57,12 @@
 
 use crate::build_layout::BuildLayout;
 use crate::manifest;
+use crate::path_util::normalize_path;
 use beamtalk_core::compilation::{DependencyMap, DependencySource};
 use beamtalk_core::file_walker::FileWalker;
 use beamtalk_core::semantic_analysis::class_hierarchy::ClassInfo;
 use beamtalk_core::source_analysis::{lex_with_eof, parse};
-use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
+use camino::{Utf8Path, Utf8PathBuf};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Mutex, OnceLock, PoisonError};
 use std::time::SystemTime;
@@ -176,50 +177,6 @@ pub fn resolve_dependency_class_infos(project_root: &Utf8Path) -> (bool, Vec<Cla
     }
 
     (has_package_dependencies, class_infos)
-}
-
-/// Normalize a path by resolving `.` and `..` components without filesystem
-/// access (mirrors `commands::deps::path::normalize_path`, duplicated here
-/// per the module doc's note on the binary/library crate split — BT-2836).
-///
-/// Unlike `std::fs::canonicalize`, this does not require the path to exist
-/// and does not resolve symlinks.
-fn normalize_path(path: &Utf8Path) -> Utf8PathBuf {
-    let mut components = Vec::new();
-    for component in path.components() {
-        match component {
-            Utf8Component::CurDir => {
-                // Skip `.`
-            }
-            Utf8Component::ParentDir => match components.last().copied() {
-                // Already at the filesystem root — an extra `..` is a no-op
-                // rather than something to pop or accumulate (BT-2836 review
-                // finding: popping `RootDir` here would turn `/foo/../..`
-                // into `.` instead of `/`).
-                Some(Utf8Component::RootDir) => {}
-                // Nothing to pop yet, or a run of leading `..`s in a
-                // relative path — accumulate.
-                None | Some(Utf8Component::ParentDir) => components.push(component),
-                // A real component precedes it — cancel the two out.
-                Some(_) => {
-                    components.pop();
-                }
-            },
-            _ => {
-                components.push(component);
-            }
-        }
-    }
-
-    if components.is_empty() {
-        return Utf8PathBuf::from(".");
-    }
-
-    let mut result = Utf8PathBuf::new();
-    for component in components {
-        result.push(component.as_str());
-    }
-    result
 }
 
 /// Cheap staleness signal for a dependency's source tree (BT-2837): the
@@ -344,38 +301,6 @@ mod tests {
             fs::create_dir_all(parent).unwrap();
         }
         fs::write(path, contents).unwrap();
-    }
-
-    // BT-2836: direct unit coverage for the duplicated `normalize_path`
-    // (mirrors `commands::deps::path`'s own `test_normalize_path_*` tests).
-    #[test]
-    fn normalize_path_resolves_parent() {
-        let path = Utf8PathBuf::from("/home/user/project/../dep");
-        assert_eq!(normalize_path(&path), Utf8PathBuf::from("/home/user/dep"));
-    }
-
-    #[test]
-    fn normalize_path_resolves_dot() {
-        let path = Utf8PathBuf::from("/home/user/./project");
-        assert_eq!(
-            normalize_path(&path),
-            Utf8PathBuf::from("/home/user/project")
-        );
-    }
-
-    #[test]
-    fn normalize_path_multiple_parents() {
-        let path = Utf8PathBuf::from("/home/user/project/../../dep");
-        assert_eq!(normalize_path(&path), Utf8PathBuf::from("/home/dep"));
-    }
-
-    #[test]
-    fn normalize_path_parent_at_root() {
-        // A `..` chain that consumes every real component and then hits
-        // root must not pop `RootDir` itself — `/foo/../..` is still `/`,
-        // not `.` (review finding on PR #2989).
-        let path = Utf8PathBuf::from("/foo/../..");
-        assert_eq!(normalize_path(&path), Utf8PathBuf::from("/"));
     }
 
     // BT-2837: `resolve_dependency_class_infos` now reads/writes a

--- a/crates/beamtalk-cli/src/lib.rs
+++ b/crates/beamtalk-cli/src/lib.rs
@@ -12,6 +12,7 @@
 //!   resolution shared with `beamtalk-mcp` (BT-2823)
 //! - [`native_type_specs`] — Erlang FFI type-spec extraction shared with
 //!   `beamtalk-mcp` (BT-2858)
+//! - [`path_util`] — shared `normalize_path` utility (filesystem-free `.`/`..` resolution)
 //! - [`pid_liveness`] — cross-platform "is this PID alive?" check, shared
 //!   with `tests/cli_common` (BT-3077)
 
@@ -20,5 +21,6 @@ pub mod dependency_classes;
 pub mod erlc;
 pub mod manifest;
 pub mod native_type_specs;
+pub mod path_util;
 pub mod pid_liveness;
 pub mod repl_startup;

--- a/crates/beamtalk-cli/src/path_util.rs
+++ b/crates/beamtalk-cli/src/path_util.rs
@@ -1,0 +1,83 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared path utilities for the Beamtalk CLI.
+
+use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
+
+/// Normalize a path by resolving `.` and `..` components without filesystem access.
+///
+/// Unlike `std::fs::canonicalize`, this does not require the path to exist and
+/// does not resolve symlinks.
+pub fn normalize_path(path: &Utf8Path) -> Utf8PathBuf {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            Utf8Component::CurDir => {
+                // Skip `.`
+            }
+            Utf8Component::ParentDir => match components.last().copied() {
+                // Already at the filesystem root — an extra `..` is a no-op
+                // rather than something to pop or accumulate (BT-2836 review
+                // finding: popping `RootDir` here would turn `/foo/../..`
+                // into `.` instead of `/`).
+                Some(Utf8Component::RootDir) => {}
+                // Nothing to pop yet, or a run of leading `..`s in a
+                // relative path — accumulate.
+                None | Some(Utf8Component::ParentDir) => components.push(component),
+                // A real component precedes it — cancel the two out.
+                Some(_) => {
+                    components.pop();
+                }
+            },
+            _ => {
+                components.push(component);
+            }
+        }
+    }
+
+    if components.is_empty() {
+        return Utf8PathBuf::from(".");
+    }
+
+    let mut result = Utf8PathBuf::new();
+    for component in components {
+        result.push(component.as_str());
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_path_resolves_parent() {
+        let path = Utf8PathBuf::from("/home/user/project/../dep");
+        assert_eq!(normalize_path(&path), Utf8PathBuf::from("/home/user/dep"));
+    }
+
+    #[test]
+    fn normalize_path_resolves_dot() {
+        let path = Utf8PathBuf::from("/home/user/./project");
+        assert_eq!(
+            normalize_path(&path),
+            Utf8PathBuf::from("/home/user/project")
+        );
+    }
+
+    #[test]
+    fn normalize_path_multiple_parents() {
+        let path = Utf8PathBuf::from("/home/user/project/../../dep");
+        assert_eq!(normalize_path(&path), Utf8PathBuf::from("/home/dep"));
+    }
+
+    #[test]
+    fn normalize_path_parent_at_root() {
+        // A `..` chain that consumes every real component and then hits
+        // root must not pop `RootDir` itself — `/foo/../..` is still `/`,
+        // not `.` (BT-2836 review finding).
+        let path = Utf8PathBuf::from("/foo/../..");
+        assert_eq!(normalize_path(&path), Utf8PathBuf::from("/"));
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts `normalize_path` (filesystem-free `.`/`..` resolution) from two duplicated locations into a single `crates/beamtalk-cli/src/path_util.rs` module
- Deletes the "mirrors … duplicated here … Keep the two algorithms in sync" comment that flagged this in BT-2836
- Consolidates the 4 duplicate `normalize_path` unit tests into `path_util`'s own `#[cfg(test)]` block

## Background

`normalize_path` was duplicated between `commands/deps/path.rs` (binary crate) and `dependency_classes.rs` (library crate), with an explicit "keep in sync" comment at `dependency_classes.rs:182`. The reason was that the library module could not reach into the binary's private `commands::` tree. However, the binary already links against the library — so the correct fix is to move the single canonical implementation into the library's new `path_util` module and have both callers import from there.

## Files changed

- `src/path_util.rs` — new; single `pub fn normalize_path` + 4 tests
- `src/lib.rs` — add `pub mod path_util`
- `src/dependency_classes.rs` — replace local copy with `use crate::path_util::normalize_path`; remove duplicate tests
- `src/commands/deps/path.rs` — replace local copy with `use beamtalk_cli::path_util::normalize_path`; remove duplicate tests

## Test plan

- [x] `cargo build -p beamtalk-cli` — clean
- [x] `cargo test -p beamtalk-cli --lib` — 147 passed, 0 failed
- [x] `cargo clippy -p beamtalk-cli` — no warnings
- [x] `cargo build -p beamtalk-mcp` — clean (consumer of the library)
- [x] Pre-push hook (clippy, fmt, dialyzer, stdlib build) — all passed

---
_Generated by [Claude Code](https://claude.ai/code/session_011aNavcJgXXxsTtHehQEcBK)_