### PR TITLE
test(repl-protocol): tighten remove_from_system placeholder assertions

### DIFF
--- a/tests/repl-protocol/cases/remove_from_system.btscript
+++ b/tests/repl-protocol/cases/remove_from_system.btscript
@@ -21,7 +21,7 @@
 
 Value subclass: TempClassForRemoval
   greet => "hello"
-// => _
+// => TempClassForRemoval
 
 // Verify class is defined
 TempClassForRemoval new greet
@@ -37,7 +37,7 @@ Object allSubclasses includes: TempClassForRemoval
 
 // Save a reference to the class before removing it
 tempClass := TempClassForRemoval
-// => _
+// => TempClassForRemoval
 
 // Remove the class
 TempClassForRemoval removeFromSystem


### PR DESCRIPTION
## Summary

Replace two `// => _` wildcard assertions in `tests/repl-protocol/cases/remove_from_system.btscript` with exact expected values:

- **Line 24** — class definition (`Value subclass: TempClassForRemoval … // => _`) → `// => TempClassForRemoval`. Class definitions always return the newly-defined class object, displayed as the class name.
- **Line 40** — class object reference (`tempClass := TempClassForRemoval // => _`) → `// => TempClassForRemoval`. Evaluating a class name returns the class object, which displays as its name.

The third `// => _` (line 60, a `ChangeEntry` object) is legitimately non-deterministic and stays a wildcard.

## Evidence

Pattern confirmed by three existing btscript files:
- `adr_0105_killer_demo.btscript`: `Actor subclass: KillerDemoCounter … // => KillerDemoCounter`
- `recheck_image_and_precheck.btscript`: `Actor subclass: RecheckPrecheckCounter … // => RecheckPrecheckCounter`
- `workspace_native_api.btscript`: `Beamtalk classNamed: #Integer // => Integer`

## Test plan

- [x] `just test-repl-protocol` passes (confirmed locally; the two infrastructure-timeout failures seen in parallel runs are BEAM startup flakes unrelated to this file)
- [x] Pre-push hooks pass (clippy, dialyzer, stdlib build, spec validation)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBdZ9u2dkBvFDtL1VgiZHJ)_