### PR TITLE
LiveView Changes pane: same-selector different-side rows are visually ambiguous and share a toggle key (BT-3195)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -653,9 +653,13 @@ defmodule BtAttachWeb.WorkspaceLive do
       |> assign_browser_native_modules()
       |> assign_browser_type_aliases()
       # BT-2636: the set of expanded Changes-pane rows (keyed by the row's
-      # `{class, selector}`), driven by the leading disclosure caret. A row's
-      # structured net-vs-disk diff renders beneath it only while its key is in
-      # this set; collapsed by default so the table stays compact.
+      # `{class, selector, side}` — BT-3195 added `side` so a same-selector
+      # instance-side and class-side entry, both now possible simultaneously
+      # since BT-3187's `(class, selector, side)` shadow-key fix, get
+      # independent toggle state instead of sharing one), driven by the
+      # leading disclosure caret. A row's structured net-vs-disk diff renders
+      # beneath it only while its key is in this set; collapsed by default so
+      # the table stays compact.
       |> assign(:expanded_changes, MapSet.new())
       # BT-2591: the four mount-time workspace reads (browser classes, bindings,
       # the active ChangeLog, the autoflush flag) used to run as *synchronous*
@@ -1743,7 +1747,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   # entry is visible.
   def handle_event("revert", %{"class" => class, "selector" => selector} = params, socket)
       when is_binary(class) and is_binary(selector) do
-    side = present_revert_side(Map.get(params, "entry-side"))
+    side = present_side_param(Map.get(params, "entry-side"))
     {:noreply, revert_change(socket, class, selector, side)}
   end
 
@@ -1754,12 +1758,26 @@ defmodule BtAttachWeb.WorkspaceLive do
   end
 
   # Toggle the structured diff disclosure for one Changes-pane row (BT-2636),
-  # keyed by the row's `{class, selector}` carried on the leading caret. Pure view
-  # state — no workspace round-trip; flips the key in/out of `:expanded_changes`,
-  # showing/hiding that row's `unified_diff` body.
-  def handle_event("toggle_change_diff", %{"class" => class, "selector" => selector}, socket)
+  # keyed by the row's `{class, selector, side}` carried on the leading caret
+  # (`phx-value-entry-side`, BT-3195 — reuses `present_side_param/1`'s `""` →
+  # `nil` normalisation, the same one the revert button's
+  # `phx-value-entry-side` already relies on, so both controls agree on what
+  # "no side" means). Named `entry-side`, not `side`, for the same reason the
+  # revert button is: it doesn't collide with the browser's `phx-value-side`
+  # instance/class toggle (BT-2491), so a `button[phx-value-side=...]`
+  # selector in a test doesn't match this caret too. Pure view state — no
+  # workspace round-trip; flips the key in/out of `:expanded_changes`,
+  # showing/hiding that row's `unified_diff` body. Before BT-3195 this keyed
+  # on `{class, selector}` alone, so a same-selector instance-side and
+  # class-side row (possible since BT-3187's shadow-key fix) shared one
+  # toggle — expanding one flipped the other too.
+  def handle_event(
+        "toggle_change_diff",
+        %{"class" => class, "selector" => selector} = params,
+        socket
+      )
       when is_binary(class) and is_binary(selector) do
-    key = {class, selector}
+    key = {class, selector, present_side_param(Map.get(params, "entry-side"))}
 
     expanded =
       if MapSet.member?(socket.assigns.expanded_changes, key) do
@@ -3897,12 +3915,30 @@ defmodule BtAttachWeb.WorkspaceLive do
     snake_chars(rest, c >= ?a and c <= ?z, [c | acc])
   end
 
-  # Normalise the `phx-value-entry-side` param (a plain HTML attribute string) to
-  # the `side` the Facade/`revert/3` expect: `""` (a sideless new-class row's
-  # `phx-value-entry-side={c[:side] || ""}`) and a missing/non-binary value both
-  # mean "no side constraint" (ADR 0112, BT-3187).
-  defp present_revert_side(side) when is_binary(side) and side != "", do: side
-  defp present_revert_side(_), do: nil
+  # Normalise a `phx-value-entry-side` param (a plain HTML attribute string)
+  # back to the `side` the row's `c[:side]` carries: `""` (a sideless
+  # new-class row's `phx-value-entry-side={c[:side] || ""}`) and a
+  # missing/non-binary value both mean "no side" (ADR 0112, BT-3187). Shared
+  # by the revert button and the diff-toggle caret's `entry-side` param
+  # (BT-3195) so both controls agree on what "no side" means and neither
+  # duplicates the other's normalisation.
+  defp present_side_param(side) when is_binary(side) and side != "", do: side
+  defp present_side_param(_), do: nil
+
+  # Human-readable Kind/Side label for one Changes-pane row (BT-3195): before
+  # this, the table had no column distinguishing an instance-side patch from a
+  # class-side patch/removal of the same selector, so the two rows — both
+  # possible simultaneously since BT-3187's `(class, selector, side)`
+  # shadow-key fix — were visually identical apart from their (also-identical)
+  # Class/Selector/Intent/Flushable/Author cells. `kind: "instance"`/`"class"`
+  # already implies its own side, so only `"remove-method"` (whose kind alone
+  # doesn't say which method table it targets) appends the explicit `side`;
+  # an unrecognised future kind falls back to the raw value rather than
+  # crashing, matching the ChangeLog's own `kind() :: … | unknown` fallback
+  # (`beamtalk_workspace_changelog.erl`).
+  defp change_kind_label(%{kind: "remove-method"} = c), do: "remove (#{c[:side] || "?"})"
+  defp change_kind_label(%{kind: "new-class"}), do: "new class"
+  defp change_kind_label(%{kind: kind}), do: kind
 
   # Revert one pending method patch (BT-2293). On success the prior body is
   # re-installed (a fresh durable entry) and the Changes pane refreshes; a
@@ -4070,8 +4106,10 @@ defmodule BtAttachWeb.WorkspaceLive do
   # `handle_async(:mount_load, …)` and the sync refresh path.
   defp apply_changes(socket, rows) when is_list(rows) do
     # Prune expanded-diff carets for rows that have left @changes (flush /
-    # revert), so a re-saved method doesn't re-appear already-expanded.
-    live_keys = MapSet.new(rows, &{&1.class, &1.selector})
+    # revert), so a re-saved method doesn't re-appear already-expanded. Keyed
+    # by `{class, selector, side}` (BT-3195), matching the toggle handler and
+    # the template's `expanded` lookup below.
+    live_keys = MapSet.new(rows, &{&1.class, &1.selector, &1[:side]})
     expanded = MapSet.intersection(socket.assigns.expanded_changes, live_keys)
     assign(socket, changes: rows, changes_error: nil, expanded_changes: expanded)
   end
@@ -9250,6 +9288,13 @@ defmodule BtAttachWeb.WorkspaceLive do
                             <th class="diff-toggle-col"></th>
                             <th>Class</th>
                             <th>Selector</th>
+                            <%!-- Kind/side column (BT-3195): before this, a
+                                 same-selector instance-side patch and a
+                                 class-side patch/removal — both possible
+                                 simultaneously since BT-3187's `(class,
+                                 selector, side)` shadow-key fix — rendered as
+                                 visually identical rows. --%>
+                            <th>Kind</th>
                             <th>Intent</th>
                             <th>Flushable</th>
                             <th>Author</th>
@@ -9259,7 +9304,8 @@ defmodule BtAttachWeb.WorkspaceLive do
                         </thead>
                         <tbody>
                           <%= for c <- @changes do %>
-                            <% expanded = MapSet.member?(@expanded_changes, {c.class, c.selector}) %>
+                            <% expanded =
+                              MapSet.member?(@expanded_changes, {c.class, c.selector, c[:side]}) %>
                             <tr>
                               <%!-- Leading disclosure caret (BT-2636): toggles
                                    this row's structured net-vs-disk diff. Only
@@ -9267,7 +9313,12 @@ defmodule BtAttachWeb.WorkspaceLive do
                                    defensive `:if={c[:diff]}` guard the old
                                    in-column disclosure used — a method reverted to
                                    its on-disk body has no net change and never
-                                   reaches this pane). --%>
+                                   reaches this pane). `phx-value-entry-side`
+                                   (BT-3195) keys the expand/collapse state on this
+                                   row's side too, alongside `phx-value-class`/
+                                   `-selector` — see `handle_event("toggle_change_diff", …)`
+                                   for why a same-selector instance-side and
+                                   class-side row need independent toggle state. --%>
                               <td class="diff-toggle-col">
                                 <button
                                   :if={c[:diff]}
@@ -9276,6 +9327,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                                   phx-click="toggle_change_diff"
                                   phx-value-class={c.class}
                                   phx-value-selector={c.selector}
+                                  phx-value-entry-side={c[:side] || ""}
                                   aria-expanded={to_string(expanded)}
                                   title={if expanded, do: "Hide diff", else: "Show diff"}
                                 >
@@ -9284,6 +9336,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                               </td>
                               <td class="k">{c.class}</td>
                               <td>{c.selector}</td>
+                              <td>{change_kind_label(c)}</td>
                               <td>{c.intent}</td>
                               <td>{if c.flushable, do: "yes", else: "no"}</td>
                               <td>{c.author_kind}</td>
@@ -9338,7 +9391,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                                  beneath the row while expanded. Reuses the shared
                                  `unified_diff/1` renderer with the Git pane. --%>
                             <tr :if={c[:diff] && expanded} class="diff-row">
-                              <td colspan={if @role == :owner, do: 7, else: 6}>
+                              <td colspan={if @role == :owner, do: 8, else: 7}>
                                 <.unified_diff diff={c[:diff]} />
                               </td>
                             </tr>

--- a/editors/liveview/test/bt_attach_web/workspace_changes_side_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_changes_side_test.exs
@@ -1,0 +1,207 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.WorkspaceChangesSideTest do
+  @moduledoc """
+  Changes-pane Kind/Side column + row-toggle independence (BT-3195).
+
+  Follow-up from BT-3187 (ADR 0112 Phase 3, `removeSelector:` ChangeLog
+  entries + `side` field): the `(class, selector, side)` shadow-key fix
+  (`beamtalk_workspace_changelog:shadow_key/1`) newly allows an instance-side
+  patch and a class-side patch/removal of the *same selector name* to both be
+  active pending ChangeLog rows simultaneously. Before that fix, only one
+  entry per `(class, selector)` could ever be active, so two rows never
+  shared a key — this scenario, and the ambiguity it creates, are new.
+
+  Driven through the full LiveView stack against the stubbed workspace
+  client (`StubWorkspaceClient.seed_change_row/1`, BT-3195) — a same-selector
+  instance-side/class-side pair can't be expressed via `save_method/3`'s
+  `{class, selector}`-keyed write path, which structurally holds only one
+  entry per selector, regardless of side.
+  """
+  use BtAttachWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias BtAttachWeb.StubWorkspaceClient
+
+  setup do
+    Application.put_env(:bt_attach, :workspace_client, StubWorkspaceClient)
+
+    Application.put_env(:bt_attach, :oidc, %{
+      issuer: "https://idp",
+      client_id: "id",
+      redirect_uri: "https://ide/callback",
+      groups_claim: "groups",
+      client_secret: "x",
+      roles: %{"owner" => ["beamtalk-owners"], "observer" => ["beamtalk-observers"]}
+    })
+
+    Application.put_env(:bt_attach, :session_ttl_secs, 3600)
+
+    on_exit(fn ->
+      Application.delete_env(:bt_attach, :workspace_client)
+      Application.delete_env(:bt_attach, :oidc)
+      Application.delete_env(:bt_attach, :session_ttl_secs)
+      StubWorkspaceClient.stop_state(2_000)
+    end)
+
+    {:ok, _} = StubWorkspaceClient.start_state()
+
+    :ok
+  end
+
+  defp owner_conn(conn) do
+    Plug.Test.init_test_session(conn, %{
+      "bt_user" => %{"sub" => "alice", "groups" => ["beamtalk-owners"]},
+      "bt_logged_in_at" => System.system_time(:second)
+    })
+  end
+
+  # A row's Kind cell sits right after its Class/Selector cells in the same
+  # `<tr>` (workspace_live.ex's Changes-pane table); matching non-greedily
+  # from the class name to the Kind cell ties the assertion to the *correct*
+  # row rather than any row sharing the same selector.
+  defp kind_cell_for(html, class, selector, kind) do
+    html =~
+      ~r/<td class="k">#{Regex.escape(class)}<\/td>\s*<td>#{Regex.escape(selector)}<\/td>\s*<td>#{Regex.escape(kind)}<\/td>/
+  end
+
+  describe "Kind/Side column (BT-3195)" do
+    test "an instance-side and class-side row for the same selector show distinct Kind cells and toggle independently",
+         %{conn: conn} do
+      class = "Bt3195Sides#{System.unique_integer([:positive])}"
+
+      instance_diff = " foo => 1\n-  self.value\n+  NINETY_NINE_MARKER"
+      class_diff = " class foo => 2\n-  self.value\n+  ONE_HUNDRED_MARKER"
+
+      # Two ChangeLog rows sharing `(class, "foo")`, differing only by side —
+      # exactly the scenario BT-3187's `(class, selector, side)` shadow-key fix
+      # newly allows to coexist (previously impossible: only one entry per
+      # `(class, selector)` could ever be active).
+      StubWorkspaceClient.seed_change_row(%{
+        class: class,
+        selector: "foo",
+        kind: "instance",
+        side: "instance",
+        intent: "durable",
+        flushable: true,
+        flushed: false,
+        author_kind: "human",
+        diff: instance_diff
+      })
+
+      StubWorkspaceClient.seed_change_row(%{
+        class: class,
+        selector: "foo",
+        kind: "class",
+        side: "class",
+        intent: "durable",
+        flushable: true,
+        flushed: false,
+        author_kind: "human",
+        diff: class_diff
+      })
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      changes_html = render_click(view, "dock_tab", %{"tab" => "changes"})
+
+      # (1) Visually distinguishable: the Kind column renders "instance" for
+      # one row and "class" for the other, even though Class/Selector are
+      # identical on both.
+      assert kind_cell_for(changes_html, class, "foo", "instance")
+      assert kind_cell_for(changes_html, class, "foo", "class")
+
+      instance_caret =
+        ~s(button[phx-click="toggle_change_diff"][phx-value-class="#{class}"][phx-value-selector="foo"][phx-value-entry-side="instance"])
+
+      class_caret =
+        ~s(button[phx-click="toggle_change_diff"][phx-value-class="#{class}"][phx-value-selector="foo"][phx-value-entry-side="class"])
+
+      # Two distinct carets exist (not one shared control) — both collapsed
+      # by default.
+      assert has_element?(view, instance_caret <> ~s([aria-expanded="false"]))
+      assert has_element?(view, class_caret <> ~s([aria-expanded="false"]))
+
+      # (2) Independently expandable: expanding the instance-side row's diff
+      # must NOT flip the class-side row's toggle. Before BT-3195, both rows
+      # keyed on `{class, selector}` alone, so this click would have expanded
+      # both.
+      after_instance_expand = view |> element(instance_caret) |> render_click()
+
+      assert has_element?(view, instance_caret <> ~s([aria-expanded="true"]))
+      assert has_element?(view, class_caret <> ~s([aria-expanded="false"]))
+      assert after_instance_expand =~ "NINETY_NINE_MARKER"
+      refute after_instance_expand =~ "ONE_HUNDRED_MARKER"
+
+      # Expanding the class-side row too: both now independently expanded,
+      # each showing its own diff.
+      after_class_expand = view |> element(class_caret) |> render_click()
+      assert has_element?(view, instance_caret <> ~s([aria-expanded="true"]))
+      assert has_element?(view, class_caret <> ~s([aria-expanded="true"]))
+      assert after_class_expand =~ "ONE_HUNDRED_MARKER"
+
+      # (3) Collapsing the instance-side row again must leave the class-side
+      # row's (still-expanded) toggle untouched — the definitive proof the two
+      # rows no longer share one MapSet key.
+      after_instance_collapse = view |> element(instance_caret) |> render_click()
+      assert has_element?(view, instance_caret <> ~s([aria-expanded="false"]))
+      assert has_element?(view, class_caret <> ~s([aria-expanded="true"]))
+      refute after_instance_collapse =~ "NINETY_NINE_MARKER"
+      assert after_instance_collapse =~ "ONE_HUNDRED_MARKER"
+    end
+
+    test "a remove-method row's Kind cell names its side; a new-class row's names neither",
+         %{conn: conn} do
+      class = "Bt3195Kinds#{System.unique_integer([:positive])}"
+
+      # `remove-method` never carries a diff (`method_delta/1`'s catch-all,
+      # `beamtalk_workspace_changelog.erl`) — its Kind cell is the only visual
+      # cue distinguishing it from an instance/class-side patch of the same
+      # selector, so this asserts that label directly rather than through the
+      # (absent) diff-toggle caret.
+      StubWorkspaceClient.seed_change_row(%{
+        class: class,
+        selector: "bar",
+        kind: "remove-method",
+        side: "class",
+        intent: "durable",
+        flushable: true,
+        flushed: false,
+        author_kind: "human",
+        diff: nil
+      })
+
+      # A new-class row carries no selector and no side (ADR 0112: side is
+      # meaningful only for a method-table target).
+      StubWorkspaceClient.seed_change_row(%{
+        class: class,
+        selector: "(class)",
+        kind: "new-class",
+        side: nil,
+        intent: "durable",
+        flushable: true,
+        flushed: false,
+        author_kind: "human",
+        diff: nil
+      })
+
+      {:ok, view, _html} = live(owner_conn(conn), "/")
+      changes_html = render_click(view, "dock_tab", %{"tab" => "changes"})
+
+      assert kind_cell_for(changes_html, class, "bar", "remove (class)")
+      assert kind_cell_for(changes_html, class, "(class)", "new class")
+
+      # Neither row carries a diff, so neither gets a disclosure caret.
+      refute has_element?(
+               view,
+               ~s(button[phx-click="toggle_change_diff"][phx-value-class="#{class}"][phx-value-selector="bar"])
+             )
+
+      refute has_element?(
+               view,
+               "button[phx-click=\"toggle_change_diff\"][phx-value-class=\"#{class}\"][phx-value-selector=\"(class)\"]"
+             )
+    end
+  end
+end

--- a/editors/liveview/test/support/stub_workspace_client.ex
+++ b/editors/liveview/test/support/stub_workspace_client.ex
@@ -59,6 +59,15 @@ defmodule BtAttachWeb.StubWorkspaceClient do
               # surfaced by `change_history` so the Changes-pane disclosure caret +
               # structured diff render can be driven without a real workspace.
               change_diffs: %{},
+              # BT-3195: fully custom ChangeLog rows appended to `change_history`'s
+              # derived-from-`changes` list, in insertion order. `save_method/3`'s
+              # 2-arity write path has no `side` concept (real saves don't need one
+              # here), so it can't express two rows sharing `{class, selector}` but
+              # differing by `kind`/`side` — the scenario `save_method/3`'s
+              # `{class, selector}`-keyed `changes` map structurally can't hold twice
+              # over. `seed_change_row/1` seeds one directly instead. `[]` = no extra
+              # rows (the default; every other stub test is unaffected).
+              extra_changes: [],
               # BT-2619: a one-shot barrier for the async mount-load reads. When a
               # test arms the gate (`arm_mount_gate/0`), the FIRST `browse_classes`
               # call (the mount-load task's first read) blocks until the test calls
@@ -305,27 +314,45 @@ defmodule BtAttachWeb.StubWorkspaceClient do
   def change_history do
     diffs = get(:change_diffs) || %{}
 
-    get(:changes)
-    |> Enum.map(fn {{class, selector}, _file} ->
-      %{
-        class: class,
-        selector: selector,
-        kind: "method",
-        intent: "durable",
-        flushable: true,
-        flushed: false,
-        author_kind: "liveview",
-        # BT-2636: seeded net-vs-disk diff so a test can drive the Changes-pane
-        # disclosure caret + structured `unified_diff` render. nil by default.
-        diff: Map.get(diffs, {class, selector})
-      }
-    end)
-    |> Enum.reverse()
+    derived =
+      get(:changes)
+      |> Enum.map(fn {{class, selector}, _file} ->
+        %{
+          class: class,
+          selector: selector,
+          kind: "method",
+          intent: "durable",
+          flushable: true,
+          flushed: false,
+          author_kind: "liveview",
+          # BT-2636: seeded net-vs-disk diff so a test can drive the Changes-pane
+          # disclosure caret + structured `unified_diff` render. nil by default.
+          diff: Map.get(diffs, {class, selector})
+        }
+      end)
+      |> Enum.reverse()
+
+    derived ++ get(:extra_changes)
   end
 
   @doc "Test helper: seed the net-vs-disk diff string for a `{class, selector}`."
   def set_change_diff(class, selector, diff) when is_binary(diff) do
     update(:change_diffs, fn diffs -> Map.put(diffs || %{}, {class, selector}, diff) end)
+  end
+
+  @doc """
+  Test helper (BT-3195): append one fully custom ChangeLog row to
+  `change_history`'s result, after the rows derived from `:changes`. `row` must
+  already be in the LiveView's expected shape (the same keys `entry_to_row/1`
+  produces for a real workspace: `class`, `selector`, `kind`, `intent`,
+  `flushable`, `flushed`, `author_kind`, `diff`, and optionally `side`) — this
+  helper does no shaping of its own, unlike `seed_change/2`, so a test can drive
+  scenarios the `{class, selector}`-keyed `:changes` map can't represent, e.g. a
+  same-selector instance-side and class-side row active simultaneously (ADR
+  0112, BT-3187's shadow-key fix).
+  """
+  def seed_change_row(row) when is_map(row) do
+    update(:extra_changes, fn rows -> rows ++ [row] end)
   end
 
   # ADR 0105 Phase 1 (BT-2779): current live snapshot of reload-induced


### PR DESCRIPTION
Fixes https://linear.app/beamtalk/issue/BT-3195

## Summary

Follow-up from BT-3187 (ADR 0112 Phase 3, `removeSelector:` ChangeLog entries + `side` field), flagged by the Claude review bot on PR #3407.

BT-3187's `(class, selector, side)` shadow-key fix (`beamtalk_workspace_changelog:shadow_key/1`, `beamtalk_workspace_flush:target_key/1`) newly allows an instance-side patch and a class-side patch/removal for the same selector *name* to both be active pending ChangeLog rows simultaneously (proven by `remove_selector_and_instance_patch_do_not_shadow_across_sides`). Before that fix, only one entry per `(class, selector)` could ever be active, so two rows never shared a key.

The LiveView Changes pane wasn't updated for this newly-possible scenario:

1. The table's visible columns (Class/Selector/Intent/Flushable/Author) had no Kind/Side column, so the two rows were visually indistinguishable.
2. The row-expansion toggle state (`@expanded_changes`) was keyed on `{class, selector}` only, so expanding one row's diff disclosure also flipped the other's.

## Changes

- Add a **Kind** column (`change_kind_label/1`) so same-selector rows render distinguishable text — `"instance"`/`"class"` for patches, `"remove (instance)"`/`"remove (class)"` for `remove-method` entries, `"new class"` for new-class entries.
- Key `@expanded_changes` and the `toggle_change_diff` handler on `{class, selector, side}` instead of `{class, selector}`, carried via a new `phx-value-entry-side` attribute on the diff-toggle caret (named `entry-side`, not `side`, to avoid colliding with the browser's instance/class `phx-value-side` toggle — matching the revert button's existing convention).
- Rename `present_revert_side/1` → `present_side_param/1`, now shared by both the revert button and the diff-toggle caret (no duplicated normalisation logic).
- Extend `StubWorkspaceClient` with `seed_change_row/1` so a fast LiveView test can drive a same-selector instance-side/class-side row pair — a scenario `save_method/3`'s `{class, selector}`-keyed write path structurally can't express.
- Add `workspace_changes_side_test.exs` covering: distinct Kind cells for a same-selector instance/class-side pair, independent expand/collapse of the two rows (the core regression), and Kind labels for `remove-method`/`new-class` rows.

## Test plan

- [x] `just ci-changed` — build, lint, full test suite (Rust + stdlib + BUnit + Erlang runtime + metamorphic), corpus/generated-builtins/surface-drift checks — all green
- [x] `mix test` (editors/liveview, excludes workspace/playwright tags) — 497 passed, including the 2 new BT-3195 tests
- [x] `mix format --check-formatted` — clean
- [x] Pre-push hook (full CI incl. Dialyzer) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CeTtDi5ua6oSuVrkEMvCCM)_