### PR TITLE
Parser: thread method header indent instead of hardcoded col&lt;=2 boundary (BT-3223)

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/method_span_corpus_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/method_span_corpus_tests.rs
@@ -657,30 +657,14 @@ fn corpus_method_definitions(module: &Module) -> Vec<(String, &crate::ast::Metho
 /// stdlib + `examples/` corpus, not just an asserted invariant in a comment
 /// (this project's no-"keep-in-sync"-comment-without-a-test rule).
 ///
-/// **Known exceptions (BT-3223, tracked separately — not a BT-3217 defect):**
-/// two `SystemNavigation.bt` methods trip a *pre-existing* parser edge case
-/// unrelated to either walk here — `is_at_declaration_level_expect`
-/// (`source_analysis/parser/declarations.rs`) misclassifies a body-level
-/// `@expect` as declaration-level when the enclosing method is rendered at
-/// column 0 (`unparse_method`'s bare-method shape, exactly what
-/// `find_all_sends_in_source`'s synthetic-wrap reparse uses), truncating the
-/// *syntactic* walk's method body early and silently dropping its trailing
-/// sends — a real, independent completeness gap in `find_all_sends_in_source`
-/// itself, not something `collect_receiver_spans` (which walks the original,
-/// correctly-parsed AST directly) reproduces. `KNOWN_DIVERGENT_METHODS` is
-/// this test's explicit, narrow acknowledgment of that gap: any divergence
-/// *not* in this list still fails the test, and BT-3223's own acceptance
-/// criteria require this list emptied once the parser bug is fixed.
-const KNOWN_DIVERGENT_METHODS: &[(&str, &str)] = &[
-    (
-        "SystemNavigation.bt",
-        "SystemNavigation.isAnnouncementClass: (instance)",
-    ),
-    (
-        "SystemNavigation.bt",
-        "SystemNavigation.extensionTargets:names: (instance)",
-    ),
-];
+/// Was non-empty for two `SystemNavigation.bt` methods until BT-3223 fixed
+/// the underlying parser bug (`is_at_declaration_level_expect` misclassified
+/// a body-level `@expect` as declaration-level when the enclosing method was
+/// rendered at column 0 — exactly `find_all_sends_in_source`'s synthetic-wrap
+/// shape). Kept empty-but-present rather than removed: any *new* divergence
+/// still fails the test outright, and a future one gets the same narrow,
+/// documented allowlist entry this one did rather than silently masking it.
+const KNOWN_DIVERGENT_METHODS: &[(&str, &str)] = &[];
 
 #[test]
 fn corpus_receiver_span_walk_matches_syntactic_send_walk() {

--- a/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/declarations.rs
@@ -636,7 +636,16 @@ impl Parser {
     /// method/state-declaration keeps `expect: None` — the suppression
     /// silently fails and the swallowed directive itself gets reported stale.
     /// Statement-level `@expect` inside a body (e.g. as the first statement
-    /// of a method) sits deeper than col 2 and is unaffected.
+    /// of a method) sits deeper than the enclosing method's own header
+    /// indentation and is unaffected.
+    ///
+    /// The boundary column is the *current* method's own header indentation
+    /// (`current_method_header_indent`), not a hardcoded `2`: a canonically
+    /// nested method has its header at col 2, but `method_source_walker`'s
+    /// synthetic-wrap strategy (used for xref/LSP send-collection queries)
+    /// puts a bare method's header at col 0, so its body sits at col 2 —
+    /// a hardcoded `col <= 2` would misidentify a body-level `@expect` there
+    /// as declaration-level and silently truncate the body (BT-3223).
     ///
     /// Unlike `is_at_method_definition()`, this is gated on `in_class_body`
     /// alone (no `!self.in_class_body` fallback): declaration-level `@expect`
@@ -650,7 +659,7 @@ impl Parser {
             && self
                 .current_token()
                 .indentation_after_newline()
-                .is_none_or(|col| col <= 2)
+                .is_none_or(|col| col <= self.current_method_header_indent.unwrap_or(2))
             && matches!(self.current_kind(), TokenKind::AtExpect)
     }
 
@@ -1461,6 +1470,12 @@ impl Parser {
     /// - `internal methodName => body` (ADR 0071)
     pub(super) fn parse_method_definition(&mut self) -> Option<MethodDefinition> {
         let start = self.current_token().span();
+        // BT-3223: capture this method's own header indentation before any
+        // tokens are consumed, so `parse_method_body` can tell a genuine
+        // class-member declaration boundary apart from body content at the
+        // same column a differently-indented header would produce (see
+        // `current_method_header_indent`'s doc comment).
+        let header_indent = self.current_token().indentation_after_newline();
         let doc_comment = self.collect_doc_comment();
         let comments = self.collect_comment_attachment();
         let method_kind = MethodKind::Primary;
@@ -1511,7 +1526,13 @@ impl Parser {
         // infer it (BT-2724).
         let previous_method_selector = self.current_method_selector.take();
         self.current_method_selector = Some(selector.name());
+        // BT-3223: thread this method's own header indentation through for
+        // the duration of its body — see `current_method_header_indent`'s
+        // doc comment and `parse_method_body`'s declaration-boundary checks.
+        let previous_method_header_indent = self.current_method_header_indent.take();
+        self.current_method_header_indent = Some(header_indent.unwrap_or(2));
         let body = self.parse_method_body();
+        self.current_method_header_indent = previous_method_header_indent;
         self.current_method_selector = previous_method_selector;
         self.in_method_body = false;
 
@@ -1645,11 +1666,15 @@ impl Parser {
         // indentation check. This is safe because `= expr` is not a valid
         // Beamtalk binary expression, so the `type Uppercase =` pattern cannot
         // appear as a legitimate statement start outside declaration position.
+        //
+        // BT-3223: the boundary column is the current method's own header
+        // indentation, not a hardcoded `2` — see
+        // `current_method_header_indent`'s doc comment.
         (!self.in_class_body
             || self
                 .current_token()
                 .indentation_after_newline()
-                .is_none_or(|col| col <= 2))
+                .is_none_or(|col| col <= self.current_method_header_indent.unwrap_or(2)))
             && self.is_at_type_alias_definition()
     }
 
@@ -1672,6 +1697,10 @@ impl Parser {
         // the body early and treats continuation keywords as a new method selector.
         // When `in_class_body` is true, canonical class members start at col 2;
         // any token deeper than col 2 is part of an expression, never a member.
+        // BT-3223: the boundary column is the *current* method's own header
+        // indentation (`current_method_header_indent`), not a hardcoded `2` —
+        // see that field's doc comment for why a hardcoded literal is wrong
+        // for `method_source_walker`'s synthetic-wrap strategy.
         #[allow(clippy::nonminimal_bool)]
         while !self.is_at_end()
             && !self.is_at_class_definition()
@@ -1679,13 +1708,14 @@ impl Parser {
             && !self.is_at_type_alias_boundary()
             && !(
                 // Only test is_at_method_definition when the token could plausibly
-                // be a class member (indentation <= 2). Deeper tokens are continuation
-                // expressions and must not trigger early exit from the method body.
+                // be a class member (indentation <= header indent). Deeper tokens
+                // are continuation expressions and must not trigger early exit
+                // from the method body.
                 (!self.in_class_body
                     || self
                         .current_token()
                         .indentation_after_newline()
-                        .is_none_or(|col| col <= 2))
+                        .is_none_or(|col| col <= self.current_method_header_indent.unwrap_or(2)))
                     && self.is_at_method_definition()
             )
             // BT-2829: a declaration-level `@expect` must end the body of the

--- a/crates/beamtalk-core/src/source_analysis/parser/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/mod.rs
@@ -750,6 +750,23 @@ pub(super) struct Parser {
     /// Whether the parser is currently inside a class body.
     /// Used to detect trailing expressions via indentation (BT-903).
     pub(super) in_class_body: bool,
+    /// The indentation column of the method definition currently being
+    /// parsed's own header token (the selector, or a leading `sealed`/
+    /// `internal`/`class` modifier) — `None` outside a method body.
+    ///
+    /// A class member declaration boundary (a fresh state/method/`@expect`
+    /// terminating the current method's body) sits at *this* column, not a
+    /// hardcoded `2`: a canonically-nested method has its header at col 2,
+    /// but `method_source_walker`'s synthetic-wrap strategy
+    /// (`Object subclass: __SyntheticAllSendsScope\n<bare method text>`)
+    /// puts the header at col 0, so its body's own statements sit at col 2 —
+    /// indistinguishable from a *canonical* declaration boundary if that
+    /// were hardcoded (BT-3223). Set in `parse_method_definition` from the
+    /// header's own first token, before any doc-comment/modifier tokens are
+    /// consumed, and restored on return so nesting (a class body found
+    /// inside a method body's own class definition) can't leak a stale
+    /// value to the outer method.
+    pub(super) current_method_header_indent: Option<usize>,
     /// Current expression nesting depth (guards against stack overflow).
     nesting_depth: usize,
     /// Indices of tokens whose leading trivia contains at least one `DocComment`.
@@ -806,6 +823,7 @@ impl Parser {
             in_method_body: false,
             current_method_selector: None,
             in_class_body: false,
+            current_method_header_indent: None,
             nesting_depth: 0,
             unattached_doc_comment_indices,
             attached_doc_comment_positions: None,

--- a/crates/beamtalk-core/src/source_analysis/parser/tests/method_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/parser/tests/method_tests.rs
@@ -1159,6 +1159,56 @@ fn standalone_method_statement_level_expect_inside_body_still_works() {
 }
 
 #[test]
+fn synthetic_wrap_shape_body_level_expect_is_not_declaration_level() {
+    // Regression test for BT-3223: `method_source_walker::find_all_sends_in_source`
+    // (and `find_all_references_in_source`) reparse a method's bare,
+    // unparsed source through a synthetic wrapper —
+    // `Object subclass: __SyntheticAllSendsScope\n<method text>` — where the
+    // method header sits at col 0 instead of the canonical col 2, so its
+    // entire body (including any `@expect`) sits at col 2: the same column
+    // `is_at_declaration_level_expect`'s old hardcoded `col <= 2` check used
+    // to treat as "declaration-level", causing it to end the body early and
+    // silently drop every statement after the `@expect` from the syntactic
+    // send/reference walk — a real completeness gap in the xref index and
+    // any LSP query riding the same source channel, not a cosmetic
+    // diagnostic. Mirrors the issue's minimal repro exactly.
+    let module = parse_ok(
+        "Object subclass: __SyntheticAllSendsScope\n\
+         bar: x =>\n\
+         \x20\x20x isNil ifTrue: [^false]\n\
+         \x20\x20// comment\n\
+         \x20\x20@expect dnu\n\
+         \x20\x20x superclassChain includes: x",
+    );
+    assert_eq!(module.classes.len(), 1);
+    let class = &module.classes[0];
+    assert_eq!(class.methods.len(), 1);
+    let method = &class.methods[0];
+    assert_eq!(
+        method.body.len(),
+        3,
+        "expected all 3 statements (ifTrue:, @expect, superclassChain includes:) \
+         retained in the body, got: {:?}",
+        method.body
+    );
+    assert!(
+        matches!(
+            method.body[1].expression,
+            Expression::ExpectDirective { .. }
+        ),
+        "expected the @expect to be swallowed as a body-level statement, not \
+         treated as a declaration boundary: {:?}",
+        method.body[1]
+    );
+    assert!(
+        matches!(method.body[2].expression, Expression::MessageSend { .. }),
+        "expected the final statement (`x superclassChain includes: x`) to \
+         survive, not be dropped/misattached as trailing class-body content: {:?}",
+        method.body[2]
+    );
+}
+
+#[test]
 fn declaration_level_expect_does_not_strand_preceding_doc_comment() {
     // Companion regression to the swallowing bug above: a `/// ...` doc
     // comment written directly above a declaration-level `@expect` sits in


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-3223/parser-mis-terminates-a-0-indented-method-body-at-a-low-indent-expect

## Summary

Found while implementing BT-3217 (xref `recv_type` write path, PR #3446) and its required corpus conformance test. Not part of Epic BT-2798 itself — a genuine, pre-existing parser completeness bug, filed as its own follow-up.

`Parser::is_at_declaration_level_expect` (and two structurally identical checks — the `is_at_method_definition()` guard in `parse_method_body`'s loop condition, and `is_at_type_alias_boundary`) treated any token at indentation `<= 2` while `in_class_body` as "declaration-level" — i.e. the start of a fresh class member, ending the current method's body. This assumed a method is always canonically nested (header at col 2, body at col 4+), which breaks for `method_source_walker`'s synthetic-wrap strategy (`Object subclass: __SyntheticAllSendsScope\n<bare method text>`, used by `find_all_sends_in_source`/`find_all_references_in_source` for xref and LSP queries): the wrapped method's header sits at col 0, so its *entire body* — including any `@expect` — sits at col 2, indistinguishable from a genuine declaration boundary.

**Effect:** a synthetic-wrapped method containing a body-level `@expect` before its final statement had its body silently truncated there, with the remainder misparsed as trailing class-body content — a real, silent completeness gap in the ADR 0087 xref index and any LSP feature riding the same query, not a cosmetic diagnostic. Confirmed in two real corpus methods (`SystemNavigation.bt`'s `isAnnouncementClass:`/`extensionTargets:names:`), tracked as an explicit, narrow allowlist in BT-3217's corpus conformance test pending this fix.

## Fix

Capture the method's own header indentation in `parse_method_definition` (before any tokens are consumed) into a new `current_method_header_indent: Option<usize>` parser field, threaded for the duration of that method's body (save/restore, same pattern as the existing `current_method_selector`/`in_method_body` fields). Replace every hardcoded `col <= 2` boundary check with `col <= self.current_method_header_indent.unwrap_or(2)` — a canonically-nested method still gets the same `2` it always did; a synthetic-wrapped one correctly gets `0`, so its col-2 body content is never mistaken for a declaration boundary.

Fixed all three occurrences of the identical magic-number pattern (`is_at_declaration_level_expect`, the inline `is_at_method_definition` guard, `is_at_type_alias_boundary`) rather than only the `@expect` one the issue names — they're the same one-line invariant repeated three times using a literal that was wrong in the same way, and threading the state once but only fixing one call site would leave the other two as an equally real, still-undetected latent bug (a `type X = ...`-shaped expression at col 2 in a synthetic-wrapped body would still falsely truncate the same way).

## Tests

- New regression test `synthetic_wrap_shape_body_level_expect_is_not_declaration_level` (`source_analysis/parser/tests/method_tests.rs`) — the issue's exact minimal repro, verifying all 3 statements (including the one after `@expect`) survive.
- `KNOWN_DIVERGENT_METHODS` in BT-3217's `corpus_receiver_span_walk_matches_syntactic_send_walk` (`source_analysis/method_span_corpus_tests.rs`) emptied per this issue's acceptance criteria — the test's own "every allowlist entry must still actually diverge" assertion now fails loudly if it's ever non-empty again, so a regression here would be caught immediately.
- Full parser test suite (600 tests) and full `beamtalk-core` lib suite (5737 tests) — all green, no regressions from the boundary-check change on canonically-nested methods (which keep the same `2` they always used).

## Testing

- `just ci-changed` — full build, clippy, dialyzer, all formatting checks, Rust tests, Erlang runtime EUnit, stdlib tests, BUnit, metamorphic tests, corpus check, surface-drift check: all green.

## Out of scope

- Nothing else — this is a pure parser bug fix with no schema/runtime/codegen changes, matching the issue's own scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUP4xDUPTzhKZgpRiWLYQL)_