### PR TITLE
Pre-existing failure: epmd loopback test in dev sandbox (BT-3235)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -9,6 +9,21 @@
 set shell := ["bash", "-uc"]
 set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-Command"]
 
+# BT-3235: pin epmd's bind address for every recipe that shells out to
+# rebar3/mix/erl (build-erlang, test-runtime, perf, dialyzer, ...). epmd is a
+# per-user singleton daemon: whichever process starts it first wins its bind
+# posture for the rest of the session, and epmd's own default (no -address)
+# is *all* interfaces (ADR 0091 Decision 5, finding F1) — the same gap
+# `beamtalk-workspace`'s `resolve_epmd_address` and `startup_command.rs`
+# already close for workspace-node launches. On a shared dev box running
+# concurrent toolchain invocations (several agent worktrees building/testing
+# at once), an unpinned `rebar3 eunit`/`compile` can auto-start a genuinely
+# promiscuous epmd before this pin ever gets a chance to apply — closing the
+# gap here removes this project's own tooling as a source of that. Respects
+# an operator-set ERL_EPMD_ADDRESS (e.g. a trusted private-network address)
+# rather than clobbering it, matching `resolve_epmd_address`'s own fallback.
+export ERL_EPMD_ADDRESS := env_var_or_default("ERL_EPMD_ADDRESS", "127.0.0.1")
+
 # Default recipe (list all tasks)
 default:
     @just --list

--- a/crates/beamtalk-cli/src/commands/workspace/epmd.rs
+++ b/crates/beamtalk-cli/src/commands/workspace/epmd.rs
@@ -223,10 +223,36 @@ mod tests {
         // must not classify it as Promiscuous. A `Promiscuous` result here is a
         // genuine finding (a stray epmd bound to 0.0.0.0), not test flakiness —
         // which is exactly the posture this check is meant to catch.
-        assert!(
-            !matches!(check_epmd_loopback(), EpmdPosture::Promiscuous(_)),
-            "default deployment must not expose epmd on a public interface"
-        );
+        //
+        // BT-3235: on a shared dev box running several concurrent Erlang/OTP
+        // toolchain invocations (e.g. multiple agent worktrees building/testing
+        // at once), this *can* legitimately fail — epmd is a per-user singleton
+        // daemon, and whichever process starts it first wins its bind posture
+        // (all interfaces by default, absent `-address`/`ERL_EPMD_ADDRESS`) for
+        // the rest of the session. Investigation found no false-positive mode in
+        // `primary_non_loopback_ipv4`/`epmd_reachable_at` (verified against a
+        // real LAN interface + an active Tailscale VPN interface: the kernel's
+        // default-route choice was stable and neither IP hairpinned to a
+        // loopback-bound epmd) — a failure here is a real posture violation
+        // worth investigating, not something to silence. The Justfile now pins
+        // `ERL_EPMD_ADDRESS=127.0.0.1` for every recipe so this project's own
+        // build/test tooling can't be the culprit; see the panic message below
+        // for how to tell an external stray epmd apart from a regression here.
+        if let EpmdPosture::Promiscuous(ip) = check_epmd_loopback() {
+            let names = query_epmd_names();
+            panic!(
+                "default deployment must not expose epmd on a public interface: \
+                 epmd answered on {ip}:{EPMD_PORT}.\n\
+                 epmd -names reports: {names:?}\n\
+                 epmd is a shared, per-user daemon — this is usually *other* Erlang/OTP \
+                 tooling on this host that started it without ERL_EPMD_ADDRESS pinned to \
+                 loopback before this project's own tooling got a chance to (epmd keeps its \
+                 bind posture until killed). If the names above aren't this project's own \
+                 workspace/bt_attach nodes, that confirms an external cause. Remediation: \
+                 `epmd -kill` (only if no other Erlang node on this host needs it) and re-run \
+                 — this project's tooling will restart epmd pinned to loopback."
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Investigates and closes the gap behind `bt2424_default_deployment_keeps_epmd_off_public_interfaces` reportedly failing on unmodified `main` in a shared dev sandbox (BT-3235).

**Root-cause finding:** the probe (`primary_non_loopback_ipv4` / `epmd_reachable_at`) has no false-positive mode — verified 10/10 stable runs against this sandbox's real LAN interface *and* an active Tailscale VPN interface (the kernel's default-route choice was stable, and neither IP hairpinned to a loopback-bound epmd). A `Promiscuous` result is a real ADR-0091 posture violation, not test flakiness.

The plausible cause is the one the code's own comments already anticipated: epmd is a per-user *singleton* daemon whose default bind (absent `-address`/`ERL_EPMD_ADDRESS`) is *all* interfaces. On a shared box running several concurrent Erlang/OTP toolchain invocations at once (multiple agent worktrees building/testing), whichever `rebar3`/`mix`/`erl` invocation starts epmd first wins its bind posture for the rest of the session — including for invocations from *this* project's own build/test tooling, which previously never pinned `ERL_EPMD_ADDRESS` the way the workspace-node launcher already does.

## Changes

- **`Justfile`**: pin `ERL_EPMD_ADDRESS=127.0.0.1` (respecting an operator override) for every recipe, closing the gap for this project's own `rebar3`/`mix` invocations — mirrors the same fallback already used by `beamtalk-workspace::resolve_epmd_address` and `startup_command.rs` for workspace-node launches.
- **`crates/beamtalk-cli/src/commands/workspace/epmd.rs`**: enrich the test's failure output (offending IP, `epmd -names`, remediation steps) so any future occurrence — e.g. from tooling outside this repo's control — is immediately actionable instead of a bare panic. The assertion itself is unchanged (still a hard failure on `Promiscuous`, correctly).

## Test plan

- [x] `cargo test -p beamtalk-cli --bin beamtalk commands::workspace::epmd::` — 7/7 passing, including 10 manual reruns of the `bt2424_...` test with no flakiness observed
- [x] `cargo fmt --check` / `cargo clippy -p beamtalk-cli --all-targets` clean
- [x] `just --evaluate ERL_EPMD_ADDRESS` confirms the Justfile default resolves to `127.0.0.1`
- [x] Verified pre-existing, unrelated sandbox flakiness (network/registry-dependent `beamtalk-cli` tests, and BT-3226's known-flaky `spawn_front_with_port_retry` timing tests) via `git stash` comparison — identical failure counts with and without this change
- [x] Pre-push hook (full lint + dialyzer + build) passed

Linear: https://linear.app/beamtalk/issue/BT-3235

🤖 Generated with [Claude Code](https://claude.com/claude-code)