### PR TITLE
test(repl-json): cover catch blocks, encode_error variants, future completed path

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_json_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_json_tests.erl
@@ -1446,3 +1446,94 @@ format_error_message_invalid_module_test() ->
     %% Falls through to generic formatter
     ?assert(is_binary(Msg)),
     ?assert(byte_size(Msg) > 0).
+
+%%% ============================================================================
+%%% Catch-block coverage tests (BT-nightly-20260820)
+%%% ============================================================================
+
+%% format_error/1 catch branch (lines 88, 94-95).
+%% A tagged-exception map whose `error` field is not a #beamtalk_error{} record
+%% causes beamtalk_error:format/1 to throw function_clause inside
+%% format_error_message/1.  The outer try/catch in format_error/1 produces a
+%% fallback error response instead of crashing.
+format_error_catch_test() ->
+    Reason = #{'$beamtalk_class' => 'TestClass', error => not_a_beamtalk_error_record},
+    Result = beamtalk_repl_json:format_error(Reason),
+    {ok, Decoded} = beamtalk_repl_json:parse_json(Result),
+    ?assertEqual(<<"error">>, maps:get(<<"type">>, Decoded)),
+    ?assert(is_binary(maps:get(<<"message">>, Decoded))).
+
+%% format_error_with_warnings/2 catch branch (lines 136, 142-143).
+%% Same trigger as above; the with-warnings variant has its own catch block.
+format_error_with_warnings_catch_test() ->
+    Reason = #{'$beamtalk_class' => 'TestClass', error => not_a_beamtalk_error_record},
+    Result = beamtalk_repl_json:format_error_with_warnings(Reason, []),
+    {ok, Decoded} = beamtalk_repl_json:parse_json(Result),
+    ?assertEqual(<<"error">>, maps:get(<<"type">>, Decoded)),
+    ?assert(is_binary(maps:get(<<"message">>, Decoded))).
+
+%%% ============================================================================
+%%% encode_reloaded/5 with warnings (line 231)
+%%% ============================================================================
+
+%% maybe_add_warnings_reloaded/2 second clause fires when Warnings is non-empty.
+encode_reloaded_with_warnings_test() ->
+    Classes = [#{name => "Counter"}],
+    {ok, Msg} = beamtalk_repl_protocol:decode(
+        <<"{\"op\":\"reload\",\"id\":\"wtest1\",\"session\":\"sess1\"}">>
+    ),
+    Warnings = [<<"reload triggered">>, <<"state migration skipped">>],
+    Result = beamtalk_repl_json:encode_reloaded(Classes, 0, [], Msg, Warnings),
+    {ok, Decoded} = beamtalk_repl_json:parse_json(Result),
+    ?assertEqual([<<"Counter">>], maps:get(<<"classes">>, Decoded)),
+    ?assertEqual(Warnings, maps:get(<<"warnings">>, Decoded)).
+
+%%% ============================================================================
+%%% encode_error/2, /4, /5 (lines 236, 241, 251)
+%%% ============================================================================
+
+encode_error_2_test() ->
+    {ok, Msg} = beamtalk_repl_protocol:decode(
+        <<"{\"op\":\"eval\",\"id\":\"eid1\",\"session\":\"sess1\"}">>
+    ),
+    Result = beamtalk_repl_json:encode_error(some_error, Msg),
+    {ok, Decoded} = beamtalk_repl_json:parse_json(Result),
+    ?assert(is_binary(maps:get(<<"error">>, Decoded))),
+    ?assertEqual([<<"done">>, <<"error">>], maps:get(<<"status">>, Decoded)).
+
+encode_error_4_test() ->
+    {ok, Msg} = beamtalk_repl_protocol:decode(
+        <<"{\"op\":\"eval\",\"id\":\"eid2\",\"session\":\"sess1\"}">>
+    ),
+    Result = beamtalk_repl_json:encode_error(some_error, Msg, <<"stdout">>, []),
+    {ok, Decoded} = beamtalk_repl_json:parse_json(Result),
+    ?assert(is_binary(maps:get(<<"error">>, Decoded))),
+    ?assertEqual([<<"done">>, <<"error">>], maps:get(<<"status">>, Decoded)).
+
+encode_error_5_test() ->
+    {ok, Msg} = beamtalk_repl_protocol:decode(
+        <<"{\"op\":\"eval\",\"id\":\"eid3\",\"session\":\"sess1\"}">>
+    ),
+    Result = beamtalk_repl_json:encode_error(some_error, Msg, <<"stdout">>, [], #{
+        <<"hint">> => <<"check syntax">>
+    }),
+    {ok, Decoded} = beamtalk_repl_json:parse_json(Result),
+    ?assert(is_binary(maps:get(<<"error">>, Decoded))),
+    ?assertEqual(<<"check syntax">>, maps:get(<<"hint">>, Decoded)).
+
+%%% ============================================================================
+%%% term_to_json_future_pid/1 completed path (line 383)
+%%% ============================================================================
+
+%% The `false` branch of is_process_alive/1 in term_to_json_future_pid/1 fires
+%% when the underlying future process has already exited.  Monitor guarantees
+%% the process is gone before the assertion.
+term_to_json_future_completed_test() ->
+    Pid = spawn(fun() -> ok end),
+    MRef = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', MRef, process, Pid, _} -> ok
+    after 1000 -> error(timeout)
+    end,
+    Result = beamtalk_repl_json:term_to_json({beamtalk_future, Pid}),
+    ?assertEqual(<<"#Future<completed>">>, Result).


### PR DESCRIPTION
## Summary

- Add 7 EUnit tests to `beamtalk_repl_json_tests.erl` targeting 11 previously-uncovered lines in `beamtalk_repl_json.erl` (from 74% → ~83% line coverage).
- All 201 tests pass; erlfmt formatting verified.

### Covered lines

| Test | Lines covered | Mechanism |
|---|---|---|
| `format_error_catch_test` | 88, 94–95 | Tagged-exception map with non-record `error` field causes `beamtalk_error:format/1` to throw `function_clause`; outer catch returns fallback JSON |
| `format_error_with_warnings_catch_test` | 136, 142–143 | Same trigger, parallel catch block in `format_error_with_warnings/2` |
| `encode_reloaded_with_warnings_test` | 231 | `encode_reloaded/5` with non-empty warnings reaches `maybe_add_warnings_reloaded/2` second clause |
| `encode_error_2_test` | 236 | Direct call to `encode_error/2` |
| `encode_error_4_test` | 241 | Direct call to `encode_error/4` |
| `encode_error_5_test` | 251 | Direct call to `encode_error/5` with metadata map |
| `term_to_json_future_completed_test` | 383 | Spawns a process, monitors it, awaits 'DOWN', then asserts `term_to_json({beamtalk_future, DeadPid}) == <<"#Future<completed>">>` |

### Remaining uncovered (deferred)

- Lines 71–72, 115–116: `format_response` / `format_response_with_warnings` catch blocks — `term_to_json` is too defensive to trigger in unit tests without mocking.
- Lines 309–317, 332–333, 338, 376, 378, 380, 408, 411, 429, 484–487: require live actor infrastructure (Metaclass objects, pending/resolved/rejected futures, actor dispatch, singleton binding names).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRfLpVmjQpPvHt1zDcoLVJ)_