### PR TITLE
xref: precise Union/Intersection recv_type keying for senders_of/2 (BT-3215)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs
@@ -62,7 +62,21 @@ enum RecvType {
     /// `beamtalk_class_registry:class_object_tag/1` rather than falling into
     /// the "otherwise unresolved" bucket by omission (spike §1e).
     ClassObject(EcoString),
-    /// Everything else: `Union`/`Intersection`/`Negation`/`Dynamic`/`Never`,
+    /// BT-3215: a `Union{members}` receiver where *every* member itself
+    /// resolves to a single name or class-object tag (never `Dynamic`) —
+    /// the already-rendered atoms, sorted and deduplicated. The read path's
+    /// `is_relevant/3` treats this with OR-semantics: relevant iff *any*
+    /// member is relevant, since the receiver could be any one of them at
+    /// runtime.
+    Union(Vec<EcoString>),
+    /// BT-3215: same resolution rule as [`RecvType::Union`], for
+    /// `Intersection{members}`. The read path uses AND-semantics: relevant
+    /// only if *every* member is relevant, since the receiver must
+    /// simultaneously satisfy all of them.
+    Intersection(Vec<EcoString>),
+    /// Everything else: `Negation`/`Dynamic`/`Never`, a `Union`/
+    /// `Intersection` with at least one member that doesn't resolve to a
+    /// single name (nested composed type, `Dynamic`, oversized atom, …),
     /// no `TypeMap` entry at all, or a `Known` whose provenance is
     /// `Extracted` (native/FFI, ADR 0075) or `Aliased` (ADR 0108) — neither
     /// of those two names has a `beamtalk_class_metadata` row, so coarsening
@@ -91,19 +105,62 @@ fn project_recv_type(ty: &InferredType) -> RecvType {
             | TypeProvenance::Substituted(_) => RecvType::Name(class_name.clone()),
         },
         InferredType::Meta { class_name, .. } => RecvType::ClassObject(class_name.clone()),
-        InferredType::Union { .. }
-        | InferredType::Dynamic(_)
-        | InferredType::Never
-        | InferredType::Negation { .. }
-        | InferredType::Intersection { .. } => RecvType::Dynamic,
+        // BT-3215: project each member the same way a single-name receiver
+        // would be projected; if every member resolves cleanly, key on the
+        // member list instead of coarsening the whole composed type away.
+        InferredType::Union { members, .. } => project_composed(members, RecvType::Union),
+        InferredType::Intersection { members, .. } => {
+            project_composed(members, RecvType::Intersection)
+        }
+        InferredType::Dynamic(_) | InferredType::Never | InferredType::Negation { .. } => {
+            RecvType::Dynamic
+        }
     }
 }
 
-/// Renders a [`RecvType`] as the Core Erlang atom literal baked into a
-/// `method_xref` send entry's `recv_type` field, falling back to `'dynamic'`
-/// for a name that would exceed Erlang's 255-byte atom cap (mirrors the
-/// `MAX_ATOM_BYTES` guard `build_method_xref_entry` already applies to
-/// selectors and class references).
+/// BT-3215: shared `Union`/`Intersection` projection — resolves each member
+/// to the same single atom [`recv_type_atom`] would render for it as a
+/// standalone receiver, via [`project_recv_type`] recursively. A nested
+/// composed type or anything else that isn't a clean single name (`Dynamic`,
+/// an oversized atom, a native/alias-coarsened `Known`, …) makes any member
+/// unresolvable — per Constraint 2 ("cannot be narrowed and must never be
+/// excluded"), a *partial* member list would be unsound: dropping an
+/// unresolvable member and keying on only the resolvable ones would make the
+/// read path wrongly exclude a real dependent whose receiver happens to be
+/// typed as that dropped member at runtime. So any unresolvable member
+/// coarsens the *entire* composed type to `dynamic`, exactly like a
+/// single-name receiver that doesn't resolve.
+fn project_composed(members: &[InferredType], make: fn(Vec<EcoString>) -> RecvType) -> RecvType {
+    const MAX_ATOM_BYTES: usize = 255;
+    let mut names: Vec<EcoString> = Vec::with_capacity(members.len());
+    for member in members {
+        let resolved = match project_recv_type(member) {
+            RecvType::Name(name) if name.len() <= MAX_ATOM_BYTES => name,
+            RecvType::ClassObject(name) if name.len() + " class".len() <= MAX_ATOM_BYTES => {
+                EcoString::from(super::super::util::metaclass_tag(&name))
+            }
+            RecvType::Name(_)
+            | RecvType::ClassObject(_)
+            | RecvType::Union(_)
+            | RecvType::Intersection(_)
+            | RecvType::Dynamic => return RecvType::Dynamic,
+        };
+        names.push(resolved);
+    }
+    names.sort();
+    names.dedup();
+    make(names)
+}
+
+/// Renders a [`RecvType`] as the Core Erlang literal baked into a
+/// `method_xref` send entry's `recv_type` field: a bare atom for
+/// `Name`/`ClassObject`/`Dynamic`, or a `{'union' | 'intersection',
+/// [Atom, ...]}` tuple for a composed type (BT-3215). Falls back to
+/// `'dynamic'` for a name that would exceed Erlang's 255-byte atom cap
+/// (mirrors the `MAX_ATOM_BYTES` guard `build_method_xref_entry` already
+/// applies to selectors and class references) — `project_composed` already
+/// enforces this per member, so `Union`/`Intersection` never reach here with
+/// an oversized member atom.
 fn recv_type_atom(recv_type: &RecvType) -> Document<'static> {
     const MAX_ATOM_BYTES: usize = 255;
     match recv_type {
@@ -111,8 +168,21 @@ fn recv_type_atom(recv_type: &RecvType) -> Document<'static> {
         RecvType::ClassObject(name) if name.len() + " class".len() <= MAX_ATOM_BYTES => {
             leaf::atom(super::super::util::metaclass_tag(name))
         }
+        RecvType::Union(names) => docvec!["{'union', ", recv_type_name_list_doc(names), "}"],
+        RecvType::Intersection(names) => {
+            docvec!["{'intersection', ", recv_type_name_list_doc(names), "}"]
+        }
         RecvType::Name(_) | RecvType::ClassObject(_) | RecvType::Dynamic => leaf::atom("dynamic"),
     }
+}
+
+/// Renders a `[Atom, ...]` Core Erlang list of already-resolved member
+/// names for a `Union`/`Intersection` `recv_type` (BT-3215) — the shared
+/// bracket/comma-join helper the two `recv_type_atom` composed-type arms
+/// use, mirroring `meta_type_repr_list_doc`'s bracket/join pattern.
+fn recv_type_name_list_doc(names: &[EcoString]) -> Document<'static> {
+    let parts: Vec<Document<'static>> = names.iter().map(|n| leaf::atom(n.to_string())).collect();
+    docvec!["[", join(parts, &Document::Str(", ")), "]"]
 }
 
 /// BT-2734: Compiler-derived `__signature__` / `__doc__` selector-map entries
@@ -5605,6 +5675,7 @@ mod tests {
     use crate::semantic_analysis::{DynamicReason, InferredType, TypeProvenance};
     use crate::source_analysis::Span;
     use crate::test_helpers::test_support::make_actor_class;
+    use ecow::EcoString;
 
     fn s() -> Span {
         Span::new(0, 0)
@@ -5720,20 +5791,88 @@ mod tests {
     }
 
     #[test]
-    fn project_recv_type_union_coarsens_to_dynamic() {
-        let ty = InferredType::simple_union(&["Integer", "String"]);
+    fn project_recv_type_union_of_resolvable_members_yields_union() {
+        // BT-3215: every member resolves to a clean single name, so the
+        // whole union keys precisely instead of coarsening to `dynamic`.
+        let ty = InferredType::simple_union(&["String", "Integer"]);
+        assert!(matches!(
+            project_recv_type(&ty),
+            RecvType::Union(names) if names == vec![EcoString::from("Integer"), EcoString::from("String")]
+        ));
+    }
+
+    #[test]
+    fn project_recv_type_union_dedupes_members() {
+        // Two members that resolve to the same name (e.g. distinct
+        // provenance for the same class) must not double up in the list.
+        let ty = InferredType::Union {
+            members: vec![
+                known("Foo", TypeProvenance::Inferred(s())),
+                known("Foo", TypeProvenance::Declared(s())),
+            ],
+            provenance: TypeProvenance::Inferred(s()),
+        };
+        assert!(matches!(
+            project_recv_type(&ty),
+            RecvType::Union(names) if names == vec![EcoString::from("Foo")]
+        ));
+    }
+
+    #[test]
+    fn project_recv_type_union_with_unresolvable_member_coarsens_to_dynamic() {
+        // BT-3215: a partial member list would be unsound (Constraint 2) —
+        // one member that can't resolve to a clean name (here, `Dynamic`)
+        // must coarsen the *whole* union, not just drop that member.
+        let ty = InferredType::Union {
+            members: vec![
+                known("Foo", TypeProvenance::Inferred(s())),
+                InferredType::Dynamic(DynamicReason::Unknown),
+            ],
+            provenance: TypeProvenance::Inferred(s()),
+        };
         assert!(matches!(project_recv_type(&ty), RecvType::Dynamic));
     }
 
     #[test]
-    fn project_recv_type_intersection_coarsens_to_dynamic() {
-        // ADR 0068 protocol composition (`Collection(Object) & Comparable`) —
-        // deferred to `dynamic` in v1 (ADR 0115 Alternatives Considered;
-        // precise keying tracked separately as BT-3215).
+    fn project_recv_type_union_with_nested_composed_member_coarsens_to_dynamic() {
+        // A member that is itself a `Union`/`Intersection` never resolves
+        // to a single name (`project_composed` only builds one level of
+        // member list), so it coarsens the outer union too.
+        let ty = InferredType::Union {
+            members: vec![
+                known("Foo", TypeProvenance::Inferred(s())),
+                InferredType::simple_union(&["Bar", "Baz"]),
+            ],
+            provenance: TypeProvenance::Inferred(s()),
+        };
+        assert!(matches!(project_recv_type(&ty), RecvType::Dynamic));
+    }
+
+    #[test]
+    fn project_recv_type_intersection_of_resolvable_members_yields_intersection() {
+        // BT-3215: ADR 0068 protocol composition
+        // (`Collection(Object) & Comparable`) now keys precisely instead of
+        // deferring to `dynamic`.
+        let ty = InferredType::Intersection {
+            members: vec![
+                known("Printable", TypeProvenance::Inferred(s())),
+                known("Comparable", TypeProvenance::Inferred(s())),
+            ],
+            provenance: TypeProvenance::Inferred(s()),
+        };
+        assert!(matches!(
+            project_recv_type(&ty),
+            RecvType::Intersection(names)
+                if names == vec![EcoString::from("Comparable"), EcoString::from("Printable")]
+        ));
+    }
+
+    #[test]
+    fn project_recv_type_intersection_with_unresolvable_member_coarsens_to_dynamic() {
         let ty = InferredType::Intersection {
             members: vec![
                 known("Comparable", TypeProvenance::Inferred(s())),
-                known("Printable", TypeProvenance::Inferred(s())),
+                known("List", TypeProvenance::Extracted),
             ],
             provenance: TypeProvenance::Inferred(s()),
         };

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/recv_type.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/recv_type.rs
@@ -91,10 +91,18 @@ fn find_send_entry<'a>(code: &'a str, selector: &str) -> &'a str {
 }
 
 fn assert_recv_type(entry: &str, expected: &str) {
-    let needle = format!("'recv_type' => '{expected}'");
+    assert_recv_type_raw(entry, &format!("'{expected}'"));
+}
+
+/// Like [`assert_recv_type`], but `expected_raw` is the exact literal text
+/// after `'recv_type' => ` — for a composed `{'union', [...]}`/
+/// `{'intersection', [...]}` tuple (BT-3215), which isn't a single quoted
+/// atom.
+fn assert_recv_type_raw(entry: &str, expected_raw: &str) {
+    let needle = format!("'recv_type' => {expected_raw}");
     assert!(
         entry.contains(&needle),
-        "expected recv_type {expected:?}, got entry:\n{entry}"
+        "expected recv_type {expected_raw}, got entry:\n{entry}"
     );
 }
 
@@ -155,11 +163,13 @@ fn untyped_local_receiver_coarsens_to_dynamic_class_side() {
 }
 
 // ---------------------------------------------------------------------------
-// Union-typed local — coarsens to dynamic (write-path v1, ADR 0115 Alternatives)
+// Union-typed local — resolves to a composed `{'union', [...]}` recv_type
+// when every member resolves cleanly (BT-3215; write-path v1 coarsened this
+// to `dynamic`, see ADR 0115 Alternatives Considered).
 // ---------------------------------------------------------------------------
 
 #[test]
-fn union_typed_local_receiver_coarsens_to_dynamic() {
+fn union_typed_local_receiver_resolves_to_composed_union() {
     let code = codegen_self_sufficient(concat!(
         "Object subclass: Widget\n",
         "  ping => 1\n\n",
@@ -170,8 +180,19 @@ fn union_typed_local_receiver_coarsens_to_dynamic() {
         "    w ping\n",
     ));
     let entry = find_send_entry(&code, "ping");
-    assert_recv_type(entry, "dynamic");
+    assert_recv_type_raw(entry, "{'union', ['Gadget', 'Widget']}");
 }
+
+// A union with an unresolvable member (e.g. a native/FFI type with no
+// `beamtalk_class_metadata` row) coarsening the whole union to `dynamic` is
+// covered directly at the unit level
+// (`project_recv_type_union_with_unresolvable_member_coarsens_to_dynamic` in
+// `gen_server/methods.rs`) rather than fixtured here — same call the
+// original PR made for `Intersection`/`Negation` above: constructing a
+// `::`-annotated local whose *member* type resolves through
+// `TypeProvenance::Extracted` needs native-registry fixture machinery this
+// file doesn't otherwise exercise, for a result the unit test already pins
+// precisely.
 
 // ---------------------------------------------------------------------------
 // Self-send — instance and class side both resolve to the method's own

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl
@@ -115,7 +115,18 @@ See also: docs/ADR/0087-maintained-xref-index-for-system-navigation.md
 %% `beamtalk_class_registry:class_object_tag/1` already uses — rather than
 %% falling into `dynamic` by omission.
 -type name() :: atom().
--type recv_type() :: name() | dynamic.
+%% BT-3215: a `Union`/`Intersection`-typed receiver whose members *all*
+%% resolved to a single `name()` each (write path: `project_composed` in
+%% `crates/.../gen_server/methods.rs`) — never a partial member list; a
+%% union/intersection with even one unresolvable member coarsens to
+%% `dynamic` in its entirety at write time, per Constraint 2 ("cannot be
+%% narrowed and must never be excluded" — a partial list would let the read
+%% path wrongly exclude a real dependent typed as the dropped member). Read
+%% path (`is_relevant/5`): `{union, Names}` is relevant iff *any* member is
+%% relevant (the receiver could be any one of them at runtime); `{intersection,
+%% Names}` iff *all* members are relevant (the receiver must simultaneously
+%% satisfy every one).
+-type recv_type() :: name() | {union, [name()]} | {intersection, [name()]} | dynamic.
 
 -type send_entry() :: #{
     selector := selector(),
@@ -653,18 +664,64 @@ is_relevant(Site, BaseChanged, ChangedIsClassSide, Related, Cache) ->
             {true, Cache};
         {ok, dynamic} ->
             {true, Cache};
+        {ok, {union, Names}} ->
+            %% BT-3215: relevant iff *any* member is — the receiver could be
+            %% any one of the union's members at runtime.
+            union_relevant(Names, BaseChanged, ChangedIsClassSide, Related, Cache);
+        {ok, {intersection, Names}} ->
+            %% BT-3215: relevant iff *every* member is — the receiver must
+            %% simultaneously satisfy all of them.
+            intersection_relevant(Names, BaseChanged, ChangedIsClassSide, Related, Cache);
         {ok, T} ->
-            {BaseT, SiteIsClassSide} = split_class_object_tag(T),
-            case SiteIsClassSide =:= ChangedIsClassSide of
-                false ->
-                    %% Amendment 3: a class-object (`Meta{C}`) receiver only
-                    %% ever dispatches through the metaclass (class-side)
-                    %% chain, and a plain instance-typed receiver only
-                    %% through the instance chain — never collapse the two.
-                    {false, Cache};
-                true ->
-                    relatedness(BaseT, BaseChanged, Related, Cache)
-            end
+            member_relevant(T, BaseChanged, ChangedIsClassSide, Related, Cache)
+    end.
+
+%% Shared single-name relevance test `is_relevant/5`'s plain-`T` clause and
+%% both BT-3215 composed-type folds below reduce to, member-by-member: strip
+%% any `' class'` class-object tag, apply Amendment 3's side check, then
+%% `relatedness/4`.
+-spec member_relevant(name(), class_name(), boolean(), sets:set(class_name()), relevance_cache()) ->
+    {boolean(), relevance_cache()}.
+member_relevant(T, BaseChanged, ChangedIsClassSide, Related, Cache) ->
+    {BaseT, SiteIsClassSide} = split_class_object_tag(T),
+    case SiteIsClassSide =:= ChangedIsClassSide of
+        false ->
+            %% Amendment 3: a class-object (`Meta{C}`) receiver only ever
+            %% dispatches through the metaclass (class-side) chain, and a
+            %% plain instance-typed receiver only through the instance
+            %% chain — never collapse the two.
+            {false, Cache};
+        true ->
+            relatedness(BaseT, BaseChanged, Related, Cache)
+    end.
+
+%% BT-3215: OR-fold over a `{union, Names}` member list — short-circuits on
+%% the first relevant member (no need to evaluate, or cache, the rest), still
+%% threading `Cache` through whatever prefix it did evaluate.
+-spec union_relevant([name()], class_name(), boolean(), sets:set(class_name()), relevance_cache()) ->
+    {boolean(), relevance_cache()}.
+union_relevant([], _BaseChanged, _ChangedIsClassSide, _Related, Cache) ->
+    {false, Cache};
+union_relevant([T | Rest], BaseChanged, ChangedIsClassSide, Related, Cache) ->
+    case member_relevant(T, BaseChanged, ChangedIsClassSide, Related, Cache) of
+        {true, Cache1} -> {true, Cache1};
+        {false, Cache1} -> union_relevant(Rest, BaseChanged, ChangedIsClassSide, Related, Cache1)
+    end.
+
+%% BT-3215: AND-fold over an `{intersection, Names}` member list —
+%% short-circuits on the first irrelevant member.
+-spec intersection_relevant(
+    [name()], class_name(), boolean(), sets:set(class_name()), relevance_cache()
+) ->
+    {boolean(), relevance_cache()}.
+intersection_relevant([], _BaseChanged, _ChangedIsClassSide, _Related, Cache) ->
+    {true, Cache};
+intersection_relevant([T | Rest], BaseChanged, ChangedIsClassSide, Related, Cache) ->
+    case member_relevant(T, BaseChanged, ChangedIsClassSide, Related, Cache) of
+        {false, Cache1} ->
+            {false, Cache1};
+        {true, Cache1} ->
+            intersection_relevant(Rest, BaseChanged, ChangedIsClassSide, Related, Cache1)
     end.
 
 -spec relatedness(name(), class_name(), sets:set(class_name()), relevance_cache()) ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_xref_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_xref_tests.erl
@@ -2258,6 +2258,240 @@ bt3218_drain_trace_counts(Conforms, IsProtocol) ->
     end.
 
 %%====================================================================
+%% BT-3215 (ADR 0115 follow-up): composed Union/Intersection recv_type
+%%====================================================================
+
+%% EUnit: `{union, Names}` — relevant iff *any* member matches (OR-semantics).
+%% `'Bt3218Sibling'` and `'Bt3218Leaf'` sit on different branches of the
+%% `bt3218_hierarchy_setup/0` tree (Sibling is a direct child of Root; Leaf is
+%% two levels down the Mid branch), so a `ChangedClass` can be related to
+%% exactly one, the other, both, or neither.
+union_recv_type_relevant_iff_any_member_matches_test_() ->
+    {setup,
+        fun() ->
+            Pid = setup(),
+            bt3218_hierarchy_setup(),
+            ok = beamtalk_class_metadata:insert(
+                'Bt3215Standalone', undefined, undefined, none, undefined
+            ),
+            Pid
+        end,
+        fun(Pid) ->
+            beamtalk_class_metadata:delete('Bt3215Standalone'),
+            bt3218_hierarchy_cleanup(),
+            cleanup(Pid)
+        end,
+        fun(_Pid) ->
+            [
+                ?_test(begin
+                    ok = beamtalk_xref:register_class('Bt3215UnionOwner', [
+                        #{
+                            class_side => false,
+                            selector => 'mUnion',
+                            line => 1,
+                            sends => [
+                                #{
+                                    selector => 'bt3215UnionSel',
+                                    line => 2,
+                                    recv_kind => other,
+                                    recv_type => {union, ['Bt3218Sibling', 'Bt3218Leaf']}
+                                }
+                            ],
+                            references => [],
+                            source_status => indexed,
+                            provenance => class_body
+                        }
+                    ]),
+                    try
+                        %% Only the second member (`Leaf`, an ancestor of
+                        %% GrandLeaf) matches — still relevant.
+                        ?assertEqual(
+                            1,
+                            length(
+                                beamtalk_xref:senders_of('bt3215UnionSel', 'Bt3218GrandLeaf')
+                            )
+                        ),
+                        %% Only the first member (`Sibling`, matching itself)
+                        %% matches — still relevant.
+                        ?assertEqual(
+                            1,
+                            length(
+                                beamtalk_xref:senders_of('bt3215UnionSel', 'Bt3218Sibling')
+                            )
+                        ),
+                        %% Both members match (SuperRoot is ancestor of, and
+                        %% therefore hierarchy-related to, everything).
+                        ?assertEqual(
+                            1,
+                            length(
+                                beamtalk_xref:senders_of('bt3215UnionSel', 'Bt3218SuperRoot')
+                            )
+                        ),
+                        %% Neither member matches — a standalone class related
+                        %% to nothing in the fixture hierarchy.
+                        ?assertEqual(
+                            0,
+                            length(
+                                beamtalk_xref:senders_of('bt3215UnionSel', 'Bt3215Standalone')
+                            )
+                        )
+                    after
+                        ok = beamtalk_xref:purge_class('Bt3215UnionOwner')
+                    end
+                end)
+            ]
+        end}.
+
+%% EUnit: `{intersection, Names}` — relevant iff *all* members match
+%% (AND-semantics). `'Bt3218Root'` is an ancestor of every fixture class;
+%% `'Bt3218Sibling'` is related only to itself, `Root`, and `SuperRoot`, so a
+%% `ChangedClass` matching `Root` alone (without also matching `Sibling`) is
+%% the case that distinguishes AND from OR.
+intersection_recv_type_relevant_iff_all_members_match_test_() ->
+    {setup,
+        fun() ->
+            Pid = setup(),
+            bt3218_hierarchy_setup(),
+            ok = beamtalk_class_metadata:insert(
+                'Bt3215Standalone', undefined, undefined, none, undefined
+            ),
+            Pid
+        end,
+        fun(Pid) ->
+            beamtalk_class_metadata:delete('Bt3215Standalone'),
+            bt3218_hierarchy_cleanup(),
+            cleanup(Pid)
+        end,
+        fun(_Pid) ->
+            [
+                ?_test(begin
+                    ok = beamtalk_xref:register_class('Bt3215IntersectionOwner', [
+                        #{
+                            class_side => false,
+                            selector => 'mIntersection',
+                            line => 1,
+                            sends => [
+                                #{
+                                    selector => 'bt3215IntersectionSel',
+                                    line => 2,
+                                    recv_kind => other,
+                                    recv_type => {intersection, ['Bt3218Root', 'Bt3218Sibling']}
+                                }
+                            ],
+                            references => [],
+                            source_status => indexed,
+                            provenance => class_body
+                        }
+                    ]),
+                    try
+                        %% Both members match: Sibling is itself, and Root is
+                        %% its ancestor.
+                        ?assertEqual(
+                            1,
+                            length(
+                                beamtalk_xref:senders_of(
+                                    'bt3215IntersectionSel', 'Bt3218Sibling'
+                                )
+                            )
+                        ),
+                        %% Only `Root` matches (Mid is unrelated to Sibling's
+                        %% branch) — the intersection as a whole is NOT
+                        %% relevant, proving this is AND, not OR.
+                        ?assertEqual(
+                            0,
+                            length(
+                                beamtalk_xref:senders_of('bt3215IntersectionSel', 'Bt3218Mid')
+                            )
+                        ),
+                        %% Neither member matches.
+                        ?assertEqual(
+                            0,
+                            length(
+                                beamtalk_xref:senders_of(
+                                    'bt3215IntersectionSel', 'Bt3215Standalone'
+                                )
+                            )
+                        )
+                    after
+                        ok = beamtalk_xref:purge_class('Bt3215IntersectionOwner')
+                    end
+                end)
+            ]
+        end}.
+
+%% EUnit regression: the pre-existing single-name and `dynamic` `recv_type`
+%% paths are unaffected by the `{union, _}`/`{intersection, _}` clauses added
+%% to `is_relevant/5`.
+single_name_and_dynamic_recv_type_unaffected_by_composed_types_test_() ->
+    {setup,
+        fun() ->
+            Pid = setup(),
+            bt3218_hierarchy_setup(),
+            Pid
+        end,
+        fun(Pid) ->
+            bt3218_hierarchy_cleanup(),
+            cleanup(Pid)
+        end,
+        fun(_Pid) ->
+            [
+                ?_test(begin
+                    ok = beamtalk_xref:register_class('Bt3215RegressionOwner', [
+                        #{
+                            class_side => false,
+                            selector => 'mPlainName',
+                            line => 1,
+                            sends => [
+                                #{
+                                    selector => 'bt3215RegressionSel',
+                                    line => 2,
+                                    recv_kind => other,
+                                    recv_type => 'Bt3218Leaf'
+                                }
+                            ],
+                            references => [],
+                            source_status => indexed,
+                            provenance => class_body
+                        },
+                        #{
+                            class_side => false,
+                            selector => 'mDynamic',
+                            line => 3,
+                            sends => [
+                                #{
+                                    selector => 'bt3215RegressionSel',
+                                    line => 4,
+                                    recv_kind => other,
+                                    recv_type => dynamic
+                                }
+                            ],
+                            references => [],
+                            source_status => indexed,
+                            provenance => class_body
+                        }
+                    ]),
+                    try
+                        %% Plain single-name: relevant for a related class...
+                        RelatedMethods = lists:sort([
+                            maps:get(method, S)
+                         || S <- beamtalk_xref:senders_of('bt3215RegressionSel', 'Bt3218Mid')
+                        ]),
+                        ?assertEqual(['mDynamic', 'mPlainName'], RelatedMethods),
+                        %% ...and NOT relevant for an unrelated one, while
+                        %% `dynamic` is always relevant regardless.
+                        UnrelatedMethods = lists:sort([
+                            maps:get(method, S)
+                         || S <- beamtalk_xref:senders_of('bt3215RegressionSel', 'Bt3218Sibling')
+                        ]),
+                        ?assertEqual(['mDynamic'], UnrelatedMethods)
+                    after
+                        ok = beamtalk_xref:purge_class('Bt3215RegressionOwner')
+                    end
+                end)
+            ]
+        end}.
+
+%%====================================================================
 %% Internal helpers
 %%====================================================================
 


### PR DESCRIPTION
## Summary

- Extends ADR 0115's `recv_type` xref key from single-name receivers to composed `Union`/`Intersection` receivers, replacing the v1 coarsen-to-`dynamic` fallback that ADR 0115 deliberately deferred (see its *Alternatives Considered* § "Precise composed/intersected-type keying").
- Write path (`build_method_xref_entry`, `crates/beamtalk-core/src/codegen/core_erlang/gen_server/methods.rs`): when a send's receiver is `InferredType::Union{members}`/`Intersection{members}`, each member is projected to a name via the same class-or-protocol projection ADR 0115 already uses for the single-name case. If **every** member resolves cleanly, the whole receiver is keyed as `{'union', [Names]}`/`{'intersection', [Names]}`; if even one member is unresolvable, the entire composed type coarsens to `dynamic` — never a partial member list, per ADR 0115 Constraint 2 ("cannot be narrowed and must never be excluded").
- Read path (`is_relevant/5`, `runtime/apps/beamtalk_runtime/src/beamtalk_xref.erl`): two new clauses reuse the existing single-name relevance test (hierarchy-relatedness for a class, `conforms_to/2` for a protocol) member-wise, via a new shared `member_relevant/5` helper —
  - `{union, Names}` is relevant iff *any* member is relevant (OR-fold, short-circuits on the first match).
  - `{intersection, Names}` is relevant iff *all* members are relevant (AND-fold, short-circuits on the first non-match).
  - Both fold over the existing Amendment-1 memoization cache, so a repeated member name across sites still costs one relatedness check.

## Design rationale

No new algorithm — this is a mechanical member-wise application of the already-shipped single-name relevance test, following the design sketch ADR 0115 already laid out and deferred. The only genuinely new decision is the write-path's all-or-nothing resolution rule: a composed type with one unresolvable member could either drop that member from the list or coarsen the whole type to `dynamic`. Dropping it would let the read path silently exclude a real dependent typed as the dropped member — unsound per Constraint 2 — so the write path always coarsens the whole composed type rather than emitting a partial list.

## Testing

- `cargo test -p beamtalk-core recv_type` — 28/28 pass (6 new: union/intersection resolution, member deduplication, unresolvable-member coarsening, nested-composed-member coarsening).
- `cargo clippy -p beamtalk-core --all-targets` / `cargo fmt --all -- --check` — clean.
- `rebar3 as test eunit --module=beamtalk_xref_tests` — 36/36 pass (3 new: union relevant-iff-any-member, intersection relevant-iff-all-members, regression check that single-name/`dynamic` paths are unaffected).
- `rebar3 fmt --check` / `rebar3 dialyzer` — clean.
- `escript perf/bench_senders_xref.escript` / `escript perf/bench_recheck_fanout.escript` — no regression; numbers match the BT-3220 baseline (additive `case` clauses on an already-`dynamic`-coarsened path that real stdlib code doesn't yet exercise).

Closes BT-3215.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUP4xDUPTzhKZgpRiWLYQL)_