### PR TITLE
Converge remaining ~/.beamtalk root lookups onto beamtalk_workspace::beamtalk_root_dir() (BT-3227)

### DIFF
--- a/crates/beamtalk-cli/src/commands/deps/registry.rs
+++ b/crates/beamtalk-cli/src/commands/deps/registry.rs
@@ -382,15 +382,16 @@ fn registry_cache_root(url: &str, project_root: &Utf8Path) -> Utf8PathBuf {
         }
     }
 
-    dirs::home_dir()
-        .and_then(|home| Utf8PathBuf::from_path_buf(home).ok())
+    beamtalk_workspace::beamtalk_root_dir()
+        .ok()
+        .and_then(|root| Utf8PathBuf::from_path_buf(root).ok())
         .map_or_else(
             || {
                 BuildLayout::new(project_root)
                     .registry_dir()
                     .join(cache_key(url))
             },
-            |home| home.join(".beamtalk").join("registry").join(cache_key(url)),
+            |root| root.join("registry").join(cache_key(url)),
         )
 }
 

--- a/crates/beamtalk-core/Cargo.toml
+++ b/crates/beamtalk-core/Cargo.toml
@@ -21,6 +21,11 @@ thiserror.workspace = true
 miette.workspace = true
 stacker.workspace = true
 dirs.workspace = true
+# why: BT-3227 — `beamtalk_root_dir()` is the shared leaf under every
+# `~/.beamtalk/` resolution (see `beamtalk-workspace`'s doc comment); this
+# crate's project-root discovery must not re-derive `dirs::home_dir()`
+# independently.
+beamtalk-workspace.workspace = true
 # why: BT-2859 — no longer optional: `ffi_type_specs`'s on-disk spec cache
 # (ADR 0075) unconditionally derives Serialize/Deserialize on its cache-entry
 # type. The `serde` *feature* below still independently gates the optional

--- a/crates/beamtalk-core/src/project/mod.rs
+++ b/crates/beamtalk-core/src/project/mod.rs
@@ -23,7 +23,7 @@ const PROJECT_MARKERS: &[&str] = &[".beamtalk", "beamtalk.toml", ".git"];
 
 /// Returns the global Beamtalk config directory (`~/.beamtalk`), if resolvable.
 fn global_beamtalk_dir() -> Option<PathBuf> {
-    dirs::home_dir().map(|home| home.join(".beamtalk"))
+    beamtalk_workspace::beamtalk_root_dir().ok()
 }
 
 /// Check whether a `.beamtalk` marker refers to global config, not a project marker.


### PR DESCRIPTION
Linear issue: https://linear.app/beamtalk/issue/BT-3227

## Summary

- `beamtalk-core`'s project-root discovery (`crates/beamtalk-core/src/project/mod.rs`) and `beamtalk-cli`'s registry cache directory resolution (`crates/beamtalk-cli/src/commands/deps/registry.rs`) each independently re-derived `dirs::home_dir().join(".beamtalk")` instead of using the shared `beamtalk_workspace::beamtalk_root_dir()` leaf BT-3225 introduced.
- Confirmed `beamtalk-workspace` has no dependency back onto `beamtalk-core` (its own deps are just `dirs`, `miette`, `sha2`, `tracing`), so `beamtalk-core` can depend on it directly without creating a cycle.
- Converged both call sites onto `beamtalk_workspace::beamtalk_root_dir()`. No behavior change — same resolved paths, same missing-home fallback semantics (verified via existing `test_registry_cache_root_no_home_dir_still_keys_by_url` and the `beamtalk-core`/`beamtalk-cli` project-root discovery test suites).

## Key changes

- `crates/beamtalk-core/Cargo.toml`: add `beamtalk-workspace` dependency.
- `crates/beamtalk-core/src/project/mod.rs`: `global_beamtalk_dir()` now calls `beamtalk_workspace::beamtalk_root_dir().ok()`.
- `crates/beamtalk-cli/src/commands/deps/registry.rs`: `registry_cache_root()` now calls `beamtalk_workspace::beamtalk_root_dir()`.

## Follow-up filed

Code review turned up a third, previously unlisted duplicate (`crates/beamtalk-cli/src/paths.rs`'s `beamtalk_dir()`) not in this issue's scope — filed as [BT-3234](https://linear.app/beamtalk/issue/BT-3234) rather than expanding this PR.

## Test plan

- [x] `just build` / `just clippy` / `just fmt-check` clean
- [x] `just test` (Rust unit tests, stdlib, BUnit) — all pass except a pre-existing, unrelated `bt2424_default_deployment_keeps_epmd_off_public_interfaces` failure caused by other epmd daemons already running on this shared dev machine; reproduced identically on `main` without this change
- [x] `just check-corpus` / `just check-generated-builtins` / `just check-surface-drift` clean