### PR TITLE
workspace_live_test.exs: fix ChangeLog revert-button e2e wording drift (BT-3231)

### DIFF
--- a/.github/workflows/liveview-e2e.yml
+++ b/.github/workflows/liveview-e2e.yml
@@ -23,16 +23,26 @@ name: LiveView IDE e2e (workspace + browser)
 # only `:playwright`-tagged tests. We piggyback the `:workspace` suite here, on the
 # job that already builds the toolchain and boots a workspace, rather than paying a
 # second Rust build in liveview.yml or deferring coverage to a nightly leg.
+#
+# BT-3231: also scoped to `runtime/apps/beamtalk_workspace/**` — the
+# `:workspace` suite's `workspace_live_test.exs` exercises ChangeLog/revert/
+# flush behavior owned entirely by that app, over real RPCs to a live
+# workspace node. A runtime-only PR touching it (e.g. fca7c19f/BT-3208's
+# `do_revert/3` error-message rewording) can silently change what this suite
+# asserts on without ever re-running it, since it previously had no
+# runtime-side trigger at all.
 on:
   push:
     branches: [main]
     paths:
       - 'editors/liveview/**'
+      - 'runtime/apps/beamtalk_workspace/**'
       - '.github/workflows/liveview-e2e.yml'
   pull_request:
     branches: [main]
     paths:
       - 'editors/liveview/**'
+      - 'runtime/apps/beamtalk_workspace/**'
       - '.github/workflows/liveview-e2e.yml'
 
 concurrency:

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -750,18 +750,24 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     # This class is eval-defined (no on-disk `sources/` file), exactly like
     # the plain modify-revert e2e above — `revert_method/3` cannot reconstruct
     # the removed method's prior body from disk, so it returns a structured
-    # "no recorded prior body" explanation rather than silently restoring or
-    # crashing. The point under test is the UI binding BT-3194 fixes: the
-    # `remove-method` row's revert button now exists and its click reaches
-    # `revert_method/3` end-to-end — proven by getting back this specific,
-    # expected domain response — rather than the button being silently absent
-    # (the bug) or the LiveView echoing a raw error tuple/crashing. Body
-    # restoration itself is covered at the domain layer by
-    # `revert_remove_method_entry_restores_removed_instance_method` and
+    # "prior body could not be recovered" explanation rather than silently
+    # restoring or crashing. (BT-3208/ADR 0113 generalized this message's
+    # wording — it used to say "no recorded prior body" / "method body"
+    # specifically; `do_revert/3`'s `no_prev_source` arm now shares one
+    # message across a method-modify revert AND a `'remove-class'` revert,
+    # so the wording had to stop naming "method body" specifically. See
+    # `beamtalk_workspace_interface_primitives:do_revert/3`'s `{error,
+    # no_prev_source}` clause.) The point under test is the UI binding
+    # BT-3194 fixes: the `remove-method` row's revert button now exists and
+    # its click reaches `revert_method/3` end-to-end — proven by getting back
+    # this specific, expected domain response — rather than the button being
+    # silently absent (the bug) or the LiveView echoing a raw error
+    # tuple/crashing. Body restoration itself is covered at the domain layer
+    # by `revert_remove_method_entry_restores_removed_instance_method` and
     # `revert_method_selects_correct_side_entry_when_both_sides_have_entries`
     # (`beamtalk_workspace_revert_tests.erl`), which use an on-disk project
     # class so a prior body is actually recorded to restore.
-    assert revert_html =~ "revert:" and revert_html =~ "no recorded prior body"
+    assert revert_html =~ "revert:" and revert_html =~ "prior body could not be recovered"
     refute revert_html =~ "beamtalk_error"
     refute revert_html =~ "{:error"
 

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_revert_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_revert_tests.erl
@@ -59,6 +59,16 @@ runs before reinstalling a pending `"remove-class"` entry's snapshot, so a
 concurrent out-of-band edit landing on the recorded `sourceFile` while the
 removal sat pending is detected (and refused) instead of silently discarded.
 
+BT-3231: also covers the method-level `no_prev_source` revert path for an
+EVAL-defined class (no on-disk `sources/` file at all — the LiveView
+Workspace eval-form scenario), asserting on `do_revert/3`'s error message
+text. BT-3208 generalized that message's wording (it used to name "method
+body" specifically; the shared arm now also serves a `'remove-class'`
+whole-file revert) without any EUnit coverage of the literal text, so a
+LiveView e2e test (`workspace_live_test.exs`, BT-3194) that asserted on the
+old wording broke silently — `liveview-e2e.yml`'s path-scoping never re-ran
+it for runtime-only PRs. This test closes that gap at the fast Erlang layer.
+
 These boot the full stack (compiler port + runtime + workspace_meta + changelog)
 against an isolated, in-project temp tree so the live install / remove and the
 flushable-with-prev-source recording paths run for real, then drive revert
@@ -128,7 +138,12 @@ revert_e2e_test_() ->
             fun revert_remove_class_entry_detects_drift_from_unflushed_patch_too/1,
             fun revert_remove_class_entry_detects_file_deleted_externally/1,
             fun revert_remove_method_entry_after_flush_is_unsupported/1,
-            fun revert_remove_class_entry_after_flush_is_unsupported/1
+            fun revert_remove_class_entry_after_flush_is_unsupported/1,
+            %% BT-3231: `"remove-method"` revert on an eval-defined class (no
+            %% on-disk `sources/` file at all) — the `do_revert/3`
+            %% `no_prev_source` message-wording regression the LiveView e2e
+            %% test caught, uncovered by any EUnit test until now.
+            fun revert_remove_method_entry_on_eval_defined_class_has_no_source_to_recover_from/1
         ]}}.
 
 %% Start the heavy, node-global apps once for the whole suite (the compiler port
@@ -969,6 +984,55 @@ revert_remove_class_entry_dynamic_class_has_no_source_to_reinstall_from(_Ctx) ->
     ),
     [
         ?_assertMatch({error, #beamtalk_error{}}, RevertResult)
+    ].
+
+%% BT-3231: the method-level counterpart of
+%% `revert_remove_class_entry_dynamic_class_has_no_source_to_reinstall_from/1`
+%% above — a `"remove-method"` entry on an EVAL-defined class (no on-disk
+%% `sources/` file at all, exactly the LiveView Workspace eval-form scenario:
+%% `handle_class_definition/7` installs the class via `load_class_module/3`
+%% with an empty `""` path, so `class_source_file/1` returns `nil` and
+%% `emit_remove_change_entry/5` records no `source_file`/`prev_source` on the
+%% entry). `find_revert_target/3` has no recorded prior body and no on-disk
+%% file to recover it from, so `do_revert/3` reaches its `{error,
+%% no_prev_source}` arm and raises loudly rather than silently no-op'ing or
+%% restoring the wrong thing.
+%%
+%% This is a regression guard for the exact break BT-3231 diagnosed: fca7c19f
+%% (BT-3208, ADR 0113 Phase 3) generalized this arm's message wording from
+%% "this entry has no recorded prior body ... method body" to "this entry's
+%% prior body could not be recovered ... pre-patch state" (so the same message
+%% reads correctly for a `'remove-class'` whole-file revert too) — a
+%% deliberate, correct change, but the LiveView e2e test asserting on the old
+%% literal substring broke silently because `liveview-e2e.yml`'s path-scoping
+%% never re-ran it for a runtime-only PR. Asserting on the message text here
+%% means the next wording change is caught by the fast Erlang suite instead of
+%% only a path-scoped e2e lane.
+revert_remove_method_entry_on_eval_defined_class_has_no_source_to_recover_from(#{unique := U}) ->
+    ClassName = list_to_binary("Bt3231EvalRm" ++ U),
+    ClassSrc = binary_to_list(
+        iolist_to_binary([<<"Actor subclass: ">>, ClassName, <<"\n  greeting => 1\n">>])
+    ),
+    {ok, _ClassNameOut, _DefOutput, _DefWarnings, State1} =
+        beamtalk_repl_eval:do_eval(ClassSrc, beamtalk_repl_state:new(undefined, 0)),
+    RemoveExpr = binary_to_list(
+        iolist_to_binary([ClassName, <<" removeSelector: #greeting">>])
+    ),
+    {ok, _RemoveValue, _RemoveOutput, _RemoveWarnings, _State2} =
+        beamtalk_repl_eval:do_eval(RemoveExpr, State1),
+    RevertResult = beamtalk_workspace_interface_primitives:revert_method(
+        ClassName, <<"greeting">>, instance
+    ),
+    [
+        ?_assertMatch({error, #beamtalk_error{}}, RevertResult),
+        ?_assert(
+            case RevertResult of
+                {error, #beamtalk_error{message = Msg}} ->
+                    binary:match(Msg, <<"prior body could not be recovered">>) =/= nomatch;
+                _ ->
+                    false
+            end
+        )
     ].
 
 %% Mirrors `recover_prev_from_disk_resolves_remove_method_entry_via_entry_side/1`


### PR DESCRIPTION
Fixes https://linear.app/beamtalk/issue/BT-3231

## Root cause

`editors/liveview/test/bt_attach_web/workspace_live_test.exs`'s ChangeLog revert-button e2e test (BT-3194) asserted on the literal substring `"no recorded prior body"` in the revert error message for a `remove-method` entry on an eval-defined class with no on-disk `sources/` file.

`fca7c19f` (BT-3208, ADR 0113 Phase 3) deliberately generalized `beamtalk_workspace_interface_primitives:do_revert/3`'s `{error, no_prev_source}` message wording — from "this entry has no recorded prior body ... method body" to "this entry's prior body could not be recovered ... pre-patch state" — so the same message reads correctly for both a method-modify revert and a new `'remove-class'` whole-file revert. This was a correct, intentional change, but it silently broke the e2e test's literal assertion.

No CI lane caught it: `liveview-e2e.yml` is path-scoped to `editors/liveview/**`, and BT-3208's PR (#3429) never touched that path, so the `:workspace` e2e suite never re-ran against the change.

Confirmed by bisecting against `fca7c19f` directly (message-wording change) and by running the full `:workspace` e2e suite locally against a live workspace node, both on a fresh node and against a persistent node with accumulated ChangeLog history — 89/89 passing after the fix, both ways.

## Changes

- `editors/liveview/test/bt_attach_web/workspace_live_test.exs` — update the revert assertion to match the current message text (`"prior body could not be recovered"`), with a comment documenting the wording history so a future rewording doesn't repeat this.
- `runtime/apps/beamtalk_workspace/test/beamtalk_workspace_revert_tests.erl` — new EUnit regression test (`revert_remove_method_entry_on_eval_defined_class_has_no_source_to_recover_from`) covering the exact same eval-defined-class/`remove-method`/`no_prev_source` scenario at the fast Erlang layer, so a future wording change is caught by `just test` instead of only a path-scoped e2e lane. Mirrors the existing `remove-class` analog (`revert_remove_class_entry_dynamic_class_has_no_source_to_reinstall_from`).
- `.github/workflows/liveview-e2e.yml` — also trigger on `runtime/apps/beamtalk_workspace/**` changes, since the `:workspace` e2e suite exercises ChangeLog/revert/flush behavior owned entirely by that app. This closes the CI gap the issue describes (BT-3231's own suggested next step).

The e2e test's own expectation was **not** changed to accommodate a bug — the new message wording is the correct, current behavior; only the test's stale literal-string assertion was updated to match it.

## Test plan

- [x] `mix test --only workspace test/bt_attach_web/workspace_live_test.exs` — 89/89 passed, run against both a fresh workspace node and a persistent node with accumulated ChangeLog state from prior runs
- [x] `rebar3 eunit --module=beamtalk_workspace_revert_tests` — 125/125 passed (includes new regression test)
- [x] `just test-runtime` — 5810 + 1837 tests, 0 failures (full beamtalk_runtime/beamtalk_workspace/beamtalk_compiler EUnit suite)
- [x] `just test-stdlib` — 233/233 passed
- [x] `just test-bunit` — 3305/3307 passed, 0 failed (pre-existing, unrelated to this change)
- [x] `just test-metamorphic` — 520/520 passed
- [x] `rebar3 dialyzer` — clean
- [x] `mix format --check-formatted` / `rebar3 fmt --check` — clean
- [x] `just clippy` / `just fmt-check` / `just build` — clean

**Known unrelated failure:** `just test`'s Rust suite fails on `commands::workspace::epmd::tests::bt2424_default_deployment_keeps_epmd_off_public_interfaces` — this is an environment-dependent check that the local machine's `epmd` isn't bound to a public interface. This shared dev/CI worktree's `epmd` was already promiscuously bound (`*.4369`, confirmed via `epmd -names`/`netstat`) before this session started, from other tooling/parallel agents — unrelated to this diff (no Rust files touched). Verified in isolation and via `git stash`-equivalent reasoning: no code in the diff touches `crates/beamtalk-cli/src/commands/workspace/epmd.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)