### PR TITLE
docs: daily refresh 2026-08-21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,7 @@
 
 ### Internal
 
+- **xref `recv_type` schema + compile-time write path (ADR 0115 Phase 2)** — the `beamtalk_xref` send-entry schema gains a `recv_type` field recording the inferred receiver type at each message-send site. Populated at compile time from the existing `TypeMap`; the runtime live-patch path emits `dynamic` unconditionally (no type-checker access). `Meta{C}` receivers render as `'<C> class'` (reusing `class_object_tag/1`'s convention). A corpus conformance test verifies the new receiver-span walk against the syntactic send walk across stdlib + examples. No user-visible behavior change yet — the read path (`senders_of/2` narrowing) ships in Phase 3 (BT-3217, #3446).
 - Deduplicate MCP/LSP tool expression builders (`save_class_expr`, `flush_expr`, `remove_method_expr`, etc.) into `beamtalk_core::tool_expr` (BT-3193, #3415).
 - Extract shared REPL `:flush` meta-command argument parsing into `repl_meta_exprs` module (BT-3196, #3418).
 - Extract `normalize_path` to shared `path_util` module in beamtalk-cli (#3409).


### PR DESCRIPTION
## Summary

Daily documentation refresh covering 8 commits merged to `main` in the last 24 hours.

### Commits reviewed

| SHA | Title | Doc change |
|-----|-------|------------|
| `685f578` | xref receiver-type key: Phase 2 schema + compile-time write path (BT-3217) | CHANGELOG "Internal" entry — xref schema gains `recv_type` field, compile-time write path only; no user-visible behavior change (read path is Phase 3) |

### Skipped (internal / test-only / docs-only / excluded)

| SHA | Title | Reason |
|-----|-------|--------|
| `f6235fb` | docs: ADR 0115 Phase 1 validation spike findings | Internal docs (`docs/internal/`) + throwaway instrumentation — no user-visible surface |
| `a8056e7` | docs: add implementation tracking to ADR 0115 | Excluded — purely `docs/ADR/` |
| `a98f29f` | docs: add ADR 0115 - receiver-type key for senders_of/1 lookup | Excluded — purely `docs/ADR/` |
| `c95eb4c` | refactor(test): extract SupervisionNode fixture helpers | Test-only refactoring (`stdlib/test/`) — no user-visible change |
| `8650b10` | test(repl-json): cover catch blocks, encode_error variants | Test-only (`runtime/apps/*/test/`) — no user-visible change |
| `238d2e6` | refactor(cli): delegate class-name check to `is_valid_class_name` | Internal refactoring — behavior unchanged, deduplication only |
| `c58b304` | docs: daily refresh 2026-08-20 | Previous day's documentation refresh |

### Docs updated

- **`CHANGELOG.md`** — 1 new entry under Unreleased / Internal: xref `recv_type` schema + compile-time write path (BT-3217, #3446)

### Not updated

- No user-facing documentation changes warranted — the xref `recv_type` field is internal infrastructure with no behavior change until Phase 3 (BT-3218) ships the read path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5VVV9HtNMBFMChSUsxpRn)_