### PR TITLE
refactor(cli): delegate class-name check in run.rs to is_valid_class_name

### DIFF
--- a/crates/beamtalk-cli/src/commands/run.rs
+++ b/crates/beamtalk-cli/src/commands/run.rs
@@ -153,15 +153,7 @@ fn ensure_runtime_built(
 /// Returns `true` when the selector is the arity-1 keyword form (carries args),
 /// `false` for the unary form.
 pub(crate) fn validate_class_and_selector(class_name: &str, selector: &str) -> Result<bool> {
-    if class_name.is_empty()
-        || !class_name
-            .chars()
-            .next()
-            .is_some_and(|c| c.is_ascii_uppercase())
-        || class_name
-            .chars()
-            .any(|c| !c.is_ascii_alphanumeric() && c != '_')
-    {
+    if !beamtalk_core::source_analysis::is_valid_class_name(class_name) {
         miette::bail!(
             "Invalid class name '{class_name}': class names must start with an ASCII uppercase \
              letter and contain only ASCII alphanumeric characters and underscores"


### PR DESCRIPTION
## Summary

`validate_class_and_selector` in `crates/beamtalk-cli/src/commands/run.rs` was reimplementing the class-name boolean check inline instead of delegating to the canonical function `beamtalk_core::source_analysis::is_valid_class_name`.

The canonical function's doc comment at `crates/beamtalk-core/src/source_analysis/mod.rs:74–76` explicitly requires:

> "This is the canonical definition; tools that validate user-supplied class names (LSP, MCP, CLI) must delegate their boolean check here so the rule stays in one place."

The MCP server (`crates/beamtalk-mcp/src/server.rs:154–162`) already complied; the CLI's `run.rs` was the only surface that did not.

## Change

Replace the 9-line inline predicate with a single call to `is_valid_class_name`:

```rust
// Before
if class_name.is_empty()
    || !class_name.chars().next().is_some_and(|c| c.is_ascii_uppercase())
    || class_name.chars().any(|c| !c.is_ascii_alphanumeric() && c != '_')
{ ... }

// After
if !beamtalk_core::source_analysis::is_valid_class_name(class_name) { ... }
```

The error message, selector validation logic (lines 163–206), and all behaviour are unchanged.

## Verification

- `cargo clippy -p beamtalk-cli` — clean
- `cargo test -p beamtalk-cli -- commands::run::tests` — 30/30 passed (all 5 `validate_class_and_selector` tests pass)
- Pre-push hooks: Dialyzer, Erlang lint, Rust fmt — all green

---
_Generated by [Claude Code](https://claude.ai/code/session_018AZ75QgQHKpNMSiirLqJkR)_