### PR TITLE
docs: ADR 0115 Phase 1 validation spike findings BT-3216

### DIFF
--- a/crates/beamtalk-core/tests/bt3216_spike_probe.rs
+++ b/crates/beamtalk-core/tests/bt3216_spike_probe.rs
@@ -1,0 +1,225 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+//! BT-3216 / ADR 0115 Phase 1 spike instrumentation.
+//!
+//! Measures how many message-send *receiver* expressions across `stdlib/src`
+//! have an entry in the type checker's [`TypeMap`], and which `InferredType`
+//! variant they carry — the numbers behind
+//! `docs/internal/adr-0115-phase1-spike-findings.md` §1.
+//!
+//! `#[ignore]` on purpose: this reports, it does not assert, and it reads
+//! `stdlib/src` through a path relative to the crate directory. Run it
+//! explicitly:
+//!
+//! ```text
+//! cargo test -p beamtalk-core --test bt3216_spike_probe -- --ignored --nocapture
+//! ```
+
+use beamtalk_core::ast::Expression;
+use beamtalk_core::semantic_analysis::class_hierarchy::ClassHierarchy;
+use beamtalk_core::semantic_analysis::type_checker::{InferredType, infer_types_and_returns};
+use beamtalk_core::source_analysis::{Span, lex_with_eof, parse};
+
+/// Percentage of `d`, guarding a zero denominator.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "reporting-only counts, far below f64's 2^53 exact-integer range"
+)]
+fn pct(n: usize, d: usize) -> f64 {
+    100.0 * n as f64 / d.max(1) as f64
+}
+
+fn collect_receiver_spans(expr: &Expression, out: &mut Vec<(String, Span)>) {
+    use beamtalk_core::ast::MessageSelector;
+    match expr {
+        Expression::MessageSend {
+            receiver,
+            selector,
+            arguments,
+            ..
+        } => {
+            let name = match selector {
+                MessageSelector::Unary(n) | MessageSelector::Binary(n) => n.to_string(),
+                MessageSelector::Keyword(parts) => {
+                    parts.iter().map(|p| p.keyword.as_str()).collect()
+                }
+            };
+            out.push((name, receiver.span()));
+            collect_receiver_spans(receiver, out);
+            for a in arguments {
+                collect_receiver_spans(a, out);
+            }
+        }
+        Expression::Cascade {
+            receiver, messages, ..
+        } => {
+            out.push(("<cascade>".to_string(), receiver.span()));
+            collect_receiver_spans(receiver, out);
+            for m in messages {
+                for a in &m.arguments {
+                    collect_receiver_spans(a, out);
+                }
+            }
+        }
+        Expression::Parenthesized { expression, .. } => collect_receiver_spans(expression, out),
+        Expression::Return { value, .. } | Expression::DestructureAssignment { value, .. } => {
+            collect_receiver_spans(value, out);
+        }
+        Expression::Assignment { target, value, .. } => {
+            collect_receiver_spans(target, out);
+            collect_receiver_spans(value, out);
+        }
+        Expression::FieldAccess { receiver, .. } => collect_receiver_spans(receiver, out),
+        Expression::Block(b) => {
+            for stmt in &b.body {
+                collect_receiver_spans(&stmt.expression, out);
+            }
+        }
+        Expression::Match { value, arms, .. } => {
+            collect_receiver_spans(value, out);
+            for arm in arms {
+                collect_receiver_spans(&arm.body, out);
+            }
+        }
+        Expression::ListLiteral { elements, tail, .. } => {
+            for e in elements {
+                collect_receiver_spans(e, out);
+            }
+            if let Some(t) = tail {
+                collect_receiver_spans(t, out);
+            }
+        }
+        Expression::ArrayLiteral { elements, .. } => {
+            for e in elements {
+                collect_receiver_spans(e, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Per-variant tallies of how the type checker typed each send receiver.
+#[derive(Default)]
+struct Counts {
+    entries: usize,
+    receivers: usize,
+    in_map: usize,
+    known: usize,
+    dynamic: usize,
+    meta: usize,
+    union: usize,
+    other: usize,
+}
+
+impl Counts {
+    fn tally(&mut self, ty: Option<&InferredType>) {
+        match ty {
+            Some(InferredType::Known { .. }) => self.known += 1,
+            Some(InferredType::Dynamic(_)) => self.dynamic += 1,
+            Some(InferredType::Meta { .. }) => self.meta += 1,
+            Some(InferredType::Union { .. }) => self.union += 1,
+            Some(_) => self.other += 1,
+            None => return,
+        }
+        self.in_map += 1;
+    }
+}
+
+/// Type-check one file and fold its receiver types into `counts`.
+fn scan_file(path: &str, counts: &mut Counts) -> usize {
+    let Ok(source) = std::fs::read_to_string(path) else {
+        return 0;
+    };
+    let tokens = lex_with_eof(&source);
+    let (module, _diags) = parse(tokens);
+    let (Ok(hierarchy), _) = ClassHierarchy::build(&module) else {
+        println!("  SKIP {path}: hierarchy build failed");
+        return 0;
+    };
+    let (type_map, _) = infer_types_and_returns(&module, &hierarchy, None);
+
+    let mut recvs = Vec::new();
+    for class in &module.classes {
+        for m in class.methods.iter().chain(class.class_methods.iter()) {
+            for stmt in &m.body {
+                collect_receiver_spans(&stmt.expression, &mut recvs);
+            }
+        }
+    }
+
+    let before = counts.in_map;
+    for (_selector, span) in &recvs {
+        counts.tally(type_map.get(*span));
+    }
+    let missed = recvs.len() - (counts.in_map - before);
+    if missed > 0 {
+        println!(
+            "  MISS {path}: {missed} of {} receivers absent from TypeMap",
+            recvs.len()
+        );
+    }
+    counts.entries += type_map.len();
+    counts.receivers += recvs.len();
+    recvs.len()
+}
+
+#[test]
+#[ignore = "BT-3216 spike instrumentation: reports numbers, asserts nothing"]
+fn probe() {
+    let mut files: Vec<std::path::PathBuf> = std::fs::read_dir("../../stdlib/src")
+        .expect("stdlib/src")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "bt"))
+        .collect();
+    files.sort();
+
+    let mut counts = Counts::default();
+    let mut worst: (usize, String) = (0, String::new());
+    for path in &files {
+        let path = path.display().to_string();
+        let sends = scan_file(&path, &mut counts);
+        if sends > worst.0 {
+            worst = (sends, path);
+        }
+    }
+
+    let total = counts.receivers;
+    println!("--- BT-3216 TypeMap receiver-span coverage over stdlib/src ---");
+    println!("files                  : {}", files.len());
+    println!("total TypeMap entries  : {}", counts.entries);
+    println!("send receivers         : {total}");
+    println!(
+        "receivers in TypeMap   : {} ({:.1}%)",
+        counts.in_map,
+        pct(counts.in_map, total)
+    );
+    println!(
+        "  Known{{..}}             : {} ({:.1}%)  <- would key recv_type",
+        counts.known,
+        pct(counts.known, total)
+    );
+    println!(
+        "  Meta{{C}} (class object) : {} ({:.1}%)  <- ADR write path has no rule for this",
+        counts.meta,
+        pct(counts.meta, total)
+    );
+    println!(
+        "  Union                  : {} ({:.1}%)",
+        counts.union,
+        pct(counts.union, total)
+    );
+    println!(
+        "  Dynamic(_)             : {} ({:.1}%)",
+        counts.dynamic,
+        pct(counts.dynamic, total)
+    );
+    println!(
+        "  Never/Negation/Inter.  : {} ({:.1}%)",
+        counts.other,
+        pct(counts.other, total)
+    );
+    println!(
+        "largest file by sends  : {} ({} receivers)",
+        worst.1, worst.0
+    );
+}

--- a/crates/beamtalk-examples/corpus.json
+++ b/crates/beamtalk-examples/corpus.json
@@ -17,7 +17,7 @@
     },
     {
       "id": "docs-beamtalk-language-features-block-1",
-      "title": "Character Literal Methods (beamtalk-language-features)",
+      "title": "Character Methods (beamtalk-language-features)",
       "category": "language-reference",
       "tags": [
         "beamtalk-language-features",
@@ -29,7 +29,7 @@
         "toString",
         "to_string"
       ],
-      "source": "$A asInteger              // => 65\n$A asString               // => \"A\"\n$A printString            // => \"$A\"\n$A uppercase              // => 65\n$A lowercase              // => 97\n$A class                  // => Character\n$A respondsTo: #uppercase // => true\nCharacter value: 65       // => $A",
+      "source": "$A asInteger              // => 65\n$A asString               // => \"A\"\n$A printString            // => \"$A\"\n$A uppercase              // => 65\n$A lowercase              // => 97\n$A class                  // => Character\n$A respondsTo: #uppercase // => true\nCharacter value: 65       // => $A\n(Character value: 10) asString   // => \"\\n\" (LF, not \"10\")\n$a uppercase asString            // => \"A\"",
       "explanation": "Code example from docs/beamtalk-language-features.md"
     },
     {

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -20,12 +20,15 @@ This directory contains internal implementation documentation, design decisions,
 | [Coverage Analysis](coverage-analysis.md) | Core Erlang compilation verification test coverage analysis |
 | [Class-Keyed ETS Tables Investigation](class-keyed-ets-tables-investigation.md) | BT-2222 survey + decision on consolidating the six class-keyed ETS tables |
 
-### Implementation Tracking
+### Spike Findings
+
+Validation spikes run ahead of an ADR's implementation phases — each records
+what held, what broke, and what the following phase must change as a result.
 
 | Document | Description |
 |----------|-------------|
-| [Operator Implementation Status](OPERATOR_IMPLEMENTATION_STATUS.md) | Cross-reference of documented vs. implemented binary operators |
-| [Coverage Analysis](COVERAGE_ANALYSIS.md) | Core Erlang compilation verification test coverage analysis |
+| [ADR 0105 Phase 0](adr-0105-phase0-spike-findings.md) | BT-2776: live image re-checking — signature capture, dependent lookup, batched port re-check |
+| [ADR 0115 Phase 1](adr-0115-phase1-spike-findings.md) | BT-3216: xref receiver-type key — `InferredType` reachability, hierarchy-closure and `conforms_to/2` cost, default-fallback soundness |
 
 ## When to Add Documents Here
 

--- a/docs/internal/adr-0115-phase1-spike-findings.md
+++ b/docs/internal/adr-0115-phase1-spike-findings.md
@@ -1,0 +1,366 @@
+# ADR 0115 — Phase 1 Validation Spike Findings (BT-3216)
+
+**Status:** complete · **Deliverable:** knowledge, not code.
+**Question:** can Phase 2 commit to ADR 0115's `recv_type` schema as written, or
+does something load-bearing not hold?
+
+**Evidence artefacts committed** (both are spike instrumentation, not production
+code — neither runs in CI):
+
+- `runtime/perf/bench_recv_type_spike.escript` — runs `hierarchy_related_classes/1`,
+  `conforms_to/2` and `is_relevant/3` *transcribed verbatim from ADR 0115
+  §"Read path"* against a live 109-class stdlib workspace. No schema or runtime
+  change; the proposed functions live inside the escript.
+  `cd runtime && escript perf/bench_recv_type_spike.escript`
+- `crates/beamtalk-core/tests/bt3216_spike_probe.rs` — `#[ignore]`d reporting
+  probe measuring `TypeMap` receiver-span coverage across `stdlib/src`.
+  `cargo test -p beamtalk-core --test bt3216_spike_probe -- --ignored --nocapture`
+
+Timings below are from an unloaded dev container, reported as the range across
+three runs. They are order-of-magnitude evidence, not a regression baseline.
+
+## Headline
+
+| # | Assumption | Verdict | One-line evidence |
+|---|---|---|---|
+| 1 | `InferredType` reachable at `build_method_xref_list` | **Partial — blocked, but not for the reason the ADR predicted** | Inference already runs on the right module and the result is *discarded*; no second pass is needed. The blocker is that `build_method_xref_entry` walks a **re-unparsed, re-parsed copy** of the method, so its `SendHit`s have no key into a span-keyed `TypeMap`. |
+| 2 | `hierarchy_related_classes/1` cheap | **Held, with a scaling caveat** | 474–508 µs for a root-class change, 6–7 µs otherwise — but `direct_subclasses/1` is a full-table `ets:match`, so the closure is **O(N²) in class count**. |
+| 3 | `conforms_to/2` cheap enough to call per site | **Broke** | 59–135 µs per call (a `gen_server:call` per ancestor level, per required selector, halting on a hit). All-protocol worst case: `senders_of/2` costs **3.3–16.3 ms** vs `senders_of/1`'s 34–38 µs — a 100–400x regression on the hot-reload path the ADR exists to speed up. |
+| 4 | Generation-bump default leaves legacy rows "always relevant" | **Held for the stated case; broke for two adjacent ones** | Missing-field rows correctly default to relevant. But a `recv_type` naming *anything the registries cannot resolve* — including **a protocol whose module is not currently registered** — is silently **excluded**. That is a correctness bug, not a precision gap. |
+
+**Recommendation: Phase 2 may proceed, but not with the schema and read path
+exactly as written.** Three amendments are required (§5). None of them
+invalidate the ADR's decision; all of them are things this spike existed to
+find.
+
+---
+
+## 1 — Is `InferredType` reachable at `build_method_xref_list`?
+
+**Verdict: not today. But the ADR mis-identified the risk.**
+
+ADR 0115 §Implementation warned: *"if `InferredType` proves expensive or
+unavailable at the needed pipeline point, the design may need to fall back to
+computing types lazily/on-demand at xref-entry-construction time — a real cost
+increase."* That fallback is **not needed**. Inference is already run, on the
+right module, in the right process, in both compile paths — and thrown away.
+
+### 1a. The inference results already exist and are discarded
+
+**Driver path** (`semantic_analysis/mod.rs:687-705`): `analyze` runs
+`TypeChecker::check_module_with_protocols_and_aliases`, lifts
+`take_method_return_types()` onto `AnalysisResult.method_return_types`, then
+`take_type_map()` into a local, hands it to the `Analyser`, and drops it when
+`analyze` returns. `AnalysisResult` (`semantic_analysis/mod.rs:102-161`) has no
+`type_map` field. The `Analyser` already exposes it back
+(`semantic_analysis/analyser.rs:44`, `fn type_map(&self) -> &TypeMap`).
+
+**Self-sufficient path** (`codegen/core_erlang/mod.rs:944`): codegen calls
+`infer_method_return_types`, which internally does a full `check_module` and
+returns only the return-type map (`type_checker/mod.rs:337-348`).
+**`infer_types_and_returns` already exists** (`type_checker/mod.rs:359-370`) and
+returns `(TypeMap, method_return_types)` from that *same single pass* — a
+literal drop-in with no extra inference.
+
+**Retention cost is negligible.** `TypeMap` is `HashMap<Span, InferredType>`
+with `Span` a `(u32, u32)` byte range. Measured over all 109 `stdlib/src` files:
+**6,552 entries total**, ~60 per module.
+
+### 1b. Receiver-span coverage is excellent — this validates the ADR's core bet
+
+Across `stdlib/src` (109 files, 2,218 message-send receiver expressions):
+
+| Receiver's `InferredType` | Count | Share |
+|---|---|---|
+| present in `TypeMap` at all | 2,196 | **99.0 %** |
+| `Known { .. }` — would key `recv_type` | 1,778 | **80.2 %** |
+| `Meta { class_name }` — class-object receiver | 303 | 13.7 % |
+| `Union` | 53 | 2.4 % |
+| `Dynamic(_)` | 62 | 2.8 % |
+| `Never` / `Negation` / `Intersection` | 0 | 0.0 % |
+
+80 % of stdlib sends would carry a concrete name rather than the `dynamic`
+fallback. This is the number behind the ADR's Steelman claim that inferred
+beats declared-annotation-only, and it holds comfortably.
+
+### 1c. The actual blocker: a coordinate-space mismatch, not availability
+
+`build_method_xref_entry` (`codegen/core_erlang/gen_server/methods.rs:2751-2833`)
+does **not** walk the original AST. It calls
+`extract_method_source(method)` → `unparse::unparse_method` — a *pretty-printed
+re-render* of the method — and hands the string to
+`find_all_sends_in_source` (`method_source_walker.rs:121-138`), which prefixes
+`"Object subclass: __SyntheticAllSendsScope\n"`, **re-lexes and re-parses** it,
+and walks that *fresh* AST.
+
+`SendHit` (`method_source_walker.rs:92-106`) carries `selector`, `line`,
+`receiver: ReceiverKind`, `target_module` — **no span**. Any span it could
+carry would index the synthetic string, not the file. `TypeMap` is keyed by
+`Span` = byte offsets into the **original source file**
+(`source_analysis/span.rs:11-31`). **There is no join key today.**
+
+Byte-offset arithmetic is not a viable rescue.
+`source_analysis/method_span_corpus_tests.rs:550-600` shows the round trip only
+reconstructs `disk[span]` after `dedent` → `unparse_method` →
+`reindent_method_source` → `match_trailing_newline`, and only for the
+formatter-clean stdlib/examples corpus. For user source that is not
+`just fmt`-clean, unparse output is not byte-identical to disk at all, so an
+offset map would be both fragile and per-line.
+
+### 1d. Exact plumbing Phase 2 needs
+
+1. Add `pub type_map: TypeMap` to `AnalysisResult`. `analyze` already computes
+   it (`semantic_analysis/mod.rs:705`) and moves it into the `Analyser`, which
+   exposes it back as `type_map(&self) -> &TypeMap` (`analyser.rs:44`). Note
+   `analyser.result` is still consumed after that point
+   (`check_block_capture_sendability`, then the `block_info`/`diagnostics`
+   moves), so recover the map by destructuring the `Analyser` at the end rather
+   than by a consuming accessor mid-way.
+2. Stash it on `CoreErlangGenerator` via the existing
+   `CodegenOptions::with_analysis` channel. Every production driver already
+   hands off analysis (`beamtalk-cli/src/beam_compiler.rs:762`,
+   `beamtalk-compiler-port/src/main.rs:1621/1696/1957/2207`).
+3. In the self-sufficient path (`codegen/core_erlang/mod.rs:944`) swap
+   `infer_method_return_types` → `infer_types_and_returns`. Zero extra passes.
+4. **The real work — join `SendHit` to a receiver span.** Phase 2 must pick one
+   explicitly:
+   - **(A) AST-directed receiver walk over the original `&MethodDefinition`
+     (recommended).** `build_method_xref_entry` already holds it, with
+     file-absolute spans. Add a second, span-carrying pre-order walk and join to
+     the existing `find_all_sends_in_source` hits **by pre-order ordinal**.
+     Cheap — but it rests on two assumptions, not one: that unparse→reparse is
+     pre-order-structure-preserving, *and* that the new walk replicates
+     `collect_sends`'s exact traversal, including its cascade expansion (one hit
+     per cascade message, receiver recorded before its own subtrees). The join
+     must also run before `methods.rs`'s `MAX_ATOM_BYTES` selector filter, which
+     drops hits after the walk. Per this repo's
+     no-"keep-in-sync"-comment-without-a-test rule, those assumptions need a
+     **corpus conformance test** (hit count and selector sequence identical
+     between the two walks, over the same corpus
+     `method_span_corpus_tests.rs` already uses), not a comment.
+   - **(B) Add an optional `receiver_span` to `SendHit`,** populated only on an
+     AST-directed invocation. Larger change to a module whose leaf position is
+     deliberate (ADR 0115 Constraint 3), and the fallback/live-patch callers
+     still have no spans — it converges on the same asymmetry as (A).
+   - Not viable: byte-offset remapping (§1c).
+5. Keep `method_source_walker` a leaf. The `&TypeMap` join belongs in
+   `methods.rs` (codegen), not inside the walker — the walker must not gain a
+   `semantic_analysis` dependency.
+
+### 1e. Finding not in the ADR — `Meta{C}` receivers get no rule
+
+13.7 % of stdlib send receivers infer to `InferredType::Meta { class_name }` — a
+class-object receiver (`Counter spawn`, `Transcript showLine:`). ADR 0115's
+write path enumerates `Known` → name, and "`Union`, `Intersection`,
+`Negation`, `Dynamic(_)`, or otherwise unresolved" → `dynamic`. `Meta` lands in
+the second bucket by omission, discarding narrowing on the **entire class-side
+send population** for no stated reason.
+
+The runtime already has a name for these: `beamtalk_class_registry:class_object_tag/1`
+renders `'Foo'` as `'Foo class'`. Phase 2 should decide this deliberately —
+it is a schema-shape decision, which is exactly what this spike exists to
+de-risk — rather than inherit it silently.
+
+---
+
+## 2 — `hierarchy_related_classes/1` cost
+
+**Verdict: held, but it degrades quadratically and the constant is larger than
+"one chain walk plus one closure" suggests.**
+
+Live workspace shape: **109 loaded classes, max ancestor depth 5**, root breadth
+`ProtoObject` 108 / `Object` 105 descendants.
+
+The **ancestor** half is genuinely cheap:
+`beamtalk_class_metadata:lookup_superclass/1` is a keyed `set` ETS read, ≤5 deep.
+
+The **descendant** half is not. `beamtalk_class_registry:all_subclasses/1`
+(`beamtalk_class_registry.erl:670-680`) calls `direct_subclasses/1` once per node
+in the subtree; `direct_subclasses/1` calls
+`beamtalk_class_metadata:match_subclasses/1`
+(`beamtalk_class_metadata.erl:349-375`), which is a **full-table `ets:match/2`**.
+The table is a `set` keyed on `#class_metadata.name`
+(`beamtalk_class_metadata.erl:126-133`), so the *superclass* column is
+unindexed and every call scans all rows.
+
+| Measurement | Result |
+|---|---|
+| `match_subclasses/1` (one full-table scan) | 4.1–4.7 µs |
+| `all_subclasses('ProtoObject')` | 457–495 µs |
+| implied scans per closure | **104–110** ≈ one per loaded class |
+| `hierarchy_related_classes('ProtoObject')` | 474–508 µs |
+| `hierarchy_related_classes(<mid or leaf>)` | 6–7 µs |
+| `beamtalk_xref:senders_of/1`, hottest selector (`at:`, 70 sites) | 34–38 µs |
+| `senders_of/2` with `ChangedClass = Object` | 536–556 µs |
+
+So a root-class change makes the per-trigger lookup **~15x** today's. In
+absolute terms that is fine at today's scale — sub-millisecond, dwarfed by the
+~18.5 ms/class compile the filter exists to avoid (ADR 0105 Phase 0 spike). But
+the work is **O(N²) in class count**: at 1,000 loaded classes the same code does
+~100x the scanning (tens of ms) with no compile-side saving to match.
+
+**For Phase 3:** compute `Related` once per trigger (the ADR already does), and
+skip computing it at all when no site carries a nominal `recv_type`. Giving
+`beamtalk_class_metadata` a superclass index so `direct_subclasses/1` stops
+scanning is out of scope for ADR 0115 but is the change that makes this design
+scale — filed as **BT-3221**.
+
+---
+
+## 3 — `conforms_to/2` cost when called per site
+
+**Verdict: broke. This is the finding that most contradicts the ADR.**
+
+ADR 0115 presents the protocol branch as free reuse: *"reuses the already-shipped
+runtime conformance check (ADR 0068), not a new algorithm."* Reuse it is; free it
+is not.
+
+`beamtalk_protocol_registry:conforms_to/2`
+(`beamtalk_protocol_registry.erl:187-212`) is a **structural** check. For every
+required instance method (including those inherited via `extending`) it calls
+`beamtalk_behaviour_intrinsics:classCanUnderstandFromName/2`
+(`beamtalk_behaviour_intrinsics.erl:317-328`), which walks the ancestor chain
+calling `beamtalk_object_class:has_method/2` — and `has_method/2`
+(`beamtalk_object_class.erl:402-428`) is a **`gen_server:call` to the class
+process**. The walk halts at the first level that answers, so the cost is one
+`gen_server:call` per ancestor level *until a hit*, per required selector —
+which means the **worst case is a class that does not conform**, walking every
+selector to the root before returning `false`. There is **no memoisation
+anywhere** on this path, and because it is process messaging it also contends
+with whatever those class gen_servers are doing during the reload.
+
+| Measurement (70-site selector, `ChangedClass = Collection`) | Result |
+|---|---|
+| `conforms_to/2`, single call (`Printable`, `JsonRepresentable`) | **59–135 µs** |
+| `senders_of/1` today (no filter) | 34–38 µs |
+| `senders_of/2`, all rows legacy (no `recv_type`) | 80–83 µs |
+| `senders_of/2`, migrated, nominal-skewed types | 69–78 µs |
+| **`senders_of/2`, migrated, all rows protocol-typed** | **3,346–16,272 µs** |
+| same, with `is_protocol`/`conforms_to` memoised per distinct `recv_type` | **156–530 µs** |
+
+The all-protocol worst case is a **~100–400x regression on a hot-reload path**,
+and it scales *linearly with fan-out* — precisely the large-fan-out regime ADR
+0115 exists to fix. A large-fan-out, protocol-typed selector would make
+`senders_of/2` slower than the compile it is filtering out, inverting the ADR's
+entire premise.
+
+Two mitigations, both cheap:
+
+1. **Memoise within the call.** `is_protocol/1` and `conforms_to/2` depend only
+   on `(ChangedClass, T)`, and `ChangedClass` is fixed for the whole
+   `senders_of/2` call. A fold with a small `#{recv_type => boolean()}` cache
+   drops the worst case **20–30x** (measured above), and helps the realistic
+   nominal case too (69–78 µs → 47–51 µs). The ADR's `is_relevant/3` as written
+   is a stateless predicate inside a list comprehension, re-evaluating per site;
+   it should be a fold. **Phase 3 must take this.**
+2. **Consider a registry-level conformance cache.** `conforms_to/2` results are
+   stable between class reloads. Caching them in the protocol registry, keyed
+   `{ClassName, ProtocolName}` and invalidated on class/protocol
+   (un)registration, would help every caller — including the class-load-time
+   `conformsTo:`/`protocols` queries that already pay this cost. Out of scope
+   for ADR 0115; filed as **BT-3222**.
+
+---
+
+## 4 — Generation-bump default fallback
+
+**Verdict: the stated case holds. Two adjacent cases silently narrow, and the
+ADR does not cover them.**
+
+Fixture: `is_relevant/3` transcribed verbatim from ADR 0115 §"Read path", run
+against the live registry with `ChangedClass = 'Integer'`
+(escript §C).
+
+| Site | Result | Correct? |
+|---|---|---|
+| legacy row, no `recv_type` key | `true` | ✅ as designed (3rd clause) |
+| `recv_type => dynamic` | `true` | ✅ |
+| `recv_type => 'Integer'` (self) | `true` | ✅ |
+| `recv_type => 'Number'` (ancestor) | `true` | ✅ |
+| `recv_type => 'Character'` (descendant) | `true` | ✅ |
+| `recv_type => 'ThrowError'` (unrelated branch) | `false` | ✅ correctly excluded |
+| **`recv_type => 'NoSuchClassXYZ'`** (name unknown to both registries) | **`false`** | ❌ **silently excluded** |
+| **`recv_type => 'UnloadedProto'`** (protocol not currently registered) | **`false`** | ❌ **silently excluded** |
+
+The ADR's safe-default reasoning covers rows *missing the field*. It does not
+cover rows *carrying a name neither registry can resolve* — `is_relevant/3` as
+written routes those to the nominal branch, `sets:is_element(T, Related)` →
+`false` → **dropped**. Two realistic ways to land there:
+
+1. **A protocol that is not registered at query time.** `is_protocol/1` reads
+   the protocol ETS table, which is populated when the defining module loads
+   (and cleared by `unregister_protocol/1`). During a hot reload, before a
+   protocol's module has loaded, or after an unregister, a protocol-typed site
+   takes the *nominal* branch and is excluded — the exact "silently narrowing a
+   real dependent" failure ADR 0115 Constraint 2 forbids. This is a
+   **correctness bug, not a precision gap**, and because it depends on module
+   load order during a reload it will be **intermittent** and painful to
+   diagnose.
+2. **`Known { class_name }` names that are not runtime classes.** The type
+   checker's `Known` also carries native/FFI type names (`NativeTypeRegistry`,
+   ADR 0075) and alias display names (`TypeProvenance::Aliased`, ADR 0108).
+   Neither has a `beamtalk_class_metadata` row.
+
+**Required changes:**
+
+- *Phase 3 read path:* invert the default. Exclude only when `T` is **positively
+  known** to the class registry and positively unrelated; include whenever `T`
+  cannot be resolved. Concretely, add an "unresolvable ⇒ relevant" arm before
+  the `sets:is_element/2` fallback.
+- *Phase 2 write path:* decide whether the compiler is allowed to emit names
+  that are not runtime class or protocol names at all. Recommendation: coarsen
+  native- and alias-provenance `Known` to `dynamic` at write time, so the read
+  path never has to reason about them.
+
+Two things that *did* check out and need no change:
+
+- The ADR's `maps:get(recv_type, Site, dynamic)` phrasing and its three-clause
+  `is_relevant/3` match are equivalent for the missing-field case — no
+  discrepancy.
+- The generation mechanism itself is sound: `senders_of/1`
+  (`beamtalk_xref.erl:449-458`) already filters to each owner's live generation
+  via `live_gen_sites/2`, so a re-register genuinely supersedes old rows and no
+  distinct backfill pass is needed.
+
+---
+
+## 5 — Verdict for Phase 2
+
+**Proceed — the ADR's decision survives — with three amendments, all of which
+this spike exists to have found.**
+
+1. **The `InferredType` plumbing is smaller than feared, but is not the
+   plumbing the ADR described.** No lazy/on-demand inference, no second pass:
+   add `type_map` to `AnalysisResult` and swap one function call. The real work
+   is a **span join** between the type-checked AST and the re-parsed
+   `SendHit` stream (§1c–1d) — Phase 2's estimate should be re-anchored on that,
+   plus the conformance test that join needs.
+2. **`recv_type` must not be able to hold a name the read path cannot resolve,
+   and the read path must default unresolvable names to *relevant*** (§4).
+   Without this the design has a correctness bug — an intermittent one — of the
+   exact kind Constraint 1 declares non-negotiable.
+3. **The protocol branch must be memoised per `senders_of/2` call** (§3), and
+   `is_relevant/3` becomes a fold rather than a stateless predicate. Without
+   this, the protocol-typed worst case is slower than the compile it replaces.
+
+Also decide, rather than inherit: **`Meta{C}` receivers** (13.7 % of stdlib
+sends) currently fall through to `dynamic` by omission (§1e).
+
+Two follow-ups filed, both outside ADR 0115's scope but both limiting how far
+this design scales:
+
+- **BT-3221** — index the superclass column in `beamtalk_class_metadata` so
+  `direct_subclasses/1` stops full-table-scanning (§2).
+- **BT-3222** — cache `conforms_to/2` results in the protocol registry,
+  invalidated on class/protocol (un)registration (§3).
+
+## References
+
+- ADR 0115 (`docs/ADR/0115-xref-receiver-type-key.md`) — the design under test
+- ADR 0087 — the xref schema being extended · ADR 0105 — the reload re-check
+  this optimises · ADR 0025 / ADR 0068 — `InferredType`, protocols,
+  `conforms_to/2` · ADR 0114 — the sibling hierarchy-closure reuse
+- `docs/internal/adr-0105-phase0-spike-findings.md` — the precedent spike (and
+  source of the 18.5 ms/class re-check figure)
+- Epic BT-2798 · this issue BT-3216 · next phase BT-3217 · follow-ups filed
+  here: BT-3221, BT-3222

--- a/runtime/perf/bench_recv_type_spike.escript
+++ b/runtime/perf/bench_recv_type_spike.escript
@@ -1,0 +1,372 @@
+#!/usr/bin/env escript
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Spike instrumentation: ADR 0115 Phase 1 validation (BT-3216).
+%%
+%% Measures the two runtime costs ADR 0115's read path assumes are cheap, and
+%% exercises the proposed `is_relevant/3` default-fallback against a hand-built
+%% site fixture. Nothing here is production code — `senders_of/2`,
+%% `hierarchy_related_classes/1` and `is_relevant/3` are re-implemented locally,
+%% exactly as ADR 0115 §"Read path" writes them, so the spike measures the
+%% design as specified without landing any schema or runtime change (BT-3216 is
+%% investigation-only).
+%%
+%% Run from the `runtime/` directory after `just build`:
+%%
+%%   escript perf/bench_recv_type_spike.escript
+
+-mode(compile).
+
+main(_) ->
+    code:add_pathsa(filelib:wildcard("_build/default/lib/*/ebin")),
+    code:add_pathsa(filelib:wildcard("apps/*/ebin")),
+    {ok, _} = application:ensure_all_started(beamtalk_runtime),
+    timer:sleep(500),
+    lists:foreach(
+        fun(Beam) ->
+            Mod = list_to_atom(filename:basename(Beam, ".beam")),
+            code:ensure_loaded(Mod)
+        end,
+        filelib:wildcard("apps/beamtalk_stdlib/ebin/bt@stdlib@*.beam")
+    ),
+    timer:sleep(2000),
+
+    Classes = [N || {N, _M, _P} <- beamtalk_class_registry:live_class_entries()],
+    io:format("~n=== Workspace ===~n"),
+    io:format("loaded classes: ~p~n", [length(Classes)]),
+    report_shape(Classes),
+
+    io:format("~n=== A. hierarchy_related_classes/1 cost ===~n"),
+    bench_related(Classes),
+
+    io:format("~n=== B. beamtalk_protocol_registry:conforms_to/2 cost ===~n"),
+    bench_conforms(Classes),
+
+    io:format("~n=== C. is_relevant/3 default-fallback fixture ===~n"),
+    fixture_is_relevant(),
+
+    io:format("~n=== D. end-to-end senders_of/2 per-trigger cost ===~n"),
+    bench_senders_of_2(),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Hierarchy shape
+%%--------------------------------------------------------------------
+
+report_shape(Classes) ->
+    Depths = [{C, depth(C, 0)} || C <- Classes],
+    MaxDepth = lists:max([D || {_, D} <- Depths]),
+    Breadths = [{C, length(beamtalk_class_registry:all_subclasses(C))} || C <- Classes],
+    Sorted = lists:reverse(lists:keysort(2, Breadths)),
+    io:format("max ancestor depth: ~p~n", [MaxDepth]),
+    io:format("deepest: ~p~n", [lists:sublist(lists:reverse(lists:keysort(2, Depths)), 5)]),
+    io:format("widest all_subclasses/1: ~p~n", [lists:sublist(Sorted, 5)]),
+    %% direct_subclasses/1 is a full-table ets:match on a set table keyed by
+    %% class name (superclass is not a key), so it is O(classes) per call and
+    %% all_subclasses/1 makes one such call per node in the subtree.
+    Root = element(1, hd(Sorted)),
+    {MatchUs, _} = time_avg(
+        fun() -> beamtalk_class_metadata:match_subclasses(Root) end, 500
+    ),
+    {AllUs, _} = time_avg(fun() -> beamtalk_class_registry:all_subclasses(Root) end, 200),
+    io:format(
+        "  match_subclasses/1 ~.2f us | all_subclasses(~p) ~.1f us => ~.1f match scans~n",
+        [MatchUs, Root, AllUs, AllUs / MatchUs]
+    ).
+
+depth(_C, N) when N > 64 ->
+    N;
+depth(C, N) ->
+    case beamtalk_class_metadata:lookup_superclass(C) of
+        {ok, Super} when Super =/= none, Super =/= undefined -> depth(Super, N + 1);
+        _ -> N
+    end.
+
+%%--------------------------------------------------------------------
+%% A. hierarchy_related_classes/1
+%%--------------------------------------------------------------------
+
+%% ADR 0115 §Read path: {C} ∪ ancestors(C) ∪ subclasses(C), built from the
+%% registry's existing superclass-chain walk and direct_subclasses/1 closure.
+hierarchy_related_classes(C) ->
+    sets:from_list([C | ancestors(C, [])] ++ beamtalk_class_registry:all_subclasses(C)).
+
+ancestors(_C, Acc) when length(Acc) > 64 ->
+    Acc;
+ancestors(C, Acc) ->
+    case beamtalk_class_metadata:lookup_superclass(C) of
+        {ok, Super} when Super =/= none, Super =/= undefined -> ancestors(Super, [Super | Acc]);
+        _ -> Acc
+    end.
+
+bench_related(Classes) ->
+    %% Root (worst case: whole hierarchy is a descendant), a mid-tree class, a leaf.
+    Probes = probes(Classes),
+    lists:foreach(
+        fun({Label, C}) ->
+            _ = hierarchy_related_classes(C),
+            {Us, Size} = time_avg(
+                fun() -> sets:size(hierarchy_related_classes(C)) end, 200
+            ),
+            io:format("  ~s ~p related=~p ~.1f us/call~n", [Label, C, Size, Us])
+        end,
+        Probes
+    ).
+
+probes(Classes) ->
+    Breadths = [{C, length(beamtalk_class_registry:all_subclasses(C))} || C <- Classes],
+    Sorted = lists:reverse(lists:keysort(2, Breadths)),
+    {Widest, _} = hd(Sorted),
+    {Narrowest, _} = lists:last(Sorted),
+    Mid = element(1, lists:nth(max(1, length(Sorted) div 2), Sorted)),
+    [{"root", Widest}, {"mid", Mid}, {"leaf", Narrowest}].
+
+%%--------------------------------------------------------------------
+%% B. conforms_to/2
+%%--------------------------------------------------------------------
+
+bench_conforms(Classes) ->
+    Protocols = beamtalk_protocol_registry:all_protocol_names(),
+    io:format("  registered protocols: ~p~n", [length(Protocols)]),
+    case Protocols of
+        [] ->
+            io:format("  (no protocols registered in a bare stdlib workspace)~n"),
+            io:format("  registering a synthetic 3-method protocol to measure the shape~n"),
+            ok = register_synthetic_protocol(),
+            bench_conforms_for(['SpikeProto'], Classes);
+        _ ->
+            bench_conforms_for(lists:sublist(Protocols, 3), Classes)
+    end.
+
+register_synthetic_protocol() ->
+    beamtalk_protocol_registry:register_protocol(#{
+        name => 'SpikeProto',
+        module => spike_proto_mod,
+        methods => [
+            #{selector => 'printOn:', arity => 1},
+            #{selector => 'size', arity => 0},
+            #{selector => '=', arity => 1}
+        ],
+        class_methods => [],
+        extending => []
+    }).
+
+bench_conforms_for(Protocols, Classes) ->
+    Sample = lists:sublist(Classes, 1, 12),
+    lists:foreach(
+        fun(P) ->
+            _ = [beamtalk_protocol_registry:conforms_to(C, P) || C <- Sample],
+            {Us, _} = time_avg(
+                fun() ->
+                    [beamtalk_protocol_registry:conforms_to(C, P) || C <- Sample]
+                end,
+                20
+            ),
+            io:format(
+                "  protocol ~p ~.1f us for ~p classes (~.1f us/conforms_to call)~n",
+                [P, Us, length(Sample), Us / length(Sample)]
+            )
+        end,
+        Protocols
+    ).
+
+%%--------------------------------------------------------------------
+%% C. is_relevant/3 fixture — ADR 0115 §Read path, verbatim
+%%--------------------------------------------------------------------
+
+is_relevant(#{recv_type := dynamic}, _ChangedClass, _Related) ->
+    true;
+is_relevant(#{recv_type := T}, ChangedClass, Related) ->
+    case beamtalk_protocol_registry:is_protocol(T) of
+        true -> beamtalk_protocol_registry:conforms_to(ChangedClass, T);
+        false -> sets:is_element(T, Related)
+    end;
+is_relevant(#{}, _ChangedClass, _Related) ->
+    true.
+
+fixture_is_relevant() ->
+    %% Pick a real class with both an ancestor and a descendant so the
+    %% relatedness arms are exercised against the live registry.
+    Changed = pick_mid_class(),
+    Related = hierarchy_related_classes(Changed),
+    Ancestor = case ancestors(Changed, []) of
+        [] -> 'Object';
+        As -> lists:last(As)
+    end,
+    Descendant = case beamtalk_class_registry:all_subclasses(Changed) of
+        [] -> Changed;
+        [D | _] -> D
+    end,
+    Unrelated = pick_unrelated(Changed, Related),
+    io:format("  changed=~p ancestor=~p descendant=~p unrelated=~p~n",
+              [Changed, Ancestor, Descendant, Unrelated]),
+    Cases = [
+        {"legacy row (no recv_type key)", #{owner => 'X', line => 1}, true},
+        {"explicit dynamic", #{owner => 'X', recv_type => dynamic}, true},
+        {"self (== changed class)", #{owner => 'X', recv_type => Changed}, true},
+        {"ancestor-typed receiver", #{owner => 'X', recv_type => Ancestor}, true},
+        {"descendant-typed receiver", #{owner => 'X', recv_type => Descendant}, true},
+        {"unrelated branch", #{owner => 'X', recv_type => Unrelated}, false},
+        {"unknown/never-registered name", #{owner => 'X', recv_type => 'NoSuchClassXYZ'}, unknown},
+        {"unregistered protocol name", #{owner => 'X', recv_type => 'UnloadedProto'}, unknown}
+    ],
+    lists:foreach(
+        fun({Label, Site, Expect}) ->
+            Got = is_relevant(Site, Changed, Related),
+            Mark = case Expect of
+                unknown -> "?";
+                Got -> "ok";
+                _ -> "MISMATCH"
+            end,
+            io:format("  ~s -> ~p expected ~p ~s~n", [Label, Got, Expect, Mark])
+        end,
+        Cases
+    ).
+
+pick_mid_class() ->
+    Classes = [N || {N, _M, _P} <- beamtalk_class_registry:live_class_entries()],
+    Candidates = [
+        C
+     || C <- Classes,
+        beamtalk_class_registry:all_subclasses(C) =/= [],
+        ancestors(C, []) =/= []
+    ],
+    case Candidates of
+        [] -> 'Object';
+        [C | _] -> C
+    end.
+
+pick_unrelated(Changed, Related) ->
+    Classes = [N || {N, _M, _P} <- beamtalk_class_registry:live_class_entries()],
+    %% Exclude registered protocol names — a protocol-typed site takes the
+    %% conforms_to/2 branch, not the hierarchy branch, so it is not a valid
+    %% probe for "unrelated nominal class".
+    case
+        [
+            C
+         || C <- Classes,
+            C =/= Changed,
+            not sets:is_element(C, Related),
+            not beamtalk_protocol_registry:is_protocol(C)
+        ]
+    of
+        [] -> 'NoUnrelatedClass';
+        [C | _] -> C
+    end.
+
+%%--------------------------------------------------------------------
+%% D. End-to-end senders_of/2, as ADR 0115 writes it, vs a memoised variant
+%%--------------------------------------------------------------------
+
+%% ADR 0115 §Read path, verbatim.
+senders_of_2(Selector, ChangedClass) ->
+    AllSites = beamtalk_xref:senders_of(Selector),
+    Related = hierarchy_related_classes(ChangedClass),
+    [S || S <- AllSites, is_relevant(S, ChangedClass, Related)].
+
+bench_senders_of_2() ->
+    Selector = hottest_selector(),
+    Sites = beamtalk_xref:senders_of(Selector),
+    N = length(Sites),
+    io:format("  hottest selector: ~p (~p sites today)~n", [Selector, N]),
+    Changed = 'Collection',
+    io:format("  changed class: ~p~n", [Changed]),
+
+    {BaseUs, _} = time_avg(fun() -> beamtalk_xref:senders_of(Selector) end, 200),
+    io:format("  senders_of/1 (today, no filter)          ~.1f us~n", [BaseUs]),
+
+    %% (a) Fully unmigrated index: every row hits is_relevant/3's legacy clause.
+    {LegacyUs, _} = time_avg(fun() -> length(senders_of_2(Selector, Changed)) end, 200),
+    io:format("  senders_of/2, all-legacy rows            ~.1f us~n", [LegacyUs]),
+
+    %% (b) Realistic migrated index: receiver types concentrated on a handful
+    %% of nominal classes (what ordinary code produces), plus dynamic.
+    Skewed = stamp(Sites, ['List', 'Dictionary', 'String', 'Array', dynamic, dynamic]),
+    report_predicate("migrated, nominal-skewed", Skewed, Changed),
+
+    %% (c) Worst case for the protocol branch: every row protocol-typed, so
+    %% senders_of/2 pays one conforms_to/2 per site. This is the "new call
+    %% volume the registry was not sized for" case.
+    case beamtalk_protocol_registry:all_protocol_names() of
+        [] ->
+            io:format("  (no protocols registered — skipping worst case)~n");
+        Protos ->
+            AllProto = stamp(Sites, Protos),
+            report_predicate("migrated, all-protocol", AllProto, Changed)
+    end,
+
+    %% (d) Worst case for the hierarchy branch: changing a root class, so
+    %% hierarchy_related_classes/1 closes over the whole loaded hierarchy.
+    {RootUs, _} = time_avg(fun() -> length(senders_of_2(Selector, 'Object')) end, 50),
+    io:format("  senders_of/2 with changed=Object         ~.1f us~n", [RootUs]).
+
+report_predicate(Label, Rows, Changed) ->
+    {Us, Kept} = time_avg(
+        fun() ->
+            Related = hierarchy_related_classes(Changed),
+            length([S || S <- Rows, is_relevant(S, Changed, Related)])
+        end,
+        50
+    ),
+    {MemoUs, MemoKept} = time_avg(
+        fun() -> length(senders_of_2_memo_list(Rows, Changed)) end, 50
+    ),
+    io:format(
+        "  ~s: verbatim ~.1f us (kept ~p) | memoised ~.1f us (kept ~p)~n",
+        [Label, Us, Kept, MemoUs, MemoKept]
+    ).
+
+senders_of_2_memo_list(Sites, ChangedClass) ->
+    Related = hierarchy_related_classes(ChangedClass),
+    {Kept, _} = lists:foldl(
+        fun(S, {Acc, Cache}) ->
+            case maps:find(recv_type, S) of
+                error ->
+                    {[S | Acc], Cache};
+                {ok, dynamic} ->
+                    {[S | Acc], Cache};
+                {ok, T} ->
+                    case maps:find(T, Cache) of
+                        {ok, true} -> {[S | Acc], Cache};
+                        {ok, false} -> {Acc, Cache};
+                        error ->
+                            R = is_relevant(S, ChangedClass, Related),
+                            C2 = Cache#{T => R},
+                            case R of
+                                true -> {[S | Acc], C2};
+                                false -> {Acc, C2}
+                            end
+                    end
+            end
+        end,
+        {[], #{}},
+        Sites
+    ),
+    lists:reverse(Kept).
+
+stamp(Sites, Names) ->
+    N = length(Names),
+    {Out, _} = lists:foldl(
+        fun(S, {Acc, I}) ->
+            T = lists:nth((I rem N) + 1, Names),
+            {[S#{recv_type => T} | Acc], I + 1}
+        end,
+        {[], 0},
+        Sites
+    ),
+    Out.
+
+hottest_selector() ->
+    Candidates = ['printOn:', 'size', 'asString', 'value', 'at:', '='],
+    Counts = [{length(beamtalk_xref:senders_of(S)), S} || S <- Candidates],
+    {_, Best} = lists:max(Counts),
+    Best.
+
+%%--------------------------------------------------------------------
+
+time_avg(Fun, Iters) ->
+    T0 = erlang:monotonic_time(microsecond),
+    Last = lists:foldl(fun(_, _) -> Fun() end, undefined, lists:seq(1, Iters)),
+    T1 = erlang:monotonic_time(microsecond),
+    {(T1 - T0) / Iters, Last}.


### PR DESCRIPTION
## Summary

Phase 1 validation spike for ADR 0115 (BT-3216) — investigation only, no schema or runtime change, per the issue's own out-of-scope. Deliverable is a findings report; instrumentation is throwaway.

- `docs/internal/adr-0115-phase1-spike-findings.md` — full findings, evidence, and recommendations for each of the four acceptance criteria.
- `runtime/perf/bench_recv_type_spike.escript` — runs `hierarchy_related_classes/1`, `conforms_to/2`, and `is_relevant/3` **transcribed verbatim from ADR 0115 §"Read path"** against a live 109-class stdlib workspace. Not wired into CI.
- `crates/beamtalk-core/tests/bt3216_spike_probe.rs` — `#[ignore]`d probe measuring `TypeMap` receiver-span coverage across `stdlib/src`.
- `crates/beamtalk-examples/corpus.json` regenerated — it had drifted out of sync with `docs/beamtalk-language-features.md` in a prior, unrelated PR (#3440) and was failing `just check-corpus` on `main` independent of this change.
- `docs/internal/README.md` — indexes both spike-findings docs under a new "Spike Findings" section; drops a duplicated "Implementation Tracking" section whose links pointed at non-existent uppercase filenames.

**Verdict: Phase 2 (BT-3217) may proceed, but not with the schema and read path exactly as written.** Three amendments required — see the report's §5. Two scaling follow-ups were filed and are out of ADR 0115's scope: BT-3221 (index `beamtalk_class_metadata`'s superclass column) and BT-3222 (cache `conforms_to/2`).

Findings were also posted as a Linear comment on BT-3216 per the issue's acceptance criteria.

## Test plan

- [x] `just fmt`
- [x] `just ci-changed` (build, clippy, fmt-check, test, verify-threaded-ir, check-corpus, check-generated-builtins, check-surface-drift) — all green locally
- [x] `cd runtime && escript perf/bench_recv_type_spike.escript` — runs clean, no warnings
- [x] `cargo test -p beamtalk-core --test bt3216_spike_probe -- --ignored --nocapture` — runs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUP4xDUPTzhKZgpRiWLYQL

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUP4xDUPTzhKZgpRiWLYQL)_