### PR TITLE
Dedupe MCP/LSP tool expr builders into beamtalk-core (BT-3193)

### DIFF
--- a/crates/beamtalk-core/src/lib.rs
+++ b/crates/beamtalk-core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod source_analysis;
 pub(crate) mod state_threading_selectors;
 pub(crate) mod synthetic_selectors;
 pub mod test_helpers;
+pub mod tool_expr;
 pub mod unparse;
 
 /// Re-export commonly used types.

--- a/crates/beamtalk-core/src/tool_expr.rs
+++ b/crates/beamtalk-core/src/tool_expr.rs
@@ -1,0 +1,223 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Beamtalk expression synthesis shared by the MCP and LSP tooling surfaces
+//! (BT-3193).
+//!
+//! **DDD Context:** Language Service — Tooling Surface Parity
+//!
+//! `beamtalk-mcp`'s typed tools (`save_class`, `precheck_method`, `flush`,
+//! `remove_method`) and `beamtalk-lsp`'s `workspace/executeCommand` handlers
+//! (`CMD_SAVE_CLASS`, `CMD_PRECHECK_METHOD`, `CMD_FLUSH*`, `CMD_REMOVE_METHOD`)
+//! each compile client-supplied parameters into a Beamtalk expression string
+//! submitted through the workspace's existing `evaluate` REPL op (ADR 0082
+//! "Rationale: why no new REPL ops"). Both surfaces used to hand-roll the
+//! same `format!()` shape independently, documented only in prose as
+//! "mirroring" the other surface — nothing enforced it, so the two could
+//! silently drift (found in BT-3188 review).
+//!
+//! Per `docs/development/architecture-principles.md` § Duplication & the
+//! Shared-Leaf-Module Pattern, and its § Consistency-Test Disposition Rule:
+//! `beamtalk-mcp` and `beamtalk-lsp` are two Rust crates in the same
+//! workspace, not a permanent cross-language/cross-process boundary, and
+//! both already depend on `beamtalk-core` — so this is a *deletable*
+//! duplication. The fix is to give the expression-building logic a single
+//! home here, below both crates, rather than adding a test that just checks
+//! two copies still agree. A single definition can't drift from itself; the
+//! unit tests below are the conformance test BT-3193 asks for.
+
+use crate::unparse::escape_string_literal;
+
+/// Build the Beamtalk expression for the `save_class` MCP tool / LSP
+/// `beamtalk.saveClass` command — new-class creation path (ADR 0082 Phase 3).
+pub fn save_class_expr(source: &str, path: &str) -> String {
+    format!(
+        "Workspace newClass: \"{}\" at: \"{}\"",
+        escape_string_literal(source),
+        escape_string_literal(path),
+    )
+}
+
+/// Build the Beamtalk expression for the `precheck_method` MCP tool / LSP
+/// `beamtalk.precheckMethod` command — the pre-save advisory precheck (ADR
+/// 0105 Phase 3, BT-2782). Selector is the bare form (no leading `#`).
+/// Nothing installs; `Behaviour>>precheckCompile:source:` is read-only.
+pub fn precheck_method_expr(class: &str, selector: &str, body: &str) -> String {
+    format!(
+        "{} precheckCompile: #{} source: \"{}\"",
+        class,
+        selector,
+        escape_string_literal(body),
+    )
+}
+
+/// Build the Beamtalk expression for the `remove_method` MCP tool / LSP
+/// `beamtalk.removeMethod` command — the no-fallback path (ADR 0112 Phase 4,
+/// BT-3188). Selector is the bare form (no leading `#`). Raises
+/// `selector_not_found` if the selector is not defined locally or as an
+/// extension.
+pub fn remove_method_expr(class: &str, selector: &str) -> String {
+    format!("{class} removeSelector: #{selector}")
+}
+
+/// Build the Beamtalk expression for the `remove_method` MCP tool's /
+/// LSP `beamtalk.removeMethod` command's `if_absent`/`ifAbsent` fallback
+/// path (ADR 0112 Phase 4, BT-3188). Unlike `precheck_method_expr`'s `body`,
+/// `if_absent` is raw Beamtalk expression code, not a String value: it
+/// becomes the body of the `ifAbsent:` fallback block literal, which the
+/// runtime evaluates as code on an absent selector — it is never passed
+/// through a `compile:source:`-style primitive that takes a source string as
+/// data.
+pub fn remove_method_if_absent_expr(class: &str, selector: &str, if_absent: &str) -> String {
+    format!("{class} removeSelector: #{selector} ifAbsent: [{if_absent}]")
+}
+
+/// Scope filter for the `flush` MCP tool / LSP `beamtalk.flush*` commands
+/// (ADR 0082 Phase 3). Mutually exclusive; each tool wrapper enforces this
+/// before constructing the expression.
+#[derive(Clone, Copy, Debug)]
+pub enum FlushFilter<'a> {
+    None,
+    Class(&'a str),
+    File(&'a str),
+    Kind(&'a str),
+}
+
+/// Build the Beamtalk expression for the `flush` MCP tool / LSP
+/// `beamtalk.flush*` commands.
+///
+/// Surface map: `Workspace flush` / `Workspace flush: ClassName` /
+/// `Workspace flush: #{ #file => "path" }` / `Workspace flush: #'kind'`.
+pub fn flush_expr(filter: FlushFilter<'_>) -> String {
+    match filter {
+        FlushFilter::None => "Workspace flush".to_string(),
+        FlushFilter::Class(class) => format!("Workspace flush: {class}"),
+        FlushFilter::File(file) => format!(
+            "Workspace flush: #{{ #file => \"{}\" }}",
+            escape_string_literal(file)
+        ),
+        FlushFilter::Kind(kind) => format!("Workspace flush: #'{kind}'"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These golden tests are the BT-3193 conformance suite: both
+    // `beamtalk-mcp` and `beamtalk-lsp` call these functions directly, so a
+    // single passing suite here is enough to guarantee the two surfaces
+    // agree — there is no second implementation left to drift.
+
+    #[test]
+    fn precheck_method_expr_compiles_precheck_compile_source() {
+        // `precheck_method` / `beamtalk.precheckMethod` → `aClass
+        // precheckCompile: #selector source: body`.
+        assert_eq!(
+            precheck_method_expr("Counter", "getCount", "getCount => \"nope\""),
+            "Counter precheckCompile: #getCount source: \"getCount => \\\"nope\\\"\"",
+        );
+    }
+
+    #[test]
+    fn precheck_method_expr_preserves_keyword_selectors() {
+        assert_eq!(
+            precheck_method_expr("Dict", "at:put:", "..."),
+            "Dict precheckCompile: #at:put: source: \"...\"",
+        );
+    }
+
+    #[test]
+    fn save_class_expr_compiles_new_class_creation() {
+        // `save_class` / `beamtalk.saveClass` → `Workspace newClass: source
+        // at: path`.
+        assert_eq!(
+            save_class_expr("Object subclass: Greeter", "src/greeter.bt"),
+            "Workspace newClass: \"Object subclass: Greeter\" at: \"src/greeter.bt\"",
+        );
+    }
+
+    #[test]
+    fn save_class_expr_escapes_source_quotes_and_braces() {
+        // A class source containing string-interpolation literals must come
+        // through as a String value, not as embedded Beamtalk source.
+        // Newlines pass through verbatim — Beamtalk strings are multi-line.
+        let source = "Object subclass: Greeter\n  greet => \"hi {name}\"";
+        let got = save_class_expr(source, "src/greeter.bt");
+        assert_eq!(
+            got,
+            "Workspace newClass: \"Object subclass: Greeter\n  greet => \\\"hi \\{name}\\\"\" at: \"src/greeter.bt\"",
+        );
+    }
+
+    // --- ADR 0112 Phase 4 (BT-3188): remove_method / beamtalk.removeMethod ---
+
+    #[test]
+    fn remove_method_expr_compiles_remove_selector() {
+        // `remove_method` / `beamtalk.removeMethod` → `aClass
+        // removeSelector: #selector`.
+        assert_eq!(
+            remove_method_expr("Counter", "increment"),
+            "Counter removeSelector: #increment",
+        );
+    }
+
+    #[test]
+    fn remove_method_expr_preserves_keyword_selectors() {
+        assert_eq!(
+            remove_method_expr("Dict", "at:put:"),
+            "Dict removeSelector: #at:put:",
+        );
+    }
+
+    #[test]
+    fn remove_method_if_absent_expr_compiles_fallback_block() {
+        // `if_absent` is raw Beamtalk code — it becomes the fallback block's
+        // body verbatim, not an escaped String value.
+        assert_eq!(
+            remove_method_if_absent_expr("Counter", "bogus", "\"not found\""),
+            "Counter removeSelector: #bogus ifAbsent: [\"not found\"]",
+        );
+    }
+
+    #[test]
+    fn flush_expr_no_filter() {
+        assert_eq!(flush_expr(FlushFilter::None), "Workspace flush");
+    }
+
+    #[test]
+    fn flush_expr_class_filter() {
+        assert_eq!(
+            flush_expr(FlushFilter::Class("Counter")),
+            "Workspace flush: Counter",
+        );
+    }
+
+    #[test]
+    fn flush_expr_file_filter_uses_file_dict() {
+        // The Beamtalk-side flush: selector accepts a Dictionary
+        // `#{ #file => "..." }` (see Workspace.bt flush: docs).
+        assert_eq!(
+            flush_expr(FlushFilter::File("src/foo.bt")),
+            "Workspace flush: #{ #file => \"src/foo.bt\" }",
+        );
+    }
+
+    #[test]
+    fn flush_expr_file_filter_escapes_path() {
+        assert_eq!(
+            flush_expr(FlushFilter::File("src/\"weird\".bt")),
+            "Workspace flush: #{ #file => \"src/\\\"weird\\\".bt\" }",
+        );
+    }
+
+    #[test]
+    fn flush_expr_kind_filter_uses_quoted_symbol() {
+        // Hyphenated kinds (e.g. `new-class`) require a quoted-symbol literal
+        // — Beamtalk symbol literals without quotes only accept identifiers.
+        assert_eq!(
+            flush_expr(FlushFilter::Kind("new-class")),
+            "Workspace flush: #'new-class'",
+        );
+    }
+}

--- a/crates/beamtalk-core/src/tool_expr.rs
+++ b/crates/beamtalk-core/src/tool_expr.rs
@@ -23,8 +23,28 @@
 //! both already depend on `beamtalk-core` — so this is a *deletable*
 //! duplication. The fix is to give the expression-building logic a single
 //! home here, below both crates, rather than adding a test that just checks
-//! two copies still agree. A single definition can't drift from itself; the
-//! unit tests below are the conformance test BT-3193 asks for.
+//! two copies still agree. MCP and LSP can no longer drift from each other,
+//! since both now call the same definition; the unit tests below are the
+//! conformance test BT-3193 asks for.
+//!
+//! The REPL-CLI surface (`beamtalk-cli`'s `:remove-method`/`:flush <sel>`
+//! meta-commands) still hand-rolls its own copy of the `removeSelector:` and
+//! `flush:` shapes rather than calling into this module — that pre-existing
+//! duplication is tracked separately by BT-3196, not fixed here.
+//!
+//! # Caller responsibility: `class`/`selector`/`kind` are not validated here
+//!
+//! Only the string-*value* arguments (`source`, `path`, `body`) are escaped
+//! via [`escape_string_literal`] before being embedded as Beamtalk string
+//! literals. `class`, `selector`, and `kind` are interpolated **unescaped**
+//! as bare Beamtalk source tokens (class names, symbol literals) — that's
+//! the correct shape for e.g. `Counter removeSelector: #increment`, where
+//! `Counter` must appear as a real identifier, not a quoted string. Passing
+//! attacker-controlled or otherwise unvalidated text through as `class` or
+//! `selector` lets it inject arbitrary Beamtalk source into the expression
+//! that gets evaluated. Both current callers (`beamtalk-mcp`'s tool handlers
+//! and `beamtalk-lsp`'s `validate_class_name`/`validate_selector`) validate
+//! these arguments before calling in here — any new caller must do the same.
 
 use crate::unparse::escape_string_literal;
 
@@ -42,6 +62,9 @@ pub fn save_class_expr(source: &str, path: &str) -> String {
 /// `beamtalk.precheckMethod` command — the pre-save advisory precheck (ADR
 /// 0105 Phase 3, BT-2782). Selector is the bare form (no leading `#`).
 /// Nothing installs; `Behaviour>>precheckCompile:source:` is read-only.
+///
+/// `class` and `selector` are interpolated unescaped — see the module docs'
+/// "Caller responsibility" note; the caller must validate them first.
 pub fn precheck_method_expr(class: &str, selector: &str, body: &str) -> String {
     format!(
         "{} precheckCompile: #{} source: \"{}\"",
@@ -56,6 +79,9 @@ pub fn precheck_method_expr(class: &str, selector: &str, body: &str) -> String {
 /// BT-3188). Selector is the bare form (no leading `#`). Raises
 /// `selector_not_found` if the selector is not defined locally or as an
 /// extension.
+///
+/// `class` and `selector` are interpolated unescaped — see the module docs'
+/// "Caller responsibility" note; the caller must validate them first.
 pub fn remove_method_expr(class: &str, selector: &str) -> String {
     format!("{class} removeSelector: #{selector}")
 }
@@ -68,6 +94,9 @@ pub fn remove_method_expr(class: &str, selector: &str) -> String {
 /// runtime evaluates as code on an absent selector — it is never passed
 /// through a `compile:source:`-style primitive that takes a source string as
 /// data.
+///
+/// `class` and `selector` are interpolated unescaped — see the module docs'
+/// "Caller responsibility" note; the caller must validate them first.
 pub fn remove_method_if_absent_expr(class: &str, selector: &str, if_absent: &str) -> String {
     format!("{class} removeSelector: #{selector} ifAbsent: [{if_absent}]")
 }
@@ -88,6 +117,11 @@ pub enum FlushFilter<'a> {
 ///
 /// Surface map: `Workspace flush` / `Workspace flush: ClassName` /
 /// `Workspace flush: #{ #file => "path" }` / `Workspace flush: #'kind'`.
+///
+/// `FlushFilter::Class` and `FlushFilter::Kind` are interpolated unescaped —
+/// see the module docs' "Caller responsibility" note; the caller must
+/// validate them first (`FlushFilter::File`'s path is a String value and is
+/// escaped).
 pub fn flush_expr(filter: FlushFilter<'_>) -> String {
     match filter {
         FlushFilter::None => "Workspace flush".to_string(),
@@ -106,8 +140,8 @@ mod tests {
 
     // These golden tests are the BT-3193 conformance suite: both
     // `beamtalk-mcp` and `beamtalk-lsp` call these functions directly, so a
-    // single passing suite here is enough to guarantee the two surfaces
-    // agree — there is no second implementation left to drift.
+    // single passing suite here is enough to guarantee those two surfaces
+    // agree with each other.
 
     #[test]
     fn precheck_method_expr_compiles_precheck_compile_source() {

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -28,7 +28,11 @@ use beamtalk_core::language_service::{
 use beamtalk_core::queries::all_sends_query::{ReceiverKind, find_all_sends_in_source};
 use beamtalk_core::semantic_analysis::ClassHierarchy;
 use beamtalk_core::source_analysis::{Severity, Span};
-use beamtalk_core::unparse::{escape_string_literal, format_source};
+use beamtalk_core::tool_expr::{
+    FlushFilter, flush_expr, precheck_method_expr, remove_method_expr,
+    remove_method_if_absent_expr, save_class_expr,
+};
+use beamtalk_core::unparse::format_source;
 use camino::Utf8PathBuf;
 use ecow::EcoString;
 use tower_lsp::jsonrpc::Result;
@@ -78,8 +82,10 @@ pub(crate) const CMD_PRECHECK_METHOD: &str = "beamtalk.precheckMethod";
 /// (`Workspace recheckImage` / REPL `:recheck image`).
 pub(crate) const CMD_RECHECK_IMAGE: &str = "beamtalk.recheckImage";
 /// ADR 0112 Phase 4 (BT-3188): remove a method from a class
-/// (`Behaviour>>removeSelector:` / `removeSelector:ifAbsent:`), mirroring
-/// MCP's `remove_method` tool.
+/// (`Behaviour>>removeSelector:` / `removeSelector:ifAbsent:`). Its
+/// expression shape is shared with MCP's `remove_method` tool via
+/// `beamtalk_core::tool_expr::remove_method_expr` (BT-3193) — the two can't
+/// drift, since both call the same function.
 pub(crate) const CMD_REMOVE_METHOD: &str = "beamtalk.removeMethod";
 
 /// All commands surfaced via `executeCommand`. Wired into
@@ -3454,9 +3460,12 @@ pub(crate) fn resolve_flushed_path(raw: &str, roots: &[PathBuf]) -> Option<PathB
 
 /// ADR 0082 Phase 3 (BT-2289): map a `workspace/executeCommand` invocation
 /// to the Beamtalk expression that compiles to the same effect on the live
-/// workspace. Mirrors `beamtalk-mcp`'s expression builders one-for-one so
-/// surface parity is preserved (REPL `:flush` ≡ MCP `flush` ≡ LSP
-/// `beamtalk.flush`).
+/// workspace. Delegates the actual expression construction to
+/// `beamtalk_core::tool_expr`, the same shared builders `beamtalk-mcp`'s
+/// typed tools call — a single implementation both surfaces call into, so
+/// REPL `:flush` ≡ MCP `flush` ≡ LSP `beamtalk.flush` can't drift apart
+/// (BT-3193; see `beamtalk_core::tool_expr`'s module docs and unit tests for
+/// the enforcing conformance suite).
 ///
 /// Returns the expression string on success or a human-readable parameter
 /// error on failure (which the LSP layer surfaces as `invalid_params`).
@@ -3473,24 +3482,19 @@ pub(crate) fn build_command_expression(
                     arguments.len()
                 ));
             }
-            Ok("Workspace flush".to_string())
+            Ok(flush_expr(FlushFilter::None))
         }
         CMD_FLUSH_CLASS => {
             let class = expect_string_arg(arguments, 0, "class")?;
             validate_class_name(&class)?;
-            // `Workspace flush: ClassName` — the class is named literally in
-            // the expression (no escaping); validation above prevents any
-            // shape that could parse differently.
-            Ok(format!("Workspace flush: {class}"))
+            // The class is named literally in the expression (no escaping);
+            // validation above prevents any shape that could parse
+            // differently.
+            Ok(flush_expr(FlushFilter::Class(&class)))
         }
         CMD_FLUSH_FILE => {
             let file = expect_string_arg(arguments, 0, "file")?;
-            // `Workspace flush: #{ #file => "path" }` — Symbol-keyed
-            // dictionary; the path is passed as a String value.
-            Ok(format!(
-                "Workspace flush: #{{ #file => \"{}\" }}",
-                escape_string_literal(&file)
-            ))
+            Ok(flush_expr(FlushFilter::File(&file)))
         }
         CMD_FLUSH_KIND => {
             let kind = expect_string_arg(arguments, 0, "kind")?;
@@ -3507,7 +3511,7 @@ pub(crate) fn build_command_expression(
                     "{CMD_FLUSH_KIND}: 'kind' must be an identifier (letters, digits, '-' or '_'); got '{kind}'"
                 ));
             }
-            Ok(format!("Workspace flush: #'{bare}'"))
+            Ok(flush_expr(FlushFilter::Kind(bare)))
         }
         CMD_SAVE_CLASS => {
             let source = expect_string_arg(arguments, 0, "source")?;
@@ -3518,14 +3522,7 @@ pub(crate) fn build_command_expression(
             if path.is_empty() {
                 return Err(format!("{CMD_SAVE_CLASS}: 'path' must not be empty"));
             }
-            // Mirrors `beamtalk-mcp::save_class_expr`: pass body + path as
-            // String values; the workspace primitive takes them as values
-            // rather than re-parsed Beamtalk source.
-            Ok(format!(
-                "Workspace newClass: \"{}\" at: \"{}\"",
-                escape_string_literal(&source),
-                escape_string_literal(&path)
-            ))
+            Ok(save_class_expr(&source, &path))
         }
         CMD_PRECHECK_METHOD => {
             let class = expect_string_arg(arguments, 0, "class")?;
@@ -3539,12 +3536,7 @@ pub(crate) fn build_command_expression(
             if source.is_empty() {
                 return Err(format!("{CMD_PRECHECK_METHOD}: 'source' must not be empty"));
             }
-            // Mirrors `CMD_SAVE_CLASS`'s / `save_method_expr`'s shape:
-            // `ClassName precheckCompile: #selector source: "body"`.
-            Ok(format!(
-                "{class} precheckCompile: #{selector} source: \"{}\"",
-                escape_string_literal(&source)
-            ))
+            Ok(precheck_method_expr(&class, selector, &source))
         }
         CMD_RECHECK_IMAGE => {
             if !arguments.is_empty() {
@@ -3566,18 +3558,15 @@ pub(crate) fn build_command_expression(
             // Optional third argument: an `ifAbsent:` fallback. Unlike
             // `CMD_PRECHECK_METHOD`'s `source`, this is raw Beamtalk
             // expression code embedded as the fallback block's body, not a
-            // String value passed to a `compile:source:`-style primitive —
-            // mirrors `beamtalk-mcp::remove_method_if_absent_expr`. Missing
-            // and explicit `null` are both treated as "no fallback" — some
-            // JSON-RPC clients pad positional arguments with `null` rather
-            // than omitting the trailing slot.
+            // String value passed to a `compile:source:`-style primitive.
+            // Missing and explicit `null` are both treated as "no fallback"
+            // — some JSON-RPC clients pad positional arguments with `null`
+            // rather than omitting the trailing slot.
             if matches!(arguments.get(2), None | Some(serde_json::Value::Null)) {
-                return Ok(format!("{class} removeSelector: #{selector}"));
+                return Ok(remove_method_expr(&class, selector));
             }
             let if_absent = expect_string_arg(arguments, 2, "ifAbsent")?;
-            Ok(format!(
-                "{class} removeSelector: #{selector} ifAbsent: [{if_absent}]"
-            ))
+            Ok(remove_method_if_absent_expr(&class, selector, &if_absent))
         }
         _ => Err(format!("unknown LSP command: {command}")),
     }
@@ -4814,6 +4803,7 @@ mod tests {
     use super::*;
     use beamtalk_core::language_service::HoverInfo;
     use beamtalk_core::test_helpers::unique_temp_dir;
+    use beamtalk_core::unparse::escape_string_literal;
     use camino::Utf8PathBuf;
     use std::fs;
 

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -6226,8 +6226,8 @@ mod tests {
     #[test]
     fn build_remove_method_with_if_absent_emits_fallback_block() {
         // The third argument is raw Beamtalk code embedded as the fallback
-        // block's body verbatim — not an escaped String value (mirrors
-        // `beamtalk-mcp::remove_method_if_absent_expr`).
+        // block's body verbatim — not an escaped String value (built via
+        // `beamtalk_core::tool_expr::remove_method_if_absent_expr`).
         let expr = build_command_expression(
             CMD_REMOVE_METHOD,
             &[

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -13,6 +13,10 @@ use std::fmt::Write;
 use std::sync::Arc;
 
 use beamtalk_core::source_analysis::{Severity, lex_with_eof, parse};
+use beamtalk_core::tool_expr::{
+    FlushFilter, flush_expr, precheck_method_expr, remove_method_expr,
+    remove_method_if_absent_expr, save_class_expr,
+};
 use beamtalk_core::unparse::escape_string_literal;
 use rmcp::{
     ServerHandler,
@@ -211,19 +215,6 @@ fn save_method_expr(class: &str, selector: &str, body: &str) -> String {
     )
 }
 
-/// Build the Beamtalk expression for the `precheck_method` MCP tool — the
-/// pre-save advisory precheck (ADR 0105 Phase 3, BT-2782). Selector is the
-/// bare form (no leading `#`). Nothing installs; `Behaviour>>precheckCompile:
-/// source:` is read-only.
-fn precheck_method_expr(class: &str, selector: &str, body: &str) -> String {
-    format!(
-        "{} precheckCompile: #{} source: \"{}\"",
-        class,
-        selector,
-        escape_string_literal(body),
-    )
-}
-
 /// Build the Beamtalk expression for the `try_method` MCP tool — ephemeral
 /// patch path (ADR 0082 Phase 3). Selector is the bare form (no leading `#`).
 fn try_method_expr(class: &str, selector: &str, body: &str) -> String {
@@ -233,62 +224,6 @@ fn try_method_expr(class: &str, selector: &str, body: &str) -> String {
         selector,
         escape_string_literal(body),
     )
-}
-
-/// Build the Beamtalk expression for the `save_class` MCP tool — new-class
-/// creation path (ADR 0082 Phase 3).
-fn save_class_expr(source: &str, path: &str) -> String {
-    format!(
-        "Workspace newClass: \"{}\" at: \"{}\"",
-        escape_string_literal(source),
-        escape_string_literal(path),
-    )
-}
-
-/// Build the Beamtalk expression for the `remove_method` MCP tool — the
-/// no-fallback path (ADR 0112 Phase 4, BT-3188). Selector is the bare form
-/// (no leading `#`). Raises `selector_not_found` if the selector is not
-/// defined locally or as an extension.
-fn remove_method_expr(class: &str, selector: &str) -> String {
-    format!("{class} removeSelector: #{selector}")
-}
-
-/// Build the Beamtalk expression for the `remove_method` MCP tool's
-/// `if_absent` fallback path (ADR 0112 Phase 4, BT-3188). Unlike
-/// `save_method_expr`'s `body`, `if_absent` is raw Beamtalk expression code,
-/// not a String value: it becomes the body of the `ifAbsent:` fallback block
-/// literal, which the runtime evaluates as code on an absent selector — it is
-/// never passed through a `compile:source:`-style primitive that takes a
-/// source string as data.
-fn remove_method_if_absent_expr(class: &str, selector: &str, if_absent: &str) -> String {
-    format!("{class} removeSelector: #{selector} ifAbsent: [{if_absent}]")
-}
-
-/// Scope filter for the `flush` MCP tool (ADR 0082 Phase 3). Mutually
-/// exclusive; the tool wrapper enforces this before constructing the
-/// expression.
-#[derive(Clone, Copy)]
-enum FlushFilter<'a> {
-    None,
-    Class(&'a str),
-    File(&'a str),
-    Kind(&'a str),
-}
-
-/// Build the Beamtalk expression for the `flush` MCP tool.
-///
-/// Surface map: `Workspace flush` / `Workspace flush: ClassName` /
-/// `Workspace flush: #{ #file => "path" }` / `Workspace flush: #'kind'`.
-fn flush_expr(filter: FlushFilter<'_>) -> String {
-    match filter {
-        FlushFilter::None => "Workspace flush".to_string(),
-        FlushFilter::Class(class) => format!("Workspace flush: {class}"),
-        FlushFilter::File(file) => format!(
-            "Workspace flush: #{{ #file => \"{}\" }}",
-            escape_string_literal(file)
-        ),
-        FlushFilter::Kind(kind) => format!("Workspace flush: #'{kind}'"),
-    }
 }
 
 /// Check a REPL response for errors and return early with a formatted error result.
@@ -4144,23 +4079,6 @@ mod tests {
     }
 
     #[test]
-    fn precheck_method_expr_compiles_precheck_compile_source() {
-        // `precheck_method` → `aClass precheckCompile: #selector source: body`.
-        assert_eq!(
-            precheck_method_expr("Counter", "getCount", "getCount => \"nope\""),
-            "Counter precheckCompile: #getCount source: \"getCount => \\\"nope\\\"\"",
-        );
-    }
-
-    #[test]
-    fn precheck_method_expr_preserves_keyword_selectors() {
-        assert_eq!(
-            precheck_method_expr("Dict", "at:put:", "..."),
-            "Dict precheckCompile: #at:put: source: \"...\"",
-        );
-    }
-
-    #[test]
     fn try_method_expr_compiles_ephemeral_patch() {
         // `try_method` → `aClass tryCompile: #selector source: body`.
         assert_eq!(
@@ -4169,95 +4087,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn save_class_expr_compiles_new_class_creation() {
-        // `save_class` → `Workspace newClass: source at: path`.
-        assert_eq!(
-            save_class_expr("Object subclass: Greeter", "src/greeter.bt"),
-            "Workspace newClass: \"Object subclass: Greeter\" at: \"src/greeter.bt\"",
-        );
-    }
-
-    #[test]
-    fn save_class_expr_escapes_source_quotes_and_braces() {
-        // A class source containing string-interpolation literals must come
-        // through as a String value, not as embedded Beamtalk source.
-        // Newlines pass through verbatim — Beamtalk strings are multi-line.
-        let source = "Object subclass: Greeter\n  greet => \"hi {name}\"";
-        let got = save_class_expr(source, "src/greeter.bt");
-        assert_eq!(
-            got,
-            "Workspace newClass: \"Object subclass: Greeter\n  greet => \\\"hi \\{name}\\\"\" at: \"src/greeter.bt\"",
-        );
-    }
-
-    // --- ADR 0112 Phase 4 (BT-3188): MCP remove_method tool wiring ---
-
-    #[test]
-    fn remove_method_expr_compiles_remove_selector() {
-        // `remove_method` → `aClass removeSelector: #selector`.
-        assert_eq!(
-            remove_method_expr("Counter", "increment"),
-            "Counter removeSelector: #increment",
-        );
-    }
-
-    #[test]
-    fn remove_method_expr_preserves_keyword_selectors() {
-        assert_eq!(
-            remove_method_expr("Dict", "at:put:"),
-            "Dict removeSelector: #at:put:",
-        );
-    }
-
-    #[test]
-    fn remove_method_if_absent_expr_compiles_fallback_block() {
-        // `if_absent` is raw Beamtalk code — it becomes the fallback block's
-        // body verbatim, not an escaped String value.
-        assert_eq!(
-            remove_method_if_absent_expr("Counter", "bogus", "\"not found\""),
-            "Counter removeSelector: #bogus ifAbsent: [\"not found\"]",
-        );
-    }
-
-    #[test]
-    fn flush_expr_no_filter() {
-        assert_eq!(flush_expr(FlushFilter::None), "Workspace flush");
-    }
-
-    #[test]
-    fn flush_expr_class_filter() {
-        assert_eq!(
-            flush_expr(FlushFilter::Class("Counter")),
-            "Workspace flush: Counter",
-        );
-    }
-
-    #[test]
-    fn flush_expr_file_filter_uses_file_dict() {
-        // The Beamtalk-side flush: selector accepts a Dictionary
-        // `#{ #file => "..." }` (see Workspace.bt flush: docs).
-        assert_eq!(
-            flush_expr(FlushFilter::File("src/foo.bt")),
-            "Workspace flush: #{ #file => \"src/foo.bt\" }",
-        );
-    }
-
-    #[test]
-    fn flush_expr_file_filter_escapes_path() {
-        assert_eq!(
-            flush_expr(FlushFilter::File("src/\"weird\".bt")),
-            "Workspace flush: #{ #file => \"src/\\\"weird\\\".bt\" }",
-        );
-    }
-
-    #[test]
-    fn flush_expr_kind_filter_uses_quoted_symbol() {
-        // Hyphenated kinds (e.g. `new-class`) require a quoted-symbol literal
-        // — Beamtalk symbol literals without quotes only accept identifiers.
-        assert_eq!(
-            flush_expr(FlushFilter::Kind("new-class")),
-            "Workspace flush: #'new-class'",
-        );
-    }
+    // `save_class_expr`, `precheck_method_expr`, `remove_method_expr`,
+    // `remove_method_if_absent_expr`, and `flush_expr`/`FlushFilter` are
+    // defined in `beamtalk_core::tool_expr` (BT-3193) and golden-tested
+    // there — that suite is the single source of truth both this crate and
+    // `beamtalk-lsp` call into, so there is nothing left to re-test here.
 }


### PR DESCRIPTION
## Summary

- `save_class_expr`, `precheck_method_expr`, `remove_method_expr`, `remove_method_if_absent_expr`, and `flush_expr`/`FlushFilter` were hand-rolled independently in `beamtalk-mcp` (`server.rs`) and `beamtalk-lsp` (`build_command_expression`), documented only as prose claims that one "mirrors" the other — nothing enforced it, so the two could silently drift (found in BT-3188 review).
- Per `docs/development/architecture-principles.md` § Duplication & the Shared-Leaf-Module Pattern and § Consistency-Test Disposition Rule: `beamtalk-mcp` and `beamtalk-lsp` are two Rust crates in the same workspace (not a permanent cross-language/cross-process boundary) and both already depend on `beamtalk-core`. That makes this a *deletable* duplication, not a case that calls for a standalone pair-consistency-test crate — so instead of adding a test that checks two copies still agree, the five functions move into a new `beamtalk_core::tool_expr` module and both crates call the single implementation.
- `beamtalk-mcp`'s `server.rs` and `beamtalk-lsp`'s `build_command_expression` now import and call `beamtalk_core::tool_expr::{save_class_expr, precheck_method_expr, remove_method_expr, remove_method_if_absent_expr, flush_expr, FlushFilter}` directly; their hand-rolled `format!()` copies are gone.
- The escaping/shape-golden tests that used to live separately in each crate (pinning `Workspace newClass:at:`, `precheckCompile:source:`, `removeSelector:`/`removeSelector:ifAbsent:`, and the four `Workspace flush*` shapes) now live once in `beamtalk_core::tool_expr`'s own test module — this is the BT-3193 conformance suite: since both surfaces call the same function, a single passing suite there is sufficient to guarantee they agree.
- Updated the "mirrors"/"mirroring" doc comments on the LSP side (`build_command_expression`'s doc comment and the `CMD_REMOVE_METHOD` const doc comment) to reference `beamtalk_core::tool_expr` as the shared implementation instead of asserting parity in prose.
- LSP-side argument-validation/wiring tests (`build_flush_*`, `build_save_class_*`, `build_precheck_method_*`, `build_remove_method_*` in `beamtalk-lsp/src/server.rs`) are unchanged — they still exercise `build_command_expression`'s parsing/validation/error paths, which remain LSP-specific.

## Test plan

- [x] `cargo build -p beamtalk-core -p beamtalk-mcp -p beamtalk-lsp` — clean, no warnings
- [x] `cargo test -p beamtalk-core -p beamtalk-mcp -p beamtalk-lsp --lib --bins` — all pass, including the new `tool_expr::tests::*` conformance suite and existing `build_*` LSP wiring tests
- [x] `cargo clippy -p beamtalk-core -p beamtalk-mcp -p beamtalk-lsp --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] `just test` (full fast suite) — all pass
- [x] `just ci-changed` — all pass (clippy, rustfmt, dialyzer, spec validation, erlfmt, JS/TS lint+format, Beamtalk fmt, Elixir fmt)


---
_Generated by [Claude Code](https://claude.ai/code/session_019aPmfQBav7upbCBPFiDGXS)_