### PR TITLE
test(repl-ops): cover encode/dispatch branches in beamtalk_repl_ops

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_tests.erl
@@ -134,6 +134,14 @@ dispatch_tracing_invalid_arg_returns_error_term_test() ->
     ),
     ?assertMatch({error, #beamtalk_error{}}, Result).
 
+dispatch_nav_symbols_returns_value_term_test() ->
+    %% dispatch(<<"nav-symbols">>) delegates to handle_term/4, which always returns
+    %% {value, #{<<"classes">> := List}} — whether the class registry is absent
+    %% (empty list) or running (stdlib classes present).
+    Msg = make_msg(<<"nav-symbols">>),
+    Result = beamtalk_repl_ops:dispatch(<<"nav-symbols">>, #{}, Msg, self()),
+    ?assertMatch({value, #{<<"classes">> := Classes}} when is_list(Classes), Result).
+
 %% BT-2402: round-trip — encoding a dispatched term reproduces the handle_op JSON.
 encode_completions_term_matches_handle_op_json_test() ->
     Msg = make_msg(<<"complete">>),
@@ -187,6 +195,33 @@ encode_describe_term_matches_handle_op_json_test() ->
     Encoded = beamtalk_repl_ops:encode(Term, Msg),
     ViaServer = beamtalk_repl_server:handle_op(<<"describe">>, #{}, Msg, self()),
     ?assertEqual(ViaServer, Encoded).
+
+encode_loaded_term_produces_classes_json_test() ->
+    %% {loaded, Classes, Warnings} → JSON with "classes" list and "status": ["done"].
+    Msg = make_msg(<<"load-source">>),
+    Encoded = beamtalk_repl_ops:encode({loaded, [], []}, Msg),
+    Decoded = json:decode(Encoded),
+    ?assertEqual([], maps:get(<<"classes">>, Decoded)),
+    ?assertEqual([<<"done">>], maps:get(<<"status">>, Decoded)).
+
+encode_codegen_term_produces_core_erlang_json_test() ->
+    %% {codegen, CoreErlang, Warnings} → JSON with "core_erlang" field and "status": ["done"].
+    Msg = make_msg(<<"show-codegen">>),
+    CoreErl = <<"module 'Foo' ['new'/0] { }">>,
+    Encoded = beamtalk_repl_ops:encode({codegen, CoreErl, []}, Msg),
+    Decoded = json:decode(Encoded),
+    ?assertEqual(CoreErl, maps:get(<<"core_erlang">>, Decoded)),
+    ?assertEqual([<<"done">>], maps:get(<<"status">>, Decoded)).
+
+encode_inspect_binary_produces_state_json_test() ->
+    %% encode({inspect, Bin}) when is_binary(Bin) → binary inspect clause (line 243).
+    %% The binary form carries an already-serialised inspect string from the runtime.
+    Msg = make_msg(<<"inspect">>),
+    StateBin = <<"#Actor<foo> state: #{count => 0}">>,
+    Encoded = beamtalk_repl_ops:encode({inspect, StateBin}, Msg),
+    Decoded = json:decode(Encoded),
+    ?assertEqual(StateBin, maps:get(<<"state">>, Decoded)),
+    ?assertEqual([<<"done">>], maps:get(<<"status">>, Decoded)).
 
 %%====================================================================
 %% beamtalk_repl_subscriptions — facade


### PR DESCRIPTION
## Summary

Four EUnit tests added to `beamtalk_repl_ops_tests` to cover previously uncovered clauses in `beamtalk_repl_ops:dispatch/4` and `encode/2`, identified from the nightly CI coverage report (Erlang 83% overall, `beamtalk_repl_ops` at 77%).

- **`dispatch_nav_symbols_returns_value_term_test`** — exercises the `dispatch(<<"nav-symbols">>, ...)` clause (line 194) that delegates to `beamtalk_repl_ops_nav_symbols:handle_term/4`. Asserts the result is `{value, #{<<"classes">> := List}}`.

- **`encode_loaded_term_produces_classes_json_test`** — exercises `encode({loaded, Classes, Warnings}, Msg)` (line 251). Asserts the resulting JSON carries `"classes": []` and `"status": ["done"]`.

- **`encode_codegen_term_produces_core_erlang_json_test`** — exercises `encode({codegen, CoreErlang, Warnings}, Msg)` (line 269). Asserts the resulting JSON carries a `"core_erlang"` field and `"status": ["done"]`.

- **`encode_inspect_binary_produces_state_json_test`** — exercises the `encode({inspect, Bin}, Msg) when is_binary(Bin)` clause (line 243). Asserts the resulting JSON carries a `"state"` field and `"status": ["done"]`.

All tests run without a live runtime: `safe_all_classes/0` catches the absent registry, and the encode paths are pure JSON construction.

## Test plan

- [x] All 2665 `beamtalk_workspace` EUnit tests pass (`rebar3 eunit --application beamtalk_workspace`)
- [x] Pre-push hooks (clippy, fmt, dialyzer) pass
- [x] No source files modified — test-only change

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzKHJm54Fscc2pVsmqQRKY)_