### PR TITLE
Fix desktop-attach front reload loop under dev-auth (BT-3228)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/endpoint.ex
+++ b/editors/liveview/lib/bt_attach_web/endpoint.ex
@@ -16,9 +16,13 @@ defmodule BtAttachWeb.Endpoint do
     secure: Application.compile_env(:bt_attach, :secure_session, false)
   ]
 
+  # :peer_data is required by BtAttachWeb.Auth.dev_connect_ok?/1, which gates
+  # dev-auth LiveView sockets to loopback. Without it, get_connect_info(socket,
+  # :peer_data) is always nil on every connected mount, so dev-auth always
+  # halts+redirects — an infinite full-page reload loop (BT-3228).
   socket "/live", Phoenix.LiveView.Socket,
-    websocket: [connect_info: [session: @session_options]],
-    longpoll: [connect_info: [session: @session_options]]
+    websocket: [connect_info: [:peer_data, session: @session_options]],
+    longpoll: [connect_info: [:peer_data, session: @session_options]]
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/editors/liveview/test/bt_attach_web/session_lifecycle_test.exs
+++ b/editors/liveview/test/bt_attach_web/session_lifecycle_test.exs
@@ -120,4 +120,43 @@ defmodule BtAttachWeb.SessionLifecycleTest do
       assert response(conn, 403) =~ "loopback-only"
     end
   end
+
+  describe "dev-auth connected mount requires :peer_data in connect_info (BT-3228)" do
+    setup do
+      System.put_env("BT_IDE_DEV_AUTH", "1")
+      :ok
+    end
+
+    defp with_connect_info(conn, connect_info),
+      do: Plug.Conn.put_private(conn, :live_view_connect_info, connect_info)
+
+    test "the /live socket declares :peer_data, or dev-auth loops forever (regression guard)" do
+      {_path, _module, opts} =
+        Enum.find(BtAttachWeb.Endpoint.__sockets__(), fn {path, _, _} -> path == "/live" end)
+
+      assert :peer_data in get_in(opts, [:websocket, :connect_info])
+      assert :peer_data in get_in(opts, [:longpoll, :connect_info])
+    end
+
+    test "a connected mount with loopback peer_data succeeds", %{conn: conn} do
+      conn =
+        conn
+        |> authed_conn(0)
+        |> with_connect_info(%{peer_data: %{address: {127, 0, 0, 1}, port: 0, ssl_cert: nil}})
+
+      assert {:ok, _view, html} = live_probe(conn)
+      assert html =~ "probe ok"
+    end
+
+    test "a connected mount without :peer_data in connect_info (undeclared socket key, the bug) " <>
+           "is redirected rather than mounted",
+         %{conn: conn} do
+      conn =
+        conn
+        |> authed_conn(0)
+        |> with_connect_info(%{})
+
+      assert {:error, {:redirect, %{to: "/"}}} = live_probe(conn)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes the infinite full-page reload loop reported in [BT-3228](https://linear.app/beamtalk/issue/BT-3228): the desktop-attach LiveView front was full-page-reloading every ~7ms after connecting, whenever the IdP-less dev-auth path (`BT_IDE_DEV_AUTH`) is active.

**Root cause:** `BtAttachWeb.Endpoint`'s `/live` socket only requested `:session` in `connect_info`, never `:peer_data`. `BtAttachWeb.Auth.dev_connect_ok?/1` gates dev-auth sockets to loopback via `get_connect_info(socket, :peer_data)` — with `:peer_data` undeclared, that call is always `nil`, so `dev_connect_ok?` is always `false`, and `on_mount` halts + redirects to `/` on *every* connected mount. That's an infinite reload loop with no error logged (clean redirect, not a crash), a fresh CSRF token each cycle (brand-new page load), and `_mount_attempts` always `"0"` — matching every symptom in the original report.

The original report's "stale static assets" theory was investigated and ruled out: Phoenix LiveView 1.0.18's `phx-track-static`/`static_changed?/1` mechanism is opt-in and this app never calls it.

## Key changes

- `editors/liveview/lib/bt_attach_web/endpoint.ex` — declare `:peer_data` in both `websocket`/`longpoll` `connect_info` for the `/live` socket.
- `editors/liveview/test/bt_attach_web/session_lifecycle_test.exs` — regression tests:
  - A config-level test asserting the socket declares `:peer_data` (verified this fails without the fix — the existing dev-auth tests never caught this because `Phoenix.LiveViewTest`'s default `connect_info` is derived from the test `conn` directly, bypassing the declared socket config).
  - Functional tests exercising `dev_connect_ok?` via an explicit `connect_info` map (loopback succeeds; missing `:peer_data` redirects).

## Test plan

- [x] `mix test` — 500 passed (editors/liveview)
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] Confirmed the new config-level test fails without the fix (reverted `endpoint.ex` locally, reran)

🤖 Generated with [Claude Code](https://claude.com/claude-code)