### PR TITLE
refactor: extract validate_selector_input into beamtalk-core

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/mod.rs
@@ -92,8 +92,8 @@ pub fn is_valid_class_name(name: &str) -> bool {
 /// contains alphanumerics) are rejected.
 ///
 /// This is the canonical definition; tools that validate user-supplied
-/// selectors (LSP, MCP) must delegate their boolean check here so the rule
-/// stays in one place.
+/// selectors (LSP, MCP) must use [`validate_selector_input`] (which delegates
+/// here) so both the boolean rule and its error messages stay in one place.
 pub fn is_valid_selector(sel: &str) -> bool {
     fn is_binary_selector_char(c: char) -> bool {
         matches!(
@@ -110,6 +110,39 @@ pub fn is_valid_selector(sel: &str) -> bool {
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == ':'),
     }
+}
+
+/// Validates a user-supplied selector string, returning an error description
+/// on failure.
+///
+/// Returns `Ok(())` for valid selectors. Returns `Err(message)` with a
+/// human-readable description for two failure modes:
+/// - empty input
+/// - a non-empty string that fails the shape rules of [`is_valid_selector`]
+///
+/// This is the single source of truth for selector validation error messages.
+/// Callers (LSP, MCP) convert the `String` error into their own error type:
+///
+/// ```text
+/// // LSP (returns Result<(), String>):
+/// beamtalk_core::source_analysis::validate_selector_input(sel)?;
+///
+/// // MCP (returns Result<(), rmcp::ErrorData>):
+/// beamtalk_core::source_analysis::validate_selector_input(sel)
+///     .map_err(|e| rmcp::ErrorData::invalid_params(e, None))?;
+/// ```
+///
+/// # Errors
+///
+/// Returns `Err(message)` when `sel` is empty or fails [`is_valid_selector`].
+pub fn validate_selector_input(sel: &str) -> Result<(), String> {
+    if sel.is_empty() {
+        return Err("selector must not be empty".to_string());
+    }
+    if !is_valid_selector(sel) {
+        return Err(format!("invalid selector: '{sel}'"));
+    }
+    Ok(())
 }
 
 /// Returns `true` if `c` should be treated as part of a completion "word" —

--- a/crates/beamtalk-lsp/src/server.rs
+++ b/crates/beamtalk-lsp/src/server.rs
@@ -3870,16 +3870,10 @@ fn validate_class_name(name: &str) -> std::result::Result<(), String> {
 
 /// Validate a Beamtalk selector (unary, keyword, or binary) before splicing
 /// it unescaped into a `#selector` literal in a built expression (ADR 0105
-/// Phase 3, BT-2782's `CMD_PRECHECK_METHOD`). The canonical shape check is
-/// `beamtalk_core::source_analysis::is_valid_selector`.
+/// Phase 3, BT-2782's `CMD_PRECHECK_METHOD`). Delegates to the canonical
+/// implementation in `beamtalk_core::source_analysis::validate_selector_input`.
 fn validate_selector(sel: &str) -> std::result::Result<(), String> {
-    if sel.is_empty() {
-        return Err("selector must not be empty".to_string());
-    }
-    if !beamtalk_core::source_analysis::is_valid_selector(sel) {
-        return Err(format!("invalid selector: '{sel}'"));
-    }
-    Ok(())
+    beamtalk_core::source_analysis::validate_selector_input(sel)
 }
 
 fn workspace_roots(params: &InitializeParams) -> Vec<PathBuf> {

--- a/crates/beamtalk-mcp/src/server.rs
+++ b/crates/beamtalk-mcp/src/server.rs
@@ -181,22 +181,11 @@ fn validate_erlang_module_name(name: &str) -> Result<(), rmcp::ErrorData> {
 /// Validate that a string is a valid Beamtalk selector.
 ///
 /// Accepts keyword/unary selectors (`increment`, `at:put:`) and binary operator
-/// selectors (`+`, `>=`, `**`). The canonical shape check is
-/// `beamtalk_core::source_analysis::is_valid_selector`.
+/// selectors (`+`, `>=`, `**`). Delegates to the canonical implementation in
+/// `beamtalk_core::source_analysis::validate_selector_input`.
 fn validate_selector(sel: &str) -> Result<(), rmcp::ErrorData> {
-    if sel.is_empty() {
-        return Err(rmcp::ErrorData::invalid_params(
-            "Selector must not be empty.",
-            None,
-        ));
-    }
-    if !beamtalk_core::source_analysis::is_valid_selector(sel) {
-        return Err(rmcp::ErrorData::invalid_params(
-            format!("Invalid selector: '{sel}'."),
-            None,
-        ));
-    }
-    Ok(())
+    beamtalk_core::source_analysis::validate_selector_input(sel)
+        .map_err(|e| rmcp::ErrorData::invalid_params(e, None))
 }
 
 /// Pretty-print a JSON value, falling back to `Display` on serialization error.


### PR DESCRIPTION
## Summary

`validate_selector` was duplicated between `beamtalk-mcp` and `beamtalk-lsp` — identical logic, but independently maintained. The error messages had already drifted: MCP used `"Selector must not be empty."` (capital S, trailing period) while LSP used `"selector must not be empty"` (lowercase, no period). This is the exact anti-pattern described in `docs/development/architecture-principles.md` §6.

Both crates already delegated the boolean check to `beamtalk_core::source_analysis::is_valid_selector`; the existing docstring there even says "tools that validate user-supplied selectors (LSP, MCP) must delegate their boolean check here so the rule stays in one place." This PR extends that mandate to include the error messages.

## Changes

- **`crates/beamtalk-core/src/source_analysis/mod.rs`** — adds `pub fn validate_selector_input(sel: &str) -> Result<(), String>` directly after `is_valid_selector`. This is the single source of truth for both validation logic and error messages. Updates the `is_valid_selector` docstring to point callers to `validate_selector_input`.
- **`crates/beamtalk-lsp/src/server.rs`** — `validate_selector` becomes a one-liner delegating to the shared helper (same `Result<(), String>` type, zero change at call sites).
- **`crates/beamtalk-mcp/src/server.rs`** — `validate_selector` becomes a two-liner: delegate and map the `String` error to `rmcp::ErrorData`.

## Why it's safe

- All existing tests assert only `.is_ok()` / `.is_err()`, never message text — no test breaks from the message standardization.
- The boolean validation logic is unchanged (delegates to `is_valid_selector`).
- All 8 call sites (MCP: 6, LSP: 2) use `?` and need no changes.
- 3 files touched, no generated files, no `VERSION`, no `CHANGELOG.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPkG6MRFtbhaTaNQgK1WND)_