### PR TITLE
Extract shared parsing for REPL :flush meta-command (BT-3196)

### DIFF
--- a/crates/beamtalk-cli/src/commands/repl/mod.rs
+++ b/crates/beamtalk-cli/src/commands/repl/mod.rs
@@ -770,15 +770,14 @@ fn handle_repl_command(line: &str, client: &mut ReplClient) -> CommandResult {
         CommandAction::Interrupt => handle_interrupt(client),
         // BT-2287 / ADR 0082 Phase 3: REPL alias for `Workspace flush`.
         CommandAction::Flush => eval_and_display(client, "Workspace flush"),
+        // BT-2287 / ADR 0082 Phase 3 (expression-building extracted to
+        // `beamtalk_cli::repl_meta_exprs` in BT-3196, matching
+        // `:remove-method`'s pattern): `:flush <selector>` desugars to
+        // `Workspace flush: <selector>`.
         CommandAction::FlushArg(selector) => {
-            // BT-2287 / ADR 0082 Phase 3: `:flush <selector>` desugars to
-            // `Workspace flush: <selector>`. The selector is passed through
-            // verbatim so users can pass a Class (`Counter`), a Symbol
-            // (`#'new-class'`), or a Dictionary (`#{ #file => "path" }`).
-            if selector.is_empty() {
-                eprintln!("Usage: :flush [<Class>|#kind|#{{ #file => \"path\" }}]");
-            } else {
-                eval_and_display(client, &format!("Workspace flush: {selector}"));
+            match beamtalk_cli::repl_meta_exprs::flush_expr_for(selector) {
+                Some(expr) => eval_and_display(client, &expr),
+                None => eprintln!("Usage: :flush [<Class>|#kind|#{{ #file => \"path\" }}]"),
             }
         }
         // BT-2287 / ADR 0082 Phase 3: REPL alias for `Workspace changes`.
@@ -1833,16 +1832,15 @@ mod tests {
     // them as `evaluate` of a known string. These tests pin the translation.
     // -----------------------------------------------------------------------
 
-    /// Construct the Beamtalk expression a `:flush <selector>` line dispatches
-    /// to. Mirrors the format used in `handle_repl_command` so the tests catch
-    /// translation drift.
+    /// Construct the Beamtalk expression a `:flush <selector>` line
+    /// dispatches to: `commands::FLUSH.arg` extracts the selector exactly as
+    /// `classify_command` does, and `repl_meta_exprs::flush_expr_for` — the
+    /// same shared function `handle_repl_command`'s real dispatch and
+    /// `tests/repl_protocol.rs` call — builds the expression, so this test
+    /// can only drift from production behaviour if that shared function's
+    /// own contract changes (BT-3196).
     fn flush_expr_for(line: &str) -> Option<String> {
-        let selector = commands::FLUSH.arg(line).unwrap_or("");
-        if selector.is_empty() {
-            None
-        } else {
-            Some(format!("Workspace flush: {selector}"))
-        }
+        beamtalk_cli::repl_meta_exprs::flush_expr_for(commands::FLUSH.arg(line).unwrap_or(""))
     }
 
     #[test]

--- a/crates/beamtalk-cli/src/repl_meta_exprs.rs
+++ b/crates/beamtalk-cli/src/repl_meta_exprs.rs
@@ -8,10 +8,10 @@
 //! These live in the library target (rather than `commands/repl/mod.rs`,
 //! which is private to the binary target) specifically so the integration
 //! test — which links only the library target — can call the real parsing
-//! logic instead of re-implementing it. A hand-copied "mirror" of this
-//! logic in the test harness previously drifted from the real
-//! implementation twice in a row (BT-3189); see BT-3196 for extracting
-//! `:flush <sel>`'s equivalent duplication the same way.
+//! logic instead of re-implementing it. A hand-copied "mirror" of
+//! `remove_method_expr_for`'s logic in the test harness previously drifted
+//! from the real implementation twice in a row (BT-3189); `:flush <sel>`'s
+//! equivalent duplication was extracted the same way in BT-3196.
 
 /// Construct the `<Class> removeSelector: #<selector>` expression a
 /// `:remove-method <Class> <selector>` REPL line dispatches to (ADR 0112
@@ -36,6 +36,31 @@ pub fn remove_method_expr_for(arg: &str) -> Option<String> {
         return None;
     }
     Some(format!("{class} removeSelector: #{selector}"))
+}
+
+/// Construct the `Workspace flush: <selector>` expression a `:flush
+/// <selector>` REPL line dispatches to (ADR 0082 Phase 3, BT-2287).
+///
+/// `selector` is passed through **verbatim** (only trimmed) into the
+/// generated expression, so callers can pass a Class (`Counter`), a Symbol
+/// kind (`#'new-class'`), or a Dictionary (`#{ #file => "path" }`) — unlike
+/// [`remove_method_expr_for`], there is no leading-`#` stripping here since
+/// a `#`-prefixed selector is a legitimate Symbol-kind argument, not a
+/// Symbol-literal-decorated method name.
+///
+/// Returns `None` when `selector` is empty (including a selector that is
+/// only whitespace, once trimmed), so the caller can print a usage hint
+/// instead of evaluating a malformed bare `Workspace flush: ` send — this
+/// emptiness check is exactly the kind of guard a hand-copied test-harness
+/// mirror can silently drop (as `remove_method_expr_for`'s did for its own
+/// `#`-stripping order in BT-3189); routing both callers through this one
+/// function makes that class of drift structurally impossible.
+pub fn flush_expr_for(selector: &str) -> Option<String> {
+    let selector = selector.trim();
+    if selector.is_empty() {
+        return None;
+    }
+    Some(format!("Workspace flush: {selector}"))
 }
 
 #[cfg(test)]
@@ -109,5 +134,61 @@ mod tests {
             remove_method_expr_for("Counter #  increment"),
             Some("Counter removeSelector: #increment".to_string())
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // flush_expr_for
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn flush_class_selector_translates_to_workspace_flush_message() {
+        assert_eq!(
+            flush_expr_for("Counter"),
+            Some("Workspace flush: Counter".to_string())
+        );
+    }
+
+    #[test]
+    fn flush_symbol_kind_selector_translates_verbatim() {
+        // A leading "#" here is a legitimate Symbol-kind argument (not a
+        // decorated method name like `remove_method_expr_for`'s selector),
+        // so it must survive untouched.
+        assert_eq!(
+            flush_expr_for("#'new-class'"),
+            Some("Workspace flush: #'new-class'".to_string())
+        );
+    }
+
+    #[test]
+    fn flush_dictionary_selector_translates_verbatim() {
+        assert_eq!(
+            flush_expr_for("#{ #file => \"src/foo.bt\" }"),
+            Some("Workspace flush: #{ #file => \"src/foo.bt\" }".to_string())
+        );
+    }
+
+    #[test]
+    fn flush_trims_surrounding_whitespace() {
+        assert_eq!(
+            flush_expr_for("  Counter  "),
+            Some("Workspace flush: Counter".to_string())
+        );
+    }
+
+    #[test]
+    fn flush_with_empty_selector_reports_no_expression() {
+        assert_eq!(flush_expr_for(""), None);
+    }
+
+    #[test]
+    fn flush_with_whitespace_only_selector_reports_no_expression() {
+        // The historical-bug-class risk this guards against: a hand-copied
+        // test-harness mirror of `Workspace flush: {selector}` that skips
+        // this emptiness check (as the old `tests/repl_protocol.rs` inline
+        // duplicate did) would blindly eval a malformed bare
+        // `Workspace flush: ` send instead of hitting the usage-error path.
+        // Because both the real dispatch and the test harness now call this
+        // one function, that drift can no longer happen.
+        assert_eq!(flush_expr_for("   "), None);
     }
 }

--- a/crates/beamtalk-cli/tests/repl_protocol.rs
+++ b/crates/beamtalk-cli/tests/repl_protocol.rs
@@ -1360,9 +1360,15 @@ fn run_test_file(path: &PathBuf, client: &mut ReplClient) -> (usize, Vec<String>
             // BT-2287 / ADR 0082 Phase 3: `:flush` → `Workspace flush`.
             client.eval("Workspace flush")
         } else if case.expression.starts_with(":flush ") {
-            // BT-2287 / ADR 0082 Phase 3: `:flush <sel>` → `Workspace flush: <sel>`.
-            let selector = case.expression.strip_prefix(":flush ").unwrap().trim();
-            client.eval(&format!("Workspace flush: {selector}"))
+            // BT-2287 / ADR 0082 Phase 3: `:flush <sel>` → `Workspace flush: <sel>`,
+            // via the same `flush_expr_for` the real REPL dispatch calls
+            // (`beamtalk_cli::repl_meta_exprs`) — not a hand-copied mirror,
+            // so this harness can't drift from production behavior (BT-3196).
+            let selector = case.expression.strip_prefix(":flush ").unwrap();
+            match beamtalk_cli::repl_meta_exprs::flush_expr_for(selector) {
+                Some(expr) => client.eval(&expr),
+                None => Err("Usage: :flush [<Class>|#kind|#{ #file => \"path\" }]".to_string()),
+            }
         } else if case.expression == ":changes" {
             // BT-2287 / ADR 0082 Phase 3: `:changes` → `Workspace changes`.
             client.eval("Workspace changes")


### PR DESCRIPTION
Linear issue: https://linear.app/beamtalk/issue/BT-3196/extract-shared-parsing-for-repl-meta-command-expression-builders

## Summary

Follow-up from BT-3189 (ADR 0112 Phase 4). The `:remove-method` half of this
duplication was already fixed during that epic (`remove_method_expr_for` in
`beamtalk_cli::repl_meta_exprs`, shared between the real REPL dispatch and
`tests/repl_protocol.rs`). This PR applies the same fix to the remaining
`:flush <sel>` duplication flagged by the Claude review bot on PR #3412.

- Added `flush_expr_for` to `crates/beamtalk-cli/src/repl_meta_exprs.rs`
  (same module, same doc-comment/test conventions as `remove_method_expr_for`).
- `commands/repl/mod.rs`'s real `FlushArg` dispatch now calls the shared
  function instead of an inline `format!`; its own unit-test helper now
  composes the real `commands::FLUSH.arg` extraction with the shared builder
  instead of re-implementing the formatting logic.
- `tests/repl_protocol.rs`'s `:flush <sel>` harness branch now calls the
  shared function instead of a hand-copied duplicate.
- Added a regression test (`flush_with_whitespace_only_selector_reports_no_expression`)
  proving the historical-bug-class risk (a test-harness mirror silently
  skipping the emptiness check, as happened for `:remove-method`'s
  `#`-stripping order in BT-3189) is now structurally impossible: both
  callers route through the one function, so drift can't happen.

No user-facing behavior change to either meta-command.

## Test plan

- [x] `cargo test -p beamtalk-cli --lib repl_meta_exprs` — 15/15 pass
- [x] `cargo test -p beamtalk-cli --bin beamtalk flush` — 7/7 pass
- [x] `just ci-changed` — full run, including the REPL-protocol E2E suite
      (`repl_flush_changes_dirty.btscript`, `repl_remove_method.btscript`)
      and `just build && just clippy && just fmt-check` via the pre-push hook

---
Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeTtDi5ua6oSuVrkEMvCCM)_