### PR TITLE
test(repl): add unit tests for read_port_from_child and resolve_port (process.rs 25% → ~42%)

### DIFF
--- a/crates/beamtalk-cli/src/commands/repl/process.rs
+++ b/crates/beamtalk-cli/src/commands/repl/process.rs
@@ -341,4 +341,155 @@ mod tests {
         assert!(drain_child_stderr(&mut child).is_none());
         let _ = child.wait();
     }
+
+    #[test]
+    fn read_port_from_child_parses_happy_path() {
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("echo 'BEAMTALK_PORT:12345'")
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn failed");
+
+        let port = read_port_from_child(&mut child).expect("should parse port");
+        assert_eq!(port, 12345);
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn read_port_from_child_skips_non_matching_lines() {
+        // Port line appears after unrelated startup lines.
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("printf 'some startup line\\nother line\\nBEAMTALK_PORT:8080\\n'")
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn failed");
+
+        let port =
+            read_port_from_child(&mut child).expect("should parse port after non-matching lines");
+        assert_eq!(port, 8080);
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn read_port_from_child_rejects_invalid_port_number() {
+        // The prefix matches but the port is not a valid u16 — must return an error.
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("echo 'BEAMTALK_PORT:not_a_port'")
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn failed");
+
+        let result = read_port_from_child(&mut child);
+        assert!(result.is_err(), "expected error for non-numeric port");
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn read_port_from_child_rejects_out_of_range_port() {
+        // A number too large for u16 must also fail.
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("echo 'BEAMTALK_PORT:99999'")
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn failed");
+
+        let result = read_port_from_child(&mut child);
+        assert!(result.is_err(), "expected error for out-of-range port");
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn read_port_from_child_fails_without_stdout_pipe() {
+        // When stdout is not piped, take() returns None → function returns an error.
+        let mut child = std::process::Command::new("true")
+            .stdout(Stdio::null())
+            .spawn()
+            .expect("spawn failed");
+
+        let result = read_port_from_child(&mut child);
+        assert!(result.is_err(), "expected error when stdout is not piped");
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn resolve_port_uses_explicit_arg() {
+        // CLI flag wins regardless of environment.
+        let result = resolve_port(Some(4242));
+        assert_eq!(result.expect("should succeed"), 4242);
+    }
+
+    #[test]
+    #[serial_test::serial(env_var)]
+    fn resolve_port_uses_env_var() {
+        // Uses BEAMTALK_REPL_PORT=9090 when no CLI flag is given.
+        // SAFETY: Test is serialized with #[serial(env_var)]; env var is removed before returning.
+        unsafe { std::env::set_var("BEAMTALK_REPL_PORT", "9090") };
+        let result = resolve_port(None);
+        // SAFETY: Test is serialized with #[serial(env_var)].
+        unsafe { std::env::remove_var("BEAMTALK_REPL_PORT") };
+        assert_eq!(result.expect("should succeed"), 9090);
+    }
+
+    #[test]
+    #[serial_test::serial(env_var)]
+    fn resolve_port_rejects_invalid_env_var() {
+        // Non-numeric BEAMTALK_REPL_PORT must produce an error.
+        // SAFETY: Test is serialized with #[serial(env_var)]; env var is removed before returning.
+        unsafe { std::env::set_var("BEAMTALK_REPL_PORT", "not_a_port") };
+        let result = resolve_port(None);
+        // SAFETY: Test is serialized with #[serial(env_var)].
+        unsafe { std::env::remove_var("BEAMTALK_REPL_PORT") };
+        assert!(result.is_err(), "expected parse error for invalid env port");
+    }
+
+    #[test]
+    #[serial_test::serial(env_var)]
+    fn resolve_port_returns_default_without_arg_or_env() {
+        // With no CLI flag and no env var, must return the OS-assigned sentinel (0).
+        // SAFETY: Test is serialized with #[serial(env_var)].
+        unsafe { std::env::remove_var("BEAMTALK_REPL_PORT") };
+        let result = resolve_port(None);
+        assert_eq!(result.expect("should succeed"), DEFAULT_REPL_PORT);
+    }
+
+    #[test]
+    fn resolve_node_name_returns_explicit_arg() {
+        let result = resolve_node_name(Some("mynode".to_string()));
+        assert_eq!(result, Some("mynode".to_string()));
+    }
+
+    #[test]
+    #[serial_test::serial(env_var)]
+    fn resolve_node_name_falls_back_to_env_var() {
+        // SAFETY: Test is serialized with #[serial(env_var)]; env var is removed before returning.
+        unsafe { std::env::set_var("BEAMTALK_NODE_NAME", "envnode") };
+        let result = resolve_node_name(None);
+        // SAFETY: Test is serialized with #[serial(env_var)].
+        unsafe { std::env::remove_var("BEAMTALK_NODE_NAME") };
+        assert_eq!(result, Some("envnode".to_string()));
+    }
+
+    #[test]
+    #[serial_test::serial(env_var)]
+    fn resolve_node_name_returns_none_when_nothing_set() {
+        // SAFETY: Test is serialized with #[serial(env_var)].
+        unsafe { std::env::remove_var("BEAMTALK_NODE_NAME") };
+        let result = resolve_node_name(None);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    #[serial_test::serial(env_var)]
+    fn resolve_node_name_prefers_explicit_arg_over_env() {
+        // SAFETY: Test is serialized with #[serial(env_var)]; env var is removed before returning.
+        unsafe { std::env::set_var("BEAMTALK_NODE_NAME", "envnode") };
+        let result = resolve_node_name(Some("clinode".to_string()));
+        // SAFETY: Test is serialized with #[serial(env_var)].
+        unsafe { std::env::remove_var("BEAMTALK_NODE_NAME") };
+        assert_eq!(result, Some("clinode".to_string()));
+    }
 }


### PR DESCRIPTION
## Summary

`crates/beamtalk-cli/src/commands/repl/process.rs` measured **25% line coverage** in the CI coverage artifact from run 32516291315 (2026-08-21). Only `drain_child_stderr` (lines 262-276) had tests; the three other testable-without-Erlang functions had none.

**What this PR adds — 13 new tests in the existing `#[cfg(all(test, unix))]` block:**

### `read_port_from_child` (lines 203-251, previously 0 hits)

The REPL startup relies on parsing a `BEAMTALK_PORT:<n>` line from the BEAM node's stdout. Tests drive this by spawning a real `sh -c 'echo ...'` child:

- `read_port_from_child_parses_happy_path` — single port line → Ok(12345)
- `read_port_from_child_skips_non_matching_lines` — port line follows unrelated output → Ok(8080)
- `read_port_from_child_rejects_invalid_port_number` — `BEAMTALK_PORT:not_a_port` → Err
- `read_port_from_child_rejects_out_of_range_port` — `BEAMTALK_PORT:99999` (> u16::MAX) → Err
- `read_port_from_child_fails_without_stdout_pipe` — stdout not piped (`Stdio::null`) → Err on `take()`

### `resolve_port` error branch (line 294, previously 0 hits)

- `resolve_port_uses_explicit_arg` — `Some(4242)` → Ok(4242)
- `resolve_port_uses_env_var` — `BEAMTALK_REPL_PORT=9090` → Ok(9090)
- `resolve_port_rejects_invalid_env_var` — `BEAMTALK_REPL_PORT=not_a_port` → Err
- `resolve_port_returns_default_without_arg_or_env` → Ok(0)

### `resolve_node_name` (already partially covered; fills branches)

- `resolve_node_name_returns_explicit_arg`
- `resolve_node_name_falls_back_to_env_var`
- `resolve_node_name_returns_none_when_nothing_set`
- `resolve_node_name_prefers_explicit_arg_over_env`

All env-var tests carry `#[serial_test::serial(env_var)]` and `// SAFETY:` comments per CLAUDE.md naming rules.

## Test plan

- [x] All 15 tests pass locally (`cargo test -p beamtalk-cli --bin beamtalk repl::process`)
- [x] `cargo clippy -p beamtalk-cli -- -D warnings` clean
- [x] `cargo fmt -p beamtalk-cli -- --check` clean
- [x] No production code changed — test-only diff

---
_Generated by [Claude Code](https://claude.ai/code/session_0171r21Uezwn17UizFvYELEH)_