### PR TITLE
Runtime: index superclass column so direct_subclasses/1 stops full-table scanning (BT-3221)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_metadata.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_metadata.erl
@@ -634,9 +634,10 @@ reset_runtime_class_methods(Name) ->
 %% `undefined` writes). `undefined` never has a corresponding index row —
 %% only actually-written superclass values (including the literal atom
 %% `none` for a root class) do — so it is never inserted or deleted as an
-%% edge target. Best-effort: a table-absent race (only possible mid-teardown,
-%% since new/0 always runs first in every caller) degrades to leaving the
-%% index momentarily stale rather than crashing the write it is attached to.
+%% edge target. Best-effort: a table-absent race (e.g. mid-teardown, or
+%% `delete/1`'s call site, which does not call `new/0` first) degrades to
+%% leaving the index momentarily stale rather than crashing the write it is
+%% attached to.
 -spec sync_subclass_index(class_name(), superclass() | undefined, superclass() | undefined) -> ok.
 sync_subclass_index(_Name, Same, Same) ->
     ok;

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_metadata.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_metadata.erl
@@ -43,6 +43,27 @@ absence of the others.
   the supervisor is alive so `beamtalk_runtime_sup` is set as `{heir, ...}`. The
   table therefore survives both a class-process crash and an app-master swap.
 
+## Reverse subclass index (BT-3221)
+
+`match_subclasses/1` is answered from a second table,
+`beamtalk_class_subclass_index` — a `bag` of `{Superclass, ClassName}` edges,
+keyed on `Superclass` — instead of an `ets:match/2` scan of every row in
+`?TABLE`. A `bag` table (many rows per key) cannot share `?TABLE`'s `set`
+semantics, so this is a genuine second table rather than a field on the
+existing row; the "second table" it replaces is only the mental model of a
+"seventh, independently-lifecycled table" that BT-2222 weighed against — this
+one has no owner module, public API, or lifecycle of its own. It is created
+and destroyed by this module's own `new/0`, and every write that can change a
+row's `superclass` (`insert/5`, `merge_identity/5`, `delete/1`) maintains it
+as an internal side effect via `sync_subclass_index/3`, keyed off the row's
+*previous* superclass value (read via `field/2` before the write lands) so a
+re-register that changes superclass removes the stale edge from the old
+parent rather than leaving it to accumulate. Storing the edge independently of
+the superclass's own row (rather than as a `subclasses` list field on it)
+means a class's children stay discoverable even if the parent's own row is
+gone (e.g. a crash mid-teardown) — matching the exact-scan semantics this
+replaces, which never depended on the queried class having a row at all.
+
 ## Concurrency
 
 `new/0` uses try/catch around `ets:new/2` for the TOCTOU race between
@@ -85,6 +106,10 @@ a table deleted between an existence check and the op (teardown/shutdown).
 %% `has_runtime_class_methods` flag gates reads on this table so compile-time-only
 %% classes pay nothing on the dispatch hot path (BT-2008).
 -define(FUN_TABLE, beamtalk_class_method_funs).
+%% BT-3221: reverse-edge index for match_subclasses/1 — a `bag` of
+%% {Superclass, ClassName} rows, keyed on Superclass. See moduledoc "Reverse
+%% subclass index".
+-define(SUBCLASS_INDEX, beamtalk_class_subclass_index).
 
 -type class_name() :: atom().
 -type superclass() :: class_name() | none.
@@ -135,6 +160,14 @@ new() ->
     %% Key = {DefiningClass, Selector}, Value = #{block, arity}.
     ensure_table(?FUN_TABLE, [
         set,
+        public,
+        named_table,
+        {read_concurrency, true}
+    ]),
+    %% BT-3221: reverse-edge index, {Superclass, ClassName} rows, default
+    %% keypos 1 (Superclass). `bag` because a superclass has many subclasses.
+    ensure_table(?SUBCLASS_INDEX, [
+        bag,
         public,
         named_table,
         {read_concurrency, true}
@@ -196,14 +229,20 @@ insert(Name, Module, Selectors, Superclass, IsAbstract) ->
         is_abstract = IsAbstract
     },
     new(),
+    %% BT-3221: read the row's previous superclass (undefined if there was no
+    %% row yet) before overwriting it, so the subclass index can drop the
+    %% stale edge from the old superclass if this call changes it.
+    OldSuperclass = field(Name, #class_metadata.superclass),
     try
         ets:insert(?TABLE, Row),
+        sync_subclass_index(Name, OldSuperclass, Superclass),
         ok
     catch
         error:badarg ->
             %% Table vanished between new/0 and ets:insert/2 — recreate and retry once.
             new(),
             ets:insert(?TABLE, Row),
+            sync_subclass_index(Name, OldSuperclass, Superclass),
             ok
     end.
 
@@ -235,6 +274,10 @@ apply_class_info/2`) always has a row already (the class went through
     ok.
 merge_identity(Name, Module, Selectors, Superclass, IsAbstract) ->
     new(),
+    %% BT-3221: read the previous superclass before the update lands, so a
+    %% re-register that changes superclass can drop the stale reverse edge
+    %% from the old parent (see sync_subclass_index/3).
+    OldSuperclass = field(Name, #class_metadata.superclass),
     %% ets:update_element/3 does NOT raise on a missing key — it returns
     %% `false` (only a missing/unwritable *table* raises badarg) — so the
     %% fallback to row creation must branch on the boolean return, not on a
@@ -248,10 +291,13 @@ merge_identity(Name, Module, Selectors, Superclass, IsAbstract) ->
         ])
     of
         true ->
+            sync_subclass_index(Name, OldSuperclass, Superclass),
             ok;
         false ->
             %% No existing row — fall back to row creation. A brand-new row
             %% has no funs to preserve, so insert/5's gate reset is correct.
+            %% insert/5 re-reads the (still-absent) old superclass itself, so
+            %% this never double-applies the index update.
             insert(Name, Module, Selectors, Superclass, IsAbstract)
     catch
         error:badarg ->
@@ -271,8 +317,16 @@ delete(Name) ->
     %% a class that is removed (or whose process terminates) leaves no stale
     %% dispatch entries behind.
     delete_class_method_funs(Name),
+    %% BT-3221: read the superclass before the row disappears, so the reverse
+    %% edge {Superclass, Name} can be dropped from the subclass index too —
+    %% otherwise Name would linger forever as a phantom subclass of its old
+    %% superclass. This does NOT touch edges keyed on Name itself (i.e. rows
+    %% for Name's own children) — those stay valid; a class's children remain
+    %% discoverable even if its own row is gone (see moduledoc).
+    OldSuperclass = field(Name, #class_metadata.superclass),
     try
         ets:delete(?TABLE, Name),
+        sync_subclass_index(Name, OldSuperclass, undefined),
         ok
     catch
         error:badarg -> ok
@@ -344,31 +398,20 @@ lookup_is_abstract(Name) ->
 -doc """
 Return all class names whose direct superclass is `Name`.
 
-Returns `[]` if the table does not exist.
+BT-3221: an indexed `ets:lookup/2` on the `beamtalk_class_subclass_index`
+reverse-edge table, not a full-table scan of `?TABLE` — O(subclass count)
+instead of O(loaded-class count). Returns `[]` if the index table does not
+exist (mirrors the old table-absent contract, now against the table this
+function actually reads).
 """.
 -spec match_subclasses(class_name()) -> [class_name()].
 match_subclasses(Name) ->
-    case ets:info(?TABLE) of
+    case ets:info(?SUBCLASS_INDEX) of
         undefined ->
             [];
         _ ->
             try
-                %% Build the match pattern from record field indices rather than a
-                %% literal tuple, so it stays correct if the record's fields are
-                %% reordered or extended. (Record syntax `#class_metadata{_ = '_'}`
-                %% can't be used here — it assigns the atom '_' to typed fields and
-                %% trips dialyzer.) Bind the name column, match the superclass column.
-                Pattern = erlang:make_tuple(
-                    record_info(size, class_metadata),
-                    '_',
-                    [
-                        {1, class_metadata},
-                        {#class_metadata.name, '$1'},
-                        {#class_metadata.superclass, Name}
-                    ]
-                ),
-                Matches = ets:match(?TABLE, Pattern),
-                [N || [N] <- Matches]
+                [ClassName || {_Superclass, ClassName} <- ets:lookup(?SUBCLASS_INDEX, Name)]
             catch
                 error:badarg -> []
             end
@@ -582,6 +625,49 @@ reset_runtime_class_methods(Name) ->
 %%====================================================================
 %% Internal
 %%====================================================================
+
+%% BT-3221: reconcile the {Superclass, ClassName} reverse-edge index with a
+%% row write that set Name's superclass to NewSuperclass, given the value it
+%% held immediately before (OldSuperclass, `undefined` if there was no prior
+%% row or the field was never written). A no-op when the value didn't change
+%% (covers the common re-register-with-same-superclass case, and repeated
+%% `undefined` writes). `undefined` never has a corresponding index row —
+%% only actually-written superclass values (including the literal atom
+%% `none` for a root class) do — so it is never inserted or deleted as an
+%% edge target. Best-effort: a table-absent race (only possible mid-teardown,
+%% since new/0 always runs first in every caller) degrades to leaving the
+%% index momentarily stale rather than crashing the write it is attached to.
+-spec sync_subclass_index(class_name(), superclass() | undefined, superclass() | undefined) -> ok.
+sync_subclass_index(_Name, Same, Same) ->
+    ok;
+sync_subclass_index(Name, OldSuperclass, NewSuperclass) ->
+    case OldSuperclass of
+        undefined -> ok;
+        _ -> delete_subclass_edge(OldSuperclass, Name)
+    end,
+    case NewSuperclass of
+        undefined -> ok;
+        _ -> insert_subclass_edge(NewSuperclass, Name)
+    end,
+    ok.
+
+-spec insert_subclass_edge(superclass(), class_name()) -> ok.
+insert_subclass_edge(Superclass, Name) ->
+    try
+        ets:insert(?SUBCLASS_INDEX, {Superclass, Name}),
+        ok
+    catch
+        error:badarg -> ok
+    end.
+
+-spec delete_subclass_edge(superclass(), class_name()) -> ok.
+delete_subclass_edge(Superclass, Name) ->
+    try
+        ets:delete_object(?SUBCLASS_INDEX, {Superclass, Name}),
+        ok
+    catch
+        error:badarg -> ok
+    end.
 
 %% Fetch a single field via ets:lookup_element/4 (OTP 26+), which copies only
 %% that element instead of the whole row — measurably faster than ets:lookup/2

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
@@ -583,11 +583,13 @@ find_class_method_in_chain/2` already uses) over `beamtalk_class_metadata:
 lookup_superclass/1` reads for the ancestor half — pure ETS, no
 `gen_server:call`.
 
-The descendant half is a full-table `ets:match/2` per node in the subtree
-(`beamtalk_class_metadata:match_subclasses/1` is unindexed on the
-superclass column) — O(N²) in loaded-class count for a root-class change,
-~500 µs at today's 109-class stdlib scale (spike §2). Accepted as-is for
-this issue; indexing that column is the separate follow-up BT-3221.
+The descendant half was a full-table `ets:match/2` per node in the subtree
+(O(N²) in loaded-class count for a root-class change, ~500 µs at the
+109-class stdlib scale measured in spike §2) until BT-3221 gave
+`beamtalk_class_metadata:match_subclasses/1` a reverse-edge index
+(`beamtalk_class_subclass_index`, a `bag` keyed on superclass): now one
+indexed `ets:lookup/2` per node, so the closure's scan count no longer
+tracks loaded-class count.
 """.
 -spec hierarchy_related_classes(class_name()) -> sets:set(class_name()).
 hierarchy_related_classes(ChangedClass) ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_metadata_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_metadata_tests.erl
@@ -12,34 +12,49 @@
 -define(TABLE, beamtalk_class_metadata).
 %% BT-2266: sibling table holding runtime class-method funs.
 -define(FUN_TABLE, beamtalk_class_method_funs).
+%% BT-3221: reverse-edge index backing match_subclasses/1.
+-define(SUBCLASS_INDEX, beamtalk_class_subclass_index).
 
 %% Save/clear/restore the shared table around each test so the live runtime's
-%% rows (if any) are not disturbed.
+%% rows (if any) are not disturbed. BT-3221: insert/5 and friends also write
+%% ?SUBCLASS_INDEX, so it must be cleared/restored in lockstep with ?TABLE —
+%% otherwise edges from one test's classes (e.g. 'Object' -> 'Actor') leak
+%% into the next test's match_subclasses/1 assertions via the index table,
+%% which ets:delete_all_objects(?TABLE) alone does not touch.
 with_clean_table(Fun) ->
     beamtalk_class_metadata:new(),
     Saved = ets:tab2list(?TABLE),
+    SavedIndex = ets:tab2list(?SUBCLASS_INDEX),
     ets:delete_all_objects(?TABLE),
+    ets:delete_all_objects(?SUBCLASS_INDEX),
     try
         Fun()
     after
         ets:delete_all_objects(?TABLE),
-        ets:insert(?TABLE, Saved)
+        ets:delete_all_objects(?SUBCLASS_INDEX),
+        ets:insert(?TABLE, Saved),
+        ets:insert(?SUBCLASS_INDEX, SavedIndex)
     end.
 
-%% BT-2266: clean both the metadata table and the funs sibling table.
+%% BT-2266 / BT-3221: clean the metadata table, the funs sibling table, and
+%% the subclass index together.
 with_clean_tables(Fun) ->
     beamtalk_class_metadata:new(),
     SavedMeta = ets:tab2list(?TABLE),
     SavedFuns = ets:tab2list(?FUN_TABLE),
+    SavedIndex = ets:tab2list(?SUBCLASS_INDEX),
     ets:delete_all_objects(?TABLE),
     ets:delete_all_objects(?FUN_TABLE),
+    ets:delete_all_objects(?SUBCLASS_INDEX),
     try
         Fun()
     after
         ets:delete_all_objects(?TABLE),
         ets:delete_all_objects(?FUN_TABLE),
+        ets:delete_all_objects(?SUBCLASS_INDEX),
         ets:insert(?TABLE, SavedMeta),
-        ets:insert(?FUN_TABLE, SavedFuns)
+        ets:insert(?FUN_TABLE, SavedFuns),
+        ets:insert(?SUBCLASS_INDEX, SavedIndex)
     end.
 
 %%====================================================================
@@ -194,6 +209,94 @@ match_subclasses_test() ->
         ?assertEqual(
             ['Counter', 'Timer'], lists:sort(beamtalk_class_metadata:match_subclasses('Actor'))
         )
+    end).
+
+%%====================================================================
+%% BT-3221: subclass index invalidation — register, re-register (same and
+%% changed superclass), and removal.
+%%====================================================================
+
+%% insert/5 (row creation, the class gen_server's init/1 path) publishes a
+%% reverse edge immediately.
+match_subclasses_reflects_insert_test() ->
+    with_clean_table(fun() ->
+        ?assertEqual([], beamtalk_class_metadata:match_subclasses('Object')),
+        ok = beamtalk_class_metadata:insert('Widget', m, [], 'Object', undefined),
+        ?assertEqual(['Widget'], beamtalk_class_metadata:match_subclasses('Object'))
+    end).
+
+%% merge_identity/5 (the reload path) re-registering a class under the SAME
+%% superclass must not duplicate the edge or disturb it.
+match_subclasses_reflects_reregister_same_superclass_test() ->
+    with_clean_table(fun() ->
+        ok = beamtalk_class_metadata:insert('Widget', m, [], 'Object', undefined),
+        ok = beamtalk_class_metadata:merge_identity('Widget', m2, [], 'Object', true),
+        ?assertEqual(['Widget'], beamtalk_class_metadata:match_subclasses('Object')),
+        %% Field update still landed.
+        ?assertEqual({ok, m2}, beamtalk_class_metadata:lookup_module('Widget'))
+    end).
+
+%% merge_identity/5 re-registering a class under a DIFFERENT superclass must
+%% drop the stale edge from the old superclass and publish one under the new
+%% superclass — the core invalidation case a naive cache would get wrong.
+match_subclasses_reflects_reregister_changed_superclass_test() ->
+    with_clean_table(fun() ->
+        ok = beamtalk_class_metadata:insert('Object', undefined, undefined, none, undefined),
+        ok = beamtalk_class_metadata:insert('Value', undefined, undefined, none, undefined),
+        ok = beamtalk_class_metadata:insert('Widget', m, [], 'Object', undefined),
+        ?assertEqual(['Widget'], beamtalk_class_metadata:match_subclasses('Object')),
+        ?assertEqual([], beamtalk_class_metadata:match_subclasses('Value')),
+
+        ok = beamtalk_class_metadata:merge_identity('Widget', m, [], 'Value', undefined),
+
+        ?assertEqual(
+            [], beamtalk_class_metadata:match_subclasses('Object')
+        ),
+        ?assertEqual(['Widget'], beamtalk_class_metadata:match_subclasses('Value'))
+    end).
+
+%% insert/5 called on an already-existing row (a full-row overwrite, not the
+%% documented usage but defensively covered — e.g. a crash-recovery re-init)
+%% must also invalidate a stale edge from the row's previous superclass.
+match_subclasses_reflects_insert_changed_superclass_test() ->
+    with_clean_table(fun() ->
+        ok = beamtalk_class_metadata:insert('Widget', m, [], 'Object', undefined),
+        ?assertEqual(['Widget'], beamtalk_class_metadata:match_subclasses('Object')),
+        ok = beamtalk_class_metadata:insert('Widget', m, [], 'Value', undefined),
+        ?assertEqual([], beamtalk_class_metadata:match_subclasses('Object')),
+        ?assertEqual(['Widget'], beamtalk_class_metadata:match_subclasses('Value'))
+    end).
+
+%% delete/1 (class teardown / classRemoveFromSystem) removes the edge from
+%% its (former) superclass so the deleted class stops appearing as a subclass.
+match_subclasses_reflects_delete_test() ->
+    with_clean_table(fun() ->
+        ok = beamtalk_class_metadata:insert('Widget', m, [], 'Object', undefined),
+        ?assertEqual(['Widget'], beamtalk_class_metadata:match_subclasses('Object')),
+        ok = beamtalk_class_metadata:delete('Widget'),
+        ?assertEqual([], beamtalk_class_metadata:match_subclasses('Object'))
+    end).
+
+%% delete/1 on a class that itself has (still-registered) subclasses must not
+%% disturb the edges those children published — deleting a row only removes
+%% the row's own out-edge to its superclass, never edges keyed on the row's
+%% own name. (classRemoveFromSystem already refuses removal while direct
+%% subclasses exist, but the index must not rely on that guard for
+%% correctness — see beamtalk_class_metadata module doc.)
+match_subclasses_survives_parent_delete_test() ->
+    with_clean_table(fun() ->
+        ok = beamtalk_class_metadata:insert('Object', undefined, undefined, none, undefined),
+        ok = beamtalk_class_metadata:insert('Widget', m, [], 'Object', undefined),
+        ok = beamtalk_class_metadata:delete('Object'),
+        ?assertEqual(['Widget'], beamtalk_class_metadata:match_subclasses('Object'))
+    end).
+
+%% delete/1 on a class with no row (never registered, or already deleted) is
+%% a no-op on the index too.
+match_subclasses_delete_missing_is_ok_test() ->
+    with_clean_table(fun() ->
+        ?assertEqual(ok, beamtalk_class_metadata:delete('NeverRegistered')),
+        ?assertEqual([], beamtalk_class_metadata:match_subclasses('Object'))
     end).
 
 foldl_collects_entries_with_superclass_test() ->
@@ -381,7 +484,10 @@ merge_identity_creates_row_when_absent_test() ->
         ok = beamtalk_class_metadata:merge_identity('Fresh', m, [a], 'Object', false),
         ?assertEqual({ok, m}, beamtalk_class_metadata:lookup_module('Fresh')),
         ?assertEqual({ok, m, [a]}, beamtalk_class_metadata:lookup_methods('Fresh')),
-        ?assertNot(beamtalk_class_metadata:has_runtime_class_methods('Fresh'))
+        ?assertNot(beamtalk_class_metadata:has_runtime_class_methods('Fresh')),
+        %% BT-3221: the create-fallback path also publishes the subclass
+        %% index edge — it must not require a row to have pre-existed.
+        ?assertEqual(['Fresh'], beamtalk_class_metadata:match_subclasses('Object'))
     end).
 
 %% reset_runtime_class_methods/1 explicitly clears the gate without touching
@@ -477,21 +583,27 @@ all_builtins_includes_core_classes_test() ->
 %%====================================================================
 
 %% Helper: delete the main metadata table, run Fun, restore state.
-%% Used by the three tests below that exercise the "table absent" return
-%% values of match_subclasses/1, foldl/2, and lookup_methods/1.
+%% Used by the tests below that exercise the "table absent" return
+%% values of foldl/2, foldl_modules/2, and lookup_methods/1. BT-3221: also
+%% clears/restores ?SUBCLASS_INDEX for isolation, even though none of these
+%% read it, since it is populated by the same insert/5 calls that seed ?TABLE.
 with_no_main_table(Fun) ->
     beamtalk_class_metadata:new(),
     SavedMeta = ets:tab2list(?TABLE),
     SavedFuns = ets:tab2list(?FUN_TABLE),
+    SavedIndex = ets:tab2list(?SUBCLASS_INDEX),
     ets:delete(?TABLE),
+    ets:delete_all_objects(?SUBCLASS_INDEX),
     try
         Fun()
     after
         beamtalk_class_metadata:new(),
         ets:delete_all_objects(?TABLE),
         ets:delete_all_objects(?FUN_TABLE),
+        ets:delete_all_objects(?SUBCLASS_INDEX),
         ets:insert(?TABLE, SavedMeta),
-        ets:insert(?FUN_TABLE, SavedFuns)
+        ets:insert(?FUN_TABLE, SavedFuns),
+        ets:insert(?SUBCLASS_INDEX, SavedIndex)
     end.
 
 %% Helper: delete the fun table, run Fun, restore state.
@@ -504,6 +616,7 @@ with_no_fun_table(Fun) ->
     beamtalk_class_metadata:new(),
     SavedMeta = ets:tab2list(?TABLE),
     SavedFuns = ets:tab2list(?FUN_TABLE),
+    SavedIndex = ets:tab2list(?SUBCLASS_INDEX),
     ets:delete(?FUN_TABLE),
     try
         Fun()
@@ -511,13 +624,36 @@ with_no_fun_table(Fun) ->
         beamtalk_class_metadata:new(),
         ets:delete_all_objects(?TABLE),
         ets:delete_all_objects(?FUN_TABLE),
+        ets:delete_all_objects(?SUBCLASS_INDEX),
         ets:insert(?TABLE, SavedMeta),
-        ets:insert(?FUN_TABLE, SavedFuns)
+        ets:insert(?FUN_TABLE, SavedFuns),
+        ets:insert(?SUBCLASS_INDEX, SavedIndex)
     end.
 
-%% match_subclasses/1 returns [] when the metadata table does not exist.
+%% Helper: delete the subclass index table, run Fun, restore state. BT-3221:
+%% match_subclasses/1 now reads ?SUBCLASS_INDEX, not ?TABLE, so its
+%% "table absent" contract is exercised against the table it actually reads.
+with_no_subclass_index_table(Fun) ->
+    beamtalk_class_metadata:new(),
+    SavedMeta = ets:tab2list(?TABLE),
+    SavedFuns = ets:tab2list(?FUN_TABLE),
+    SavedIndex = ets:tab2list(?SUBCLASS_INDEX),
+    ets:delete(?SUBCLASS_INDEX),
+    try
+        Fun()
+    after
+        beamtalk_class_metadata:new(),
+        ets:delete_all_objects(?TABLE),
+        ets:delete_all_objects(?FUN_TABLE),
+        ets:delete_all_objects(?SUBCLASS_INDEX),
+        ets:insert(?TABLE, SavedMeta),
+        ets:insert(?FUN_TABLE, SavedFuns),
+        ets:insert(?SUBCLASS_INDEX, SavedIndex)
+    end.
+
+%% match_subclasses/1 returns [] when the subclass index table does not exist.
 match_subclasses_when_table_absent_test() ->
-    with_no_main_table(fun() ->
+    with_no_subclass_index_table(fun() ->
         ?assertEqual([], beamtalk_class_metadata:match_subclasses('Object'))
     end).
 

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_registry_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_registry_tests.erl
@@ -208,16 +208,26 @@ direct_subclasses_test_() ->
         fun() ->
             beamtalk_class_registry:ensure_hierarchy_table(),
             Saved = ets:tab2list(beamtalk_class_metadata),
+            %% BT-3221: direct_subclasses/1 now reads beamtalk_class_subclass_index,
+            %% a table separate from beamtalk_class_metadata. Wiping only the main
+            %% table (as before) leaves this test's real, currently-loaded classes
+            %% still indexed, so 'Object'/'Actor' would resolve to their genuine
+            %% subclasses instead of this fixture's synthetic ones — must be
+            %% cleared/restored in lockstep with the main table.
+            SavedIndex = ets:tab2list(beamtalk_class_subclass_index),
             ets:delete_all_objects(beamtalk_class_metadata),
+            ets:delete_all_objects(beamtalk_class_subclass_index),
             beamtalk_class_metadata:insert('Object', undefined, undefined, none, undefined),
             beamtalk_class_metadata:insert('Actor', undefined, undefined, 'Object', undefined),
             beamtalk_class_metadata:insert('Counter', undefined, undefined, 'Actor', undefined),
             beamtalk_class_metadata:insert('Timer', undefined, undefined, 'Actor', undefined),
-            Saved
+            {Saved, SavedIndex}
         end,
-        fun(Saved) ->
+        fun({Saved, SavedIndex}) ->
             ets:delete_all_objects(beamtalk_class_metadata),
-            ets:insert(beamtalk_class_metadata, Saved)
+            ets:delete_all_objects(beamtalk_class_subclass_index),
+            ets:insert(beamtalk_class_metadata, Saved),
+            ets:insert(beamtalk_class_subclass_index, SavedIndex)
         end,
         [
             {"direct children of Actor", fun() ->
@@ -244,16 +254,22 @@ all_subclasses_test_() ->
         fun() ->
             beamtalk_class_registry:ensure_hierarchy_table(),
             Saved = ets:tab2list(beamtalk_class_metadata),
+            %% BT-3221: see direct_subclasses_test_/0's setup for why the
+            %% subclass index must be cleared/restored alongside the main table.
+            SavedIndex = ets:tab2list(beamtalk_class_subclass_index),
             ets:delete_all_objects(beamtalk_class_metadata),
+            ets:delete_all_objects(beamtalk_class_subclass_index),
             beamtalk_class_metadata:insert('Object', undefined, undefined, none, undefined),
             beamtalk_class_metadata:insert('Actor', undefined, undefined, 'Object', undefined),
             beamtalk_class_metadata:insert('Counter', undefined, undefined, 'Actor', undefined),
             beamtalk_class_metadata:insert('Timer', undefined, undefined, 'Actor', undefined),
-            Saved
+            {Saved, SavedIndex}
         end,
-        fun(Saved) ->
+        fun({Saved, SavedIndex}) ->
             ets:delete_all_objects(beamtalk_class_metadata),
-            ets:insert(beamtalk_class_metadata, Saved)
+            ets:delete_all_objects(beamtalk_class_subclass_index),
+            ets:insert(beamtalk_class_metadata, Saved),
+            ets:insert(beamtalk_class_subclass_index, SavedIndex)
         end,
         [
             {"all subclasses of Object", fun() ->


### PR DESCRIPTION
## Summary

[BT-3221](https://linear.app/beamtalk/issue/BT-3221/index-the-superclass-column-in-beamtalk-class-metadata-so-direct) — a scaling follow-up from the ADR 0115 Phase 1 validation spike (BT-3216, see `docs/internal/adr-0115-phase1-spike-findings.md` §2).

`beamtalk_class_registry:direct_subclasses/1` delegated to `beamtalk_class_metadata:match_subclasses/1`, which ran a **full-table `ets:match/2`** scan (the `beamtalk_class_metadata` table is a `set` keyed by class name, so `superclass` is unindexed). `all_subclasses/1` calls `direct_subclasses/1` once per node in the subtree it walks, so the transitive closure was **O(N²) in loaded-class count**.

This adds a reverse-edge index — `beamtalk_class_subclass_index`, a `bag` of `{Superclass, ClassName}` rows keyed on `Superclass` — maintained internally by `beamtalk_class_metadata`'s existing write paths (`insert/5`, `merge_identity/5`, `delete/1`). Each write reads the row's *previous* superclass value before landing the new one, so a re-register that changes superclass drops the stale edge from the old parent. `match_subclasses/1` is now a single indexed `ets:lookup/2`.

### Design choice

The spike surfaced two options: a `bag` sibling table keyed on superclass, or an `ets:select` match spec (still a scan). I went with the `bag` sibling table, and — per BT-2222's class-keyed-ETS-table survey (`docs/internal/class-keyed-ets-tables-investigation.md`) — kept it as an *internal* implementation detail of `beamtalk_class_metadata` rather than a new independently-lifecycled table: no owner module, no public API, created/destroyed by the same `new/0`, populated only as a side effect of the writes that already touch `superclass`.

I considered folding the reverse edges into the *existing* row instead (a `subclasses` list field on each class's own row, avoiding a second physical table entirely) — this is the more literal reading of the issue's "reverse-edge index on the existing row" framing. I rejected it: storing a class's children on the *parent's own row* means that data disappears if the parent's row is torn down (e.g. mid-crash, since `terminate/2` runs unconditionally on any process exit, not just the guarded `classRemoveFromSystem` path) while children still exist — and the exact-scan behaviour being replaced never depended on the queried class having a row at all. A separate `bag` table keyed independently of either endpoint's own row lifecycle preserves that invariant exactly, at the cost of one extra table.

### Measured (109-class stdlib workspace, `runtime/perf/bench_recv_type_spike.escript`, unloaded dev container, 3-run ranges)

| | before | after |
|---|---|---|
| `match_subclasses/1` (single call) | 4.9–10.9 µs | 0.6–1.0 µs |
| `all_subclasses('ProtoObject')` (108 descendants) | 474.6–492.1 µs | 71.4–107.1 µs |
| `hierarchy_related_classes('ProtoObject')` | 469.9–475.8 µs | 71.9–120.6 µs |

The raw "match scans" count per closure (~100–110) is unchanged — it's the number of subtree nodes visited, not the index change's target. What changed is that each of those scans is now an O(1) indexed lookup instead of an O(loaded-class-count) full-table scan, so the *cost per scan* stops tracking loaded-class count — at 1,000 loaded classes this stays roughly flat instead of costing ~100x today's numbers.

## Acceptance criteria

- [x] `direct_subclasses/1` resolves without scanning every metadata row
- [x] Index stays consistent across registration, re-registration (same and changed superclass), and removal
- [x] `all_subclasses/1`/`direct_subclasses/1` keep their exact contracts (sorted atom lists, `[]` when table absent, `badarg`-safe during teardown)
- [x] Measured improvement recorded above
- [x] EUnit coverage for every invalidation case (register, re-register same/changed superclass including the create-fallback path, delete, and survival of a parent-row delete)

## Files changed

- `runtime/apps/beamtalk_runtime/src/beamtalk_class_metadata.erl` — the index table, its lifecycle, and the write-path/read-path changes
- `runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl` — doc comment update (this was the module documenting the O(N²) cost as accepted-for-now with a pointer to this issue)
- `runtime/apps/beamtalk_runtime/test/beamtalk_class_metadata_tests.erl` — new invalidation-case tests + existing helpers updated to manage the new table
- `runtime/apps/beamtalk_runtime/test/beamtalk_class_registry_tests.erl` — two fixtures that directly manipulate the raw ETS table updated to clear/restore the new index table too (otherwise real loaded-class data leaks through it into the fixture's synthetic hierarchy)

## Test plan

- [x] `just ci-changed` — full local CI (build, lint/clippy/fmt, Rust tests, stdlib tests, BUnit, runtime EUnit 5797+1837 tests, metamorphic tests, corpus check, surface-drift check) — all green
- [x] `just dialyzer` — clean
- [x] Before/after perf numbers captured against `bench_recv_type_spike.escript` (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUP4xDUPTzhKZgpRiWLYQL


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUP4xDUPTzhKZgpRiWLYQL)_