### PR TITLE
Desktop launcher: stage logging, in-app log viewer, capture front stdout/stderr (BT-3225)

### DIFF
--- a/crates/beamtalk-cli/src/commands/workspace/startup_command.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/startup_command.rs
@@ -126,16 +126,17 @@ pub(super) fn build_detached_node_command(
         cmd.env("HOME", home);
     }
     // Keep Erlang distribution off untrusted networks by default (ADR 0091
-    // Decision 5): pin the address epmd binds/contacts to loopback so a node
-    // that *starts* epmd does not expose the port mapper on `0.0.0.0`. epmd is a
-    // persistent per-user daemon, so this only governs an epmd this node starts;
-    // a pre-existing promiscuous epmd is caught separately by the launcher's
-    // preflight check (`epmd::check_epmd_loopback`). An operator deploying across
-    // a trusted private network can override by exporting `ERL_EPMD_ADDRESS`
-    // (e.g. the private interface address) before launching — never `0.0.0.0`.
-    let epmd_address =
-        std::env::var("ERL_EPMD_ADDRESS").unwrap_or_else(|_| "127.0.0.1".to_string());
-    cmd.env("ERL_EPMD_ADDRESS", epmd_address);
+    // Decision 5) — see `beamtalk_workspace::resolve_epmd_address`'s doc
+    // comment for the full rationale, shared with
+    // `beamtalk-desktop-broker`'s own front-spawn env (`spawn::build_env`).
+    // epmd is a persistent per-user daemon, so this only governs an epmd
+    // this node starts; a pre-existing promiscuous epmd is caught
+    // separately by the launcher's preflight check
+    // (`epmd::check_epmd_loopback`).
+    cmd.env(
+        "ERL_EPMD_ADDRESS",
+        beamtalk_workspace::resolve_epmd_address(),
+    );
     // Locale settings for proper string handling
     for var in &["LANG", "LC_ALL"] {
         if let Ok(val) = std::env::var(var) {

--- a/crates/beamtalk-desktop-broker/src/oidc_guard.rs
+++ b/crates/beamtalk-desktop-broker/src/oidc_guard.rs
@@ -95,9 +95,8 @@ pub fn default_ide_config_path() -> PathBuf {
             return PathBuf::from(path);
         }
     }
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".beamtalk")
+    beamtalk_workspace::beamtalk_root_dir()
+        .unwrap_or_else(|_| PathBuf::from(".beamtalk"))
         .join("ide.toml")
 }
 

--- a/crates/beamtalk-desktop-broker/src/reap.rs
+++ b/crates/beamtalk-desktop-broker/src/reap.rs
@@ -154,13 +154,13 @@ pub struct FrontRecord {
 ///
 /// Returns an error if the home directory cannot be determined.
 pub fn state_dir() -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or_else(|| {
+    let root = beamtalk_workspace::beamtalk_root_dir().map_err(|_| {
         crate::error::BrokerError::Io(std::io::Error::new(
             ErrorKind::NotFound,
             "could not determine home directory",
         ))
     })?;
-    Ok(home.join(".beamtalk").join("desktop-broker"))
+    Ok(root.join("desktop-broker"))
 }
 
 fn record_path(dir: &Path, workspace_id: &str, port: u16) -> PathBuf {

--- a/crates/beamtalk-desktop-broker/src/spawn.rs
+++ b/crates/beamtalk-desktop-broker/src/spawn.rs
@@ -171,8 +171,29 @@ impl SpawnConfig {
 /// (`BT_WORKSPACE_NODE`, `BT_WORKSPACE_COOKIE`, `SECRET_KEY_BASE`,
 /// `PHX_SERVER`, `RELEASE_TMP`) that don't go through this function — it
 /// does not report the full env set there, only the cross-platform baseline.
+///
+/// `ERL_EPMD_ADDRESS` here (resolved by
+/// [`beamtalk_workspace::resolve_epmd_address`], shared with
+/// `beamtalk-cli`'s own workspace startup — see that function's doc
+/// comment for the full ADR 0091 Decision 5 rationale) keeps Erlang
+/// distribution off untrusted networks by pinning the address epmd
+/// binds/contacts to loopback, so a node that *starts* epmd (as the
+/// front's own lazy `ensure_distributed/0` does, the first time anything
+/// calls its `/readiness` endpoint) does not expose the port mapper on
+/// `0.0.0.0`. Without this, a Tauri app launched from Finder/dock — which
+/// does not inherit whatever `ERL_EPMD_ADDRESS` a user's shell profile
+/// might set, unlike a terminal-launched `beamtalk workspace create` —
+/// would leave epmd to its own un-pinned default the moment it's the first
+/// thing on the machine to start one. `bin/server`
+/// (`editors/liveview/rel/overlays/bin/server`) does not set this itself,
+/// so it must come from here, same as every other var in this function; a
+/// pre-existing promiscuous epmd from *other* tooling is a separate case,
+/// caught by the CLI's own preflight check
+/// (`beamtalk_cli::commands::workspace::epmd::check_epmd_loopback`), not by
+/// anything this broker can control after the fact.
 #[must_use]
 pub fn build_env(config: &SpawnConfig) -> Vec<(String, String)> {
+    let epmd_address = beamtalk_workspace::resolve_epmd_address();
     vec![
         ("PORT".to_string(), config.port.to_string()),
         ("BT_ATTACH_BIND_IP".to_string(), config.bind_ip.clone()),
@@ -181,6 +202,7 @@ pub fn build_env(config: &SpawnConfig) -> Vec<(String, String)> {
             attach_node_suffix(&config.workspace_id),
         ),
         ("RELEASE_DISTRIBUTION".to_string(), "none".to_string()),
+        ("ERL_EPMD_ADDRESS".to_string(), epmd_address),
     ]
 }
 
@@ -820,7 +842,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn build_env_sets_the_four_required_vars() {
+    fn build_env_sets_the_five_required_vars() {
+        let _guard = crate::test_support::ENV_LOCK.lock().unwrap();
+        // SAFETY: guarded by ENV_LOCK above.
+        unsafe { std::env::remove_var("ERL_EPMD_ADDRESS") };
         let config = SpawnConfig::new(PathBuf::from("/bin/true"), "abc123", 4567);
         let env = build_env(&config);
         assert_eq!(
@@ -830,8 +855,23 @@ mod tests {
                 ("BT_ATTACH_BIND_IP".to_string(), "127.0.0.1".to_string()),
                 ("BT_ATTACH_NODE_SUFFIX".to_string(), "abc123".to_string()),
                 ("RELEASE_DISTRIBUTION".to_string(), "none".to_string()),
+                ("ERL_EPMD_ADDRESS".to_string(), "127.0.0.1".to_string()),
             ]
         );
+    }
+
+    #[test]
+    fn build_env_respects_an_operator_provided_erl_epmd_address() {
+        // BT-3225 review follow-up: a trusted-private-network operator can
+        // still override the loopback pin — see build_env's doc comment.
+        let _guard = crate::test_support::ENV_LOCK.lock().unwrap();
+        // SAFETY: guarded by ENV_LOCK above.
+        unsafe { std::env::set_var("ERL_EPMD_ADDRESS", "10.0.0.5") };
+        let config = SpawnConfig::new(PathBuf::from("/bin/true"), "abc123", 4567);
+        let env = build_env(&config);
+        // SAFETY: guarded by ENV_LOCK above.
+        unsafe { std::env::remove_var("ERL_EPMD_ADDRESS") };
+        assert!(env.contains(&("ERL_EPMD_ADDRESS".to_string(), "10.0.0.5".to_string())));
     }
 
     #[test]

--- a/crates/beamtalk-desktop-broker/src/spawn.rs
+++ b/crates/beamtalk-desktop-broker/src/spawn.rs
@@ -109,8 +109,10 @@
 //! still misses (e.g. a crash in the narrow assign-after-spawn window).
 
 use std::cell::RefCell;
-use std::path::PathBuf;
-use std::process::{Child, Command};
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
 use crate::error::{BrokerError, Result};
@@ -292,6 +294,8 @@ pub fn spawn_front(config: &SpawnConfig) -> Result<SpawnedFront> {
         ));
     }
 
+    redirect_front_stdio(&mut cmd, &config.workspace_id);
+
     detach(&mut cmd);
 
     // Created before `cmd.spawn()` (not after) so there is no
@@ -337,6 +341,44 @@ pub fn spawn_front(config: &SpawnConfig) -> Result<SpawnedFront> {
     {
         Ok(SpawnedFront { child })
     }
+}
+
+/// Redirect `cmd`'s stdout/stderr to `~/.beamtalk/workspaces/<id>/attach.log`
+/// (append mode, accumulating across restarts — mirrors `workspace.log`'s own
+/// convention on the workspace-node side) instead of the default inherited
+/// stdio. Inherited stdio is the packaged Tauri app's own — i.e. nowhere, in
+/// a release build (`windows_subsystem = "windows"` on Windows; macOS/Linux
+/// app bundles have no attached terminal either) — so without this, a
+/// spawned front's crash or an Elixir-side exception is invisible short of
+/// running the release binary manually from a terminal (BT-3225).
+///
+/// Best-effort: if the log file can't be opened (e.g. the workspace
+/// directory somehow isn't writable), stdout/stderr fall back to
+/// [`Stdio::null`] rather than failing the whole spawn over a logging
+/// nicety — `attach.log`'s absence is itself a signal something is wrong on
+/// this machine, for whoever goes looking for it.
+fn redirect_front_stdio(cmd: &mut Command, workspace_id: &str) {
+    let stdio_pair = beamtalk_workspace::workspace_dir(workspace_id)
+        .ok()
+        .and_then(|dir| open_front_log(&dir.join("attach.log")).ok());
+
+    if let Some((stdout_file, stderr_file)) = stdio_pair {
+        cmd.stdout(Stdio::from(stdout_file));
+        cmd.stderr(Stdio::from(stderr_file));
+    } else {
+        cmd.stdout(Stdio::null());
+        cmd.stderr(Stdio::null());
+    }
+}
+
+/// Open `path` for append (creating it if absent) and return two handles to
+/// the same underlying file description — via [`File::try_clone`], not two
+/// independent `open` calls — so stdout and stderr share one file offset and
+/// interleave in write order rather than racing to overwrite each other.
+fn open_front_log(path: &Path) -> io::Result<(File, File)> {
+    let file = OpenOptions::new().create(true).append(true).open(path)?;
+    let cloned = file.try_clone()?;
+    Ok((file, cloned))
 }
 
 /// Kill and reap `child` after it was successfully spawned but
@@ -1399,6 +1441,64 @@ mod tests {
 
         let _ = child.kill();
         let _ = child.wait();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn spawn_front_with_port_retry_captures_front_stdout_and_stderr_to_attach_log() {
+        // BT-3225: the spawned front's stdout/stderr must land in
+        // `~/.beamtalk/workspaces/<id>/attach.log`, not the packaged app's
+        // inherited (and, in a release build, nonexistent) stdio.
+        let ws = TestWorkspaceDir::new("attach_log_capture");
+        let tmp = tempfile::TempDir::new().unwrap();
+        let launcher = write_launcher_script(
+            tmp.path(),
+            "server",
+            "echo stdout-marker; echo stderr-marker 1>&2; sleep 5",
+        );
+
+        let mut config = SpawnAttemptConfig::new(launcher, ws.id.clone());
+        config.ide_toml_path = tmp.path().join("ide.toml"); // doesn't exist: no OIDC
+        config.bind_failure_grace = Duration::from_millis(100);
+
+        let (mut child, _port) =
+            spawn_front_with_port_retry(&config).expect("should spawn and bind on first try");
+
+        let log_path = beamtalk_workspace::workspace_dir(&ws.id)
+            .unwrap()
+            .join("attach.log");
+        let contents = wait_for_file_contents(&log_path, Duration::from_secs(2));
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert!(
+            contents.contains("stdout-marker"),
+            "expected attach.log to contain the launcher's stdout, got: {contents:?}"
+        );
+        assert!(
+            contents.contains("stderr-marker"),
+            "expected attach.log to contain the launcher's stderr, got: {contents:?}"
+        );
+    }
+
+    /// Poll `path` until it exists and is non-empty, or `timeout` elapses —
+    /// the launcher script's `echo`s race this test process reading the file
+    /// it just told the OS to create.
+    #[cfg(unix)]
+    fn wait_for_file_contents(path: &std::path::Path, timeout: Duration) -> String {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if let Ok(contents) = std::fs::read_to_string(path) {
+                if !contents.is_empty() {
+                    return contents;
+                }
+            }
+            if std::time::Instant::now() >= deadline {
+                return std::fs::read_to_string(path).unwrap_or_default();
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
     }
 
     #[cfg(unix)]

--- a/crates/beamtalk-desktop-broker/src/spawn.rs
+++ b/crates/beamtalk-desktop-broker/src/spawn.rs
@@ -375,8 +375,25 @@ fn redirect_front_stdio(cmd: &mut Command, workspace_id: &str) {
 /// the same underlying file description — via [`File::try_clone`], not two
 /// independent `open` calls — so stdout and stderr share one file offset and
 /// interleave in write order rather than racing to overwrite each other.
+///
+/// Created `0o600` (owner-only) on Unix, matching every other
+/// security-relevant file already in the same workspace directory
+/// (`workspace.log`, `cookie`, `vm.args`, `pid`, `port` are all `0600`) —
+/// the front's own `Logger` output can carry the same class of sensitive
+/// runtime detail `workspace.log` does, so it gets the same posture rather
+/// than the world-readable default (`create(true)`'s default mode, same as
+/// e.g. `metadata.json` — appropriate there, not here). No Windows
+/// equivalent is set here; it inherits the parent directory's ACLs, same as
+/// this crate's other Windows gaps this module's doc comment already notes.
 fn open_front_log(path: &Path) -> io::Result<(File, File)> {
-    let file = OpenOptions::new().create(true).append(true).open(path)?;
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let file = options.open(path)?;
     let cloned = file.try_clone()?;
     Ok((file, cloned))
 }
@@ -1479,6 +1496,17 @@ mod tests {
         assert!(
             contents.contains("stderr-marker"),
             "expected attach.log to contain the launcher's stderr, got: {contents:?}"
+        );
+
+        // attach.log can carry the same class of sensitive runtime detail
+        // workspace.log does — must be owner-only, not the world-readable
+        // default (BT-3225 review follow-up).
+        let mode = std::os::unix::fs::PermissionsExt::mode(
+            &std::fs::metadata(&log_path).unwrap().permissions(),
+        ) & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "attach.log should be created 0600, got {mode:o}"
         );
     }
 

--- a/crates/beamtalk-workspace/src/lib.rs
+++ b/crates/beamtalk-workspace/src/lib.rs
@@ -87,6 +87,25 @@ pub fn beamtalk_root_dir() -> Result<PathBuf> {
     Ok(home.join(".beamtalk"))
 }
 
+/// Resolve the address epmd should bind/contact: `ERL_EPMD_ADDRESS` if the
+/// operator has set one (e.g. a trusted private network's interface), else
+/// loopback (`127.0.0.1`) — the default posture for every Beamtalk-spawned
+/// BEAM node (ADR 0091 Decision 5), so a node that *starts* epmd (there is
+/// only one epmd per machine; whoever gets there first sets its bind
+/// address for as long as it keeps running) never exposes the port mapper
+/// on `0.0.0.0`. Shared by `beamtalk-cli`'s workspace startup
+/// (`commands::workspace::startup_command`) and
+/// `beamtalk-desktop-broker`'s front spawn (`spawn::build_env`) — both set
+/// `ERL_EPMD_ADDRESS` in the child process env from this same resolution,
+/// rather than each re-deriving the "does the operator want to override
+/// loopback" policy independently. Never returns `"0.0.0.0"` on its own —
+/// an operator who explicitly exports that anyway is making their own
+/// informed choice, not something this function should second-guess.
+#[must_use]
+pub fn resolve_epmd_address() -> String {
+    std::env::var("ERL_EPMD_ADDRESS").unwrap_or_else(|_| "127.0.0.1".to_string())
+}
+
 /// Get the base directory for all workspaces (`~/.beamtalk/workspaces/`).
 ///
 /// # Errors
@@ -203,6 +222,32 @@ pub fn parse_repl_workspace_id(stdout: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Guards every test below that reads/mutates `ERL_EPMD_ADDRESS` — Rust
+    // runs tests in this binary concurrently by default, and
+    // `std::env::set_var`/`remove_var` racing a concurrent `env::var` read
+    // in another thread is a real hazard, not a theoretical one (mirrors
+    // `beamtalk-desktop-broker::test_support::ENV_LOCK`'s same discipline).
+    static EPMD_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn resolve_epmd_address_defaults_to_loopback() {
+        let _guard = EPMD_ENV_LOCK.lock().unwrap();
+        // SAFETY: guarded by EPMD_ENV_LOCK above.
+        unsafe { std::env::remove_var("ERL_EPMD_ADDRESS") };
+        assert_eq!(resolve_epmd_address(), "127.0.0.1");
+    }
+
+    #[test]
+    fn resolve_epmd_address_respects_an_operator_override() {
+        let _guard = EPMD_ENV_LOCK.lock().unwrap();
+        // SAFETY: guarded by EPMD_ENV_LOCK above.
+        unsafe { std::env::set_var("ERL_EPMD_ADDRESS", "10.0.0.5") };
+        let result = resolve_epmd_address();
+        // SAFETY: guarded by EPMD_ENV_LOCK above.
+        unsafe { std::env::remove_var("ERL_EPMD_ADDRESS") };
+        assert_eq!(result, "10.0.0.5");
+    }
 
     #[test]
     fn workspaces_base_dir_is_workspaces_under_beamtalk_root_dir() {

--- a/crates/beamtalk-workspace/src/lib.rs
+++ b/crates/beamtalk-workspace/src/lib.rs
@@ -74,14 +74,26 @@ pub fn generate_workspace_id(project_path: &Path) -> Result<String> {
     Ok(hash_workspace_path_string(path_str))
 }
 
+/// Get the root Beamtalk state directory (`~/.beamtalk/`) — the shared leaf
+/// under every tool that needs it (workspace storage here, the desktop
+/// launcher's log file, ...), so none of them re-derive `dirs::home_dir()`
+/// on their own.
+///
+/// # Errors
+///
+/// Returns an error if the home directory cannot be determined.
+pub fn beamtalk_root_dir() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| miette!("Could not determine home directory"))?;
+    Ok(home.join(".beamtalk"))
+}
+
 /// Get the base directory for all workspaces (`~/.beamtalk/workspaces/`).
 ///
 /// # Errors
 ///
 /// Returns an error if the home directory cannot be determined.
 pub fn workspaces_base_dir() -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or_else(|| miette!("Could not determine home directory"))?;
-    Ok(home.join(".beamtalk").join("workspaces"))
+    Ok(beamtalk_root_dir()?.join("workspaces"))
 }
 
 /// Get the workspace directory for a given workspace ID.
@@ -191,6 +203,14 @@ pub fn parse_repl_workspace_id(stdout: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn workspaces_base_dir_is_workspaces_under_beamtalk_root_dir() {
+        assert_eq!(
+            workspaces_base_dir().unwrap(),
+            beamtalk_root_dir().unwrap().join("workspaces")
+        );
+    }
 
     #[test]
     fn test_generate_workspace_id_length() {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -270,11 +270,15 @@ version = "0.1.0"
 dependencies = [
  "beamtalk-desktop-broker",
  "beamtalk-desktop-shell",
+ "beamtalk-workspace",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-single-instance",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1975,6 +1979,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,6 +2078,15 @@ dependencies = [
  "log",
  "tendril",
  "web_atoms",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2192,6 +2211,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -3205,6 +3233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3369,6 +3406,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -3804,6 +3847,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4048,6 +4100,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.19",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4065,6 +4130,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4231,6 +4326,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-compare"

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-single-instance",
+ "tempfile",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -47,3 +47,6 @@ tracing-appender = "0.2"
 beamtalk-desktop-broker = { path = "../../crates/beamtalk-desktop-broker" }
 beamtalk-desktop-shell = { path = "../../crates/beamtalk-desktop-shell" }
 beamtalk-workspace = { path = "../../crates/beamtalk-workspace" }
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -41,5 +41,9 @@ tauri = { version = "2", features = [] }
 tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
+tracing-appender = "0.2"
 beamtalk-desktop-broker = { path = "../../crates/beamtalk-desktop-broker" }
 beamtalk-desktop-shell = { path = "../../crates/beamtalk-desktop-shell" }
+beamtalk-workspace = { path = "../../crates/beamtalk-workspace" }

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -122,6 +122,7 @@ pub fn attach(
     // workspace both saw "nothing tracked" and both spawned a front. See
     // `beamtalk_desktop_shell::attach`'s module docs.
     let decision = locked(&state.attach).decide_and_claim(&workspace_id);
+    tracing::info!(workspace_id = %workspace_id, ?decision, "attach requested");
 
     let generation = match decision {
         AttachDecision::FocusExisting { window_id, .. } => {
@@ -161,12 +162,20 @@ fn attach_and_open_window(
     generation: u64,
 ) -> Result<AttachOutcome, String> {
     emit_progress(app, workspace_id, "spawning");
+    tracing::info!(workspace_id, "spawning front");
 
     let launcher = state.launcher.clone();
     let spawn_config = SpawnAttemptConfig::new(launcher, workspace_id.to_string());
-    let (child, port) = beamtalk_desktop_broker::spawn::spawn_front_with_port_retry(&spawn_config)
-        .map_err(|e| e.to_string())?;
+    let (child, port) =
+        match beamtalk_desktop_broker::spawn::spawn_front_with_port_retry(&spawn_config) {
+            Ok(result) => result,
+            Err(err) => {
+                tracing::error!(workspace_id, %err, "spawn failed");
+                return Err(err.to_string());
+            }
+        };
     let pid = child.id();
+    tracing::info!(workspace_id, port, pid, "front spawned");
 
     // Persist the orphan-reaping record *and* start tracking the child in
     // `state.children` immediately after a successful spawn — before the
@@ -192,6 +201,7 @@ fn attach_and_open_window(
     locked(&state.children).insert(workspace_id.to_string(), child);
 
     emit_progress(app, workspace_id, "probing");
+    tracing::info!(workspace_id, port, "waiting for front readiness");
 
     let timeouts = ProbeTimeouts::default_local();
     let probe = readiness::http_probe("127.0.0.1", port, timeouts);
@@ -201,6 +211,7 @@ fn attach_and_open_window(
         ATTACH_POLL_INTERVAL,
         probe,
     );
+    tracing::info!(workspace_id, ?final_state, "readiness wait finished");
 
     match final_state {
         ReadinessState::Ready(_version) => {
@@ -240,12 +251,14 @@ fn attach_and_open_window(
             }
         }
         ReadinessState::Failed(reason) => {
+            tracing::error!(workspace_id, ?reason, "readiness failed");
             kill_and_untrack(state, workspace_id, port);
             return Err(format!(
                 "workspace '{workspace_id}' is unreachable: {reason:?}"
             ));
         }
         ReadinessState::TimedOut(stage) => {
+            tracing::error!(workspace_id, ?stage, "readiness timed out");
             kill_and_untrack(state, workspace_id, port);
             return Err(format!(
                 "timed out waiting for workspace '{workspace_id}' ({stage:?})"
@@ -267,6 +280,9 @@ fn attach_and_open_window(
         }
     }
 
+    emit_progress(app, workspace_id, "opening");
+    tracing::info!(workspace_id, port, "opening workspace window");
+
     let label = window_label(workspace_id);
     let url = format!("http://127.0.0.1:{port}/")
         .parse::<tauri::Url>()
@@ -277,6 +293,7 @@ fn attach_and_open_window(
     {
         Ok(window) => window,
         Err(err) => {
+            tracing::error!(workspace_id, %err, "failed to open workspace window");
             // The front is up and ready but we couldn't open a window for
             // it — kill it rather than leaking a live, untracked, cookie-
             // bearing process for the rest of this session.
@@ -321,6 +338,10 @@ fn attach_and_open_window(
         // down without emitting anything, so there's no double-cleanup or
         // reentrancy to reason about here) and clear the on-disk front
         // record rather than leaving that behind.
+        tracing::warn!(
+            workspace_id,
+            "attach cancelled by a concurrent detach/quit after window open"
+        );
         let _ = window.destroy();
         kill_and_untrack(state, workspace_id, port);
         return Err(format!(
@@ -330,6 +351,7 @@ fn attach_and_open_window(
     // The child is already tracked in `state.children` (inserted right
     // after spawn, above) — nothing more to do there on the success path.
 
+    tracing::info!(workspace_id, port, pid, "attach complete");
     spawn_monitor(app.clone(), workspace_id.to_string(), port, generation);
 
     Ok(AttachOutcome::Opened)
@@ -383,6 +405,7 @@ pub fn detach_internal(
     state: &AppState,
     workspace_id: &str,
 ) -> Result<(), String> {
+    tracing::info!(workspace_id, "detaching");
     let removed = locked(&state.attach).remove(workspace_id);
 
     if let Some(mut child) = locked(&state.children).remove(workspace_id) {
@@ -427,10 +450,19 @@ pub fn create_workspace(workspace_id: String) -> Result<(), String> {
     cli_ops::create_workspace(&cli_path, &workspace_id).map_err(|e| e.to_string())
 }
 
+/// Tail of `~/.beamtalk/launcher.log`, for the picker UI's log panel to seed
+/// itself with recent history on open — live updates after that arrive via
+/// the `launcher-log-line` event ([`crate::logging::spawn_log_relay`]).
+#[tauri::command(async)]
+pub fn get_launcher_logs(limit: Option<usize>) -> Result<Vec<String>, String> {
+    Ok(crate::logging::read_recent_logs(limit.unwrap_or(500)))
+}
+
 /// Quit: detach every tracked workspace (kills every front process, not
 /// just the picker), then exit the app.
 #[tauri::command(async)]
 pub fn quit(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
+    tracing::info!("quit requested");
     detach_all(&app, &state);
     app.exit(0);
     Ok(())
@@ -460,6 +492,7 @@ pub fn quit(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
 /// meant to guarantee they get killed.
 pub fn detach_all(app: &AppHandle, state: &AppState) {
     let ids: Vec<String> = locked(&state.children).keys().cloned().collect();
+    tracing::info!(count = ids.len(), "detaching all tracked fronts");
     for id in ids {
         let _ = detach_internal(app, state, &id);
     }
@@ -663,6 +696,7 @@ fn reflect_connection_state(
     workspace_id: &str,
     connection_state: &monitor::ConnectionState,
 ) {
+    tracing::info!(workspace_id, ?connection_state, "connection state changed");
     let label = window_label(workspace_id);
     if let Some(window) = app.get_webview_window(&label) {
         let base_title = format!("Beamtalk — {workspace_id}");

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -284,7 +284,21 @@ fn attach_and_open_window(
     tracing::info!(workspace_id, port, "opening workspace window");
 
     let label = window_label(workspace_id);
-    let url = format!("http://127.0.0.1:{port}/")
+    // `localhost`, not `127.0.0.1`: the front's zero-config endpoint config
+    // (`editors/liveview/config/runtime.exs`, the `PHX_HOST` unset case)
+    // advertises `url: [host: "localhost", ...]` and — since it never sets
+    // `check_origin` itself, Phoenix's own default (`true`, checked against
+    // that configured host) applies — rejects any WebSocket/LiveView
+    // upgrade whose `Origin` header doesn't match it. Opening the window at
+    // `127.0.0.1` sent an `Origin: http://127.0.0.1:<port>` that endpoint
+    // always rejected ("Could not check origin for Phoenix.Socket
+    // transport"), leaving the LiveView page stuck on its own pre-connected
+    // render ("Connecting to workspace…") forever — the readiness probe
+    // above only checks a plain HTTP GET, which carries no `Origin` header
+    // and was never affected. `localhost` resolves to the same loopback
+    // address this window was always restricted to (`BT_ATTACH_BIND_IP`
+    // above), so this changes nothing about which interfaces are reachable.
+    let url = format!("http://localhost:{port}/")
         .parse::<tauri::Url>()
         .map_err(|e| format!("invalid front URL: {e}"))?;
     let window = match WebviewWindowBuilder::new(app, label.clone(), WebviewUrl::External(url))
@@ -464,6 +478,14 @@ pub fn get_launcher_logs(limit: Option<usize>) -> Result<Vec<String>, String> {
 pub fn quit(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
     tracing::info!("quit requested");
     detach_all(&app, &state);
+    // Best-effort and idempotent (`LoggingGuard::flush` is a `.take()`):
+    // flush explicitly here rather than relying solely on `main.rs`'s
+    // `RunEvent::ExitRequested` handler, since it's not guaranteed that
+    // `app.exit()` below re-delivers that event before the process
+    // actually tears down.
+    if let Some(guard) = app.try_state::<Mutex<crate::logging::LoggingGuard>>() {
+        guard.lock().unwrap_or_else(|e| e.into_inner()).flush();
+    }
     app.exit(0);
     Ok(())
 }

--- a/desktop/src-tauri/src/logging.rs
+++ b/desktop/src-tauri/src/logging.rs
@@ -18,7 +18,7 @@
 //! on the *spawned front's* side, fixed alongside this).
 
 use std::io;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::mpsc;
 
 use tauri::{AppHandle, Emitter};
@@ -29,13 +29,46 @@ use tracing_subscriber::util::SubscriberInitExt;
 /// [`spawn_log_relay`].
 pub const LOG_LINE_EVENT: &str = "launcher-log-line";
 
+/// File name under `~/.beamtalk/` — shared between [`init_logging`] (writes)
+/// and [`read_recent_logs`] (reads), so the two can't drift apart.
+const LOG_FILE_NAME: &str = "launcher.log";
+
+/// Bounds how much of `launcher.log` [`read_recent_logs`] reads from disk.
+/// The file is never rotated (`Rotation::NEVER`) and accumulates across
+/// every restart, so a long-lived install's log can grow large; reading the
+/// whole thing just to keep the last few thousand lines would get slower
+/// and heavier every day the app stays installed. Generous enough that a
+/// realistic `limit` (the picker UI caps its own display at 2000 lines)
+/// almost never needs the "there weren't enough lines in this window" retry
+/// this function's implementation does. Full rotation is tracked separately
+/// (BT-3228) — this is only a read-side bound, not a write-side cap.
+const MAX_TAIL_READ_BYTES: u64 = 2 * 1024 * 1024;
+
 /// Keeps `tracing-appender`'s background flush thread alive; dropping this
-/// stops file writes. [`init_logging`]'s caller must hold it for the
-/// process lifetime — a `let` binding in `main()` that's never read again
-/// is enough, since it only needs to out live `app.run()`, not be used by
-/// it.
+/// stops file writes. `None` means file logging is disabled — either
+/// `launcher.log` couldn't be opened (see [`init_logging`]'s doc comment),
+/// or nothing was ever configured (a fresh [`LoggingGuard`] outside this
+/// module, which does not happen in practice — [`init_logging`] is the only
+/// constructor).
 pub struct LoggingGuard {
-    _file_guard: tracing_appender::non_blocking::WorkerGuard,
+    file_guard: Option<tracing_appender::non_blocking::WorkerGuard>,
+}
+
+impl LoggingGuard {
+    /// Force any buffered log lines to flush *now*, by dropping the
+    /// underlying file guard in place, rather than waiting for this
+    /// `LoggingGuard` itself to be dropped.
+    ///
+    /// Exists because `main()`'s own scope-end drop may never run:
+    /// `tauri::App::run` hands control to `tao`'s event loop, which on some
+    /// platforms exits the OS process from *inside* that call rather than
+    /// returning — so a plain `let _logging_guard = ...;` binding in
+    /// `main()` provides no actual flush-on-quit guarantee. `main.rs` calls
+    /// this from its `RunEvent::ExitRequested` handler instead, at the one
+    /// point it reliably knows shutdown is starting.
+    pub fn flush(&mut self) {
+        self.file_guard.take();
+    }
 }
 
 /// A line-buffering [`io::Write`] that forwards each complete line to `tx`
@@ -63,11 +96,41 @@ impl io::Write for ChannelWriter {
     }
 }
 
+/// Create `path` ahead of `tracing-appender`'s own open, `0600` (owner-only)
+/// on Unix — matching every other security-relevant file already under
+/// `~/.beamtalk/` (`workspace.log`, `cookie`, `vm.args`, `attach.log` —
+/// see `beamtalk_desktop_broker::spawn::open_front_log`'s doc comment for
+/// the same reasoning). `launcher.log` isn't as sensitive as a workspace's
+/// own cookie, but it does record project paths, workspace ids, and ports —
+/// enough to match the same posture rather than the world-readable default.
+/// Best-effort and creation-only, same limitation `open_front_log` already
+/// accepts: a file that already exists from before this code ran keeps
+/// whatever mode it had.
+#[cfg(unix)]
+fn ensure_owner_only(path: &Path) {
+    use std::os::unix::fs::OpenOptionsExt;
+    let _ = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(0o600)
+        .open(path);
+}
+
+#[cfg(not(unix))]
+fn ensure_owner_only(_path: &Path) {}
+
 /// Initialize the launcher's `tracing` subscriber: a file layer at
 /// `~/.beamtalk/launcher.log` (append, across restarts) plus a channel
 /// layer whose receiver [`spawn_log_relay`] later drains. Falls back to the
-/// OS temp dir if `~/.beamtalk` can't be resolved, rather than failing app
-/// startup over a logging nicety.
+/// OS temp dir if `~/.beamtalk` can't be resolved, and degrades to
+/// channel-only logging (no crash) if `launcher.log` itself can't be
+/// opened — e.g. `~/.beamtalk` owned by another user from a prior `sudo`
+/// invocation, or a full/read-only home directory. This function runs as
+/// the very first thing in `main()`, before any window exists; a hard
+/// `.expect()` here (which `tracing_appender::rolling::never` — the
+/// convenience constructor this used before this fix — has internally)
+/// would silently kill the app on launch with no visible error in a
+/// packaged build.
 ///
 /// Defaults to `info` (not the CLI's `warn`, see
 /// `beamtalk-cli/src/main.rs`'s own `EnvFilter` setup) — this subscriber
@@ -81,14 +144,38 @@ impl io::Write for ChannelWriter {
 #[must_use]
 pub fn init_logging() -> (LoggingGuard, mpsc::Receiver<String>) {
     let root_dir = beamtalk_workspace::beamtalk_root_dir().unwrap_or_else(|_| std::env::temp_dir());
-    let file_appender = tracing_appender::rolling::never(&root_dir, "launcher.log");
-    let (non_blocking, file_guard) = tracing_appender::non_blocking(file_appender);
+    let log_path = root_dir.join(LOG_FILE_NAME);
+    ensure_owner_only(&log_path);
+
+    let file_appender = tracing_appender::rolling::Builder::new()
+        .rotation(tracing_appender::rolling::Rotation::NEVER)
+        .filename_prefix(LOG_FILE_NAME)
+        .build(&root_dir)
+        .map_err(|err| {
+            eprintln!(
+                "beamtalk-desktop: could not open {}: {err} — file logging disabled, \
+                 in-app log panel still works",
+                log_path.display()
+            );
+        })
+        .ok();
+
+    let (file_layer, file_guard) = match file_appender {
+        Some(appender) => {
+            let (non_blocking, guard) = tracing_appender::non_blocking(appender);
+            (
+                Some(
+                    tracing_subscriber::fmt::layer()
+                        .with_writer(non_blocking)
+                        .with_ansi(false),
+                ),
+                Some(guard),
+            )
+        }
+        None => (None, None),
+    };
 
     let (tx, rx) = mpsc::channel();
-
-    let file_layer = tracing_subscriber::fmt::layer()
-        .with_writer(non_blocking)
-        .with_ansi(false);
     let channel_layer = tracing_subscriber::fmt::layer()
         .with_writer(move || ChannelWriter { tx: tx.clone() })
         .with_ansi(false);
@@ -102,12 +189,7 @@ pub fn init_logging() -> (LoggingGuard, mpsc::Receiver<String>) {
         .with(channel_layer)
         .init();
 
-    (
-        LoggingGuard {
-            _file_guard: file_guard,
-        },
-        rx,
-    )
+    (LoggingGuard { file_guard }, rx)
 }
 
 /// Spawn the background thread that drains `rx` (fed by [`init_logging`]'s
@@ -134,11 +216,112 @@ pub fn read_recent_logs(limit: usize) -> Vec<String> {
     let Ok(root_dir) = beamtalk_workspace::beamtalk_root_dir() else {
         return Vec::new();
     };
-    let path: PathBuf = root_dir.join("launcher.log");
-    let Ok(contents) = std::fs::read_to_string(&path) else {
+    read_recent_lines_from(&root_dir.join(LOG_FILE_NAME), limit)
+}
+
+/// [`read_recent_logs`]'s actual logic, parameterized over the file path so
+/// it's testable against a temp file instead of the real
+/// `~/.beamtalk/launcher.log` (`read_recent_logs` itself can't be — it
+/// hardcodes the real path via `beamtalk_workspace::beamtalk_root_dir`).
+///
+/// Bounded to the last [`MAX_TAIL_READ_BYTES`] of the file (BT-3225 review
+/// follow-up) rather than reading it in full — `launcher.log` has no
+/// rotation yet (BT-3228) and grows across every restart.
+fn read_recent_lines_from(path: &Path, limit: usize) -> Vec<String> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let Ok(mut file) = std::fs::File::open(path) else {
         return Vec::new();
     };
-    let lines: Vec<String> = contents.lines().map(str::to_string).collect();
+    let Ok(len) = file.metadata().map(|m| m.len()) else {
+        return Vec::new();
+    };
+
+    let seek_start = len.saturating_sub(MAX_TAIL_READ_BYTES);
+    let truncated = seek_start > 0;
+    if truncated && file.seek(SeekFrom::Start(seek_start)).is_err() {
+        return Vec::new();
+    }
+
+    let mut buf = Vec::new();
+    if file.read_to_end(&mut buf).is_err() {
+        return Vec::new();
+    }
+
+    // `from_utf8_lossy`, not `String::from_utf8` — a seek into the middle
+    // of the file can land mid-character, and lossy conversion turns that
+    // into a replacement character at the start instead of failing the
+    // whole read.
+    let text = String::from_utf8_lossy(&buf);
+    let mut lines: Vec<String> = text.lines().map(str::to_string).collect();
+    if truncated && !lines.is_empty() {
+        // The seek can also land mid-*line* (not just mid-character); the
+        // fragment before the first real newline is a partial line, not a
+        // full one — drop it rather than show a truncated log line.
+        lines.remove(0);
+    }
+
     let start = lines.len().saturating_sub(limit);
     lines[start..].to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_recent_lines_from_returns_empty_for_a_missing_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("nonexistent.log");
+        assert_eq!(read_recent_lines_from(&path, 100), Vec::<String>::new());
+    }
+
+    #[test]
+    fn read_recent_lines_from_returns_the_last_n_lines() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("launcher.log");
+        std::fs::write(&path, "one\ntwo\nthree\nfour\nfive\n").unwrap();
+
+        assert_eq!(read_recent_lines_from(&path, 2), vec!["four", "five"]);
+        assert_eq!(
+            read_recent_lines_from(&path, 100),
+            vec!["one", "two", "three", "four", "five"]
+        );
+    }
+
+    #[test]
+    fn read_recent_lines_from_bounds_the_read_and_drops_the_partial_leading_line() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("launcher.log");
+
+        // Bigger than MAX_TAIL_READ_BYTES, so the read must seek — one
+        // filler line long enough that a handful of them safely exceeds the
+        // bound, followed by a handful of short, distinctly-markered lines
+        // at the very end.
+        let filler_line = "x".repeat(1024);
+        let filler_lines_needed = (MAX_TAIL_READ_BYTES / filler_line.len() as u64) + 10;
+        let mut content = String::new();
+        for _ in 0..filler_lines_needed {
+            content.push_str(&filler_line);
+            content.push('\n');
+        }
+        content.push_str("tail-marker-1\ntail-marker-2\ntail-marker-3\n");
+        std::fs::write(&path, &content).unwrap();
+
+        // `limit: 3` — exactly the three tail markers, none of the filler.
+        // A `limit` large enough to also request filler lines would
+        // legitimately return some (they're real lines within the bounded
+        // 2MB window) — this asserts the seek reached near the true end of
+        // a much larger file and the partial leading line landed on a
+        // filler line's boundary was dropped cleanly, not that filler can
+        // never appear in a result.
+        let result = read_recent_lines_from(&path, 3);
+
+        assert_eq!(
+            result,
+            vec!["tail-marker-1", "tail-marker-2", "tail-marker-3"],
+            "expected exactly the three tail markers, in order, with no \
+             truncated filler fragment ahead of them"
+        );
+    }
 }

--- a/desktop/src-tauri/src/logging.rs
+++ b/desktop/src-tauri/src/logging.rs
@@ -41,7 +41,7 @@ const LOG_FILE_NAME: &str = "launcher.log";
 /// realistic `limit` (the picker UI caps its own display at 2000 lines)
 /// almost never needs the "there weren't enough lines in this window" retry
 /// this function's implementation does. Full rotation is tracked separately
-/// (BT-3228) — this is only a read-side bound, not a write-side cap.
+/// (BT-3229) — this is only a read-side bound, not a write-side cap.
 const MAX_TAIL_READ_BYTES: u64 = 2 * 1024 * 1024;
 
 /// Keeps `tracing-appender`'s background flush thread alive; dropping this
@@ -226,7 +226,7 @@ pub fn read_recent_logs(limit: usize) -> Vec<String> {
 ///
 /// Bounded to the last [`MAX_TAIL_READ_BYTES`] of the file (BT-3225 review
 /// follow-up) rather than reading it in full — `launcher.log` has no
-/// rotation yet (BT-3228) and grows across every restart.
+/// rotation yet (BT-3229) and grows across every restart.
 fn read_recent_lines_from(path: &Path, limit: usize) -> Vec<String> {
     use std::io::{Read, Seek, SeekFrom};
 

--- a/desktop/src-tauri/src/logging.rs
+++ b/desktop/src-tauri/src/logging.rs
@@ -1,0 +1,144 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Launcher-side structured logging (BT-3225): every real stage of the
+//! attach/spawn/readiness flow gets a `tracing` event. Two sinks:
+//! `~/.beamtalk/launcher.log` (persisted across restarts, `tail -f`-able —
+//! mirrors `~/.beamtalk/workspaces/<id>/workspace.log`'s own convention on
+//! the workspace-node side), and a channel drained by [`spawn_log_relay`]
+//! once an [`AppHandle`] exists, forwarding each line to the picker UI's
+//! log panel as a [`LOG_LINE_EVENT`].
+//!
+//! Without this, `beamtalk-desktop-broker`'s own `tracing::info!/warn!`
+//! calls (`discovery.rs`, `reap.rs`) went nowhere — no subscriber was ever
+//! installed, and a packaged build has no attached terminal to inherit
+//! stdio from even if one had been (`windows_subsystem = "windows"` on
+//! Windows; macOS/Linux app bundles have none either — see
+//! `beamtalk_desktop_broker::spawn`'s `redirect_front_stdio`, the same gap
+//! on the *spawned front's* side, fixed alongside this).
+
+use std::io;
+use std::path::PathBuf;
+use std::sync::mpsc;
+
+use tauri::{AppHandle, Emitter};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+/// Frontend event name carrying one formatted log line — see
+/// [`spawn_log_relay`].
+pub const LOG_LINE_EVENT: &str = "launcher-log-line";
+
+/// Keeps `tracing-appender`'s background flush thread alive; dropping this
+/// stops file writes. [`init_logging`]'s caller must hold it for the
+/// process lifetime — a `let` binding in `main()` that's never read again
+/// is enough, since it only needs to out live `app.run()`, not be used by
+/// it.
+pub struct LoggingGuard {
+    _file_guard: tracing_appender::non_blocking::WorkerGuard,
+}
+
+/// A line-buffering [`io::Write`] that forwards each complete line to `tx`
+/// — the picker UI's log panel wants whole lines, not arbitrary byte
+/// chunks, and `tracing_subscriber`'s `fmt` layer does not guarantee one
+/// `write` call per event.
+#[derive(Clone)]
+struct ChannelWriter {
+    tx: mpsc::Sender<String>,
+}
+
+impl io::Write for ChannelWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        for line in String::from_utf8_lossy(buf).lines() {
+            // Best-effort: a closed receiver (log panel never opened, or
+            // the app is mid-shutdown) just means no one is listening right
+            // now — not a reason to fail a tracing write over.
+            let _ = self.tx.send(line.to_string());
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Initialize the launcher's `tracing` subscriber: a file layer at
+/// `~/.beamtalk/launcher.log` (append, across restarts) plus a channel
+/// layer whose receiver [`spawn_log_relay`] later drains. Falls back to the
+/// OS temp dir if `~/.beamtalk` can't be resolved, rather than failing app
+/// startup over a logging nicety.
+///
+/// Defaults to `info` (not the CLI's `warn`, see
+/// `beamtalk-cli/src/main.rs`'s own `EnvFilter` setup) — this subscriber
+/// exists specifically to make the attach/spawn/readiness stage events
+/// (`crate::commands`) visible without requiring `RUST_LOG` to be set by
+/// hand; `RUST_LOG` still overrides it exactly as the CLI's does.
+///
+/// Must be called exactly once, before any `tracing::` call this process
+/// makes — including `beamtalk-desktop-broker`'s `discovery`/`reap` calls
+/// `main()`'s own `.setup()` triggers.
+#[must_use]
+pub fn init_logging() -> (LoggingGuard, mpsc::Receiver<String>) {
+    let root_dir = beamtalk_workspace::beamtalk_root_dir().unwrap_or_else(|_| std::env::temp_dir());
+    let file_appender = tracing_appender::rolling::never(&root_dir, "launcher.log");
+    let (non_blocking, file_guard) = tracing_appender::non_blocking(file_appender);
+
+    let (tx, rx) = mpsc::channel();
+
+    let file_layer = tracing_subscriber::fmt::layer()
+        .with_writer(non_blocking)
+        .with_ansi(false);
+    let channel_layer = tracing_subscriber::fmt::layer()
+        .with_writer(move || ChannelWriter { tx: tx.clone() })
+        .with_ansi(false);
+
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(file_layer)
+        .with(channel_layer)
+        .init();
+
+    (
+        LoggingGuard {
+            _file_guard: file_guard,
+        },
+        rx,
+    )
+}
+
+/// Spawn the background thread that drains `rx` (fed by [`init_logging`]'s
+/// channel layer) and forwards each line to the frontend as a
+/// [`LOG_LINE_EVENT`]. Split out from `init_logging` because an
+/// [`AppHandle`] only exists once the Tauri app is built — `init_logging`
+/// itself must run earlier, before any other `tracing::` call in `main()`'s
+/// own `.setup()`.
+pub fn spawn_log_relay(app: AppHandle, rx: mpsc::Receiver<String>) {
+    std::thread::spawn(move || {
+        for line in rx {
+            let _ = app.emit(LOG_LINE_EVENT, line);
+        }
+    });
+}
+
+/// Read the tail of `~/.beamtalk/launcher.log` — up to `limit` lines — to
+/// seed the picker UI's log panel with recent history on open, before any
+/// live [`LOG_LINE_EVENT`] has fired. Returns an empty vec (not an error)
+/// if the file doesn't exist yet — nothing has logged since the log
+/// directory was created, not a failure worth surfacing to the UI.
+#[must_use]
+pub fn read_recent_logs(limit: usize) -> Vec<String> {
+    let Ok(root_dir) = beamtalk_workspace::beamtalk_root_dir() else {
+        return Vec::new();
+    };
+    let path: PathBuf = root_dir.join("launcher.log");
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    let lines: Vec<String> = contents.lines().map(str::to_string).collect();
+    let start = lines.len().saturating_sub(limit);
+    lines[start..].to_vec()
+}

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -26,18 +26,25 @@ mod launcher;
 mod logging;
 mod state;
 
+use std::sync::Mutex;
+
 use tauri::Manager;
 
+use logging::LoggingGuard;
 use state::AppState;
 
 fn main() {
     // Must run before any other `tracing::` call this process makes,
     // including the reap sweep and `resolve_launcher_path` calls in
     // `.setup()` just below — see `logging::init_logging`'s doc comment.
-    // `_logging_guard` is never read again, but must stay alive until
-    // `app.run()` below returns (dropping it early would silently stop
-    // `launcher.log` file writes).
-    let (_logging_guard, log_rx) = logging::init_logging();
+    // Managed as Tauri state (below, in `.setup()`) rather than left as a
+    // local binding: `commands::quit` and this file's own
+    // `RunEvent::ExitRequested` handler both need to call
+    // `LoggingGuard::flush` explicitly at shutdown — a plain `let` binding
+    // here would only flush on `main()`'s own scope exit, which
+    // `app.run()` below may never reach (see `LoggingGuard::flush`'s doc
+    // comment for why).
+    let (logging_guard, log_rx) = logging::init_logging();
 
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
@@ -74,6 +81,7 @@ fn main() {
             let launcher = launcher::resolve_launcher_path(app.handle());
             tracing::info!(launcher = %launcher.display(), "resolved bt_attach launcher path");
             app.manage(AppState::new(launcher));
+            app.manage(Mutex::new(logging_guard));
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -98,6 +106,14 @@ fn main() {
         if let tauri::RunEvent::ExitRequested { .. } = event {
             let state = app_handle.state::<AppState>();
             commands::detach_all(app_handle, &state);
+            // Best-effort and idempotent (`LoggingGuard::flush` is a
+            // `.take()`) — `commands::quit`'s in-app "Quit" path already
+            // calls this itself, so this only matters for an OS-level quit
+            // (Cmd-Q, taskbar close, SIGTERM, …), which never goes through
+            // that command at all.
+            if let Some(guard) = app_handle.try_state::<Mutex<LoggingGuard>>() {
+                guard.lock().unwrap_or_else(|e| e.into_inner()).flush();
+            }
         }
     });
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -23,6 +23,7 @@
 mod commands;
 mod dto;
 mod launcher;
+mod logging;
 mod state;
 
 use tauri::Manager;
@@ -30,6 +31,14 @@ use tauri::Manager;
 use state::AppState;
 
 fn main() {
+    // Must run before any other `tracing::` call this process makes,
+    // including the reap sweep and `resolve_launcher_path` calls in
+    // `.setup()` just below — see `logging::init_logging`'s doc comment.
+    // `_logging_guard` is never read again, but must stay alive until
+    // `app.run()` below returns (dropping it early would silently stop
+    // `launcher.log` file writes).
+    let (_logging_guard, log_rx) = logging::init_logging();
+
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
             // Second launch: focus the existing picker rather than starting
@@ -40,15 +49,30 @@ fn main() {
                 let _ = window.unminimize();
             }
         }))
-        .setup(|app| {
+        .setup(move |app| {
+            // The frontend log panel's live feed — needs a real AppHandle,
+            // which only exists from here on (see `logging::spawn_log_relay`'s
+            // doc comment for why this can't happen inside `init_logging`
+            // itself).
+            logging::spawn_log_relay(app.handle().clone(), log_rx);
+
             // Broker-restart duty (ADR 0097 Broker §4 / spike criterion (g)):
             // sweep any fronts orphaned by a previous, uncleanly-terminated
             // broker process before this one starts tracking anything new.
-            if let Ok(dir) = beamtalk_desktop_broker::reap::state_dir() {
-                let _ = beamtalk_desktop_broker::reap::sweep(&dir);
+            match beamtalk_desktop_broker::reap::state_dir() {
+                Ok(dir) => match beamtalk_desktop_broker::reap::sweep(&dir) {
+                    Ok(report) => {
+                        tracing::info!(?report, "swept orphaned fronts from a previous broker run");
+                    }
+                    Err(err) => tracing::warn!(%err, "orphan sweep failed"),
+                },
+                Err(err) => {
+                    tracing::warn!(%err, "could not resolve broker state dir; skipped orphan sweep")
+                }
             }
 
             let launcher = launcher::resolve_launcher_path(app.handle());
+            tracing::info!(launcher = %launcher.display(), "resolved bt_attach launcher path");
             app.manage(AppState::new(launcher));
             Ok(())
         })
@@ -58,6 +82,7 @@ fn main() {
             commands::detach,
             commands::create_workspace,
             commands::quit,
+            commands::get_launcher_logs,
         ])
         .build(tauri::generate_context!())
         .expect("error while building the beamtalk desktop app");

--- a/desktop/ui/index.html
+++ b/desktop/ui/index.html
@@ -8,8 +8,19 @@
   <body>
     <header>
       <h1>Beamtalk</h1>
-      <button id="quit-button" title="Quit">Quit</button>
+      <div class="header-actions">
+        <button id="logs-button" title="Show launcher logs">Logs</button>
+        <button id="quit-button" title="Quit">Quit</button>
+      </div>
     </header>
+
+    <section id="log-panel" hidden>
+      <div class="log-panel-head">
+        <span>Launcher logs</span>
+        <button id="log-panel-close-button" title="Close">Close</button>
+      </div>
+      <pre id="log-output"></pre>
+    </section>
 
     <main id="app">
       <p id="status" class="status">Loading workspaces…</p>

--- a/desktop/ui/main.js
+++ b/desktop/ui/main.js
@@ -24,6 +24,10 @@ const createWorkspaceButton = document.getElementById(
 );
 const workspaceListEl = document.getElementById("workspace-list");
 const quitButton = document.getElementById("quit-button");
+const logsButton = document.getElementById("logs-button");
+const logPanelEl = document.getElementById("log-panel");
+const logOutputEl = document.getElementById("log-output");
+const logPanelCloseButton = document.getElementById("log-panel-close-button");
 
 // workspaceId -> stage string ("spawning" | "probing"), while an attach is
 // in flight.
@@ -31,6 +35,47 @@ const attachProgress = new Map();
 // workspaceId -> a short human-readable disconnected/unreachable label, for
 // attached workspaces the post-attach monitor has flagged as unhealthy.
 const connectionBadges = new Map();
+
+// BT-3225: launcher-side log lines (backend `tracing` events), fed by the
+// `launcher-log-line` event and seeded from `~/.beamtalk/launcher.log` on
+// first open. Buffered here (not just appended to the DOM) so lines that
+// arrive while the panel is closed aren't lost, and capped so a long
+// session's log can't grow the DOM without bound.
+const MAX_LOG_LINES = 2000;
+let logLines = [];
+let logsLoaded = false;
+
+function pushLogLine(line) {
+  logLines.push(line);
+  if (logLines.length > MAX_LOG_LINES) {
+    logLines = logLines.slice(logLines.length - MAX_LOG_LINES);
+  }
+  if (!logPanelEl.hidden) {
+    renderLogs();
+  }
+}
+
+function renderLogs() {
+  logOutputEl.textContent = logLines.join("\n");
+  logOutputEl.scrollTop = logOutputEl.scrollHeight;
+}
+
+async function openLogPanel() {
+  logPanelEl.hidden = false;
+  if (!logsLoaded) {
+    logsLoaded = true;
+    try {
+      const recent = await invoke("get_launcher_logs", { limit: MAX_LOG_LINES });
+      logLines = recent.concat(logLines);
+      if (logLines.length > MAX_LOG_LINES) {
+        logLines = logLines.slice(logLines.length - MAX_LOG_LINES);
+      }
+    } catch (err) {
+      logLines.push(`(failed to load launcher.log: ${err})`);
+    }
+  }
+  renderLogs();
+}
 
 // Coalescing window for `scheduleRefresh` (below) — chosen to smooth out a
 // flapping connection or several concurrent attaches firing `attach-progress`/
@@ -296,6 +341,14 @@ quitButton.addEventListener("click", () => {
   invoke("quit");
 });
 
+logsButton.addEventListener("click", () => {
+  openLogPanel();
+});
+
+logPanelCloseButton.addEventListener("click", () => {
+  logPanelEl.hidden = true;
+});
+
 // These two events are the flapping/bursty case `scheduleRefresh`'s debounce
 // exists for: a shaky connection or several concurrent attaches can each
 // fire several times a second, and without coalescing, each one used to
@@ -303,6 +356,13 @@ quitButton.addEventListener("click", () => {
 listen("attach-progress", (event) => {
   attachProgress.set(event.payload.workspace_id, event.payload.stage);
   scheduleRefresh();
+});
+
+// BT-3225: always listening (not just while the panel is open), so nothing
+// is lost between backend events and the next time the user opens it — see
+// `pushLogLine`'s doc comment.
+listen("launcher-log-line", (event) => {
+  pushLogLine(event.payload);
 });
 
 listen("connection-state-changed", (event) => {

--- a/desktop/ui/main.js
+++ b/desktop/ui/main.js
@@ -37,15 +37,22 @@ const attachProgress = new Map();
 const connectionBadges = new Map();
 
 // BT-3225: launcher-side log lines (backend `tracing` events), fed by the
-// `launcher-log-line` event and seeded from `~/.beamtalk/launcher.log` on
-// first open. Buffered here (not just appended to the DOM) so lines that
-// arrive while the panel is closed aren't lost, and capped so a long
+// `launcher-log-line` event once the panel has been opened once, seeded
+// from `~/.beamtalk/launcher.log` at that same moment. Lines that arrive
+// *before* the first open are deliberately dropped by `pushLogLine`, not
+// buffered — the same tracing event that fires `launcher-log-line` also
+// writes to `launcher.log`, so `get_launcher_logs`' file-tail read on first
+// open already contains everything that happened before it; buffering the
+// live copy too would show every one of those lines twice. Capped so a long
 // session's log can't grow the DOM without bound.
 const MAX_LOG_LINES = 2000;
 let logLines = [];
 let logsLoaded = false;
 
 function pushLogLine(line) {
+  if (!logsLoaded) {
+    return;
+  }
   logLines.push(line);
   if (logLines.length > MAX_LOG_LINES) {
     logLines = logLines.slice(logLines.length - MAX_LOG_LINES);
@@ -63,16 +70,18 @@ function renderLogs() {
 async function openLogPanel() {
   logPanelEl.hidden = false;
   if (!logsLoaded) {
-    logsLoaded = true;
+    let recent;
     try {
-      const recent = await invoke("get_launcher_logs", { limit: MAX_LOG_LINES });
-      logLines = recent.concat(logLines);
-      if (logLines.length > MAX_LOG_LINES) {
-        logLines = logLines.slice(logLines.length - MAX_LOG_LINES);
-      }
+      recent = await invoke("get_launcher_logs", { limit: MAX_LOG_LINES });
     } catch (err) {
-      logLines.push(`(failed to load launcher.log: ${err})`);
+      recent = [`(failed to load launcher.log: ${err})`];
     }
+    // Flip the flag in the same tick as the assignment (no `await` between
+    // them): any `launcher-log-line` event that arrives during the fetch
+    // above was dropped by `pushLogLine` (`logsLoaded` was still false), so
+    // assigning here can't race a concurrent append into `logLines`.
+    logLines = recent;
+    logsLoaded = true;
   }
   renderLogs();
 }

--- a/desktop/ui/style.css
+++ b/desktop/ui/style.css
@@ -151,9 +151,17 @@ button:disabled {
   position: fixed;
   inset: 0;
   z-index: 10;
-  display: flex;
   flex-direction: column;
   background: var(--bg);
+}
+
+/* `#log-panel` alone (specificity 100) would otherwise beat the browser's
+   built-in `[hidden] { display: none }` UA rule (specificity 10) and stay
+   visible — covering the whole window, workspace list included — even with
+   the `hidden` attribute set. `display` only turns on here, scoped to the
+   non-hidden case, so `hidden` wins when present. */
+#log-panel:not([hidden]) {
+  display: flex;
 }
 
 .log-panel-head {

--- a/desktop/ui/style.css
+++ b/desktop/ui/style.css
@@ -47,6 +47,11 @@ header h1 {
   margin: 0;
 }
 
+.header-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 main {
   padding: 1rem;
 }
@@ -136,7 +141,37 @@ button:disabled {
   cursor: default;
 }
 
-#quit-button {
+#quit-button,
+#logs-button {
   background: transparent;
   color: var(--fg);
+}
+
+#log-panel {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+}
+
+.log-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+}
+
+#log-output {
+  flex: 1;
+  margin: 0;
+  padding: 0.75rem 1rem;
+  overflow-y: auto;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.75rem;
+  white-space: pre-wrap;
+  word-break: break-all;
 }

--- a/docs/deployment/desktop-attach-client.md
+++ b/docs/deployment/desktop-attach-client.md
@@ -131,6 +131,15 @@ not run it, or any Beamtalk workspace, as a genuinely multi-user service.
 
 ## Troubleshooting
 
+- **Logs** — the picker's own attach/spawn/readiness stages are logged to
+  `~/.beamtalk/launcher.log`, viewable live from within the app itself via
+  the header's **Logs** button, or by tailing the file directly. A spawned
+  front's own output (Elixir `Logger`/Phoenix, including exceptions and
+  endpoint errors) goes to `~/.beamtalk/workspaces/<id>/attach.log` — check
+  this first if a workspace window opens but never finishes connecting
+  (stuck on "Connecting to workspace…"), since that means the front itself
+  is up but something inside it is failing. Both accumulate across restarts
+  the same way `workspace.log` does.
 - **"Attach failed: unreachable"** (or similar) — the picker surfaces the
   same failure taxonomy the workspace's `/readiness` endpoint reports:
   `epmd_absent` (no local epmd — the workspace's own boot should have started


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-3225

The desktop picker (`desktop/src-tauri`) had no tracing subscriber installed at all, and the spawned `bt_attach` front's stdout/stderr were inherited into a packaged app's nonexistent stdio — so a stuck or crashed front was invisible short of running the release binary manually from a terminal. This surfaced while debugging exactly that symptom (a front window stuck on "Connecting to workspace…").

- **`crates/beamtalk-workspace`**: adds `beamtalk_root_dir()`, the shared `~/.beamtalk` root helper both this crate's callers and the desktop launcher now build on (converges several pre-existing duplicate `dirs::home_dir().join(".beamtalk")` call sites in the process), plus `resolve_epmd_address()`, the shared loopback-pinning policy now used by both `beamtalk-cli` and the desktop broker.
- **`crates/beamtalk-desktop-broker`**: redirects a spawned front's stdout/stderr to `~/.beamtalk/workspaces/<id>/attach.log` (0600, append) instead of inheriting; pins `ERL_EPMD_ADDRESS=127.0.0.1` for the front's env, matching what the CLI's own workspace startup already does (fixes epmd being left bound to `0.0.0.0`, confirmed live via `beamtalk repl`'s own preflight warning).
- **`desktop/src-tauri`**: wires up a `tracing_subscriber` writing to `~/.beamtalk/launcher.log` (non-panicking on an unwritable file, flushed explicitly on quit) and relaying live events to the frontend; instruments every attach/spawn/readiness/detach/monitor stage; adds a `get_launcher_logs` command.
- **`desktop/ui`**: adds an in-app log viewer panel seeded from `launcher.log` and live-updated via a `launcher-log-line` event.
- **Root cause fix**: `attach.log`'s new capture directly surfaced `"Could not check origin for Phoenix.Socket transport"` — the front's zero-config endpoint advertises `url: [host: "localhost"]`, but the window was opened at `http://127.0.0.1:<port>/`, so Phoenix's `check_origin` rejected every socket upgrade. One-line fix in `commands.rs` (open at `localhost` instead) resolves the original "stuck connecting" symptom this whole effort started from.

Full three-pass code review completed (see commit history) — permissions hardening, a log-panel dedup bug, a startup panic risk, an unflushed-shutdown-logs bug, and an unbounded-file-read all found and fixed along the way. Two follow-up issues filed for pre-existing/out-of-scope findings: BT-3226 (flaky `spawn_front_with_port_retry` tests, confirmed pre-existing on `main`), BT-3227 (two more `~/.beamtalk` duplicate lookups outside this PR's touched crates).

## Test plan

- [x] `just build` / `just clippy` / `just fmt-check` clean across the whole workspace
- [x] `cargo test -p beamtalk-workspace -p beamtalk-desktop-broker -p beamtalk-cli` — all pass except two pre-existing flakes (BT-3226), confirmed unrelated via `git stash`
- [x] `just test-desktop` (dedicated Tauri crate suite, incl. new `logging.rs` tests) — all pass
- [x] `just test-stdlib` (233/233), `just test-bunit` (3305/3307, 0 failed), `just test-runtime` (7647/7647) — all pass
- [x] Verified end-to-end against a real running instance of the app mid-review (surfaced and confirmed the origin-check root-cause fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)