### PR TITLE
Fix desktop-attach reload loop: runtime Secure flag on session cookie (BT-3233)

### DIFF
--- a/editors/liveview/config/prod.exs
+++ b/editors/liveview/config/prod.exs
@@ -3,11 +3,11 @@ import Config
 # Do not print debug messages in production
 config :logger, level: :info
 
-# Mark the session (and OIDC handshake) cookies `Secure` in production — they
-# gate an RCE-bearing tool and must only travel over HTTPS (ADR 0091, BT-2419).
-# Dev/test default to false (compile_env default) so plain-HTTP local runs and
-# the test conn still carry the cookie.
-config :bt_attach, :secure_session, true
+# The session cookies' `Secure` flag is resolved at RUNTIME in
+# config/runtime.exs from the deployment posture (PHX_HOST set → TLS →
+# Secure), because the same release binary also serves the desktop/local
+# mode on plain http://localhost, where WKWebView drops Secure cookies
+# (BT-3233). Do not reintroduce a compile-time `:secure_session` here.
 
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.

--- a/editors/liveview/config/runtime.exs
+++ b/editors/liveview/config/runtime.exs
@@ -62,6 +62,16 @@ if config_env() == :prod do
       _ -> {"http", "localhost", port}
     end
 
+  # Session (and OIDC handshake) cookies are `Secure` exactly when the IDE is
+  # reached over TLS — i.e. the same PHX_HOST posture that picked `url_scheme`
+  # above. The desktop/local-trial mode (PHX_HOST unset) serves plain
+  # http://localhost, where WKWebView (Tauri) silently drops Secure cookies —
+  # no localhost exception like Chrome/Firefox — leaving every LiveView join
+  # session-less ("stale" refusal → full-page reload → infinite reload loop,
+  # BT-3233). Read at runtime by BtAttachWeb.Endpoint.session_options/0 and
+  # BtAttachWeb.OidcHandshake.
+  config :bt_attach, :secure_session, url_scheme == "https"
+
   config :bt_attach, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
   # ADR 0097 Implementation §1b: the desktop-attach broker needs to pin this

--- a/editors/liveview/lib/bt_attach_web/endpoint.ex
+++ b/editors/liveview/lib/bt_attach_web/endpoint.ex
@@ -3,26 +3,41 @@ defmodule BtAttachWeb.Endpoint do
 
   # The authenticated session cookie (ADR 0091 Decision 1 / BT-2419). It gates an
   # RCE-bearing tool, so it is `HttpOnly` (cookie store default), `SameSite=Strict`
-  # — not Lax — and `Secure` outside dev/test. The one flow that genuinely needs a
-  # cross-site top-level redirect to carry state (browser → IdP → /oidc/callback)
+  # — not Lax — and `Secure` on TLS deployments. The one flow that genuinely needs
+  # a cross-site top-level redirect to carry state (browser → IdP → /oidc/callback)
   # does NOT rely on this cookie: the OIDC handshake state lives in a separate
   # `SameSite=Lax`, `path=/oidc`, short-lived encrypted cookie scoped to that
   # handler (`BtAttachWeb.OidcHandshake`), so the main session stays Strict.
-  @session_options [
+  @session_options_base [
     store: :cookie,
     key: "_bt_attach_key",
     signing_salt: "f7iEj/hj",
-    same_site: "Strict",
-    secure: Application.compile_env(:bt_attach, :secure_session, false)
+    same_site: "Strict"
   ]
+
+  # `:secure` must be resolved at RUNTIME (config/runtime.exs keys it off the
+  # deployment posture), not compile time: the same release binary serves both
+  # TLS remote deployments and the desktop/local-trial mode on plain
+  # http://localhost. WKWebView (the Tauri desktop webview) silently drops
+  # `Secure` cookies over plain http — it has no localhost exception like
+  # Chrome/Firefox — so a compile-time `Secure` flag left every desktop
+  # LiveView join session-less: refused as "stale", full-page reload, an
+  # infinite reload loop (BT-3233).
+  def session_options do
+    Keyword.put(
+      @session_options_base,
+      :secure,
+      Application.get_env(:bt_attach, :secure_session, false)
+    )
+  end
 
   # :peer_data is required by BtAttachWeb.Auth.dev_connect_ok?/1, which gates
   # dev-auth LiveView sockets to loopback. Without it, get_connect_info(socket,
   # :peer_data) is always nil on every connected mount, so dev-auth always
   # halts+redirects — an infinite full-page reload loop (BT-3228).
   socket "/live", Phoenix.LiveView.Socket,
-    websocket: [connect_info: [:peer_data, session: @session_options]],
-    longpoll: [connect_info: [:peer_data, session: @session_options]]
+    websocket: [connect_info: [:peer_data, session: {__MODULE__, :session_options, []}]],
+    longpoll: [connect_info: [:peer_data, session: {__MODULE__, :session_options, []}]]
 
   # Serve at "/" the static files from "priv/static" directory.
   #
@@ -52,6 +67,10 @@ defmodule BtAttachWeb.Endpoint do
 
   plug Plug.MethodOverride
   plug Plug.Head
-  plug Plug.Session, @session_options
+  plug :session
   plug BtAttachWeb.Router
+
+  # Function plug so `session_options/0` (and its runtime `:secure` flag) is
+  # re-read per request instead of frozen by a compile-time `Plug.Session` init.
+  defp session(conn, _opts), do: Plug.Session.call(conn, Plug.Session.init(session_options()))
 end

--- a/editors/liveview/test/bt_attach_web/session_lifecycle_test.exs
+++ b/editors/liveview/test/bt_attach_web/session_lifecycle_test.exs
@@ -159,4 +159,51 @@ defmodule BtAttachWeb.SessionLifecycleTest do
       assert {:error, {:redirect, %{to: "/"}}} = live_probe(conn)
     end
   end
+
+  describe "session cookie Secure flag is runtime-resolved (BT-3233)" do
+    # WKWebView (the Tauri desktop webview) silently drops `Secure` cookies
+    # over plain http — no localhost exception like Chrome/Firefox — so the
+    # desktop posture must serve the session cookie without `Secure`, while a
+    # TLS deployment keeps it. The flag must flip WITHOUT recompiling: a
+    # compile-time flag frozen into the endpoint was the bug.
+    setup do
+      on_exit(fn -> Application.delete_env(:bt_attach, :secure_session) end)
+      :ok
+    end
+
+    defp session_cookie(conn) do
+      conn
+      |> Plug.Conn.get_resp_header("set-cookie")
+      |> Enum.find(&String.starts_with?(&1, "_bt_attach_key="))
+    end
+
+    test "desktop/local posture (secure_session false): cookie is sent without Secure",
+         %{conn: conn} do
+      Application.put_env(:bt_attach, :secure_session, false)
+
+      cookie = conn |> get(~p"/") |> session_cookie()
+      assert cookie
+      refute cookie =~ ~r/;\s*secure/i
+    end
+
+    test "TLS posture (secure_session true): cookie is Secure, same compiled endpoint",
+         %{conn: conn} do
+      Application.put_env(:bt_attach, :secure_session, true)
+
+      cookie = conn |> get(~p"/") |> session_cookie()
+      assert cookie
+      assert cookie =~ ~r/;\s*secure/i
+    end
+
+    test "the /live socket's connect_info session options are an MFA, not a frozen list" do
+      {_path, _module, opts} =
+        Enum.find(BtAttachWeb.Endpoint.__sockets__(), fn {path, _, _} -> path == "/live" end)
+
+      assert {BtAttachWeb.Endpoint, :session_options, []} =
+               get_in(opts, [:websocket, :connect_info])[:session]
+
+      assert {BtAttachWeb.Endpoint, :session_options, []} =
+               get_in(opts, [:longpoll, :connect_info])[:session]
+    end
+  end
 end


### PR DESCRIPTION
## Summary

BT-3228 (#3463) fixed the dev-auth `:peer_data` redirect loop, but the desktop app **still** reload-looped on connect. Live debugging against a running release pinned the remaining cause:

- `config/prod.exs` compiled `secure_session: true` into the endpoint's `@session_options`, so the release session cookie was always `Secure`.
- The desktop front serves plain `http://localhost:<port>` inside Tauri's **WKWebView**, which — unlike Chrome/Firefox — has **no localhost exception** and silently drops `Secure` cookies over http.
- Every LiveView join therefore arrived session-less and was refused with `{"status":"error","response":{"reason":"stale"}}`; LiveView JS hard-reloads on "stale" → infinite ~8ms reload loop, **regardless of auth mode**.

Proven by driving the LiveView join protocol by hand against a running `dist-liveview` release: join **with** the session cookie mounts `status: ok`; join **without** it returns `reason: "stale"`. Invisible to `Phoenix.LiveViewTest` (bypasses real cookie transport) and to Chrome-based manual testing.

## Fix

Resolve `:secure` at **runtime** from the existing deployment posture — no new env vars:

- `config/runtime.exs` (prod): `config :bt_attach, :secure_session, url_scheme == "https"` — `PHX_HOST` set (TLS deployment) keeps `Secure`; unset (desktop/local-trial on plain http) drops it.
- `endpoint.ex`: `session_options/0` reads the app env per request (function plug for `Plug.Session`, MFA form for socket `connect_info` session).
- `oidc_handshake.ex` already reads `:secure_session` at runtime — follows automatically.
- `config/prod.exs`: compile-time flag removed (comment left explaining why it must not come back).

## Verification

Against a rebuilt `dist-liveview` release:

- no `PHX_HOST` → `Set-Cookie: _bt_attach_key=...; path=/; HttpOnly; SameSite=Strict` (no `secure`), and the connected LiveView join mounts `ok`
- `PHX_HOST=ide.example.com` → `...; path=/; secure; HttpOnly; SameSite=Strict`

## Tests

- `session_lifecycle_test.exs`: cookie has no `Secure` flag with `:secure_session false`, has it with `true` — same compiled endpoint, flipped purely at runtime (guards against reintroducing a compile-time freeze)
- socket `connect_info` session options are the MFA form, not a frozen list
- full liveview suite: 503 passed

Fixes BT-3233. Related: BT-3228 (#3463).

🤖 Generated with [Claude Code](https://claude.com/claude-code)