### PR TITLE
beamtalk repl -e only stops workspaces it spawned (BT-3224)

### DIFF
--- a/crates/beamtalk-cli/src/commands/repl/mod.rs
+++ b/crates/beamtalk-cli/src/commands/repl/mod.rs
@@ -187,9 +187,19 @@ fn read_erlang_cookie() -> Option<String> {
 }
 
 /// Decide whether ephemeral cleanup should stop a workspace node.
-/// Returns true when ephemeral flag is set and there is no local BEAM child guard (detached workspace).
-pub(crate) fn should_stop_workspace(ephemeral: bool, beam_guard_present: bool) -> bool {
-    ephemeral && !beam_guard_present
+///
+/// Returns true only when the ephemeral flag is set, there is no local BEAM
+/// child guard (i.e. the workspace is detached rather than `--foreground`),
+/// AND this invocation is the one that spawned the workspace
+/// (`is_new_workspace`). An ephemeral REPL that merely *attached* to an
+/// already-running, persistent workspace must never tear it down on exit
+/// (BT-3224) — only the invocation that started the node owns its lifecycle.
+pub(crate) fn should_stop_workspace(
+    ephemeral: bool,
+    beam_guard_present: bool,
+    is_new_workspace: bool,
+) -> bool {
+    ephemeral && !beam_guard_present && is_new_workspace
 }
 
 /// Decide whether to enter the interactive (rustyline) REPL loop.
@@ -516,7 +526,7 @@ pub fn run(
     // BEAM child is cleaned up automatically by BeamChildGuard::drop()
 
     // Ephemeral mode: stop workspace node on REPL exit (only in workspace mode)
-    if should_stop_workspace(ephemeral, beam_guard_opt.is_some()) {
+    if should_stop_workspace(ephemeral, beam_guard_opt.is_some(), is_new_workspace) {
         if let Some(workspace_id) = workspace_id_opt {
             if let Err(e) = crate::commands::workspace::stop_workspace(Some(&workspace_id), false) {
                 eprintln!("Warning: failed to stop workspace {workspace_id}: {e}");
@@ -534,18 +544,26 @@ mod ephemeral_tests {
     use super::should_stop_workspace;
 
     #[test]
-    fn stops_when_ephemeral_and_no_guard() {
-        assert!(should_stop_workspace(true, false));
+    fn stops_when_ephemeral_new_workspace_and_no_guard() {
+        assert!(should_stop_workspace(true, false, true));
     }
 
     #[test]
     fn not_stop_when_not_ephemeral() {
-        assert!(!should_stop_workspace(false, false));
+        assert!(!should_stop_workspace(false, false, true));
     }
 
     #[test]
     fn not_stop_when_guard_present() {
-        assert!(!should_stop_workspace(true, true));
+        assert!(!should_stop_workspace(true, true, true));
+    }
+
+    /// BT-3224: `beamtalk repl -e` against a pre-existing/persistent
+    /// workspace (this invocation only attached, it didn't spawn the node)
+    /// must never send a shutdown request on exit.
+    #[test]
+    fn not_stop_when_ephemeral_but_attached_to_existing_workspace() {
+        assert!(!should_stop_workspace(true, false, false));
     }
 }
 


### PR DESCRIPTION
## Summary
- `should_stop_workspace` previously stopped a workspace whenever `--ephemeral` was set and there was no local BEAM child guard (`beam_guard_present`), regardless of whether this invocation spawned the workspace or merely attached to an already-running one.
- `beamtalk repl -e` against a pre-existing/persistent workspace was therefore sending an unconditional shutdown request on exit — tearing down live sessions and distribution connections for every other client attached to that workspace (e.g. a LiveView Native desktop app), even though this invocation never spawned the node.
- Gated `should_stop_workspace` on `is_new_workspace` as well, so `-e` only tears down a node this invocation itself spawned. `--foreground` behavior is unaffected (`beam_guard_present` is always `true` there, so the gate already short-circuited to `false`).

## Changes
- `crates/beamtalk-cli/src/commands/repl/mod.rs`: `should_stop_workspace` now takes `is_new_workspace: bool` and requires it to be true; call site passes it through.
- Added regression test `not_stop_when_ephemeral_but_attached_to_existing_workspace` covering the BT-3224 scenario; updated existing `ephemeral_tests` call sites for the new parameter.

## Test plan
- [x] `cargo test -p beamtalk-cli` (repl `ephemeral_tests` module) — 4/4 pass, including new regression test
- [x] `just test` — all suites pass except a pre-existing, environment-caused failure in `commands::workspace::epmd::tests::bt2424_default_deployment_keeps_epmd_off_public_interfaces` (reproduces identically on unmodified `main` on this shared dev machine; unrelated to this change)
- [x] `cargo clippy` / `cargo fmt --check` clean
- [x] Full pre-push CI hook (build, clippy, fmt, dialyzer, lint) passed

Linear: https://linear.app/beamtalk/issue/BT-3224

🤖 Generated with [Claude Code](https://claude.com/claude-code)