### PR TITLE
test(repl): tighten 5 placeholder assertions in remove_selector.btscript

### DIFF
--- a/tests/repl-protocol/cases/remove_selector.btscript
+++ b/tests/repl-protocol/cases/remove_selector.btscript
@@ -29,11 +29,11 @@
 
 Actor subclass: RemSelParent
   greet => "parent-greet"
-// => _
+// => RemSelParent
 
 RemSelParent subclass: RemSelChild
   greet => "child-greet"
-// => _
+// => RemSelChild
 
 rsc := RemSelChild spawn
 // => Actor(RemSelChild, _)
@@ -62,11 +62,11 @@ rsc greet
 
 Actor subclass: RemSelClsParent
   class make => "parent-made"
-// => _
+// => RemSelClsParent
 
 RemSelClsParent subclass: RemSelClsChild
   class make => "child-made"
-// => _
+// => RemSelClsChild
 
 RemSelClsChild make
 // => child-made
@@ -140,7 +140,7 @@ RemSelParent removeSelector: #yetAnotherAbsentSelector ifAbsent: [RemSelParent i
 
 Value subclass: RemSelExtTarget
   field: tag = "none"
-// => _
+// => RemSelExtTarget
 
 RemSelExtTarget >> shout => "SHOUT"
 // => RemSelExtTarget>>shout


### PR DESCRIPTION
## Summary

Five inline class-definition expressions in `tests/repl-protocol/cases/remove_selector.btscript` used `// => _` wildcard assertions even though their return values are fully deterministic — the newly-registered class name. This is the same pattern already used in `inline_class_hot_reload.btscript` (e.g. `// => InlineRedefActor`). Replace each wildcard with the concrete expected value.

**Changes (`remove_selector.btscript`, 5 lines):**

| Expression | Before | After |
|---|---|---|
| `Actor subclass: RemSelParent` | `// => _` | `// => RemSelParent` |
| `RemSelParent subclass: RemSelChild` | `// => _` | `// => RemSelChild` |
| `Actor subclass: RemSelClsParent` | `// => _` | `// => RemSelClsParent` |
| `RemSelClsParent subclass: RemSelClsChild` | `// => _` | `// => RemSelClsChild` |
| `Value subclass: RemSelExtTarget` | `// => _` | `// => RemSelExtTarget` |

The two remaining wildcards (`_stdlibRemoveEntry`, `_stdlibFlush` variable assignments) are correctly left as `_` — they hold complex objects with non-deterministic internals.

## Why this is safe

- Does not change test intent — only tightens what is asserted.
- Each new expected value is confirmed deterministic: `ClassName subclass: NewClass …` returns `NewClass` in the REPL, as evidenced by the existing `inline_class_hot_reload.btscript` tests.
- `just test-repl-protocol` passes locally with all assertions in place.

## Test plan

- [x] `just test-repl-protocol` — all 3 suites pass, `remove_selector.btscript` runs its full 235-line suite

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgsBABBaj6s3dUnD4YoEUy)_