### PR TITLE
xref receiver-type key: Phase 3 senders_of/2 read path (BT-3218)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
@@ -707,26 +707,25 @@ compute_relatedness(T, BaseChanged, Related) ->
 is_known_class(Name) ->
     beamtalk_class_metadata:lookup_superclass(Name) =/= not_found.
 
--define(CLASS_OBJECT_TAG_SUFFIX, " class").
-
 %% Split a `recv_type`/`ChangedClass` name into its base class name and
 %% whether it carried the `' class'` class-object-tag suffix
 %% (`beamtalk_class_registry:class_object_tag/1`'s own convention, reused —
 %% not reinvented — by BT-3217's write path for `Meta{C}` receivers).
-%% `is_class_name/1` is the same suffix test the runtime already uses
-%% elsewhere to recognise a class-object tag.
+%% `is_class_name/1`/`class_display_name/1` are the same suffix test and
+%% strip the runtime already uses elsewhere to recognise a class-object tag
+%% — reused here rather than re-deriving the `" class"`-suffix offset.
 -spec split_class_object_tag(name()) -> {name(), boolean()}.
 split_class_object_tag(Name) ->
     case beamtalk_class_registry:is_class_name(Name) of
         true ->
-            Str = atom_to_list(Name),
-            BaseStr = lists:sublist(Str, length(Str) - length(?CLASS_OBJECT_TAG_SUFFIX)),
-            % elp:fixme W0023 intentional atom creation — `Name` is already an
-            % atom (a compiler-emitted `recv_type` or a caller-supplied
+            % elp:fixme W0023 intentional atom creation — `Name` is already
+            % an atom (a compiler-emitted `recv_type` or a caller-supplied
             % `ChangedClass`), never raw external text, so re-interning its
             % base mirrors `class_object_tag/1`'s own precedent for the
-            % inverse operation.
-            {list_to_atom(BaseStr), true};
+            % inverse operation. `class_display_name/1` never interns an
+            % atom itself (it returns a binary), so this call site is the
+            % only place that does.
+            {binary_to_atom(beamtalk_class_registry:class_display_name(Name), utf8), true};
         false ->
             {Name, false}
     end.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
@@ -36,6 +36,10 @@ See also: docs/ADR/0087-maintained-xref-index-for-system-navigation.md
 """.
 
 -include_lib("kernel/include/logger.hrl").
+%% BT-3218 (ADR 0115 Phase 3): ?MAX_HIERARCHY_DEPTH, for the ancestor-chain
+%% walk `hierarchy_related_classes/1` composes from the registry's existing
+%% primitives.
+-include("beamtalk.hrl").
 
 %% API — write path
 -export([
@@ -49,6 +53,8 @@ See also: docs/ADR/0087-maintained-xref-index-for-system-navigation.md
 %% API — read path
 -export([
     senders_of/1,
+    senders_of/2,
+    hierarchy_related_classes/1,
     senders_of_bt/1,
     references_to/1,
     references_to_bt/1,
@@ -487,6 +493,242 @@ senders_of(Selector) when is_atom(Selector) ->
                 [Site || {_Sel, Site} <- ets:lookup(?SENDERS_TABLE, Selector)]
             end),
             live_gen_sites(Sites, Snapshot)
+    end.
+
+-doc """
+Receiver-type-aware extension of `senders_of/1` (ADR 0115 Phase 3, BT-3218):
+filters `Selector`'s candidate sender sites to those whose `recv_type` could
+actually dispatch to `ChangedClass`, rather than the unsound exact-match a
+naive filter would apply. Never excludes a site whose relatedness cannot be
+determined — the whole point of this filter is to narrow `senders_of/1`'s
+already-correct-but-unfiltered result, never to silently drop a real
+dependent (ADR 0115 Constraint 1 / Constraint 2).
+
+`ChangedClass` names either the class itself (an **instance-side** change —
+a plain `class_name()` such as `'Counter'`) or its class-object (a
+**class-side** change — the same `'<C> class'` tag `recv_type` itself uses
+for a `Meta{C}` receiver, e.g. `'Counter class'`, per BT-3217's write-path
+convention). This lets one two-argument signature carry the "which side
+changed" axis Amendment 3's relatedness test needs, without a third
+parameter or a wider tuple type — `senders_of/2` and `recv_type` already
+share one atom-space convention (BT-3217's reuse of
+`beamtalk_class_registry:class_object_tag/1`), so extending it to
+`ChangedClass` is reuse, not new vocabulary.
+
+Relevance, per site (folded once per call, never re-evaluated per query —
+Amendment 1):
+
+- No `recv_type` field at all (unmigrated legacy row) → always relevant.
+- `recv_type: dynamic` → always relevant (Constraint 2 — nothing rules out
+  any class).
+- `recv_type: T` whose class-object-ness (whether it carries the `' class'`
+  suffix) disagrees with `ChangedClass`'s → never relevant. A `Meta{C}`
+  (class-object) receiver only ever dispatches through the metaclass chain
+  (class-side methods); a plain instance-typed receiver only ever dispatches
+  through the instance chain. Conflating the two would be unsound in the
+  *unsafe* direction (Amendment 3, spike §1e / BT-3217 PR #3446's
+  description) — this is a hard boundary, not a soft default.
+- Otherwise, `T` (with any `' class'` suffix stripped, on both `T` and
+  `ChangedClass`) is tested for relatedness to `ChangedClass`'s base name:
+  protocol-conformant (`beamtalk_protocol_registry:conforms_to/2`) if `T` is
+  a registered protocol, hierarchy-related (`hierarchy_related_classes/1`
+  membership) if `T` is a registered class, or — Amendment 2 — **relevant**
+  if `T` resolves to neither (an unloaded protocol module, a native/alias
+  display name that slipped past Phase 2's write-time coarsening, or a
+  genuinely unknown name). The spike
+  (`docs/internal/adr-0115-phase1-spike-findings.md` §4) found the ADR's own
+  three-clause sketch silently *excluded* this case instead — a correctness
+  bug, not a precision gap.
+
+**Amendment 1 — memoization.** `is_protocol/1` and `conforms_to/2` (the
+protocol branch) cost 59-135 µs/call (spike §3) with no memoisation of their
+own; re-evaluating them per site turns an all-protocol-typed 70-site query
+into a 3.3-16.3 ms outlier — a 100-400x regression on the hot-reload path
+this ADR exists to speed up. The fold below carries a `#{name() =>
+boolean()}` cache keyed by the (suffix-stripped) receiver name, built once
+per call and shared across every site — a repeat `recv_type` (the
+overwhelmingly common case: a handful of nominal/protocol types shared by
+many call sites) costs one cache hit instead of one registry round trip.
+""".
+-spec senders_of(selector(), class_name()) -> [site()].
+senders_of(Selector, ChangedClass) when is_atom(Selector), is_atom(ChangedClass) ->
+    AllSites = senders_of(Selector),
+    {BaseChanged, ChangedIsClassSide} = split_class_object_tag(ChangedClass),
+    Related = hierarchy_related_classes(BaseChanged),
+    {KeptRev, _Cache} = lists:foldl(
+        fun(Site, {Acc, Cache}) ->
+            case is_relevant(Site, BaseChanged, ChangedIsClassSide, Related, Cache) of
+                {true, Cache1} -> {[Site | Acc], Cache1};
+                {false, Cache1} -> {Acc, Cache1}
+            end
+        end,
+        {[], #{}},
+        AllSites
+    ),
+    lists:reverse(KeptRev).
+
+-doc """
+`{ChangedClass} ∪ ancestors(ChangedClass) ∪ subclasses(ChangedClass)` — the
+set of class names a `ChangedClass`-typed (or subtype/supertype-typed)
+receiver could actually be at runtime, per ADR 0115 Constraint 1's
+chain-walk-dispatch soundness argument (an exact-class filter would silently
+drop every subclass-inherited or ancestor-narrowed dependent).
+
+Composed entirely from already-shipped hierarchy primitives — no new
+traversal: `beamtalk_class_registry:all_subclasses/1`'s existing transitive
+`direct_subclasses/1` closure for the descendant half, and
+`beamtalk_hierarchy:walk_ancestors/3` (BT-2786, the same generic
+depth-guarded superclass-chain walker `beamtalk_class_dispatch:
+find_class_method_in_chain/2` already uses) over `beamtalk_class_metadata:
+lookup_superclass/1` reads for the ancestor half — pure ETS, no
+`gen_server:call`.
+
+The descendant half is a full-table `ets:match/2` per node in the subtree
+(`beamtalk_class_metadata:match_subclasses/1` is unindexed on the
+superclass column) — O(N²) in loaded-class count for a root-class change,
+~500 µs at today's 109-class stdlib scale (spike §2). Accepted as-is for
+this issue; indexing that column is the separate follow-up BT-3221.
+""".
+-spec hierarchy_related_classes(class_name()) -> sets:set(class_name()).
+hierarchy_related_classes(ChangedClass) ->
+    sets:from_list(
+        [ChangedClass | ancestor_classes(ChangedClass)] ++
+            beamtalk_class_registry:all_subclasses(ChangedClass),
+        [{version, 2}]
+    ).
+
+%% Every strict ancestor of `ClassName` (order not significant — set
+%% membership is all `hierarchy_related_classes/1` needs). A thin
+%% `beamtalk_hierarchy:walk_ancestors/3` wrapper (BT-2786) over
+%% `beamtalk_class_metadata:lookup_superclass/1`, riding the accumulator
+%% inside the walked node per the walker's own documented pattern (see e.g.
+%% `beamtalk_behaviour_intrinsics:walk_hierarchy/3`).
+-spec ancestor_classes(class_name()) -> [class_name()].
+ancestor_classes(ClassName) ->
+    StepFun = fun({Ancestor, Acc}, _Depth) ->
+        case Ancestor of
+            none -> {found, Acc};
+            _ -> {next, {class_superclass_or_none(Ancestor), [Ancestor | Acc]}}
+        end
+    end,
+    StartNode = {class_superclass_or_none(ClassName), []},
+    case beamtalk_hierarchy:walk_ancestors(StartNode, StepFun, ?MAX_HIERARCHY_DEPTH) of
+        {found, Acc} ->
+            Acc;
+        {max_depth_exceeded, {_LastAncestor, Acc}} ->
+            ?LOG_WARNING(
+                "hierarchy_related_classes: max hierarchy depth ~p exceeded walking ancestors of ~p — possible cycle",
+                [?MAX_HIERARCHY_DEPTH, ClassName],
+                #{domain => [beamtalk, runtime]}
+            ),
+            Acc
+    end.
+
+-spec class_superclass_or_none(class_name()) -> class_name() | none.
+class_superclass_or_none(ClassName) ->
+    case beamtalk_class_metadata:lookup_superclass(ClassName) of
+        {ok, Super} -> Super;
+        not_found -> none
+    end.
+
+%% BT-3218 (ADR 0115 Phase 3): fold state for `is_relevant/5` — memoises the
+%% hierarchy/protocol relatedness decision for a given (suffix-stripped)
+%% receiver name, since it is invariant across every site in one
+%% `senders_of/2` call sharing that name (Amendment 1).
+-type relevance_cache() :: #{name() => boolean()}.
+
+%% One fold step of `senders_of/2`'s filter. `BaseChanged`/`ChangedIsClassSide`
+%% and `Related` are fixed for the whole fold (computed once by
+%% `senders_of/2`); only `Cache` threads.
+-spec is_relevant(site(), class_name(), boolean(), sets:set(class_name()), relevance_cache()) ->
+    {boolean(), relevance_cache()}.
+is_relevant(Site, BaseChanged, ChangedIsClassSide, Related, Cache) ->
+    case maps:find(recv_type, Site) of
+        error ->
+            %% Legacy row (pre-BT-3217, or a class that hasn't reloaded since
+            %% Phase 2 shipped): always relevant, identically to how
+            %% `recv_kind`/`target_module` already default for legacy rows.
+            {true, Cache};
+        {ok, dynamic} ->
+            {true, Cache};
+        {ok, T} ->
+            {BaseT, SiteIsClassSide} = split_class_object_tag(T),
+            case SiteIsClassSide =:= ChangedIsClassSide of
+                false ->
+                    %% Amendment 3: a class-object (`Meta{C}`) receiver only
+                    %% ever dispatches through the metaclass (class-side)
+                    %% chain, and a plain instance-typed receiver only
+                    %% through the instance chain — never collapse the two.
+                    {false, Cache};
+                true ->
+                    relatedness(BaseT, BaseChanged, Related, Cache)
+            end
+    end.
+
+-spec relatedness(name(), class_name(), sets:set(class_name()), relevance_cache()) ->
+    {boolean(), relevance_cache()}.
+relatedness(T, BaseChanged, Related, Cache) ->
+    case maps:find(T, Cache) of
+        {ok, Result} ->
+            {Result, Cache};
+        error ->
+            Result = compute_relatedness(T, BaseChanged, Related),
+            {Result, Cache#{T => Result}}
+    end.
+
+%% Amendment 1's actual cost: `is_protocol/1` gates the branch and
+%% `conforms_to/2` (59-135 µs/call, spike §3) does the real work — both land
+%% inside `relatedness/4`'s cache, so this runs at most once per distinct `T`
+%% per `senders_of/2` call, never once per site.
+-spec compute_relatedness(name(), class_name(), sets:set(class_name())) -> boolean().
+compute_relatedness(T, BaseChanged, Related) ->
+    case beamtalk_protocol_registry:is_protocol(T) of
+        true ->
+            beamtalk_protocol_registry:conforms_to(BaseChanged, T);
+        false ->
+            case is_known_class(T) of
+                true ->
+                    sets:is_element(T, Related);
+                false ->
+                    %% Amendment 2 (spike §4): `T` names neither a registered
+                    %% protocol nor a registered class — an unloaded protocol
+                    %% module (intermittent, reload-order-dependent) or a
+                    %% genuinely unknown name. The ADR's own three-clause
+                    %% sketch fell through to `sets:is_element/2` here, which
+                    %% silently excludes an unresolvable name instead of
+                    %% treating it as unnarrowable — a correctness bug per
+                    %% Constraint 2 ("cannot be narrowed and must never be
+                    %% excluded"), not a hypothetical.
+                    true
+            end
+    end.
+
+-spec is_known_class(class_name()) -> boolean().
+is_known_class(Name) ->
+    beamtalk_class_metadata:lookup_superclass(Name) =/= not_found.
+
+-define(CLASS_OBJECT_TAG_SUFFIX, " class").
+
+%% Split a `recv_type`/`ChangedClass` name into its base class name and
+%% whether it carried the `' class'` class-object-tag suffix
+%% (`beamtalk_class_registry:class_object_tag/1`'s own convention, reused —
+%% not reinvented — by BT-3217's write path for `Meta{C}` receivers).
+%% `is_class_name/1` is the same suffix test the runtime already uses
+%% elsewhere to recognise a class-object tag.
+-spec split_class_object_tag(name()) -> {name(), boolean()}.
+split_class_object_tag(Name) ->
+    case beamtalk_class_registry:is_class_name(Name) of
+        true ->
+            Str = atom_to_list(Name),
+            BaseStr = lists:sublist(Str, length(Str) - length(?CLASS_OBJECT_TAG_SUFFIX)),
+            % elp:fixme W0023 intentional atom creation — `Name` is already an
+            % atom (a compiler-emitted `recv_type` or a caller-supplied
+            % `ChangedClass`), never raw external text, so re-interning its
+            % base mirrors `class_object_tag/1`'s own precedent for the
+            % inverse operation.
+            {list_to_atom(BaseStr), true};
+        false ->
+            {Name, false}
     end.
 
 -doc """
@@ -1396,10 +1638,9 @@ insert_one_method(Class, Entry, Gen) ->
                 %% (or the runtime live-patch path) carries no `recv_type`
                 %% key at all — defaulting to `dynamic` here, exactly like
                 %% `recv_kind`/`target_module` already default for legacy
-                %% rows, resolves identically to Phase 3's "always relevant"
-                %% read-time default for a genuinely absent key (both
-                %% `is_relevant/3` clauses agree — Phase 3, not yet
-                %% implemented as of this module).
+                %% rows, resolves identically to `senders_of/2`'s (BT-3218,
+                %% Phase 3) "always relevant" read-time default for a
+                %% genuinely absent key — both routes agree.
                 recv_type => maps:get(recv_type, Send, dynamic),
                 gen => Gen
             },

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_xref_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_xref_tests.erl
@@ -1710,6 +1710,554 @@ log(LogEvent, #{capture_pid := Pid}) ->
     ok.
 
 %%====================================================================
+%% BT-3218 (ADR 0115 Phase 3): senders_of/2 read path
+%%====================================================================
+
+%% A small synthetic class hierarchy, written directly into
+%% `beamtalk_class_metadata` — pure ETS, no live class gen_server needed,
+%% since `hierarchy_related_classes/1` only ever does ETS reads:
+%%
+%%   Bt3218SuperRoot
+%%     -> Bt3218Root
+%%          -> Bt3218Mid
+%%               -> Bt3218Leaf
+%%                    -> Bt3218GrandLeaf
+%%          -> Bt3218Sibling      (a sibling branch of Mid — NOT related to it)
+bt3218_hierarchy_classes() ->
+    [
+        {'Bt3218SuperRoot', none},
+        {'Bt3218Root', 'Bt3218SuperRoot'},
+        {'Bt3218Mid', 'Bt3218Root'},
+        {'Bt3218Leaf', 'Bt3218Mid'},
+        {'Bt3218GrandLeaf', 'Bt3218Leaf'},
+        {'Bt3218Sibling', 'Bt3218Root'}
+    ].
+
+bt3218_hierarchy_setup() ->
+    lists:foreach(
+        fun({Name, Super}) ->
+            ok = beamtalk_class_metadata:insert(Name, undefined, undefined, Super, undefined)
+        end,
+        bt3218_hierarchy_classes()
+    ).
+
+bt3218_hierarchy_cleanup() ->
+    lists:foreach(
+        fun({Name, _Super}) -> beamtalk_class_metadata:delete(Name) end,
+        bt3218_hierarchy_classes()
+    ).
+
+%% EUnit: hierarchy-relatedness predicate against a fixture hierarchy — same
+%% class, direct subclass, transitive subclass, direct/transitive ancestor,
+%% unrelated sibling branch.
+hierarchy_related_classes_relatedness_test_() ->
+    {setup,
+        fun() ->
+            Pid = setup(),
+            bt3218_hierarchy_setup(),
+            Pid
+        end,
+        fun(Pid) ->
+            bt3218_hierarchy_cleanup(),
+            cleanup(Pid)
+        end,
+        fun(_Pid) ->
+            [
+                ?_test(begin
+                    Related = beamtalk_xref:hierarchy_related_classes('Bt3218Mid'),
+                    %% Same class.
+                    ?assert(sets:is_element('Bt3218Mid', Related)),
+                    %% Direct subclass.
+                    ?assert(sets:is_element('Bt3218Leaf', Related)),
+                    %% Transitive subclass.
+                    ?assert(sets:is_element('Bt3218GrandLeaf', Related)),
+                    %% Direct ancestor.
+                    ?assert(sets:is_element('Bt3218Root', Related)),
+                    %% Transitive ancestor.
+                    ?assert(sets:is_element('Bt3218SuperRoot', Related)),
+                    %% Unrelated sibling branch.
+                    ?assertNot(sets:is_element('Bt3218Sibling', Related))
+                end)
+            ]
+        end}.
+
+%% A protocol-conformance fixture: a class defining the required method
+%% directly (conforms), a class defining nothing at all and with no
+%% conforming ancestor (does not conform), and a class that only conforms via
+%% an *inherited* method from its superclass (mirrors ADR 0115 Phase 3's own
+%% phased-rollout note: "a class conforming via inheritance from Object's
+%% default methods"). Live class gen_server processes (not full stdlib —
+%% `beamtalk_object_class:start_link/2` directly, mirroring
+%% `beamtalk_class_dispatch_tests.erl`'s `start_test_class/2`), since
+%% instance-side conformance (`classCanUnderstandFromName/2`) walks real
+%% class processes, unlike the class-method/extension path.
+bt3218_protocol_fixture_setup() ->
+    ok = beamtalk_protocol_registry:init(),
+    RootInfo = #{
+        superclass => none,
+        module => bt3218_xref_test_nonexistent_module,
+        instance_methods => #{'bt3218ProtoMethod' => #{arity => 0}},
+        class_methods => #{},
+        class_state => #{}
+    },
+    {ok, RootPid} = beamtalk_object_class:start_link('Bt3218ProtoRoot', RootInfo),
+    ConformsInfo = #{
+        superclass => 'Bt3218ProtoRoot',
+        module => bt3218_xref_test_nonexistent_module,
+        instance_methods => #{},
+        class_methods => #{},
+        class_state => #{}
+    },
+    {ok, ConformsPid} = beamtalk_object_class:start_link('Bt3218ProtoInherits', ConformsInfo),
+    NonConformsInfo = #{
+        superclass => none,
+        module => bt3218_xref_test_nonexistent_module,
+        instance_methods => #{},
+        class_methods => #{},
+        class_state => #{}
+    },
+    {ok, NonConformsPid} = beamtalk_object_class:start_link(
+        'Bt3218ProtoNonConforming', NonConformsInfo
+    ),
+    ok = beamtalk_protocol_registry:register_protocol(#{
+        name => 'Bt3218TestProtocol',
+        module => bt3218_test_protocol_mod,
+        required_methods => [#{selector => 'bt3218ProtoMethod', arity => 0}],
+        required_class_methods => [],
+        type_params => [],
+        extending => undefined
+    }),
+    [RootPid, ConformsPid, NonConformsPid].
+
+bt3218_protocol_fixture_cleanup(Pids) ->
+    lists:foreach(
+        fun(Pid) ->
+            (try
+                gen_server:stop(Pid, normal, 5000)
+            catch
+                _:_ -> ok
+            end)
+        end,
+        Pids
+    ),
+    ok.
+
+%% EUnit: protocol-conformance predicate against a fixture — a conforming
+%% class, a non-conforming class, a class conforming via inherited default
+%% methods.
+protocol_conformance_predicate_test_() ->
+    {setup,
+        fun() ->
+            setup(),
+            bt3218_protocol_fixture_setup()
+        end,
+        fun(Pids) ->
+            bt3218_protocol_fixture_cleanup(Pids),
+            cleanup(Pids)
+        end,
+        fun(_Pids) ->
+            [
+                {timeout, 30,
+                    ?_test(begin
+                        %% Root itself defines the required method — conforms.
+                        ?assert(
+                            beamtalk_protocol_registry:conforms_to(
+                                'Bt3218ProtoRoot', 'Bt3218TestProtocol'
+                            )
+                        ),
+                        %% Inherits the method from Root — conforms via
+                        %% inheritance.
+                        ?assert(
+                            beamtalk_protocol_registry:conforms_to(
+                                'Bt3218ProtoInherits', 'Bt3218TestProtocol'
+                            )
+                        ),
+                        %% Defines nothing and has no conforming ancestor —
+                        %% does not conform.
+                        ?assertNot(
+                            beamtalk_protocol_registry:conforms_to(
+                                'Bt3218ProtoNonConforming', 'Bt3218TestProtocol'
+                            )
+                        ),
+
+                        %% Exercised through beamtalk_xref's own read path: a
+                        %% protocol-typed site is included in senders_of/2 only
+                        %% for classes that actually conform.
+                        ok = beamtalk_xref:register_class('Bt3218ProtoSiteOwner', [
+                            #{
+                                class_side => false,
+                                selector => 'probeConforms',
+                                line => 1,
+                                sends => [
+                                    #{
+                                        selector => 'bt3218ProtoProbeSel',
+                                        line => 2,
+                                        recv_kind => other,
+                                        recv_type => 'Bt3218TestProtocol'
+                                    }
+                                ],
+                                references => [],
+                                source_status => indexed,
+                                provenance => class_body
+                            }
+                        ]),
+                        try
+                            ?assertEqual(
+                                1,
+                                length(
+                                    beamtalk_xref:senders_of(
+                                        'bt3218ProtoProbeSel', 'Bt3218ProtoInherits'
+                                    )
+                                )
+                            ),
+                            ?assertEqual(
+                                0,
+                                length(
+                                    beamtalk_xref:senders_of(
+                                        'bt3218ProtoProbeSel', 'Bt3218ProtoNonConforming'
+                                    )
+                                )
+                            )
+                        after
+                            ok = beamtalk_xref:purge_class('Bt3218ProtoSiteOwner')
+                        end
+                    end)}
+            ]
+        end}.
+
+%% EUnit: legacy row (no `recv_type` field) always included, regardless of
+%% `ChangedClass`.
+legacy_row_always_included_test_() ->
+    {setup,
+        fun() ->
+            Pid = setup(),
+            bt3218_hierarchy_setup(),
+            Pid
+        end,
+        fun(Pid) ->
+            bt3218_hierarchy_cleanup(),
+            cleanup(Pid)
+        end,
+        fun(_Pid) ->
+            [
+                ?_test(begin
+                    ok = beamtalk_xref:register_class('Bt3218LegacyOwner', [
+                        #{
+                            class_side => false,
+                            selector => 'legacyMethod',
+                            line => 1,
+                            sends => [
+                                #{selector => 'bt3218LegacySel', line => 2, recv_kind => other}
+                            ],
+                            references => [],
+                            source_status => indexed,
+                            provenance => class_body
+                        }
+                    ]),
+                    try
+                        %% Hierarchy-related ChangedClass.
+                        ?assertEqual(
+                            1,
+                            length(beamtalk_xref:senders_of('bt3218LegacySel', 'Bt3218Mid'))
+                        ),
+                        %% A totally unrelated / unresolvable ChangedClass.
+                        ?assertEqual(
+                            1,
+                            length(
+                                beamtalk_xref:senders_of(
+                                    'bt3218LegacySel', 'Bt3218NoSuchChangedClassAtAll'
+                                )
+                            )
+                        )
+                    after
+                        ok = beamtalk_xref:purge_class('Bt3218LegacyOwner')
+                    end
+                end)
+            ]
+        end}.
+
+%% EUnit: unresolvable-name defaults to relevant (Amendment 2) — both cases
+%% from the spike's fixture table: a name unknown to both registries, and a
+%% protocol not currently registered.
+unresolvable_name_defaults_to_relevant_test_() ->
+    {setup,
+        fun() ->
+            Pid = setup(),
+            bt3218_hierarchy_setup(),
+            Pid
+        end,
+        fun(Pid) ->
+            bt3218_hierarchy_cleanup(),
+            cleanup(Pid)
+        end,
+        fun(_Pid) ->
+            [
+                ?_test(begin
+                    ok = beamtalk_xref:register_class('Bt3218UnresolvableOwner', [
+                        #{
+                            class_side => false,
+                            selector => 'mUnknownClass',
+                            line => 1,
+                            sends => [
+                                #{
+                                    selector => 'bt3218UnresolvableSel',
+                                    line => 2,
+                                    recv_kind => other,
+                                    %% A name unknown to both registries (native/
+                                    %% FFI type, alias display name, or simply
+                                    %% never registered).
+                                    recv_type => 'NoSuchBt3218ClassXYZ'
+                                }
+                            ],
+                            references => [],
+                            source_status => indexed,
+                            provenance => class_body
+                        },
+                        #{
+                            class_side => false,
+                            selector => 'mUnloadedProto',
+                            line => 3,
+                            sends => [
+                                #{
+                                    selector => 'bt3218UnresolvableSel',
+                                    line => 4,
+                                    recv_kind => other,
+                                    %% A protocol name not currently registered
+                                    %% (defining module not loaded yet).
+                                    recv_type => 'Bt3218UnloadedProto'
+                                }
+                            ],
+                            references => [],
+                            source_status => indexed,
+                            provenance => class_body
+                        }
+                    ]),
+                    try
+                        Sites = beamtalk_xref:senders_of('bt3218UnresolvableSel', 'Bt3218Mid'),
+                        Methods = lists:sort([maps:get(method, S) || S <- Sites]),
+                        ?assertEqual(['mUnknownClass', 'mUnloadedProto'], Methods)
+                    after
+                        ok = beamtalk_xref:purge_class('Bt3218UnresolvableOwner')
+                    end
+                end)
+            ]
+        end}.
+
+%% EUnit: the `Meta{C}` read-path case (Amendment 3) — a `'Counter class'`-
+%% shaped site is relevant for a class-side change to `Counter` (or an
+%% ancestor/descendant class-side method), and NOT relevant for an
+%% instance-side change to the same class name.
+meta_class_object_receiver_test_() ->
+    {setup,
+        fun() ->
+            Pid = setup(),
+            bt3218_hierarchy_setup(),
+            Pid
+        end,
+        fun(Pid) ->
+            bt3218_hierarchy_cleanup(),
+            cleanup(Pid)
+        end,
+        fun(_Pid) ->
+            [
+                ?_test(begin
+                    ok = beamtalk_xref:register_class('Bt3218MetaOwner', [
+                        #{
+                            class_side => false,
+                            selector => 'mMetaSelf',
+                            line => 1,
+                            sends => [
+                                #{
+                                    selector => 'bt3218MetaSel',
+                                    line => 2,
+                                    recv_kind => other,
+                                    recv_type => 'Bt3218Mid class'
+                                }
+                            ],
+                            references => [],
+                            source_status => indexed,
+                            provenance => class_body
+                        },
+                        #{
+                            class_side => false,
+                            selector => 'mMetaDescendant',
+                            line => 3,
+                            sends => [
+                                #{
+                                    selector => 'bt3218MetaSel',
+                                    line => 4,
+                                    recv_kind => other,
+                                    recv_type => 'Bt3218Leaf class'
+                                }
+                            ],
+                            references => [],
+                            source_status => indexed,
+                            provenance => class_body
+                        },
+                        #{
+                            class_side => false,
+                            selector => 'mPlainSelf',
+                            line => 5,
+                            sends => [
+                                #{
+                                    selector => 'bt3218MetaSel',
+                                    line => 6,
+                                    recv_kind => other,
+                                    recv_type => 'Bt3218Mid'
+                                }
+                            ],
+                            references => [],
+                            source_status => indexed,
+                            provenance => class_body
+                        }
+                    ]),
+                    try
+                        %% A class-side change to Mid ('Bt3218Mid class'): the
+                        %% Meta{C} sites (self, and a class-side descendant) are
+                        %% relevant; the plain instance-typed site is not.
+                        ClassSideSites = beamtalk_xref:senders_of(
+                            'bt3218MetaSel', 'Bt3218Mid class'
+                        ),
+                        ClassSideMethods = lists:sort([
+                            maps:get(method, S)
+                         || S <- ClassSideSites
+                        ]),
+                        ?assertEqual(['mMetaDescendant', 'mMetaSelf'], ClassSideMethods),
+
+                        %% An instance-side change to the SAME class name: the
+                        %% Meta{C} sites are now excluded (never collapse to the
+                        %% plain instance-side test) — only the plain site is
+                        %% relevant.
+                        InstanceSideSites = beamtalk_xref:senders_of(
+                            'bt3218MetaSel', 'Bt3218Mid'
+                        ),
+                        InstanceSideMethods = lists:sort([
+                            maps:get(method, S)
+                         || S <- InstanceSideSites
+                        ]),
+                        ?assertEqual(['mPlainSelf'], InstanceSideMethods)
+                    after
+                        ok = beamtalk_xref:purge_class('Bt3218MetaOwner')
+                    end
+                end)
+            ]
+        end}.
+
+%% EUnit: memoization call-count assertion (Amendment 1) — N sites sharing
+%% the SAME protocol-typed `recv_type` must cost exactly one
+%% `conforms_to/2`/`is_protocol/1` call each, not one per site. Asserted via
+%% plain OTP call tracing (`erlang:trace/3` + `erlang:trace_pattern/3`) on a
+%% dedicated worker process — no mocking library in this project's deps — so
+%% this is a call-count reduction, not a timing measurement (timings are
+%% noisy; this is a correctness-of-caching property).
+memoization_call_count_test_() ->
+    {setup, fun setup/0, fun cleanup/1, fun(_Pid) ->
+        [
+            {timeout, 30,
+                ?_test(begin
+                    ok = beamtalk_protocol_registry:init(),
+                    ProtoName = 'Bt3218MemoProto',
+                    %% Empty required-method lists: conforms_to/2 is trivially
+                    %% true for any class name without needing a live class
+                    %% process, isolating the assertion to purely "how many
+                    %% times was conforms_to/2 (and is_protocol/1) actually
+                    %% invoked".
+                    ok = beamtalk_protocol_registry:register_protocol(#{
+                        name => ProtoName,
+                        module => bt3218_memo_proto_test_mod,
+                        required_methods => [],
+                        required_class_methods => [],
+                        type_params => [],
+                        extending => undefined
+                    }),
+                    N = 5,
+                    MethodXref = [
+                        #{
+                            class_side => false,
+                            selector => list_to_atom("bt3218MemoMethod" ++ integer_to_list(I)),
+                            line => I,
+                            sends => [
+                                #{
+                                    selector => 'bt3218MemoSel',
+                                    line => I,
+                                    recv_kind => other,
+                                    recv_type => ProtoName
+                                }
+                            ],
+                            references => [],
+                            source_status => indexed,
+                            provenance => class_body
+                        }
+                     || I <- lists:seq(1, N)
+                    ],
+                    ok = beamtalk_xref:register_class('Bt3218MemoOwner', MethodXref),
+                    try
+                        Self = self(),
+                        Worker = spawn(fun() ->
+                            receive
+                                go -> ok
+                            end,
+                            Result = beamtalk_xref:senders_of(
+                                'bt3218MemoSel', 'Bt3218MemoAnyChangedClass'
+                            ),
+                            Self ! {bt3218_memo_result, Result}
+                        end),
+                        1 = erlang:trace(Worker, true, [call, {tracer, Self}]),
+                        1 = erlang:trace_pattern(
+                            {beamtalk_protocol_registry, conforms_to, 2}, true, [global]
+                        ),
+                        1 = erlang:trace_pattern(
+                            {beamtalk_protocol_registry, is_protocol, 1}, true, [global]
+                        ),
+                        Worker ! go,
+                        Sites =
+                            receive
+                                {bt3218_memo_result, R} -> R
+                            after 5000 ->
+                                erlang:error(bt3218_memo_worker_timeout)
+                            end,
+                        _ = erlang:trace_pattern(
+                            {beamtalk_protocol_registry, conforms_to, 2}, false, [global]
+                        ),
+                        _ = erlang:trace_pattern(
+                            {beamtalk_protocol_registry, is_protocol, 1}, false, [global]
+                        ),
+                        %% The worker may already have exited by the time we
+                        %% get here (it sends its result then terminates) —
+                        %% disabling a dead pid's trace flags raises `badarg`
+                        %% and is a no-op anyway (flags die with the process).
+                        (try
+                            erlang:trace(Worker, false, [call])
+                        catch
+                            error:badarg -> ok
+                        end),
+
+                        ?assertEqual(N, length(Sites)),
+
+                        {ConformsCalls, IsProtocolCalls} = bt3218_drain_trace_counts(),
+                        ?assertEqual(1, ConformsCalls),
+                        ?assertEqual(1, IsProtocolCalls)
+                    after
+                        ok = beamtalk_xref:purge_class('Bt3218MemoOwner')
+                    end
+                end)}
+        ]
+    end}.
+
+bt3218_drain_trace_counts() ->
+    bt3218_drain_trace_counts(0, 0).
+
+bt3218_drain_trace_counts(Conforms, IsProtocol) ->
+    receive
+        {trace, _Pid, call, {beamtalk_protocol_registry, conforms_to, _Args}} ->
+            bt3218_drain_trace_counts(Conforms + 1, IsProtocol);
+        {trace, _Pid, call, {beamtalk_protocol_registry, is_protocol, _Args}} ->
+            bt3218_drain_trace_counts(Conforms, IsProtocol + 1)
+    after 200 ->
+        {Conforms, IsProtocol}
+    end.
+
+%%====================================================================
 %% Internal helpers
 %%====================================================================
 


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-3218/xref-receiver-type-key-phase-3-senders-of2-read-path-protocol

## Summary

Phase 3 of 5 implementing ADR 0115 (Epic BT-2798, blocked-by BT-3217's Phase 2 schema + write path, PR #3446). Adds the read path over `recv_type`: `senders_of/2`, which filters a selector's candidate sender sites to those whose `recv_type` could actually dispatch to a changed class — hierarchy-related for classes, protocol-conformant for protocols, never an unsound exact-match (ADR 0115 Constraint 1: chain-walk dispatch means a subclass- or ancestor-typed receiver can still resolve to the changed class's method).

`senders_of/1` is unchanged and untouched — `senders_of/2` is strictly additive. Per BT-3218's out-of-scope note, wiring `beamtalk_recheck` to actually call `senders_of/2` is Phase 4 (BT-3219) — this PR only adds the query.

Implements the three amendments the BT-3216 Phase 1 spike (`docs/internal/adr-0115-phase1-spike-findings.md`) required beyond ADR 0115's own `is_relevant/3` sketch, which the spike found broke in measurement against a live 109-class workspace.

## Key changes

**`hierarchy_related_classes/1`** — `{ChangedClass} ∪ ancestors(ChangedClass) ∪ subclasses(ChangedClass)`, composed entirely from already-shipped primitives: `beamtalk_class_registry:all_subclasses/1`'s existing transitive `direct_subclasses/1` closure for the descendant half, and `beamtalk_hierarchy:walk_ancestors/3` (BT-2786 — the same generic depth-guarded walker `find_class_method_in_chain/2` already uses) over `beamtalk_class_metadata:lookup_superclass/1` for the ancestor half. No new hierarchy algorithm, pure ETS reads.

**`senders_of/2`** — `senders_of(Selector, ChangedClass) -> [site()]`. `is_relevant` is a `lists:foldl` over the candidate sites, not a per-site predicate in a list comprehension:

- No `recv_type` field (legacy row) or `recv_type: dynamic` → always relevant.
- Otherwise, tested for relatedness to `ChangedClass`: protocol-conformant (`conforms_to/2`) if the name is a registered protocol, hierarchy-related (set membership) if it's a registered class, or **relevant** (Amendment 2) if it resolves to neither.

### Amendment 1 — memoization (the spike's most consequential finding)

`conforms_to/2` costs 59–135 µs/call with no memoisation of its own — the spike measured an un-memoized all-protocol-typed 70-site query at **3.3–16.3 ms**, a 100–400x regression on the exact hot-reload path ADR 0115 exists to speed up (`senders_of/1` costs 34–38 µs today). The fold above carries a `#{name() => boolean()}` cache keyed by the (suffix-stripped) receiver name, built once per `senders_of/2` call and shared across every site — a repeat `recv_type` (the common case) costs one cache hit instead of one registry round trip.

Verified by `memoization_call_count_test_` — **a call-count assertion, not a timing one** (timings are noisy; this is a correctness-of-caching property). It registers 5 sites sharing one protocol-typed `recv_type`, traces `beamtalk_protocol_registry:conforms_to/2` and `is_protocol/1` via plain OTP call tracing (`erlang:trace/3` + `erlang:trace_pattern/3` on a dedicated worker process — no mocking library in this project's deps) during `senders_of/2`, and asserts each was called exactly once, not five times.

### Amendment 2 — invert the unresolvable-name default

The ADR's three-clause `is_relevant/3` silently *excluded* a `recv_type` naming something neither registry can resolve (an unregistered/not-yet-loaded protocol module, a native/alias display name that slipped past Phase 2's write-time coarsening) — a correctness bug per Constraint 2 ("cannot be narrowed and must never be excluded"), not a precision gap. `compute_relatedness/3` now defaults such names to relevant. Covered by `unresolvable_name_defaults_to_relevant_test_`, both cases from the spike's fixture table (`'NoSuchClassXYZ'` and an unregistered protocol name).

### Amendment 3 — the `Meta{C}` (class-object receiver) shape

BT-3217 renders `InferredType::Meta{C}` receivers as `'<C> class'` (PR #3446's description: "a `recv_type: 'Counter class'` site is only ever a dependent of a change to `Counter`'s **class-side** methods, never its instance-side ones"). This is not a name either registry can resolve directly (a metaclass tag is virtual — never its own row in `beamtalk_class_metadata`), and collapsing it to the plain instance name would conflate class-side and instance-side dependents — unsafe per Constraint 1's soundness argument.

**Design decision:** `senders_of/2`'s `ChangedClass` argument accepts the *same* `'<C> class'` tag convention `recv_type` already uses, rather than adding a third parameter or a wider tuple type. `split_class_object_tag/1` strips the suffix (reusing `beamtalk_class_registry:is_class_name/1`'s existing suffix test) from both `recv_type` and `ChangedClass`, and `is_relevant` requires the two booleans to agree before ever reaching the hierarchy/protocol relatedness test — a class-object receiver is relevant only to a class-side change to a hierarchy-related class, an instance-typed receiver only to an instance-side change, and `dynamic`/absent bypass the side gate entirely (they carry no information at all, including side). This reuses the one atom-space convention BT-3217 already established (`class_object_tag/1`) instead of inventing a second one for the read side.

Covered by `meta_class_object_receiver_test_`: a `'Counter class'`-shaped site is relevant for `senders_of(Sel, 'Counter class')` (and for an ancestor/descendant class-side method) and excluded for `senders_of(Sel, 'Counter')` (same class name, instance-side).

## Tests

Full EUnit list per the issue's acceptance criteria, all in `beamtalk_xref_tests.erl`:

- `hierarchy_related_classes_relatedness_test_` — same class, direct/transitive subclass, direct/transitive ancestor, unrelated sibling branch (synthetic hierarchy via direct `beamtalk_class_metadata:insert/5` rows — pure ETS, no live class processes needed for this one).
- `protocol_conformance_predicate_test_` — a conforming class, a non-conforming class, and a class conforming via an inherited method (live `beamtalk_object_class:start_link/2` processes, mirroring `beamtalk_class_dispatch_tests.erl`'s `start_test_class/2` pattern — real instance-side conformance needs a live class process, unlike the class-method/extension path `beamtalk_protocol_registry_tests.erl` already covers).
- `legacy_row_always_included_test_` — no `recv_type` field, regardless of `ChangedClass` (hierarchy-related and totally unrelated).
- `unresolvable_name_defaults_to_relevant_test_` — Amendment 2, both spike cases.
- `memoization_call_count_test_` — Amendment 1, call-count assertion.
- `meta_class_object_receiver_test_` — Amendment 3.

33/33 tests pass in `beamtalk_xref_tests`; full suite green.

## Testing

- `just ci-changed` — full build, clippy, dialyzer, generated-spec validation, all formatting checks, Rust tests, Erlang runtime EUnit (including the new tests above), stdlib tests, BUnit, metamorphic tests, corpus check, surface-drift check: all green.
- No surface-parity doc update needed — `senders_of/2` is an internal query with no CLI/REPL/MCP/LSP-facing surface (ADR 0115's own User Impact section: "not exposed as a new Beamtalk-facing primitive").

## Out of scope (per the issue)

- Wiring `beamtalk_recheck` to call `senders_of/2` — Phase 4, BT-3219.
- Registry-level `conforms_to/2` caching across calls — BT-3222 (this PR's per-call fold/memo is required regardless of whether that lands).
- Indexing `beamtalk_class_metadata`'s superclass column so `direct_subclasses/1` stops full-table-scanning — BT-3221 (`hierarchy_related_classes/1` is O(N²) in loaded-class count for a root-class change, ~500 µs at today's 109-class scale per the spike — accepted as-is for this issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUP4xDUPTzhKZgpRiWLYQL

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUP4xDUPTzhKZgpRiWLYQL)_