### PR TITLE
Converge beamtalk-cli paths.rs beamtalk_dir() onto beamtalk_workspace::beamtalk_root_dir() (BT-3234)

### DIFF
--- a/crates/beamtalk-cli/src/paths.rs
+++ b/crates/beamtalk-cli/src/paths.rs
@@ -7,7 +7,7 @@
 
 use std::path::PathBuf;
 
-use miette::{Result, miette};
+use miette::Result;
 
 /// Directory for beamtalk state files (session-based).
 ///
@@ -28,8 +28,7 @@ use miette::{Result, miette};
 ///
 /// Returns an error if the home directory cannot be determined.
 pub fn beamtalk_dir() -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or_else(|| miette!("Could not determine home directory"))?;
-    let base = home.join(".beamtalk");
+    let base = beamtalk_workspace::beamtalk_root_dir()?;
 
     // 1. Explicit named session (highest priority)
     if let Ok(session) = std::env::var("BEAMTALK_WORKSPACE") {


### PR DESCRIPTION
Linear issue: https://linear.app/beamtalk/issue/BT-3234

## Summary

- `beamtalk-cli`'s `paths.rs::beamtalk_dir()` re-derived `dirs::home_dir().join(".beamtalk")` independently instead of using the shared `beamtalk_workspace::beamtalk_root_dir()` leaf introduced in BT-3225.
- Converged onto `beamtalk_workspace::beamtalk_root_dir()`, mirroring the `registry.rs` conversion from BT-3227 (#3467).
- No behavior change — same resolved paths, same missing-home fallback semantics, same error message text (`beamtalk_root_dir()` raises the identical miette message "Could not determine home directory").
- `BEAMTALK_WORKSPACE` env var / shell-PPID session-fallback logic below is unchanged.

## Key changes

- `crates/beamtalk-cli/src/paths.rs`: `beamtalk_dir()` now calls `beamtalk_workspace::beamtalk_root_dir()?` instead of re-deriving `dirs::home_dir()`.

## Test plan

- [x] `just build` / `just clippy` / `just fmt-check` clean
- [x] `just test` — all `beamtalk_dir` unit tests pass (`beamtalk_dir_returns_session_subdirectory`, `beamtalk_dir_respects_session_env_var`, `beamtalk_dir_sanitizes_session_names`, `beamtalk_dir_ignores_empty_session_env`)
- [x] Pre-push hook (full CI) passed