### PR TITLE
Desktop picker: sort by directory, filter buttons, bigger windows (BT-3230)

### DIFF
--- a/crates/beamtalk-desktop-broker/src/discovery.rs
+++ b/crates/beamtalk-desktop-broker/src/discovery.rs
@@ -185,8 +185,36 @@ pub fn discover_workspaces() -> Result<Vec<WorkspaceSummary>> {
         summary.alive = epmd_names.iter().any(|n| n == short_name);
         summaries.push(summary);
     }
-    summaries.sort_by(|a, b| a.id.cmp(&b.id));
+    sort_by_project_path(&mut summaries);
     Ok(summaries)
+}
+
+/// Sort key for [`discover_workspaces`]'s listing: by project path
+/// (case-insensitive), not `id` — `id` is an opaque SHA256 hash of the path
+/// (`beamtalk_workspace::generate_workspace_id`), so sorting by it scatters
+/// workspaces from the same project directory randomly through the list
+/// instead of grouping them (BT-3230). A missing `project_path` (a
+/// hand-edited/corrupted `metadata.json`) sorts after every path-having
+/// workspace; `id` is the tiebreaker for two workspaces with the same or
+/// absent path.
+///
+/// Pure (no filesystem I/O) and split out from [`discover_workspaces`]
+/// specifically so it's unit-testable directly against hand-built
+/// `WorkspaceSummary` values, without touching the real
+/// `~/.beamtalk/workspaces/` that function itself reads from.
+fn sort_by_project_path(summaries: &mut [WorkspaceSummary]) {
+    summaries.sort_by(|a, b| {
+        // `(has_no_path, lowercased_path)`, not a bare `Option<String>`:
+        // `Option`'s derived order puts `None` *before* every `Some`, the
+        // opposite of what's wanted here — this tuple's `bool` element
+        // pushes every no-path workspace after every path-having one
+        // regardless of the (irrelevant, in that case) string half.
+        let path_key = |s: &WorkspaceSummary| match &s.project_path {
+            Some(p) => (false, p.to_string_lossy().to_lowercase()),
+            None => (true, String::new()),
+        };
+        path_key(a).cmp(&path_key(b)).then_with(|| a.id.cmp(&b.id))
+    });
 }
 
 #[cfg(test)]
@@ -328,5 +356,78 @@ mod tests {
         // like. The pure-parsing behavior above covers the real logic.
         let result = discover_workspaces();
         assert!(result.is_ok(), "discovery must not error: {result:?}");
+    }
+
+    fn summary_with_path(id: &str, path: Option<&str>) -> WorkspaceSummary {
+        WorkspaceSummary {
+            id: id.to_string(),
+            project_path: path.map(PathBuf::from),
+            node_name: default_node_name(id),
+            alive: false,
+        }
+    }
+
+    #[test]
+    fn sort_by_project_path_groups_by_directory_not_id() {
+        let mut summaries = vec![
+            summary_with_path("zzz111", Some("/Users/james/source/beamtalk")),
+            summary_with_path("aaa000", Some("/Users/james/source/zebra")),
+            summary_with_path("mmm555", Some("/Users/james/source/beamtalk")),
+        ];
+
+        sort_by_project_path(&mut summaries);
+
+        // Both `beamtalk`-path workspaces land adjacent, ordered before
+        // `zebra` alphabetically — despite `id` ordering (aaa < mmm < zzz)
+        // disagreeing entirely.
+        assert_eq!(
+            summaries.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+            vec!["mmm555", "zzz111", "aaa000"]
+        );
+    }
+
+    #[test]
+    fn sort_by_project_path_is_case_insensitive() {
+        let mut summaries = vec![
+            summary_with_path("id1", Some("/Users/James/Project")),
+            summary_with_path("id2", Some("/users/adam/project")),
+        ];
+
+        sort_by_project_path(&mut summaries);
+
+        assert_eq!(
+            summaries.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+            vec!["id2", "id1"]
+        );
+    }
+
+    #[test]
+    fn sort_by_project_path_puts_missing_paths_last() {
+        let mut summaries = vec![
+            summary_with_path("no_path", None),
+            summary_with_path("has_path", Some("/anywhere")),
+        ];
+
+        sort_by_project_path(&mut summaries);
+
+        assert_eq!(
+            summaries.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+            vec!["has_path", "no_path"]
+        );
+    }
+
+    #[test]
+    fn sort_by_project_path_breaks_ties_on_id() {
+        let mut summaries = vec![
+            summary_with_path("zzz", Some("/same/path")),
+            summary_with_path("aaa", Some("/same/path")),
+        ];
+
+        sort_by_project_path(&mut summaries);
+
+        assert_eq!(
+            summaries.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+            vec!["aaa", "zzz"]
+        );
     }
 }

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -273,6 +273,15 @@ fn attach_and_open_window(
         .map_err(|e| format!("invalid front URL: {e}"))?;
     let window = match WebviewWindowBuilder::new(app, label.clone(), WebviewUrl::External(url))
         .title(format!("Beamtalk — {workspace_id}"))
+        // The workspace window is a full IDE (editor, REPL, transcript,
+        // inspector panes) — Tauri's own unset-size default (a plain
+        // 800x600) is cramped for that on anything but a small laptop
+        // display. 1400x900 is a roomy-but-not-presumptuous starting size;
+        // `resizable` isn't set `false` anywhere, so this is just the
+        // initial size, not a cap.
+        .inner_size(1400.0, 900.0)
+        .min_inner_size(720.0, 480.0)
+        .center()
         .build()
     {
         Ok(window) => window,

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -13,10 +13,10 @@
         "label": "picker",
         "title": "Beamtalk",
         "url": "index.html",
-        "width": 480,
-        "height": 640,
-        "minWidth": 360,
-        "minHeight": 420,
+        "width": 640,
+        "height": 800,
+        "minWidth": 420,
+        "minHeight": 480,
         "resizable": true
       }
     ],

--- a/desktop/ui/index.html
+++ b/desktop/ui/index.html
@@ -29,6 +29,16 @@
         </div>
       </section>
 
+      <div id="workspace-filters" class="workspace-filters" hidden>
+        <button class="filter-button" data-filter="all">All</button>
+        <button class="filter-button" data-filter="running">Running</button>
+        <button class="filter-button" data-filter="stopped">Stopped</button>
+      </div>
+
+      <p id="workspace-filter-empty" class="status" hidden>
+        No workspaces match this filter.
+      </p>
+
       <ul id="workspace-list" hidden></ul>
     </main>
 

--- a/desktop/ui/main.js
+++ b/desktop/ui/main.js
@@ -23,6 +23,11 @@ const createWorkspaceButton = document.getElementById(
   "create-workspace-button",
 );
 const workspaceListEl = document.getElementById("workspace-list");
+const workspaceFiltersEl = document.getElementById("workspace-filters");
+const workspaceFilterEmptyEl = document.getElementById(
+  "workspace-filter-empty",
+);
+const filterButtons = [...document.querySelectorAll(".filter-button")];
 const quitButton = document.getElementById("quit-button");
 
 // workspaceId -> stage string ("spawning" | "probing"), while an attach is
@@ -31,6 +36,53 @@ const attachProgress = new Map();
 // workspaceId -> a short human-readable disconnected/unreachable label, for
 // attached workspaces the post-attach monitor has flagged as unhealthy.
 const connectionBadges = new Map();
+
+// "all" | "running" | "stopped" (BT-3230) — persists across refreshes
+// (a periodic `runRefresh()` re-applies it to the freshly fetched list
+// rather than resetting to "all") until the user picks a different one.
+let currentFilter = "all";
+// The last full (unfiltered) workspace list `render()` saw — filter button
+// clicks re-render from this directly rather than re-invoking
+// `list_workspaces`, so switching filters is instant and never races a
+// concurrent backend refresh.
+let lastWorkspaces = [];
+
+// The last non-empty path segment, e.g. "/Users/james/source/beamtalk" ->
+// "beamtalk". Splits on both "/" and "\\" since `project_path` comes from
+// the picker's own host OS and this app targets Windows too (BT-2988);
+// `null` for a missing path or one with no segments (e.g. "/" or "\\"),
+// letting the caller fall back to something else rather than showing
+// nothing.
+function leafDirName(projectPath) {
+  if (!projectPath) {
+    return null;
+  }
+  const segments = projectPath.split(/[/\\]/).filter(Boolean);
+  return segments.length > 0 ? segments[segments.length - 1] : null;
+}
+
+function matchesFilter(workspace) {
+  if (currentFilter === "running") {
+    return workspace.alive;
+  }
+  if (currentFilter === "stopped") {
+    return !workspace.alive;
+  }
+  return true;
+}
+
+function setFilter(filter) {
+  currentFilter = filter;
+  for (const button of filterButtons) {
+    button.classList.toggle("active", button.dataset.filter === filter);
+  }
+  renderWorkspaceListForCurrentFilter();
+}
+
+for (const button of filterButtons) {
+  button.addEventListener("click", () => setFilter(button.dataset.filter));
+}
+setFilter(currentFilter);
 
 // Coalescing window for `scheduleRefresh` (below) — chosen to smooth out a
 // flapping connection or several concurrent attaches firing `attach-progress`/
@@ -87,21 +139,43 @@ async function runRefresh() {
 }
 
 function render(view) {
+  lastWorkspaces = view.workspaces;
   const hasWorkspaces = view.workspaces.length > 0;
   statusEl.hidden = true;
   emptyStateEl.hidden = hasWorkspaces;
-  workspaceListEl.hidden = !hasWorkspaces;
+  // Filter buttons are meaningless with nothing to filter — hide them along
+  // with the (unrelated) "create a workspace" empty state.
+  workspaceFiltersEl.hidden = !hasWorkspaces;
 
   if (!hasWorkspaces) {
     renderEmptyState(view.empty_state);
     // Nothing to reconcile against once the list is empty — clear any rows
     // left over from a prior non-empty render so the next transition back
-    // to non-empty starts from a clean slate.
+    // to non-empty starts from a clean slate. Also clears a stale
+    // "no workspaces match this filter" message left over from before the
+    // last workspace disappeared entirely.
+    workspaceListEl.hidden = true;
     workspaceListEl.replaceChildren();
+    workspaceFilterEmptyEl.hidden = true;
     return;
   }
 
-  reconcileWorkspaceList(view.workspaces);
+  renderWorkspaceListForCurrentFilter();
+}
+
+// Re-derive the visible row set from `lastWorkspaces` + `currentFilter` and
+// reconcile the list against it. Called both by `render()` (a fresh
+// backend fetch landed) and `setFilter()` (the user picked a different
+// filter over already-fetched data) — kept as one function so those two
+// triggers can't drift into different filtering logic.
+function renderWorkspaceListForCurrentFilter() {
+  if (lastWorkspaces.length === 0) {
+    return;
+  }
+  const visible = lastWorkspaces.filter(matchesFilter);
+  workspaceFilterEmptyEl.hidden = visible.length > 0;
+  workspaceListEl.hidden = visible.length === 0;
+  reconcileWorkspaceList(visible);
 }
 
 // Update `workspaceListEl` to match `workspaces` by reusing existing row
@@ -184,6 +258,10 @@ function renderWorkspaceRow(workspace) {
   name.className = "workspace-name";
   info.appendChild(name);
 
+  const id = document.createElement("span");
+  id.className = "workspace-id";
+  info.appendChild(id);
+
   const liveBadge = document.createElement("span");
   liveBadge.className = "workspace-live-badge";
   info.appendChild(liveBadge);
@@ -211,8 +289,22 @@ function renderWorkspaceRow(workspace) {
 // showing (e.g.) an open dropdown or mid-click button is left otherwise
 // undisturbed by an unrelated refresh.
 function updateWorkspaceRow(li, workspace) {
+  // BT-3230: the leaf directory name (e.g. ".../source/beamtalk" ->
+  // "beamtalk") is the one thing a human actually recognizes at a glance —
+  // promote it to the row's primary label, in place of the opaque id.
+  // Falls back to the id when there's no project_path to take a leaf from
+  // (a hand-edited/corrupted metadata.json — rare).
+  const leaf = leafDirName(workspace.project_path);
   const name = li.querySelector(".workspace-name");
-  name.textContent = workspace.id;
+  name.textContent = leaf ?? workspace.id;
+
+  const id = li.querySelector(".workspace-id");
+  // Only shown alongside a promoted leaf name — when there's no path, the
+  // primary label above already *is* the id, so repeating it here would be
+  // redundant clutter instead of the disambiguation aid it's meant to be
+  // (two different projects can share a leaf directory name).
+  id.hidden = !leaf;
+  id.textContent = leaf ? workspace.id : "";
 
   const liveBadge = li.querySelector(".workspace-live-badge");
   liveBadge.className = workspace.alive

--- a/desktop/ui/style.css
+++ b/desktop/ui/style.css
@@ -72,6 +72,26 @@ main {
   padding: 0;
 }
 
+.workspace-filters {
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.filter-button {
+  background: transparent;
+  color: var(--muted);
+  border-color: var(--border);
+  padding: 0.25rem 0.6rem;
+  font-size: 0.8rem;
+}
+
+.filter-button.active {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
 .workspace-row {
   display: flex;
   align-items: center;
@@ -90,6 +110,12 @@ main {
 
 .workspace-name {
   font-weight: 600;
+}
+
+.workspace-id {
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 }
 
 .workspace-path {


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-3230

With many test/throwaway workspaces accumulated, the picker's list was hard to scan:

- `discover_workspaces` sorted by the opaque `id` hash (`crates/beamtalk-desktop-broker/src/discovery.rs`), not the project path — workspaces from the same project scattered randomly through the list.
- Each row's primary bold label was that same opaque id, with the actual project path shown as small muted text — the one thing a human recognizes was the least visible thing in the row.
- No way to filter out stopped/test workspaces.

## Changes

- **`crates/beamtalk-desktop-broker`**: sort by `project_path` (case-insensitive, `id` as tiebreaker, no-path entries sort last) instead of `id`. Extracted into a pure `sort_by_project_path` helper with direct unit test coverage (no filesystem I/O needed).
- **`desktop/ui`**: promote the leaf directory name (e.g. `.../beamtalk` → `beamtalk`) to each row's primary label, falling back to the id only when there's no `project_path`; the id stays visible as a smaller secondary label for disambiguation. Added All/Running/Stopped filter buttons — purely client-side over the already-fetched list, no new backend command, and the selection persists across the normal periodic refresh instead of resetting.
- **Bonus** (small, done while in the same files): the workspace/IDE window had no explicit size (Tauri's bare 800×600 default) and the picker itself was a narrow 480×640 — both cramped on a large display. Picker bumped to 640×800; workspace windows now open at 1400×900, centered, with a 720×480 minimum.

## Test plan

- [x] `just build` / `just clippy` / `just fmt-check` clean
- [x] New `discovery::tests::sort_by_project_path_*` unit tests (grouping, case-insensitivity, missing-path ordering, id tiebreak)
- [x] `just test-desktop` and full `beamtalk-desktop-broker` suite pass (two pre-existing unrelated flakes — BT-3226 — confirmed on `main` independently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)