### PR TITLE
xref receiver-type key: Phase 4 wire beamtalk_recheck to senders_of/2 (BT-3219)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_recheck.erl
@@ -14,23 +14,32 @@ finds the change's known dependents and re-checks them, producing findings at
 ADR 0100 severities. Generalises the Phase 0 spike
 (`docs/internal/adr-0105-phase0-spike-findings.md`) to production.
 
-## Mechanism (ADR 0105 §Mechanism steps 2-3)
+## Mechanism (ADR 0105 §Mechanism steps 2-3, receiver-type narrowing ADR 0115)
 
-1. **Dependent lookup.** `beamtalk_xref:senders_of/1` is selector-keyed —
-   sites carry a caller (`owner`/`method`/`line`) and a receiver *kind*
-   (self/super/ffi/other), but never a receiver *class* (ADR 0087). So a
-   `size` sender on an unrelated `List` comes back alongside the real
-   `Counter` dependent; xref cannot separate them.
-2. **The receiver-type filter is not a pre-filter — it is what re-checking
-   itself does.** Each candidate caller's *whole class* is re-checked through
-   the compiler with the changed class's *current* (already-live,
-   post-install) signature. A site whose receiver resolves to a different
-   type simply re-checks clean against that signature, because the checker
-   only applies `Counter>>getCount`'s new interface to sends whose receiver
-   it infers as `Counter`. This is why the **caller cap is load-bearing**:
-   every candidate is paid for with a compile before its relevance is known
-   (ADR 0105 Alternatives — the xref receiver-type-key extension is the
-   follow-up if this proves hot).
+1. **Dependent lookup.** `beamtalk_xref:senders_of/2` (ADR 0115 Phase 4,
+   BT-3219 — `senders_of/1` before this) is selector-keyed and, since Phase
+   4, also filtered against the changed class's receiver-type relatedness:
+   sites carry a caller (`owner`/`method`/`line`), a receiver *kind*
+   (self/super/ffi/other), and — for compile-time-indexed sites — a receiver
+   *type* (`recv_type`, ADR 0087/0115). A `size` sender on an unrelated
+   `List` is now dropped by `senders_of/2` itself, before this module ever
+   sees it, *if* that site's `recv_type` was resolved at compile time;
+   `dynamic`-typed and legacy (pre-Phase-2) rows still come back alongside
+   the real `Counter` dependent — xref cannot separate those, by design
+   (ADR 0115 Constraint 2: never exclude what cannot be narrowed).
+2. **The receiver-type filter narrows the pool up front for typed code, but
+   is not a substitute for re-checking.** `senders_of/2` only excludes sites
+   it can *prove* unrelated (a resolved `recv_type` outside the changed
+   class's hierarchy/protocol-conformance set); every site it keeps —
+   including every `dynamic`-typed or legacy one — still goes through the
+   same full re-check this step always did: each surviving candidate
+   caller's *whole class* is re-checked through the compiler with the
+   changed class's *current* (already-live, post-install) signature, and a
+   site whose receiver resolves to a different type at that point simply
+   re-checks clean. This is why the **caller cap remains load-bearing** even
+   post-Phase-4: it is the backstop over the residual, unnarrowable
+   candidates `senders_of/2` cannot rule out, not a replacement for it (ADR
+   0115 §Decision).
 3. **Re-check unit is the caller's whole class**, read from the *live image*
    (`beamtalk_workspace_meta:get_class_source/1`), never disk — a flagged
    caller may itself carry unflushed edits (ADR 0082). One
@@ -198,7 +207,9 @@ covering all three "never actually re-verified" cases.
     relevant_diagnostic_leaf_change/2,
     class_name_mentioned/2,
     relevant_diagnostic_alias_change/1,
-    alias_change_candidates/1
+    alias_change_candidates/1,
+    changed_class_tag/2,
+    selector_side/1
 ]).
 -endif.
 
@@ -293,12 +304,14 @@ reload's own success/reply on this.
 -spec trigger(binary(), binary(), instance | class, classification()) -> result().
 trigger(ClassNameBin, SelectorBin, Side, Classification) ->
     try
-        %% `Side` is accepted (matching the signature store's capture/4 key)
-        %% but not threaded into do_trigger/3: beamtalk_xref:senders_of/1 is
-        %% selector-keyed only, with no instance/class-side component, so it
-        %% cannot narrow the dependent lookup. Kept in scope here purely for
-        %% the ?LOG_WARNING context below on a caught failure.
-        do_trigger(ClassNameBin, SelectorBin, Classification)
+        %% ADR 0115 Phase 4 (BT-3219): `Side` now threads all the way to
+        %% `beamtalk_xref:senders_of/2`'s `ChangedClass` argument via
+        %% `changed_class_tag/2` — it is the "which side changed" axis
+        %% Amendment 3's relatedness test needs (a class-object receiver only
+        %% ever dispatches through the metaclass chain, an instance-typed one
+        %% only through the instance chain), not merely `?LOG_WARNING` context
+        %% as it was pre-Phase-4.
+        do_trigger(ClassNameBin, SelectorBin, Side, Classification)
     catch
         Class:Reason:Stack ->
             ?LOG_WARNING(
@@ -553,11 +566,12 @@ nothing to catch it, the first instance of the new subclass to reach that
 
 ## Why this cannot reuse `trigger/4`/`trigger_shape/2`'s xref-based lookup
 
-Both existing triggers query `beamtalk_xref:senders_of/1` — a **selector**-
-keyed index of message-send call sites. There is no selector a
-`matchExhaustive:`/`Type`-pattern site "sends" that names the class it
-tests, so xref has nothing to look up here (confirmed: no such index exists
-anywhere in this codebase as of BT-2856). Absent a purpose-built index
+Both existing triggers query `beamtalk_xref:senders_of/1` (or, since ADR 0115
+Phase 4, its receiver-type-narrowed `senders_of/2` extension) — a
+**selector**-keyed index of message-send call sites, either way. There is no
+selector a `matchExhaustive:`/`Type`-pattern site "sends" that names the
+class it tests, so xref has nothing to look up here (confirmed: no such
+index exists anywhere in this codebase as of BT-2856). Absent a purpose-built index
 (a real follow-up — see the moduledoc note below), the only currently-shippable
 way to find every affected site is `trigger_image/0`'s own strategy: recompile
 every live class's own recorded source against the current (now-updated)
@@ -753,10 +767,10 @@ do_trigger_pending(ClassNameBin, SelectorBin, Side, Classification, PendingSigna
             %% BT-3109: the overlay is a plain local map, never written to
             %% `beamtalk_compiler_server` state — every other ambient class
             %% stays exactly as installed; only this one request's view of
-            %% `ClassAtom` is hypothetical. Threaded through do_trigger/4 as
+            %% `ClassAtom` is hypothetical. Threaded through do_trigger/5 as
             %% each candidate's `diagnostics/3` `class_hierarchy` option.
             Overlay = AmbientClasses#{ClassAtom => PendingMeta},
-            do_trigger(ClassNameBin, SelectorBin, Classification, Overlay)
+            do_trigger(ClassNameBin, SelectorBin, Side, Classification, Overlay)
     end.
 
 -doc """
@@ -899,33 +913,47 @@ image_finding(
         'end' => End
     }.
 
--spec do_trigger(binary(), binary(), classification()) -> result().
-do_trigger(ClassNameBin, SelectorBin, Classification) ->
+-spec do_trigger(binary(), binary(), instance | class, classification()) -> result().
+do_trigger(ClassNameBin, SelectorBin, Side, Classification) ->
     %% `trigger/4`'s path: no pending overlay, so each candidate's
     %% `diagnostics/3` call opts into the *ambient* class-hierarchy cache
     %% (`class_hierarchy => true`), exactly as before BT-3109.
-    do_trigger(ClassNameBin, SelectorBin, Classification, true).
+    do_trigger(ClassNameBin, SelectorBin, Side, Classification, true).
 
 -doc """
-`do_trigger/3` generalised to accept `ClassHierarchy` — the `class_hierarchy`
+`do_trigger/4` generalised to accept `ClassHierarchy` — the `class_hierarchy`
 option value (`beamtalk_compiler_server:diagnostics/3`) each candidate's
-diagnostics round-trip is run with. `true` (the `do_trigger/3`/`trigger/4`
+diagnostics round-trip is run with. `true` (the `do_trigger/4`/`trigger/4`
 path) opts into the ambient cache; a map (`do_trigger_pending/5`'s path, BT-
 3109) threads that exact map as a per-request overlay instead — see
 `trigger_pending/5`'s moduledoc for why this replaces the previous
 ambient-cache mutate-then-restore mechanism.
+
+ADR 0115 Phase 4 (BT-3219): the dependent lookup now calls
+`beamtalk_xref:senders_of/2`, not `/1` — `ChangedClass`
+(`changed_class_tag/2` applied to `ClassNameBin`'s atom and `Side`) narrows
+the candidate pool to sites whose receiver could actually dispatch to the
+changed method *before* `group_by_owner/1`/`apply_cap/2` ever see it, rather
+than only discovering irrelevance the expensive way, at full re-check (see
+this module's moduledoc, step 2). `apply_cap/2` itself is unchanged — it
+remains the backstop over this now-narrower candidate set: `dynamic`-typed
+and cross-hierarchy-ambiguous sends still flow through unfiltered, per ADR
+0115 Constraint 2.
 """.
--spec do_trigger(binary(), binary(), classification(), true | #{atom() => map()}) -> result().
-do_trigger(ClassNameBin, SelectorBin, Classification, ClassHierarchy) ->
+-spec do_trigger(
+    binary(), binary(), instance | class, classification(), true | #{atom() => map()}
+) -> result().
+do_trigger(ClassNameBin, SelectorBin, Side, Classification, ClassHierarchy) ->
     %% `binary_to_existing_atom/2`, not `binary_to_atom/2`: by the time a
-    %% reload reaches this trigger the selector was just compiled into a live
-    %% class, so its atom already exists — using the existing-only conversion
-    %% fails fast (caught by trigger/4) instead of ever minting a fresh atom
-    %% from what is, transitively, patch-source-derived text (atom-table
-    %% exhaustion is a standing concern for `binary_to_atom` on
-    %% externally-influenced input).
+    %% reload reaches this trigger both the selector and its containing class
+    %% were just compiled into a live class, so both atoms already exist —
+    %% using the existing-only conversion fails fast (caught by `trigger/4`)
+    %% instead of ever minting a fresh atom from what is, transitively,
+    %% patch-source-derived text (atom-table exhaustion is a standing concern
+    %% for `binary_to_atom` on externally-influenced input).
     Selector = binary_to_existing_atom(SelectorBin, utf8),
-    Sites = beamtalk_xref:senders_of(Selector),
+    ClassAtom = binary_to_existing_atom(ClassNameBin, utf8),
+    Sites = beamtalk_xref:senders_of(Selector, changed_class_tag(ClassAtom, Side)),
     OwnerGroups = group_by_owner(Sites),
     Cap = recheck_caller_cap(),
     {Kept, NotChecked} = apply_cap(OwnerGroups, Cap),
@@ -963,10 +991,33 @@ do_trigger(ClassNameBin, SelectorBin, Classification, ClassHierarchy) ->
         not_verified_owners => not_verified_owners(NotCheckedOwners, Outcomes)
     }.
 
+-doc """
+ADR 0115 Phase 4 (BT-3219): each shape-dependent selector is filtered through
+`beamtalk_xref:senders_of/2` against `ClassNameBin`, individually tagged by
+its own side — `shape_dependent_selectors/1`'s selector set mixes
+`spawnWith:` (a **class-side** message, sent to the class object itself:
+`Counter spawnWith: #{...}`, per the "class-side" constructor table in
+`docs/beamtalk-language-features.md`) with the field getter / `with*:`
+copy-setter selectors (**instance-side**, sent to an already-spawned
+instance). Using one `Side` for the whole `flatmap` would be wrong for
+whichever half it didn't match — Amendment 3's side-gating in `senders_of/2`
+excludes a site outright on a side mismatch, so a class-side `ChangedClass`
+tag applied to an instance-side selector's lookup (or vice versa) would
+silently drop every real dependent of that selector, not just narrow it.
+`selector_side/1` picks the correct tag per selector, not per class.
+""".
 -spec do_trigger_shape(binary(), [shape_field_change()]) -> result().
 do_trigger_shape(ClassNameBin, FieldChanges) ->
+    ClassAtom = binary_to_existing_atom(ClassNameBin, utf8),
     Selectors = shape_dependent_selectors(FieldChanges),
-    Sites = lists:flatmap(fun beamtalk_xref:senders_of/1, Selectors),
+    Sites = lists:flatmap(
+        fun(Selector) ->
+            beamtalk_xref:senders_of(
+                Selector, changed_class_tag(ClassAtom, selector_side(Selector))
+            )
+        end,
+        Selectors
+    ),
     OwnerGroups = group_by_owner(Sites),
     Cap = recheck_caller_cap(),
     {Kept, NotChecked} = apply_cap(OwnerGroups, Cap),
@@ -1027,6 +1078,42 @@ not_verified_owners(NotCheckedOwners, Outcomes) ->
      || {Owner, {Status, _}} <- Outcomes, Status =/= ok
     ],
     lists:usort(NotCheckedOwners ++ UnverifiedFromOutcomes).
+
+-doc """
+ADR 0115 Phase 4 (BT-3219): the `ChangedClass` argument `beamtalk_xref:
+senders_of/2` expects — `ClassAtom` unchanged for an instance-side reload, or
+its class-object tag (`'<C> class'`, via `beamtalk_runtime_api:
+class_object_tag/1`) for a class-side one. This is the identical convention
+`recv_type` itself uses for a `Meta{C}` receiver (BT-3217's write path) — the
+ADR reuses it here for `ChangedClass` rather than inventing a third parameter
+or a wider tuple type, and it is exactly what lets `senders_of/2`'s Amendment
+3 side-gating (a class-object receiver only ever dispatches through the
+metaclass chain, an instance-typed one only through the instance chain)
+apply correctly to a class-side reload.
+""".
+-spec changed_class_tag(atom(), instance | class) -> atom().
+changed_class_tag(ClassAtom, instance) ->
+    ClassAtom;
+changed_class_tag(ClassAtom, class) ->
+    beamtalk_runtime_api:class_object_tag(ClassAtom).
+
+-doc """
+Which side (`instance | class`) a shape-dependent selector
+(`shape_dependent_selectors/1`) is sent on — `do_trigger_shape/2`'s per-
+selector input to `changed_class_tag/2`. `spawnWith:` is sent to the class
+object itself (`Counter spawnWith: #{...}`, the "class-side" row of
+`docs/beamtalk-language-features.md`'s constructor table); every other
+shape-dependent selector (a field's getter or `with*:` copy-setter) is sent
+to an already-spawned instance. Getting this wrong in either direction would
+make `senders_of/2` wrongly *exclude* real dependents of that selector
+(Amendment 3 side-gates on an exact match, not a permissive superset) — not
+merely under-narrow the pool, so this is not a soft default.
+""".
+-spec selector_side(atom()) -> instance | class.
+selector_side('spawnWith:') ->
+    class;
+selector_side(_Selector) ->
+    instance.
 
 -doc """
 The selector set whose senders are candidate dependents of a shape change:

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_recheck_tests.erl
@@ -827,6 +827,165 @@ trigger_never_raises_on_unknown_selector_test_() ->
         end}}.
 
 %%====================================================================
+%% Receiver-type-aware dependent lookup (ADR 0115 Phase 4, BT-3219)
+%%====================================================================
+
+%% Pure helpers — changed_class_tag/2, selector_side/1.
+
+changed_class_tag_instance_side_is_bare_class_test() ->
+    ?assertEqual(
+        'ReCheckCounter', beamtalk_recheck:changed_class_tag('ReCheckCounter', instance)
+    ).
+
+changed_class_tag_class_side_uses_class_object_tag_test() ->
+    ?assertEqual(
+        'ReCheckCounter class', beamtalk_recheck:changed_class_tag('ReCheckCounter', class)
+    ).
+
+selector_side_spawn_with_is_class_side_test() ->
+    ?assertEqual(class, beamtalk_recheck:selector_side('spawnWith:')).
+
+selector_side_accessor_is_instance_side_test() ->
+    ?assertEqual(instance, beamtalk_recheck:selector_side(count)),
+    ?assertEqual(instance, beamtalk_recheck:selector_side('withCount:')).
+
+%% xref payload for the fan-out fixture below: one send of `Selector`, typed
+%% (`recv_type`) at `RecvType` — mirrors the compile-time write path BT-3217
+%% populates for real code (unlike `dashboard_xref/0`/`listview_xref/0`
+%% above, which deliberately omit `recv_type` to exercise the pre-Phase-2
+%% legacy-row default elsewhere in this file).
+fanout_candidate_xref(Selector, RecvType) ->
+    [
+        #{
+            class_side => false,
+            selector => 'go:',
+            line => 2,
+            sends => [
+                #{selector => Selector, line => 2, recv_kind => other, recv_type => RecvType}
+            ],
+            references => [#{class => RecvType, line => 2}],
+            source_status => indexed,
+            provenance => class_body
+        }
+    ].
+
+fanout_candidate_source(NameBin, ReceiverBin, SelectorBin) ->
+    <<
+        "Object subclass: ",
+        NameBin/binary,
+        "\n  go: c :: ",
+        ReceiverBin/binary,
+        " -> Integer => (c ",
+        SelectorBin/binary,
+        ") + 1\n"
+    >>.
+
+-spec register_fanout_candidate(atom(), atom(), atom()) -> ok.
+register_fanout_candidate(Name, Selector, RecvType) ->
+    NameBin = atom_to_binary(Name, utf8),
+    ReceiverBin = atom_to_binary(RecvType, utf8),
+    SelectorBin = atom_to_binary(Selector, utf8),
+    ok = beamtalk_xref:register_class(Name, fanout_candidate_xref(Selector, RecvType)),
+    ok = beamtalk_workspace_meta:set_class_source(
+        NameBin, fanout_candidate_source(NameBin, ReceiverBin, SelectorBin)
+    ).
+
+%% BT-3219 AC4: a synthetic fan-out fixture mirroring BT-2781's benchmark
+%% shape (real dependents interleaved with same-selector, unrelated-type
+%% false positives) for one selector, all comfortably under the default
+%% caller cap (20) so the cap plays no part in this result — proving the
+%% unrelated-type candidates are dropped from the pool by `senders_of/2`
+%% itself, *before* `apply_cap/2` ever runs, rather than merely re-checked
+%% and discarded afterward the way `signature_change_finding_and_receiver_
+%% filter_test_` above demonstrates for legacy (`recv_type`-less) rows.
+receiver_type_filter_narrows_pool_before_cap_test_() ->
+    {timeout, 30,
+        {setup, fun recheck_setup/0, fun recheck_teardown/1, fun(_) ->
+            [
+                ?_test(begin
+                    ChangedClass = 'ReCheckFanoutCounter',
+                    UnrelatedClass = 'ReCheckFanoutUnrelated',
+                    Selector = fanoutSel,
+                    SelectorBin = <<"fanoutSel">>,
+                    %% A small synthetic hierarchy, written directly into
+                    %% `beamtalk_class_metadata` (mirrors
+                    %% `beamtalk_xref_tests.erl`'s BT-3218
+                    %% `bt3218_hierarchy_setup/0` pattern) — both classes must
+                    %% be *known* to `beamtalk_class_metadata` for
+                    %% `senders_of/2`'s relatedness check to actually run the
+                    %% hierarchy-membership test rather than fall through to
+                    %% Amendment 2's "unresolvable name, default relevant"
+                    %% branch, which would defeat this test's whole point.
+                    ok = beamtalk_class_metadata:insert(
+                        ChangedClass, undefined, undefined, none, undefined
+                    ),
+                    ok = beamtalk_class_metadata:insert(
+                        UnrelatedClass, undefined, undefined, none, undefined
+                    ),
+                    try
+                        beamtalk_compiler_server:register_class(
+                            ChangedClass,
+                            counter_hierarchy(#{
+                                Selector => #{
+                                    arity => 0, param_types => [], return_type => 'String'
+                                }
+                            })
+                        ),
+
+                        RealNames = ['ReCheckFanoutReal1', 'ReCheckFanoutReal2'],
+                        UnrelatedNames = [
+                            'ReCheckFanoutFalse1',
+                            'ReCheckFanoutFalse2',
+                            'ReCheckFanoutFalse3'
+                        ],
+                        lists:foreach(
+                            fun(Name) ->
+                                register_fanout_candidate(Name, Selector, ChangedClass)
+                            end,
+                            RealNames
+                        ),
+                        lists:foreach(
+                            fun(Name) ->
+                                register_fanout_candidate(Name, Selector, UnrelatedClass)
+                            end,
+                            UnrelatedNames
+                        ),
+
+                        Result = beamtalk_recheck:trigger(
+                            atom_to_binary(ChangedClass, utf8),
+                            SelectorBin,
+                            instance,
+                            signature_change
+                        ),
+                        #{
+                            checked := Checked,
+                            total_candidates := Total,
+                            not_checked := NotChecked,
+                            checked_owners := CheckedOwners
+                        } = Result,
+
+                        %% `total_candidates` is `length(group_by_owner(Sites))`
+                        %% computed straight from `senders_of/2`'s
+                        %% already-filtered result, before `apply_cap/2` runs
+                        %% — if the unrelated-type candidates had merely been
+                        %% re-checked and discarded (the pre-Phase-4 behaviour),
+                        %% `Total` would be 5 (2 real + 3 unrelated), not 2.
+                        ?assertEqual(length(RealNames), Total),
+                        ?assertEqual(length(RealNames), Checked),
+                        ?assertEqual(0, NotChecked),
+                        ?assertEqual(
+                            lists:sort([atom_to_binary(N, utf8) || N <- RealNames]),
+                            lists:sort(CheckedOwners)
+                        )
+                    after
+                        beamtalk_class_metadata:delete(ChangedClass),
+                        beamtalk_class_metadata:delete(UnrelatedClass)
+                    end
+                end)
+            ]
+        end}}.
+
+%%====================================================================
 %% Shape-change re-check (ADR 0105 Phase 2, BT-2780)
 %%====================================================================
 


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-3219/xref-receiver-type-key-phase-4-wire-beamtalk-recheck-to-senders-of2

## Summary

Phase 4 of 5 implementing ADR 0115 (Epic BT-2798, blocked-by BT-3218's Phase 3 read path, PR #3450). This is the payoff phase: wires `beamtalk_recheck`'s reload re-check orchestration to actually call the receiver-type-aware `senders_of/2` Phase 3 built, instead of the selector-only `senders_of/1`, so the numeric caller cap (`recheck_caller_cap`/`apply_cap/2`) only has to act on a receiver-type-narrowed candidate pool instead of every syntactic sender of a selector.

`apply_cap/2` itself is unchanged and remains the backstop over the now-narrower candidate set — `dynamic`-typed and cross-hierarchy-ambiguous sends still flow through unfiltered, per ADR 0115 Constraint 2.

## Key changes

**`do_trigger/5`** (`beamtalk_recheck.erl`, was `do_trigger/4`) — `beamtalk_xref:senders_of(Selector)` becomes `beamtalk_xref:senders_of(Selector, ChangedClass)`, before `group_by_owner/1`/`apply_cap/2` run. `ChangedClass` is computed by a new `changed_class_tag/2` helper.

**`do_trigger_shape/2`** — each shape-dependent selector (`shape_dependent_selectors/1`) is now filtered through `senders_of/2` individually, rather than one `lists:flatmap(fun beamtalk_xref:senders_of/1, Selectors)` call.

### The class-side/instance-side subtlety (flagged in the issue, turned out to matter)

`senders_of/2`'s `ChangedClass` argument encodes *which side* changed (BT-3218 Amendment 3): a plain class name for an instance-side change, or the `'<C> class'` class-object tag for a class-side one — sites are excluded outright on a side mismatch, not just left unnarrowed. Two things fell out of tracing this through:

1. **`trigger/4` already receives `Side` (`instance | class`)** — it used to be accepted only for `?LOG_WARNING` context and explicitly *not* threaded into the lookup (the pre-Phase-4 comment said as much, since `senders_of/1` had no side axis to narrow on). `Side` now threads all the way to `senders_of/2` via `changed_class_tag(ClassAtom, Side)` (`instance` → bare class atom, `class` → `beamtalk_runtime_api:class_object_tag/1`'s result — the same tag convention `recv_type` itself uses, BT-3217's write path).
2. **`do_trigger_shape/2`'s selector set is not uniformly one side.** `shape_dependent_selectors/1` returns `spawnWith:` (sent to the *class object* — `Counter spawnWith: #{...}`, the "class-side" row of the language-features constructor table) unioned with each removed/retyped field's getter and `with*:` setter (sent to an *instance*). Tagging the whole selector set with one `Side` would have wrongly excluded real dependents of whichever half it didn't match — not merely under-narrowed. A new `selector_side/1` helper (`spawnWith:` → `class`, everything else → `instance`) picks the correct tag per selector.

## Tests

- `receiver_type_filter_narrows_pool_before_cap_test_` (new, `beamtalk_recheck_tests.erl`) — a synthetic fan-out fixture mirroring BT-2781's benchmark shape: 2 real-dependent candidates (`recv_type` = the changed class) and 3 unrelated-type candidates (`recv_type` = a registered-but-hierarchy-unrelated class) for one selector, all under the default cap. Asserts `total_candidates`/`checked`/`checked_owners` reflect only the 2 real dependents — proving the unrelated candidates are dropped by `senders_of/2` itself *before* `apply_cap/2` runs, not merely re-checked and discarded afterward.
- `changed_class_tag_instance_side_is_bare_class_test`, `changed_class_tag_class_side_uses_class_object_tag_test`, `selector_side_spawn_with_is_class_side_test`, `selector_side_accessor_is_instance_side_test` — pure unit coverage for the two new helpers.
- All existing `beamtalk_recheck_tests` pass unmodified: the existing integration fixtures (`dashboard_xref/0`, `listview_xref/0`, etc.) deliberately carry no `recv_type` field, so they exercise the pre-BT-3217 legacy-row default (`senders_of/2` treats a missing/`dynamic` `recv_type` as always-relevant) — same observable behavior as before this PR, confirming this is a lookup-precision change, not a behavior change to what counts as a "finding" (AC5).

## Testing

- `just ci-changed` — full build, clippy, dialyzer (clean, no new warnings), generated-spec validation, all formatting checks (Rust/Erlang/JS/Elixir/Beamtalk), Rust tests, Erlang runtime EUnit (5790 tests, 0 failures — includes `beamtalk_recheck_tests` and `beamtalk_xref_tests`), stdlib tests, BUnit, metamorphic tests, corpus check, surface-drift check, parity tests (triggered since this touches the workspace surface): all green.
- No surface-parity doc update needed — `senders_of/2` (and this wiring) has no CLI/REPL/MCP/LSP-facing surface (ADR 0115's own User Impact section: "not exposed as a new Beamtalk-facing primitive").

## Out of scope (per the issue)

- Benchmark harness updates (`bench_senders_xref.escript`/`bench_recheck_fanout.escript`) and ADR 0087/0105 doc updates — Phase 5, BT-3220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUP4xDUPTzhKZgpRiWLYQL

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUP4xDUPTzhKZgpRiWLYQL)_