### PR TITLE
test(compiler): add format_warnings and print_warnings coverage

### DIFF
--- a/runtime/apps/beamtalk_compiler/test/beamtalk_compile_diagnostics_tests.erl
+++ b/runtime/apps/beamtalk_compiler/test/beamtalk_compile_diagnostics_tests.erl
@@ -43,3 +43,47 @@ format_errors_binary_file_test() ->
 %% Empty error list renders to an empty binary.
 format_errors_empty_test() ->
     ?assertEqual(<<>>, beamtalk_compile_diagnostics:format_errors([])).
+
+%% format_warnings/1 — same rendering as format_errors/1 but with "Warning: " prefix.
+
+format_warnings_unbound_var_test() ->
+    Warnings = [{"my_module", [{none, core_lint, {unbound_var, 'State', {foo, 1}}}]}],
+    Formatted = beamtalk_compile_diagnostics:format_warnings(Warnings),
+    ?assert(is_binary(Formatted)),
+    ?assertEqual(nomatch, binary:match(Formatted, <<"{unbound_var,">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"Warning: ">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"unbound variable">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"'State'">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"foo/1">>)),
+    ?assertEqual(<<"my_module: Warning: unbound variable 'State' in foo/1\n">>, Formatted).
+
+format_warnings_multiple_test() ->
+    Warnings = [
+        {"mod_a", [{none, core_lint, {duplicate_var, 'I', {bar, 2}}}]},
+        {"mod_b", [{none, core_lint, {unbound_var, 'X', {baz, 0}}}]}
+    ],
+    Formatted = beamtalk_compile_diagnostics:format_warnings(Warnings),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"Warning: ">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"duplicate variable 'I' in bar/2">>)),
+    ?assertNotEqual(nomatch, binary:match(Formatted, <<"unbound variable 'X' in baz/0">>)).
+
+%% A binary file identifier is accepted the same as a string one.
+format_warnings_binary_file_test() ->
+    Warnings = [{<<"my_module">>, [{none, core_lint, {unbound_var, 'Y', {qux, 3}}}]}],
+    Formatted = beamtalk_compile_diagnostics:format_warnings(Warnings),
+    ?assertNotEqual(
+        nomatch, binary:match(Formatted, <<"my_module: Warning: unbound variable 'Y' in qux/3">>)
+    ).
+
+%% Empty warning list renders to an empty binary.
+format_warnings_empty_test() ->
+    ?assertEqual(<<>>, beamtalk_compile_diagnostics:format_warnings([])).
+
+%% print_warnings/1 — empty list returns ok without writing.
+print_warnings_empty_test() ->
+    ?assertEqual(ok, beamtalk_compile_diagnostics:print_warnings([])).
+
+%% print_warnings/1 — non-empty list writes to stderr and returns ok.
+print_warnings_nonempty_test() ->
+    Warnings = [{"my_module", [{none, core_lint, {unbound_var, 'State', {foo, 1}}}]}],
+    ?assertEqual(ok, beamtalk_compile_diagnostics:print_warnings(Warnings)).


### PR DESCRIPTION
## Summary

- Adds 6 EUnit tests for `format_warnings/1` and `print_warnings/1` in `beamtalk_compile_diagnostics_tests.erl`
- These two exported functions had zero test coverage; only `format_errors/1` was exercised (4 existing tests)
- Identified via the CI coverage artifact from run 32424979633 (`beamtalk_compiler` package at 72%)

## Changes

**`runtime/apps/beamtalk_compiler/test/beamtalk_compile_diagnostics_tests.erl`** — +44 lines, 0 deletions

New tests for `format_warnings/1`:
- `format_warnings_unbound_var_test` — single warning, verifies `"Warning: "` prefix and exact output `<<"my_module: Warning: unbound variable 'State' in foo/1\n">>`
- `format_warnings_multiple_test` — two warnings across different file identifiers, both rendered
- `format_warnings_binary_file_test` — binary file identifier accepted the same as a string
- `format_warnings_empty_test` — empty list → `<<>>`

New tests for `print_warnings/1`:
- `print_warnings_empty_test` — empty list → `ok` (first clause)
- `print_warnings_nonempty_test` — non-empty list → writes to stderr, returns `ok`

All 10 tests (4 existing + 6 new) pass. erlfmt clean.

## Test plan

- [x] `rebar3 eunit --module=beamtalk_compile_diagnostics_tests` — 10 tests, 0 failures
- [x] erlfmt formatting check passes
- [x] Dialyzer pre-push hook passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQpTduY8LE6xjk8DGMjRK2)_