### PR TITLE
perf(runtime): cache protocol_registry:conforms_to/2 results (BT-3222)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
@@ -655,6 +655,10 @@ init({ClassName, ClassInfo}) ->
     %% class hierarchy during dispatch sees a consistent view (announce-after-
     %% commit). Fire-and-forget; never fails class creation.
     announce_class_lifecycle('ClassLoaded', ClassName),
+    %% BT-3222: A newly-registered class may change conforms_to/2 results for
+    %% ClassName itself (a prior call, made before this class existed, could
+    %% have cached `false`) — flush so the next query re-walks live state.
+    beamtalk_protocol_registry:invalidate_conforms_cache(),
 
     {ok, State}.
 
@@ -960,6 +964,10 @@ handle_call(
     %% from the live class_state record instead.  Return types are cleared for
     %% hot-patched methods — the compiler treats them as dynamic.
     notify_hot_patch(NewState),
+    %% BT-3222: A hot-patched instance method changes what ClassName (and
+    %% every subclass inheriting through it) understands, invalidating any
+    %% cached conforms_to/2 result for either.
+    beamtalk_protocol_registry:invalidate_conforms_cache(),
     {reply, ok, NewState};
 %% ADR 0084 / BT-2266: Install or replace a class-side method with a runtime fun.
 %% Class-side mirror of {put_method, ...}. The fun is stored in the class_methods
@@ -994,6 +1002,10 @@ handle_call(
     %% is unavailable.
     put_method_xref(ClassName, true, Selector, Source),
     notify_hot_patch(NewState),
+    %% BT-3222: A hot-patched class-side method changes conforms_to/2's
+    %% class-method check (class_has_class_method/2) for ClassName and every
+    %% descendant walked through it.
+    beamtalk_protocol_registry:invalidate_conforms_cache(),
     {reply, ok, NewState};
 %% BT-572: Update class metadata after redefinition (hot reload).
 %% BT-737/BT-738: Validation (shadowing + collision) delegated to beamtalk_class_registry.
@@ -1042,6 +1054,12 @@ handle_call({update_class, ClassInfo}, _From, #class_state{name = ClassName} = S
             %% announced from the handle_call reply path after the refreshed
             %% metadata is committed.
             announce_class_lifecycle('ClassLoaded', ClassName),
+            %% BT-3222: Hot reload can change ClassName's method set (and this
+            %% is also the path classRemoveSelector/2 takes for a local-method
+            %% removal, via beamtalk_repl_eval:remove_method/4's recompile),
+            %% which changes conforms_to/2 for ClassName and every descendant
+            %% re-walked through it — flush rather than tracking descendants.
+            beamtalk_protocol_registry:invalidate_conforms_cache(),
             {reply, {ok, NewState#class_state.fields}, NewState}
     end;
 handle_call(instance_variables, _From, #class_state{fields = IVars} = State) ->

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_protocol_registry.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_protocol_registry.erl
@@ -82,9 +82,15 @@ ran. Clearing rows can't prevent that: the write simply happens after the
 clear. Stamping the generation *before* the compute and checking it *after*
 means a bump anywhere in between is always visible to the reader: the stored
 generation is behind, so it's a permanent miss for that entry, not a
-resurrected stale value (BT-3222 review round 2). Table size stays bounded
-regardless — entries are only ever overwritten per-key, never accumulate
-across bumps. Bumped on:
+resurrected stale value (BT-3222 review round 2). A repeated `{ClassName,
+ProtocolName}` pair's entry is overwritten in place, never duplicated, so
+the table doesn't grow from re-querying the same pair across generations —
+but unlike the old whole-table flush, a bump never removes rows for a pair
+that stops being queried (e.g. a class renamed or removed mid-session), so
+those linger until that exact name is queried again. Unbounded in principle
+over a long, churny hot-reload session with ever-fresh class names; accepted
+because real class/protocol names are near-universally reused, not
+uniquely generated per reload. Bumped on:
 
 - `register_protocol/1` / `unregister_protocol/1` (this module)
 - class registration and hot reload — `beamtalk_object_class:init/1` and its
@@ -441,7 +447,7 @@ Call sites are listed there.
 invalidate_conforms_cache() ->
     try
         ets:update_counter(
-            ?CONFORMS_CACHE_TABLE, ?CONFORMS_CACHE_GEN_KEY, 1, {?CONFORMS_CACHE_GEN_KEY, 1}
+            ?CONFORMS_CACHE_TABLE, ?CONFORMS_CACHE_GEN_KEY, 1, {?CONFORMS_CACHE_GEN_KEY, 0}
         ),
         ok
     catch

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_protocol_registry.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_protocol_registry.erl
@@ -60,12 +60,31 @@ ETS table (`beamtalk_protocol_conforms_cache`) keyed by `{ClassName,
 ProtocolName}`, so a repeated pair is an ETS lookup with no `gen_server:call`
 at all.
 
-Invalidation is a conservative whole-table flush (`invalidate_conforms_cache/0`)
-rather than fine-grained per-class/per-protocol tracking — conformance depends
-on the *transitive* method set, so a `put_method` on an ancestor invalidates
-every descendant's conformance, not just the class it was called on; proving a
-fine-grained scheme sound is materially harder than proving "flush everything"
-sound, and the flush itself is O(1) (`ets:delete_all_objects/1`). Flushed on:
+Invalidation is a conservative whole-cache flush rather than fine-grained
+per-class/per-protocol tracking — conformance depends on the *transitive*
+method set, so a `put_method` on an ancestor invalidates every descendant's
+conformance, not just the class it was called on; proving a fine-grained
+scheme sound is materially harder than proving "flush everything" sound.
+
+The flush is a monotonic **generation counter**, not `ets:delete_all_objects/1`
+on the results themselves: each cache entry is stamped `{Result, Gen}` with
+the generation sampled *before* `compute_conforms_to/2` runs, and
+`invalidate_conforms_cache/0` bumps a single counter rather than clearing
+rows. `cache_lookup/1` only treats an entry as a hit if its stamped `Gen`
+still equals the *current* counter. This closes a lost-invalidation race a
+row-clearing flush cannot: `compute_conforms_to/2` is a multi-`gen_server:call`
+walk that can take milliseconds (see the timings below), so a flush that
+lands *during* an in-flight compute — e.g. `beamtalk_xref:compute_relatedness/3`
+calling `conforms_to/2` from inside hot-reload's own `senders_of/2` recompute,
+concurrently with the very mutation that triggers the flush — must not let
+that compute's now-stale result land in the cache *after* the flush already
+ran. Clearing rows can't prevent that: the write simply happens after the
+clear. Stamping the generation *before* the compute and checking it *after*
+means a bump anywhere in between is always visible to the reader: the stored
+generation is behind, so it's a permanent miss for that entry, not a
+resurrected stale value (BT-3222 review round 2). Table size stays bounded
+regardless — entries are only ever overwritten per-key, never accumulate
+across bumps. Bumped on:
 
 - `register_protocol/1` / `unregister_protocol/1` (this module)
 - class registration and hot reload — `beamtalk_object_class:init/1` and its
@@ -101,6 +120,10 @@ concurrently (e.g. during test teardown).
 
 -define(PROTOCOL_TABLE, beamtalk_protocol_registry).
 -define(CONFORMS_CACHE_TABLE, beamtalk_protocol_conforms_cache).
+%% Generation-counter row inside ?CONFORMS_CACHE_TABLE (BT-3222). Not a valid
+%% `{atom(), atom()}` cache key shape, so it can never collide with a real
+%% `{ClassName, ProtocolName}` entry in the same `set` table.
+-define(CONFORMS_CACHE_GEN_KEY, '$conforms_cache_generation').
 
 %%% ============================================================================
 %%% Initialization
@@ -267,9 +290,9 @@ Returns `false` if:
 BT-3222: Results are cached in `?CONFORMS_CACHE_TABLE`, keyed by
 `{ClassName, ProtocolName}` — a repeated pair is a plain ETS lookup with no
 `gen_server:call` to any class process. See this module's "Conformance
-Cache" doc for the full invalidation list; a stale entry is never returned
-across a class or protocol mutation because every mutation site flushes the
-whole cache table.
+Cache" doc for the full invalidation list and why a generation-stamped entry,
+not a whole-table flush, is what actually makes a stale entry unreturnable
+across a class or protocol mutation.
 """.
 -spec conforms_to(atom(), atom()) -> boolean().
 conforms_to(ClassName, ProtocolName) ->
@@ -278,8 +301,12 @@ conforms_to(ClassName, ProtocolName) ->
         {ok, Cached} ->
             Cached;
         miss ->
+            %% Sampled *before* compute_conforms_to/2 runs — see the
+            %% "Conformance Cache" moduledoc for why the store below must
+            %% carry this pre-compute generation, not one read afterward.
+            Gen = current_generation(),
             Result = compute_conforms_to(ClassName, ProtocolName),
-            cache_store(CacheKey, Result),
+            cache_store(CacheKey, Result, Gen),
             Result
     end.
 
@@ -329,7 +356,10 @@ compute_conforms_to(ClassName, ProtocolName) ->
 -doc """
 Look up a cached `conforms_to/2` result.
 
-`badarg`-safe: a missing table (never initialised, or torn down
+A hit requires the entry's stamped generation to still equal the *current*
+generation counter — an entry stamped before a bump is a permanent miss,
+never a stale hit, regardless of write timing (see the "Conformance Cache"
+moduledoc). `badarg`-safe: a missing table (never initialised, or torn down
 concurrently — e.g. mid test-teardown) reports a cache miss rather than
 raising, exactly like every other lookup in this module.
 """.
@@ -341,8 +371,13 @@ cache_lookup(Key) ->
                 miss;
             _ ->
                 case ets:lookup(?CONFORMS_CACHE_TABLE, Key) of
-                    [{_, Result}] -> {ok, Result};
-                    [] -> miss
+                    [{_, {Result, Gen}}] ->
+                        case Gen =:= current_generation() of
+                            true -> {ok, Result};
+                            false -> miss
+                        end;
+                    [] ->
+                        miss
                 end
         end
     catch
@@ -350,19 +385,23 @@ cache_lookup(Key) ->
     end.
 
 -doc """
-Store a `conforms_to/2` result in the cache.
+Store a `conforms_to/2` result in the cache, stamped with the generation
+sampled before it was computed.
 
-`badarg`-safe (see `cache_lookup/1`) — a failed store just means the next
-call recomputes, never a crash.
+No compare-and-swap against the current generation is needed here — that's
+the point of stamp-and-validate-on-read (see the moduledoc): a store carrying
+a now-stale `Gen` is harmless because `cache_lookup/1` will never treat it as
+a hit. `badarg`-safe (see `cache_lookup/1`) — a failed store just means the
+next call recomputes, never a crash.
 """.
--spec cache_store({atom(), atom()}, boolean()) -> ok.
-cache_store(Key, Result) ->
+-spec cache_store({atom(), atom()}, boolean(), non_neg_integer()) -> ok.
+cache_store(Key, Result, Gen) ->
     try
         case ets:info(?CONFORMS_CACHE_TABLE) of
             undefined ->
                 ok;
             _ ->
-                ets:insert(?CONFORMS_CACHE_TABLE, {Key, Result}),
+                ets:insert(?CONFORMS_CACHE_TABLE, {Key, {Result, Gen}}),
                 ok
         end
     catch
@@ -370,29 +409,41 @@ cache_store(Key, Result) ->
     end.
 
 -doc """
-Flush every cached `conforms_to/2` result (BT-3222).
+Read the current cache generation, initialising it to `0` if this is the
+first read since the table was created.
 
-A conservative whole-table flush rather than fine-grained per-class/
-per-protocol invalidation — conformance depends on the *transitive* method
-set, so a mutation on one class can change the cached result for every
-descendant, not just itself; proving "flush everything" correct is far
-simpler than proving a fine-grained scheme tracks every such dependency, and
-the flush itself is a single O(1) `ets:delete_all_objects/1`. Call sites are
-listed in this module's "Conformance Cache" doc.
+`badarg`-safe: reports `0` if the table is missing or torn down concurrently,
+matching every other accessor in this module — a caller that gets `0` here
+either finds no matching row on the immediately-following `cache_lookup/1`
+(miss, safe) or is racing table teardown entirely, in which case the result
+is discarded anyway.
+""".
+-spec current_generation() -> non_neg_integer().
+current_generation() ->
+    try
+        ets:update_counter(
+            ?CONFORMS_CACHE_TABLE, ?CONFORMS_CACHE_GEN_KEY, 0, {?CONFORMS_CACHE_GEN_KEY, 0}
+        )
+    catch
+        error:badarg -> 0
+    end.
+
+-doc """
+Invalidate every cached `conforms_to/2` result (BT-3222) by bumping the
+generation counter — see the "Conformance Cache" moduledoc for why a
+counter bump, not `ets:delete_all_objects/1`, is what makes this race-free.
+Call sites are listed there.
 
 `badarg`-safe: a missing or concurrently-torn-down table is a no-op, matching
-`cache_lookup/1` / `cache_store/2`.
+`cache_lookup/1` / `cache_store/3`.
 """.
 -spec invalidate_conforms_cache() -> ok.
 invalidate_conforms_cache() ->
     try
-        case ets:info(?CONFORMS_CACHE_TABLE) of
-            undefined ->
-                ok;
-            _ ->
-                ets:delete_all_objects(?CONFORMS_CACHE_TABLE),
-                ok
-        end
+        ets:update_counter(
+            ?CONFORMS_CACHE_TABLE, ?CONFORMS_CACHE_GEN_KEY, 1, {?CONFORMS_CACHE_GEN_KEY, 1}
+        ),
+        ok
     catch
         error:badarg -> ok
     end.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_protocol_registry.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_protocol_registry.erl
@@ -48,6 +48,39 @@ via `beamtalk_behaviour_intrinsics:classCanUnderstandFromName/2`.
 
 See also: docs/ADR/0068-parametric-types-and-protocols.md — Stage 2
 See also: beamtalk_behaviour_intrinsics — backs the class-side primitives
+
+## Conformance Cache (BT-3222)
+
+`conforms_to/2` is a structural check: for every required selector it walks
+the ancestor chain via `classCanUnderstandFromName/2`, which is a
+`gen_server:call` per level — measured at 59-135 µs/call on a live 109-class
+workspace (`docs/internal/adr-0115-phase1-spike-findings.md` §3), four orders
+of magnitude above the ETS lookups around it. Results are cached in a second
+ETS table (`beamtalk_protocol_conforms_cache`) keyed by `{ClassName,
+ProtocolName}`, so a repeated pair is an ETS lookup with no `gen_server:call`
+at all.
+
+Invalidation is a conservative whole-table flush (`invalidate_conforms_cache/0`)
+rather than fine-grained per-class/per-protocol tracking — conformance depends
+on the *transitive* method set, so a `put_method` on an ancestor invalidates
+every descendant's conformance, not just the class it was called on; proving a
+fine-grained scheme sound is materially harder than proving "flush everything"
+sound, and the flush itself is O(1) (`ets:delete_all_objects/1`). Flushed on:
+
+- `register_protocol/1` / `unregister_protocol/1` (this module)
+- class registration and hot reload — `beamtalk_object_class:init/1` and its
+  `{update_class, _}` handler (a class's method set can change on either)
+- live method patches — `beamtalk_object_class`'s `{put_method, ...}` and
+  `{put_class_method, ...}` handlers (hot-patch / `classRemoveSelector` on a
+  local method routes through `update_class`, already covered above)
+- class removal — `beamtalk_class_lifecycle:class_removed/2` calls
+  `unregister_protocol/1` unconditionally, which flushes regardless of
+  whether the removed class's module defined any protocols itself
+
+Every cache read/write/flush is `ets:info/1`-guarded and try/catch-wrapped
+around `badarg`, matching every other table in this module — the cache is
+simply skipped (never crashes a caller) if the table is absent or torn down
+concurrently (e.g. during test teardown).
 """.
 
 -include_lib("kernel/include/logger.hrl").
@@ -62,10 +95,12 @@ See also: beamtalk_behaviour_intrinsics — backs the class-side primitives
     conforming_classes/1,
     protocol_info/1,
     is_protocol/1,
-    all_protocol_names/0
+    all_protocol_names/0,
+    invalidate_conforms_cache/0
 ]).
 
 -define(PROTOCOL_TABLE, beamtalk_protocol_registry).
+-define(CONFORMS_CACHE_TABLE, beamtalk_protocol_conforms_cache).
 
 %%% ============================================================================
 %%% Initialization
@@ -80,9 +115,19 @@ any compiled modules load their protocol definitions.
 BT-3105: Carries `beamtalk_class_registry:heir_option/0` (the runtime
 supervisor, once it is alive) so an owner crash hands the table off instead
 of destroying every registered protocol.
+
+BT-3222: Also creates the `conforms_to/2` result cache table (see this
+module's "Conformance Cache" doc), heir-protected the same way.
 """.
 -spec init() -> ok.
 init() ->
+    ensure_protocol_table(),
+    ensure_conforms_cache_table(),
+    ok.
+
+-doc "Idempotently create the protocol definitions ETS table.".
+-spec ensure_protocol_table() -> ok.
+ensure_protocol_table() ->
     case ets:info(?PROTOCOL_TABLE) of
         undefined ->
             ets:new(?PROTOCOL_TABLE, [
@@ -95,6 +140,30 @@ init() ->
             ok;
         _ ->
             %% Table already exists (e.g., re-init after hot reload)
+            ok
+    end.
+
+-doc """
+Idempotently create the `conforms_to/2` result cache ETS table (BT-3222).
+
+Keyed by `{ClassName, ProtocolName}` -> `boolean()`. Separate from
+`?PROTOCOL_TABLE` so a whole-cache flush (`invalidate_conforms_cache/0`) never
+touches registered protocol definitions.
+""".
+-spec ensure_conforms_cache_table() -> ok.
+ensure_conforms_cache_table() ->
+    case ets:info(?CONFORMS_CACHE_TABLE) of
+        undefined ->
+            ets:new(?CONFORMS_CACHE_TABLE, [
+                named_table,
+                set,
+                public,
+                {read_concurrency, true},
+                {write_concurrency, true}
+                | beamtalk_class_registry:heir_option()
+            ]),
+            ok;
+        _ ->
             ok
     end.
 
@@ -121,6 +190,10 @@ Duplicate registrations overwrite the previous entry (idempotent for hot reload)
 -spec register_protocol(map()) -> ok.
 register_protocol(#{name := Name} = Info) ->
     ets:insert(?PROTOCOL_TABLE, {Name, Info}),
+    %% BT-3222: A (re-)registered protocol can change required_methods /
+    %% extending for Name, so every cached conforms_to/2 result naming it —
+    %% for any class — is potentially stale.
+    invalidate_conforms_cache(),
     ?LOG_DEBUG(
         "Registered protocol ~p",
         [Name],
@@ -163,7 +236,14 @@ unregister_protocol(Module) when is_atom(Module) ->
                 {{'_', #{module => '$1'}}, [{'=:=', '$1', {const, Module}}], [true]}
             ]),
             ok
-    end.
+    end,
+    %% BT-3222: Unconditional, not just on an actual match — this is also the
+    %% single call `beamtalk_class_lifecycle:class_removed/2` makes for every
+    %% class removal, and a removed class's conformance results (as well as
+    %% every descendant re-walked through it) must not survive as stale
+    %% cache entries even when the removed class's own module defined no
+    %% protocol.
+    invalidate_conforms_cache().
 
 %%% ============================================================================
 %%% Query API
@@ -183,9 +263,30 @@ Returns `true` if:
 Returns `false` if:
 - The protocol is not registered (unknown or non-protocol names)
 - The class is missing one or more required selectors (instance or class)
+
+BT-3222: Results are cached in `?CONFORMS_CACHE_TABLE`, keyed by
+`{ClassName, ProtocolName}` — a repeated pair is a plain ETS lookup with no
+`gen_server:call` to any class process. See this module's "Conformance
+Cache" doc for the full invalidation list; a stale entry is never returned
+across a class or protocol mutation because every mutation site flushes the
+whole cache table.
 """.
 -spec conforms_to(atom(), atom()) -> boolean().
 conforms_to(ClassName, ProtocolName) ->
+    CacheKey = {ClassName, ProtocolName},
+    case cache_lookup(CacheKey) of
+        {ok, Cached} ->
+            Cached;
+        miss ->
+            Result = compute_conforms_to(ClassName, ProtocolName),
+            cache_store(CacheKey, Result),
+            Result
+    end.
+
+%% The uncached structural check — exactly what conforms_to/2 did before
+%% BT-3222; the caching wrapper above is the only change to its call sites.
+-spec compute_conforms_to(atom(), atom()) -> boolean().
+compute_conforms_to(ClassName, ProtocolName) ->
     case protocol_info(ProtocolName) of
         undefined ->
             %% Unknown protocol — cannot conform to something that isn't a protocol
@@ -219,6 +320,81 @@ conforms_to(ClassName, ProtocolName) ->
                     ),
                     false
             end
+    end.
+
+%%% ============================================================================
+%%% Conformance Cache (BT-3222)
+%%% ============================================================================
+
+-doc """
+Look up a cached `conforms_to/2` result.
+
+`badarg`-safe: a missing table (never initialised, or torn down
+concurrently — e.g. mid test-teardown) reports a cache miss rather than
+raising, exactly like every other lookup in this module.
+""".
+-spec cache_lookup({atom(), atom()}) -> {ok, boolean()} | miss.
+cache_lookup(Key) ->
+    try
+        case ets:info(?CONFORMS_CACHE_TABLE) of
+            undefined ->
+                miss;
+            _ ->
+                case ets:lookup(?CONFORMS_CACHE_TABLE, Key) of
+                    [{_, Result}] -> {ok, Result};
+                    [] -> miss
+                end
+        end
+    catch
+        error:badarg -> miss
+    end.
+
+-doc """
+Store a `conforms_to/2` result in the cache.
+
+`badarg`-safe (see `cache_lookup/1`) — a failed store just means the next
+call recomputes, never a crash.
+""".
+-spec cache_store({atom(), atom()}, boolean()) -> ok.
+cache_store(Key, Result) ->
+    try
+        case ets:info(?CONFORMS_CACHE_TABLE) of
+            undefined ->
+                ok;
+            _ ->
+                ets:insert(?CONFORMS_CACHE_TABLE, {Key, Result}),
+                ok
+        end
+    catch
+        error:badarg -> ok
+    end.
+
+-doc """
+Flush every cached `conforms_to/2` result (BT-3222).
+
+A conservative whole-table flush rather than fine-grained per-class/
+per-protocol invalidation — conformance depends on the *transitive* method
+set, so a mutation on one class can change the cached result for every
+descendant, not just itself; proving "flush everything" correct is far
+simpler than proving a fine-grained scheme tracks every such dependency, and
+the flush itself is a single O(1) `ets:delete_all_objects/1`. Call sites are
+listed in this module's "Conformance Cache" doc.
+
+`badarg`-safe: a missing or concurrently-torn-down table is a no-op, matching
+`cache_lookup/1` / `cache_store/2`.
+""".
+-spec invalidate_conforms_cache() -> ok.
+invalidate_conforms_cache() ->
+    try
+        case ets:info(?CONFORMS_CACHE_TABLE) of
+            undefined ->
+                ok;
+            _ ->
+                ets:delete_all_objects(?CONFORMS_CACHE_TABLE),
+                ok
+        end
+    catch
+        error:badarg -> ok
     end.
 
 -doc """

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_protocol_registry_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_protocol_registry_tests.erl
@@ -738,6 +738,53 @@ conforms_to_invalidated_by_class_removal_test() ->
     ok = beamtalk_class_lifecycle:class_removed('BT3222RemovalClass', bt3222_removal_class_mod),
     ?assertNot(beamtalk_protocol_registry:conforms_to('BT3222RemovalClass', 'BT3222RemovalProto')).
 
+-doc """
+Regression test for the lost-invalidation race flagged in review (BT-3222,
+round 2): a `compute_conforms_to/2` result that finishes *after* a
+concurrent `invalidate_conforms_cache/0` bump must never be treated as a
+cache hit.
+
+Simulated directly on the cache's public ETS table rather than with real
+concurrency (this repo has no mocking library, and reliably interleaving a
+real millisecond-scale `gen_server:call` walk against a bump within one
+EUnit test is impractical): it inserts an entry stamped with a generation
+*older* than the table's current counter — exactly what a race-losing
+`cache_store/3` call would have written had it lost the race — and asserts
+`conforms_to/2` recomputes instead of returning it.
+""".
+conforms_to_ignores_entry_stamped_with_stale_generation_test() ->
+    rt_setup(),
+    ok = beamtalk_protocol_registry:register_protocol(#{
+        name => 'BT3222RaceProto',
+        required_methods => [#{selector => ping, arity => 0}],
+        type_params => [],
+        extending => undefined
+    }),
+    {ok, Pid} = start_class_with_ping('BT3222RaceClass'),
+    %% Prime the cache table + generation counter — any conforms_to/2 call
+    %% does this as a side effect; the result itself doesn't matter here.
+    _ = beamtalk_protocol_registry:conforms_to('BT3222RaceClass', 'BT3222RaceProto'),
+    %% Bump the generation past whatever that primed entry was stamped with —
+    %% mirrors a mutation's invalidate_conforms_cache/0 firing while a
+    %% concurrent compute was still in flight.
+    ok = beamtalk_protocol_registry:invalidate_conforms_cache(),
+    CurrentGen = ets:lookup_element(
+        beamtalk_protocol_conforms_cache, '$conforms_cache_generation', 2
+    ),
+    %% Simulate a compute that started *before* the bump above landing
+    %% *after* it: a wrong (`false`) answer stamped with the now-stale
+    %% pre-bump generation, written directly to bypass conforms_to/2's own
+    %% (correct) generation sampling.
+    StaleGen = CurrentGen - 1,
+    true = ets:insert(
+        beamtalk_protocol_conforms_cache,
+        {{'BT3222RaceClass', 'BT3222RaceProto'}, {false, StaleGen}}
+    ),
+    %% A stale-generation entry must never be returned — conforms_to/2 must
+    %% recompute and see the true, current answer.
+    ?assert(beamtalk_protocol_registry:conforms_to('BT3222RaceClass', 'BT3222RaceProto')),
+    stop_class_process(Pid).
+
 -doc "invalidate_conforms_cache/0 is a no-op (never raises) when the cache table doesn't exist.".
 invalidate_conforms_cache_before_init_test() ->
     case ets:info(beamtalk_protocol_conforms_cache) of

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_protocol_registry_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_protocol_registry_tests.erl
@@ -27,7 +27,55 @@ setup() ->
         undefined -> ok;
         _ -> ets:delete_all_objects(beamtalk_protocol_registry)
     end,
+    %% BT-3222: Also clear the conforms_to/2 cache so a result cached by one
+    %% test can never leak into the next.
+    beamtalk_protocol_registry:invalidate_conforms_cache(),
     ok.
+
+-doc """
+`setup/0` plus the scaffolding needed to start real class gen_server
+processes (BT-3222 cache tests exercise class registration/hot-reload/
+put_method/removal, which `setup/0` alone doesn't need). Mirrors
+`beamtalk_object_class_tests:setup/0`.
+""".
+rt_setup() ->
+    setup(),
+    case whereis(pg) of
+        undefined ->
+            {ok, _} = pg:start_link();
+        _ ->
+            ok
+    end,
+    beamtalk_class_registry:ensure_hierarchy_table(),
+    beamtalk_class_registry:ensure_module_table(),
+    beamtalk_class_registry:ensure_pid_table(),
+    beamtalk_class_registry:ensure_loaded_classes_table(),
+    ok.
+
+-doc "Start a class registered under ClassName with a single `ping` method (arity 0).".
+-spec start_class_with_ping(atom()) -> {ok, pid()}.
+start_class_with_ping(ClassName) ->
+    ClassInfo = #{
+        name => ClassName,
+        module => list_to_atom("bt3222_mod_" ++ atom_to_list(ClassName)),
+        instance_methods => #{ping => #{block => fun() -> pong end, arity => 0}}
+    },
+    beamtalk_object_class:start(ClassName, ClassInfo).
+
+-doc "Kill a class process and wait for it to fully exit (name auto-unregisters).".
+-spec stop_class_process(pid()) -> ok.
+stop_class_process(Pid) ->
+    case is_process_alive(Pid) of
+        true ->
+            MRef = monitor(process, Pid),
+            exit(Pid, kill),
+            receive
+                {'DOWN', MRef, process, Pid, _} -> ok
+            after 1000 -> ok
+            end;
+        false ->
+            ok
+    end.
 
 %%% ============================================================================
 %%% Registration Tests
@@ -487,4 +535,215 @@ unregister_protocol_before_init_test() ->
             beamtalk_protocol_registry:init();
         _ ->
             ?assertEqual(ok, beamtalk_protocol_registry:unregister_protocol('bt3105_any_mod'))
+    end.
+
+%%% ============================================================================
+%%% BT-3222: conforms_to/2 result cache + invalidation
+%%% ============================================================================
+
+%% ADR 0112 note: classRemoveSelector/2's local-method-removal branch (the
+%% only branch that can change conforms_to/2's answer — extension removal
+%% does not, since classCanUnderstandFromName/2 never consults the extension
+%% registry) recompiles the class and hot-reloads it via
+%% beamtalk_repl_eval:remove_method/4 -> ... -> beamtalk_object_class's own
+%% {update_class, _} handler (see that module's `remove_method/4` doc). It is
+%% therefore covered by conforms_to_invalidated_by_update_class_test/0 below
+%% rather than duplicated with the heavier beamtalk_workspace live-source
+%% scaffolding beamtalk_workspace_revert_tests.erl needs to drive the
+%% primitive end to end.
+
+-doc """
+Base case: a repeated `{ClassName, ProtocolName}` pair returns the cached
+result instead of re-walking the hierarchy. Proven by killing the class
+process between the two calls — a live recompute would hit `noproc` and flip
+to `false` (mirroring `compute_conforms_to/2`'s own `catch -> false`), so the
+second call only reads `true` if it came from the cache, not a fresh walk.
+""".
+conforms_to_caches_result_across_process_death_test() ->
+    rt_setup(),
+    ok = beamtalk_protocol_registry:register_protocol(#{
+        name => 'BT3222PingProto',
+        required_methods => [#{selector => ping, arity => 0}],
+        type_params => [],
+        extending => undefined
+    }),
+    {ok, Pid} = start_class_with_ping('BT3222CacheHitClass'),
+    ?assert(beamtalk_protocol_registry:conforms_to('BT3222CacheHitClass', 'BT3222PingProto')),
+    stop_class_process(Pid),
+    %% The class process is gone; a fresh walk would fail — the cache must
+    %% still answer `true`.
+    ?assert(beamtalk_protocol_registry:conforms_to('BT3222CacheHitClass', 'BT3222PingProto')).
+
+-doc "register_protocol/1 must invalidate a stale cached `false`.".
+conforms_to_invalidated_by_protocol_registration_test() ->
+    rt_setup(),
+    {ok, Pid} = start_class_with_ping('BT3222ProtoRegClass'),
+    %% Protocol not registered yet — cannot conform (and this gets cached).
+    ?assertNot(
+        beamtalk_protocol_registry:conforms_to('BT3222ProtoRegClass', 'BT3222LatePingProto')
+    ),
+    ok = beamtalk_protocol_registry:register_protocol(#{
+        name => 'BT3222LatePingProto',
+        required_methods => [#{selector => ping, arity => 0}],
+        type_params => [],
+        extending => undefined
+    }),
+    ?assert(
+        beamtalk_protocol_registry:conforms_to('BT3222ProtoRegClass', 'BT3222LatePingProto')
+    ),
+    stop_class_process(Pid).
+
+-doc "unregister_protocol/1 must invalidate a stale cached `true`.".
+conforms_to_invalidated_by_unregister_protocol_test() ->
+    rt_setup(),
+    ok = beamtalk_protocol_registry:register_protocol(#{
+        name => 'BT3222UnregProto',
+        module => bt3222_unreg_proto_mod,
+        required_methods => [#{selector => ping, arity => 0}],
+        type_params => [],
+        extending => undefined
+    }),
+    {ok, Pid} = start_class_with_ping('BT3222UnregClass'),
+    ?assert(beamtalk_protocol_registry:conforms_to('BT3222UnregClass', 'BT3222UnregProto')),
+    ok = beamtalk_protocol_registry:unregister_protocol(bt3222_unreg_proto_mod),
+    ?assertNot(beamtalk_protocol_registry:conforms_to('BT3222UnregClass', 'BT3222UnregProto')),
+    stop_class_process(Pid).
+
+-doc """
+Class registration (`beamtalk_object_class:init/1`) must invalidate a stale
+cached `false` recorded before the class existed.
+""".
+conforms_to_invalidated_by_class_registration_test() ->
+    rt_setup(),
+    ok = beamtalk_protocol_registry:register_protocol(#{
+        name => 'BT3222RegLaterProto',
+        required_methods => [#{selector => ping, arity => 0}],
+        type_params => [],
+        extending => undefined
+    }),
+    %% Class doesn't exist yet.
+    ?assertNot(
+        beamtalk_protocol_registry:conforms_to('BT3222RegLaterClass', 'BT3222RegLaterProto')
+    ),
+    {ok, Pid} = start_class_with_ping('BT3222RegLaterClass'),
+    ?assert(
+        beamtalk_protocol_registry:conforms_to('BT3222RegLaterClass', 'BT3222RegLaterProto')
+    ),
+    stop_class_process(Pid).
+
+-doc """
+Class re-registration / hot reload (`{update_class, _}`) must invalidate a
+stale cached result — this is also the mechanism
+`classRemoveSelector:`/`removeSelector:` uses to remove a *local* method (see
+this section's note above).
+""".
+conforms_to_invalidated_by_update_class_test() ->
+    rt_setup(),
+    ok = beamtalk_protocol_registry:register_protocol(#{
+        name => 'BT3222HotReloadProto',
+        required_methods => [#{selector => ping, arity => 0}],
+        type_params => [],
+        extending => undefined
+    }),
+    ClassInfo = #{
+        name => 'BT3222HotReloadClass',
+        module => bt3222_hot_reload_mod,
+        instance_methods => #{}
+    },
+    {ok, Pid} = beamtalk_object_class:start('BT3222HotReloadClass', ClassInfo),
+    ?assertNot(
+        beamtalk_protocol_registry:conforms_to('BT3222HotReloadClass', 'BT3222HotReloadProto')
+    ),
+    NewInfo = ClassInfo#{instance_methods => #{ping => #{block => fun() -> pong end}}},
+    {ok, _Fields} = beamtalk_object_class:update_class('BT3222HotReloadClass', NewInfo),
+    ?assert(
+        beamtalk_protocol_registry:conforms_to('BT3222HotReloadClass', 'BT3222HotReloadProto')
+    ),
+    stop_class_process(Pid).
+
+-doc "put_method/4 (instance-side hot patch) must invalidate a stale cached `false`.".
+conforms_to_invalidated_by_put_method_test() ->
+    rt_setup(),
+    ok = beamtalk_protocol_registry:register_protocol(#{
+        name => 'BT3222PutMethodProto',
+        required_methods => [#{selector => ping, arity => 0}],
+        type_params => [],
+        extending => undefined
+    }),
+    ClassInfo = #{
+        name => 'BT3222PutMethodClass',
+        module => bt3222_put_method_mod,
+        instance_methods => #{}
+    },
+    {ok, Pid} = beamtalk_object_class:start('BT3222PutMethodClass', ClassInfo),
+    ?assertNot(
+        beamtalk_protocol_registry:conforms_to('BT3222PutMethodClass', 'BT3222PutMethodProto')
+    ),
+    ok = beamtalk_object_class:put_method(Pid, ping, fun() -> pong end, <<"ping => pong">>),
+    ?assert(
+        beamtalk_protocol_registry:conforms_to('BT3222PutMethodClass', 'BT3222PutMethodProto')
+    ),
+    stop_class_process(Pid).
+
+-doc "put_class_method/4 (class-side hot patch) must invalidate a stale cached `false`.".
+conforms_to_invalidated_by_put_class_method_test() ->
+    rt_setup(),
+    ok = beamtalk_protocol_registry:register_protocol(#{
+        name => 'BT3222PutClassMethodProto',
+        required_methods => [],
+        required_class_methods => [#{selector => make, arity => 0}],
+        type_params => [],
+        extending => undefined
+    }),
+    ClassInfo = #{
+        name => 'BT3222PutClassMethodClass',
+        module => bt3222_put_class_method_mod,
+        instance_methods => #{}
+    },
+    {ok, Pid} = beamtalk_object_class:start('BT3222PutClassMethodClass', ClassInfo),
+    ?assertNot(
+        beamtalk_protocol_registry:conforms_to(
+            'BT3222PutClassMethodClass', 'BT3222PutClassMethodProto'
+        )
+    ),
+    ok = beamtalk_object_class:put_class_method(Pid, make, fun() -> ok end, <<"make => ok">>),
+    ?assert(
+        beamtalk_protocol_registry:conforms_to(
+            'BT3222PutClassMethodClass', 'BT3222PutClassMethodProto'
+        )
+    ),
+    stop_class_process(Pid).
+
+-doc """
+Class removal (`beamtalk_class_lifecycle:class_removed/2`, the single
+teardown path `classRemoveFromSystemByName/1` drives) must invalidate a stale
+cached `true` for the removed class — proven the same way as the base-case
+test above: the cache still answers `true` immediately after the process
+dies (nothing has flushed it yet), and only flips to `false` once
+`class_removed/2` runs.
+""".
+conforms_to_invalidated_by_class_removal_test() ->
+    rt_setup(),
+    ok = beamtalk_protocol_registry:register_protocol(#{
+        name => 'BT3222RemovalProto',
+        required_methods => [#{selector => ping, arity => 0}],
+        type_params => [],
+        extending => undefined
+    }),
+    {ok, Pid} = start_class_with_ping('BT3222RemovalClass'),
+    ?assert(beamtalk_protocol_registry:conforms_to('BT3222RemovalClass', 'BT3222RemovalProto')),
+    stop_class_process(Pid),
+    %% Not yet flushed — still cached `true`.
+    ?assert(beamtalk_protocol_registry:conforms_to('BT3222RemovalClass', 'BT3222RemovalProto')),
+    ok = beamtalk_class_lifecycle:class_removed('BT3222RemovalClass', bt3222_removal_class_mod),
+    ?assertNot(beamtalk_protocol_registry:conforms_to('BT3222RemovalClass', 'BT3222RemovalProto')).
+
+-doc "invalidate_conforms_cache/0 is a no-op (never raises) when the cache table doesn't exist.".
+invalidate_conforms_cache_before_init_test() ->
+    case ets:info(beamtalk_protocol_conforms_cache) of
+        undefined ->
+            ?assertEqual(ok, beamtalk_protocol_registry:invalidate_conforms_cache()),
+            beamtalk_protocol_registry:init();
+        _ ->
+            ?assertEqual(ok, beamtalk_protocol_registry:invalidate_conforms_cache())
     end.


### PR DESCRIPTION
## Summary

Fixes BT-3222 (scaling follow-up from the ADR 0115 Phase 1 validation spike, BT-3216 — `docs/internal/adr-0115-phase1-spike-findings.md` §3).

`beamtalk_protocol_registry:conforms_to/2` is a structural conformance check with no memoisation at any layer. For every required instance selector (including inherited-via-`extending` ones) it calls `beamtalk_behaviour_intrinsics:classCanUnderstandFromName/2`, which walks the ancestor chain making a `gen_server:call` to the class's own process for every level. Measured at 59-135µs/call on a live 109-class workspace — four orders of magnitude above the ETS lookups around it.

This adds a second ETS table (`beamtalk_protocol_conforms_cache`), keyed by `{ClassName, ProtocolName} -> boolean()`, read/written/flushed with the same `ets:info`-guarded, `badarg`-safe pattern every other table in `beamtalk_protocol_registry` already uses.

## Invalidation strategy: whole-cache flush (not fine-grained)

Went with the issue's suggested conservative approach — flush the entire cache table on any class or protocol mutation — rather than fine-grained per-class/per-protocol tracking. Conformance depends on the *transitive* method set, so a `put_method` on an ancestor can change every descendant's cached result, not just the class it was called on; proving "flush everything" correct is a single `ets:delete_all_objects/1` call, while proving a dependency-tracking scheme sound would require reasoning about the full subclass graph on every mutation. The flush is O(1) either way, so there's no measured reason to reach for anything finer-grained.

Flush call sites (all in `beamtalk_runtime`, no new cross-app dependency):
- `register_protocol/1` / `unregister_protocol/1` (`beamtalk_protocol_registry.erl`) — also the single call `beamtalk_class_lifecycle:class_removed/2` already makes for *every* class removal, so "class removal" is covered for free by making the flush in `unregister_protocol/1` unconditional rather than gated on an actual row match.
- Class registration — `beamtalk_object_class:init/1`.
- Hot reload — the `{update_class, _}` handler. This is also the exact mechanism `classRemoveSelector:`'s local-method-removal branch uses (`beamtalk_repl_eval:remove_method/4` recompiles and hot-reloads the class), so it's covered by the same hook without a separate one.
- Live method patches — the `{put_method, _}` and `{put_class_method, _}` handlers.

(Extension-method mutations, e.g. `Class extend [...]`, are out of scope: `beamtalk_object_class:has_method/2` — what `classCanUnderstandFromName/2` actually calls — never consults the extension registry, so extensions can't change a `conforms_to/2` result to begin with; this was already true before this change.)

## Measured improvement

`escript perf/bench_recv_type_spike.escript` §B, same container, before/after this change (stash-based A/B, not cross-container):

| | before | after (warm cache) |
|---|---|---|
| `conforms_to/2` — `JsonRepresentable`, 12 classes | 148.7 µs/call | 0.6 µs/call |
| `conforms_to/2` — `Printable`, 12 classes | 202.2 µs/call | 0.7 µs/call |

In line with the spike's 59–135µs baseline. The improvement is larger than the spike's own "~20-30x from per-call memoisation" estimate because that estimate was for memoising *within* a single `senders_of/2` call (reset every invocation); a registry-level cache stays warm across calls, so a repeated `{Class, Protocol}` pair anywhere in the system — not just within one hot-reload trigger — is now a plain ETS read.

## Testing

- New EUnit coverage in `beamtalk_protocol_registry_tests.erl` (9 new tests, `conforms_to_*`), one per invalidation trigger from the acceptance criteria: protocol registration, `unregister_protocol/1`, class registration, hot reload/`update_class`, `put_method`, `put_class_method`, class removal (via `beamtalk_class_lifecycle:class_removed/2`), plus a base-case cache-hit test (kills the class process between two calls to prove the second call is served from cache, not a live re-walk) and a before-init `badarg`-safety test.
- Full `just ci-changed` run locally: build, clippy, dialyzer, fmt checks, Rust tests, Erlang runtime/stdlib/BUnit tests (5799 runtime unit tests incl. the 9 new ones, all passing), corpus check, surface-drift check — all green.

## Test plan
- [x] `just ci-changed` clean locally
- [x] New EUnit tests cover every invalidation trigger in the acceptance criteria
- [x] Before/after benchmark captured against `bench_recv_type_spike.escript` §B
- [ ] CI green on the PR
- [ ] Claude review bot findings addressed

Refs: BT-3222, BT-3216, ADR 0115, ADR 0068

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01EUP4xDUPTzhKZgpRiWLYQL

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUP4xDUPTzhKZgpRiWLYQL)_