### PR TITLE
Place class gen_server processes under a real supervisor (BT-3236)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
@@ -622,6 +622,14 @@ classRemoveFromSystemByName(ClassName) ->
                             %% uses).
                             ClassNameBin = atom_to_binary(ClassName, utf8),
                             RemovalSnapshot = capture_class_removal_snapshot(ClassNameBin),
+                            %% BT-3236: stop eager crash recovery for this
+                            %% class BEFORE killing its actors — actors are
+                            %% linked to the class gen_server, so the kills
+                            %% below can take the class process down with
+                            %% reason 'killed', which the monitor would
+                            %% otherwise classify as a crash and resurrect
+                            %% mid-removal.
+                            beamtalk_class_monitor:unwatch(ClassName),
                             %% Stop live actors of this class
                             stop_class_actors(ClassName),
                             %% Stop the class gen_server

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_monitor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_monitor.erl
@@ -244,10 +244,10 @@ restart_within_budget(
                         #{class => ClassName, reason => RestartReason}
                     )
             catch
-                Class:CatchReason ->
+                ErrClass:CatchReason ->
                     ?LOG_ERROR(
                         "Eager restart of crashed class '~p' raised ~p:~p",
-                        [ClassName, Class, CatchReason],
+                        [ClassName, ErrClass, CatchReason],
                         #{class => ClassName, reason => CatchReason}
                     )
             end,

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_monitor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_monitor.erl
@@ -33,7 +33,7 @@ Normal exits (`normal`, `shutdown`, `{shutdown, _}`) are deliberate stops —
 -include_lib("kernel/include/logger.hrl").
 
 %% API
--export([start_link/0, start_link/1, watch/2]).
+-export([start_link/0, start_link/1, watch/2, unwatch/1]).
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
@@ -73,13 +73,45 @@ start_link(Opts) ->
 Register a class process for crash monitoring.
 
 Called by `beamtalk_object_class:start/2` after every successful start
-(including restarts). A cast to an unregistered name is a silent no-op, so
-EUnit suites that start class processes without the runtime supervision
-tree need no guard.
+(including restarts). Synchronous on purpose: `start/2` must not return
+until the monitor is armed, otherwise a kill delivered before the watch is
+processed surfaces as a `noproc` 'DOWN' — indistinguishable from the
+deliberate-stop race `is_deliberate_stop(noproc)` exists for — and the
+crash would silently not be recovered. A no-op when the monitor is not
+running (EUnit suites without the runtime supervision tree).
 """.
 -spec watch(atom(), pid()) -> ok.
 watch(ClassName, Pid) ->
-    gen_server:cast(?MODULE, {watch, ClassName, Pid}).
+    case whereis(?MODULE) of
+        undefined ->
+            ok;
+        Monitor when Monitor =:= self() ->
+            %% The monitor's own eager restart re-enters start/2 → watch/2
+            %% from inside handle_info; a call-to-self would deadlock. The
+            %% self-queued cast is processed before any later message, so the
+            %% arming guarantee still effectively holds for this path.
+            gen_server:cast(?MODULE, {watch, ClassName, Pid});
+        _ ->
+            gen_server:call(?MODULE, {watch, ClassName, Pid})
+    end.
+
+-doc """
+Stop monitoring `ClassName` ahead of deliberate removal.
+
+`classRemoveFromSystemByName/1` kills the class's live actors before
+stopping the class gen_server, and actors are linked to their class process
+(spawned via `gen_server:start_link` inside the class's `{spawn, _}`
+handler) — so the kill propagates and the class dies with reason `killed`,
+which would otherwise be classified as a crash and eagerly resurrected
+mid-removal. Synchronous (a cast could lose the race against the 'DOWN'
+delivery); a no-op when the monitor is not running.
+""".
+-spec unwatch(atom()) -> ok.
+unwatch(ClassName) ->
+    case whereis(?MODULE) of
+        undefined -> ok;
+        _ -> gen_server:call(?MODULE, {unwatch, ClassName})
+    end.
 
 %%% ============================================================================
 %%% gen_server callbacks
@@ -87,25 +119,46 @@ watch(ClassName, Pid) ->
 
 init(Opts) ->
     logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
-    {ok, #state{
+    State0 = #state{
         max_restarts = maps:get(max_restarts, Opts, ?DEFAULT_MAX_RESTARTS),
         window_ms = maps:get(window_ms, Opts, ?DEFAULT_WINDOW_MS)
-    }}.
+    },
+    %% If this monitor crashed and was restarted by beamtalk_runtime_sup, the
+    %% surviving class processes are no longer watched — re-adopt them from
+    %% the pg enumeration group so eager recovery is not silently lost for
+    %% the rest of the node's life. pg may not be running in EUnit contexts.
+    Survivors =
+        try
+            [
+                {Name, Pid}
+             || Pid <- pg:get_members(beamtalk_classes),
+                {ok, Name} <- [beamtalk_class_registry:class_name_for_pid(Pid)]
+            ]
+        catch
+            _:_ -> []
+        end,
+    State1 = lists:foldl(
+        fun({Name, Pid}, Acc) -> do_watch(Name, Pid, Acc) end,
+        State0,
+        Survivors
+    ),
+    {ok, State1}.
 
+handle_call({watch, ClassName, Pid}, _From, State) ->
+    {reply, ok, do_watch(ClassName, Pid, State)};
+handle_call({unwatch, ClassName}, _From, #state{watched = Watched, refs = Refs} = State) ->
+    ClassRefs = [R || R := N <- Refs, N =:= ClassName],
+    lists:foreach(fun(R) -> erlang:demonitor(R, [flush]) end, ClassRefs),
+    RefSet = sets:from_list(ClassRefs, [{version, 2}]),
+    {reply, ok, State#state{
+        watched = maps:filter(fun(_P, R) -> not sets:is_element(R, RefSet) end, Watched),
+        refs = maps:without(ClassRefs, Refs)
+    }};
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown_call}, State}.
 
-handle_cast({watch, ClassName, Pid}, #state{watched = Watched, refs = Refs} = State) ->
-    case maps:is_key(Pid, Watched) of
-        true ->
-            {noreply, State};
-        false ->
-            Ref = erlang:monitor(process, Pid),
-            {noreply, State#state{
-                watched = Watched#{Pid => Ref},
-                refs = Refs#{Ref => ClassName}
-            }}
-    end;
+handle_cast({watch, ClassName, Pid}, State) ->
+    {noreply, do_watch(ClassName, Pid, State)};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -130,9 +183,27 @@ handle_info(_Info, State) ->
 %%% Internal
 %%% ============================================================================
 
+do_watch(ClassName, Pid, #state{watched = Watched, refs = Refs} = State) ->
+    case maps:is_key(Pid, Watched) of
+        true ->
+            State;
+        false ->
+            Ref = erlang:monitor(process, Pid),
+            State#state{
+                watched = Watched#{Pid => Ref},
+                refs = Refs#{Ref => ClassName}
+            }
+    end.
+
 is_deliberate_stop(normal) -> true;
 is_deliberate_stop(shutdown) -> true;
 is_deliberate_stop({shutdown, _}) -> true;
+%% The pid was already dead when the watch cast was processed (e.g. defined
+%% and immediately removed in the REPL). We never saw it alive, so this is
+%% not a crash to recover from — resurrecting here would defeat a deliberate
+%% stop that raced the cast. A genuine crash in that window is still covered
+%% by lazy class_send_with_recovery on the next send.
+is_deliberate_stop(noproc) -> true;
 is_deliberate_stop(_) -> false.
 
 restart_within_budget(
@@ -150,13 +221,20 @@ restart_within_budget(
                 [ClassName, Max, Window],
                 #{class => ClassName, reason => Reason}
             ),
-            State#state{history = maps:remove(ClassName, History)};
+            %% Keep the pruned history: if a lazy recovery re-registers the
+            %% class and it crashes again inside the same window, the budget
+            %% stays exhausted rather than resetting to a fresh allowance.
+            State#state{history = History#{ClassName => Recent}};
         false ->
             %% restart_class/1 rebuilds from ETS + __beamtalk_meta/0 and logs
             %% its own warning about dropped hot patches / class-var state; a
             %% successful restart re-enters watch/2 via
             %% beamtalk_object_class:start/2, so no explicit re-watch here.
-            case beamtalk_class_registry:restart_class(ClassName) of
+            %% The catch matters: supervisor:start_child exits (rather than
+            %% returning an error) while beamtalk_class_sup is itself dead or
+            %% restarting, and a monitor crash here would silently lose every
+            %% remaining watch.
+            try beamtalk_class_registry:restart_class(ClassName) of
                 {ok, _NewPid} ->
                     ok;
                 {error, RestartReason} ->
@@ -164,6 +242,13 @@ restart_within_budget(
                         "Eager restart of crashed class '~p' failed: ~p",
                         [ClassName, RestartReason],
                         #{class => ClassName, reason => RestartReason}
+                    )
+            catch
+                Class:CatchReason ->
+                    ?LOG_ERROR(
+                        "Eager restart of crashed class '~p' raised ~p:~p",
+                        [ClassName, Class, CatchReason],
+                        #{class => ClassName, reason => CatchReason}
                     )
             end,
             State#state{history = History#{ClassName => [Now | Recent]}}

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_monitor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_monitor.erl
@@ -1,0 +1,170 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_class_monitor).
+-behaviour(gen_server).
+
+%%% **DDD Context:** Object System Context
+
+-moduledoc """
+Eager crash recovery for class gen_server processes (BT-3236).
+
+`beamtalk_class_sup` starts class processes as `temporary` children, so OTP
+never auto-restarts them (see that module's doc for why). This monitor owns
+the restart policy instead: `beamtalk_object_class:start/2` registers every
+started class here via `watch/2`, and on an abnormal `'DOWN'` the monitor
+eagerly rebuilds the class through
+`beamtalk_class_registry:restart_class/1` — fresh from ETS metadata and the
+module's `__beamtalk_meta/0` — without waiting for the next message send
+(which was the pre-BT-3236 lazy path, kept as a fallback in
+`beamtalk_class_dispatch:class_send_with_recovery/3`).
+
+A per-class restart budget (`max_restarts` within `window_ms`) stops a
+crash-looping class from restarting forever: once exhausted, the class is
+dropped with a `?LOG_ERROR` and stays down until something sends to it (lazy
+recovery) or it is re-registered. The budget is per class, so one bad class
+never affects the others — the failure-isolation property a shared
+supervisor restart-intensity counter cannot provide.
+
+Normal exits (`normal`, `shutdown`, `{shutdown, _}`) are deliberate stops —
+`removeFromSystem` uses `gen_server:stop/1` — and are never restarted.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+%% API
+-export([start_link/0, start_link/1, watch/2]).
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+-define(DEFAULT_MAX_RESTARTS, 3).
+-define(DEFAULT_WINDOW_MS, 30000).
+
+-record(state, {
+    max_restarts :: pos_integer(),
+    window_ms :: pos_integer(),
+    %% pid → monitor ref, to ignore duplicate watch casts for a live pid
+    watched = #{} :: #{pid() => reference()},
+    %% monitor ref → class name, for 'DOWN' resolution
+    refs = #{} :: #{reference() => atom()},
+    %% class name → recent restart timestamps (monotonic ms), pruned to window
+    history = #{} :: #{atom() => [integer()]}
+}).
+
+%%% ============================================================================
+%%% Public API
+%%% ============================================================================
+
+-doc "Start the monitor with the default restart budget (called by beamtalk_runtime_sup).".
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    start_link(#{}).
+
+-doc """
+Start the monitor with an explicit restart budget — `max_restarts` abnormal
+exits per class within `window_ms`. Exposed for tests; production uses
+`start_link/0`.
+""".
+-spec start_link(map()) -> {ok, pid()} | {error, term()}.
+start_link(Opts) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Opts, []).
+
+-doc """
+Register a class process for crash monitoring.
+
+Called by `beamtalk_object_class:start/2` after every successful start
+(including restarts). A cast to an unregistered name is a silent no-op, so
+EUnit suites that start class processes without the runtime supervision
+tree need no guard.
+""".
+-spec watch(atom(), pid()) -> ok.
+watch(ClassName, Pid) ->
+    gen_server:cast(?MODULE, {watch, ClassName, Pid}).
+
+%%% ============================================================================
+%%% gen_server callbacks
+%%% ============================================================================
+
+init(Opts) ->
+    logger:set_process_metadata(#{domain => [beamtalk, runtime]}),
+    {ok, #state{
+        max_restarts = maps:get(max_restarts, Opts, ?DEFAULT_MAX_RESTARTS),
+        window_ms = maps:get(window_ms, Opts, ?DEFAULT_WINDOW_MS)
+    }}.
+
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_call}, State}.
+
+handle_cast({watch, ClassName, Pid}, #state{watched = Watched, refs = Refs} = State) ->
+    case maps:is_key(Pid, Watched) of
+        true ->
+            {noreply, State};
+        false ->
+            Ref = erlang:monitor(process, Pid),
+            {noreply, State#state{
+                watched = Watched#{Pid => Ref},
+                refs = Refs#{Ref => ClassName}
+            }}
+    end;
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({'DOWN', Ref, process, Pid, Reason}, #state{watched = Watched, refs = Refs} = State) ->
+    State1 = State#state{
+        watched = maps:remove(Pid, Watched),
+        refs = maps:remove(Ref, Refs)
+    },
+    case maps:find(Ref, Refs) of
+        error ->
+            {noreply, State1};
+        {ok, ClassName} ->
+            case is_deliberate_stop(Reason) of
+                true -> {noreply, State1};
+                false -> {noreply, restart_within_budget(ClassName, Reason, State1)}
+            end
+    end;
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%% ============================================================================
+%%% Internal
+%%% ============================================================================
+
+is_deliberate_stop(normal) -> true;
+is_deliberate_stop(shutdown) -> true;
+is_deliberate_stop({shutdown, _}) -> true;
+is_deliberate_stop(_) -> false.
+
+restart_within_budget(
+    ClassName,
+    Reason,
+    #state{max_restarts = Max, window_ms = Window, history = History} = State
+) ->
+    Now = erlang:monotonic_time(millisecond),
+    Recent = [T || T <- maps:get(ClassName, History, []), Now - T < Window],
+    case length(Recent) >= Max of
+        true ->
+            ?LOG_ERROR(
+                "Class process for '~p' crashed ~p times within ~pms — giving up "
+                "on eager restart (lazy recovery on next send may still apply)",
+                [ClassName, Max, Window],
+                #{class => ClassName, reason => Reason}
+            ),
+            State#state{history = maps:remove(ClassName, History)};
+        false ->
+            %% restart_class/1 rebuilds from ETS + __beamtalk_meta/0 and logs
+            %% its own warning about dropped hot patches / class-var state; a
+            %% successful restart re-enters watch/2 via
+            %% beamtalk_object_class:start/2, so no explicit re-watch here.
+            case beamtalk_class_registry:restart_class(ClassName) of
+                {ok, _NewPid} ->
+                    ok;
+                {error, RestartReason} ->
+                    ?LOG_ERROR(
+                        "Eager restart of crashed class '~p' failed: ~p",
+                        [ClassName, RestartReason],
+                        #{class => ClassName, reason => RestartReason}
+                    )
+            end,
+            State#state{history = History#{ClassName => [Now | Recent]}}
+    end.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_sup.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_sup.erl
@@ -26,6 +26,18 @@ budget.
 This supervisor is started by `beamtalk_runtime_sup` (before
 `beamtalk_bootstrap`, so the bootstrap stub classes register through it)
 and registered locally as `beamtalk_class_sup`.
+
+## Constraint: no class starts from within class init
+
+`start_child/2` serializes through this single supervisor process with an
+infinity timeout, and it blocks for the whole of
+`beamtalk_object_class:init/1`. Nothing reachable from that `init/1` may —
+directly or transitively — start another class (i.e. re-enter
+`beamtalk_object_class:start/2`): the nested `start_child` would deadlock
+the supervisor against itself with no timeout to break the cycle. Today
+`init/1`'s outward calls (xref registration, `beamtalk_protocol_registry`
+cache invalidation, compiler-server cast) are ETS-backed or async; keep it
+that way.
 """.
 
 -export([start_link/0, start_child/2]).

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_sup.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_sup.erl
@@ -1,0 +1,72 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_class_sup).
+-behaviour(supervisor).
+
+%%% **DDD Context:** Object System Context
+
+-moduledoc """
+simple_one_for_one supervisor for class gen_server processes (BT-3236).
+
+Every `beamtalk_object_class` process is started through this supervisor via
+`start_child/2`, placing class processes in the standard OTP supervision
+tree (visible in `observer` / `SystemNavigation supervisionTree`) instead of
+the previous unlinked `gen_server:start/4`.
+
+Children are `temporary`: OTP's own restart machinery is deliberately NOT
+used, because a supervisor restart would replay the original `ClassInfo`
+(stale after hot reloads) and a crash-looping class would escalate through
+restart intensity and take down every other class under this supervisor.
+Instead, eager crash recovery is owned by `beamtalk_class_monitor`, which
+rebuilds fresh state from ETS + `__beamtalk_meta/0` via
+`beamtalk_class_registry:restart_class/1` and applies a per-class restart
+budget.
+
+This supervisor is started by `beamtalk_runtime_sup` (before
+`beamtalk_bootstrap`, so the bootstrap stub classes register through it)
+and registered locally as `beamtalk_class_sup`.
+""".
+
+-export([start_link/0, start_child/2]).
+-export([init/1]).
+
+%%% ============================================================================
+%%% Public API
+%%% ============================================================================
+
+-doc "Start the supervisor (called by beamtalk_runtime_sup).".
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+-doc """
+Start a supervised class gen_server for `ClassName`.
+
+Returns `{ok, Pid}`, or `{error, {already_started, Pid}}` when the class's
+registered name is already taken — the same contract as
+`beamtalk_object_class:start/2`, whose callers all handle that tuple.
+""".
+-spec start_child(atom(), map()) -> {ok, pid()} | {error, term()}.
+start_child(ClassName, ClassInfo) ->
+    supervisor:start_child(?MODULE, [ClassName, ClassInfo]).
+
+%%% ============================================================================
+%%% supervisor callback
+%%% ============================================================================
+
+init([]) ->
+    SupFlags = #{
+        strategy => simple_one_for_one,
+        intensity => 0,
+        period => 1
+    },
+    ChildSpec = #{
+        id => beamtalk_object_class,
+        start => {beamtalk_object_class, start_link, []},
+        restart => temporary,
+        shutdown => 5000,
+        type => worker,
+        modules => [beamtalk_object_class]
+    },
+    {ok, {SupFlags, [ChildSpec]}}.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
@@ -129,11 +129,34 @@ and join the `beamtalk_classes` pg group for enumeration.
 %% API
 %%====================================================================
 
--doc "Start a class process (unlinked) for on_load registration.".
+-doc """
+Start a class process for on_load registration.
+
+BT-3236: Routes through `beamtalk_class_sup` so class processes live in the
+OTP supervision tree, and registers the pid with `beamtalk_class_monitor`
+for eager crash recovery. When the supervisor is not running (EUnit suites
+start class processes without the runtime supervision tree), falls back to
+the pre-BT-3236 unlinked `gen_server:start/4` — that fallback never fires
+in a running release, where `beamtalk_runtime_sup` starts the supervisor
+before any class registers.
+""".
 -spec start(class_name(), map()) -> {ok, pid()} | {error, term()}.
 start(ClassName, ClassInfo) ->
-    RegName = beamtalk_class_registry:registry_name(ClassName),
-    gen_server:start({local, RegName}, ?MODULE, {ClassName, ClassInfo}, []).
+    Result =
+        case whereis(beamtalk_class_sup) of
+            undefined ->
+                RegName = beamtalk_class_registry:registry_name(ClassName),
+                gen_server:start({local, RegName}, ?MODULE, {ClassName, ClassInfo}, []);
+            _SupPid ->
+                beamtalk_class_sup:start_child(ClassName, ClassInfo)
+        end,
+    case Result of
+        {ok, Pid} ->
+            beamtalk_class_monitor:watch(ClassName, Pid),
+            {ok, Pid};
+        Other ->
+            Other
+    end.
 
 -doc "Start a class process with full options.".
 -spec start_link(class_name(), map()) -> {ok, pid()} | {error, term()}.

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_object_class.erl
@@ -145,6 +145,21 @@ start(ClassName, ClassInfo) ->
     Result =
         case whereis(beamtalk_class_sup) of
             undefined ->
+                %% Expected in standalone EUnit suites. In a running release
+                %% this branch means beamtalk_class_sup is dead or mid-restart
+                %% — the class still starts, but unsupervised; make that
+                %% visible rather than silently degrading.
+                case whereis(beamtalk_runtime_sup) of
+                    undefined ->
+                        ok;
+                    _ ->
+                        ?LOG_WARNING(
+                            "beamtalk_class_sup not running — starting class "
+                            "'~p' unsupervised",
+                            [ClassName],
+                            #{class => ClassName}
+                        )
+                end,
                 RegName = beamtalk_class_registry:registry_name(ClassName),
                 gen_server:start({local, RegName}, ?MODULE, {ClassName, ClassInfo}, []);
             _SupPid ->

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_process_navigation.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_process_navigation.erl
@@ -455,6 +455,11 @@ infra_deny_list() ->
             beamtalk_trace_store,
             beamtalk_subprocess_sup,
             beamtalk_reactive_subprocess_sup,
+            %% BT-3236: class gen_servers moved under a supervisor; keep them
+            %% (and their recovery monitor) out of the default snapshot, as
+            %% class processes always were before supervision.
+            beamtalk_class_sup,
+            beamtalk_class_monitor,
             %% Workspace plumbing: the workspace supervisor itself, the
             %% ChangeLog, the compiler server/port, the REPL compiler.
             beamtalk_workspace_sup,

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_runtime_sup.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_runtime_sup.erl
@@ -44,6 +44,27 @@ init([]) ->
             type => worker,
             modules => [beamtalk_xref]
         },
+        %% Supervisor for class gen_servers (BT-3236). MUST come before
+        %% beamtalk_bootstrap so the stub classes (Class/Metaclass/
+        %% ClassBuilder) already register through the supervision tree.
+        #{
+            id => beamtalk_class_sup,
+            start => {beamtalk_class_sup, start_link, []},
+            restart => permanent,
+            shutdown => 5000,
+            type => supervisor,
+            modules => [beamtalk_class_sup]
+        },
+        %% Eager crash recovery for class processes (BT-3236). Same ordering
+        %% constraint as beamtalk_class_sup: up before any class registers.
+        #{
+            id => beamtalk_class_monitor,
+            start => {beamtalk_class_monitor, start_link, []},
+            restart => permanent,
+            shutdown => 5000,
+            type => worker,
+            modules => [beamtalk_class_monitor]
+        },
         %% Bootstrap the class hierarchy first
         #{
             id => beamtalk_bootstrap,

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_sup_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_sup_tests.erl
@@ -31,12 +31,27 @@ setup(MonitorOpts) ->
 
 teardown(#{sup := SupPid, monitor := MonPid}) ->
     %% Stop the monitor FIRST so class cleanup below cannot trigger eager
-    %% restarts, then stop each remaining class gracefully, then the sup.
+    %% restarts, then stop this module's classes gracefully, then the sup.
     %% Leaving either registered would change the routing behaviour of every
-    %% test module that runs after this one in the same VM.
+    %% test module that runs after this one in the same VM. Only classes this
+    %% module created (SupTest3236* prefix) are stopped — the pg group is
+    %% shared with other suites in the same EUnit node.
     stop_if_alive(MonPid),
+    %% A test may have replaced the monitor (monitor_restart_readopts_test_);
+    %% stop whatever currently holds the registered name too.
+    stop_if_alive(whereis(beamtalk_class_monitor)),
     lists:foreach(
-        fun(Pid) -> stop_if_alive(Pid) end,
+        fun(Pid) ->
+            case beamtalk_class_registry:class_name_for_pid(Pid) of
+                {ok, Name} ->
+                    case string:prefix(atom_to_list(Name), "SupTest3236") of
+                        nomatch -> ok;
+                        _ -> stop_if_alive(Pid)
+                    end;
+                not_found ->
+                    ok
+            end
+        end,
         try
             pg:get_members(beamtalk_classes)
         catch
@@ -286,3 +301,46 @@ fallback_without_sup_test_() ->
                 end}
             ]
         end}.
+
+unwatch_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            {"unwatched class is not restarted even on an abnormal exit", fun() ->
+                {ok, Pid} = beamtalk_object_class:start('SupTest3236H', minimal_class_info()),
+                %% Let the watch cast land, then unwatch (synchronous).
+                ok = beamtalk_class_monitor:unwatch('SupTest3236H'),
+                kill_and_wait(Pid),
+                timer:sleep(300),
+                ?assertEqual(undefined, beamtalk_class_registry:whereis_class('SupTest3236H'))
+            end}
+        ]
+    end}.
+
+monitor_restart_readopts_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(Ctx) ->
+        [
+            {"a restarted monitor re-adopts surviving classes from pg",
+                {timeout, 30, fun() ->
+                    #{monitor := MonPid} = Ctx,
+                    {ok, OldPid} = beamtalk_object_class:start(
+                        'SupTest3236I', minimal_class_info()
+                    ),
+                    %% Simulate a monitor crash/restart cycle: the replacement
+                    %% must pick the surviving class back up from pg on init,
+                    %% not silently lose eager recovery (adversarial finding).
+                    stop_if_alive(MonPid),
+                    {ok, NewMon} = beamtalk_class_monitor:start_link(),
+                    ?assert(is_process_alive(NewMon)),
+                    kill_and_wait(OldPid),
+                    ?assertEqual(
+                        ok,
+                        wait_until(fun() ->
+                            case beamtalk_class_registry:whereis_class('SupTest3236I') of
+                                undefined -> false;
+                                P -> P =/= OldPid
+                            end
+                        end)
+                    )
+                end}}
+        ]
+    end}.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_sup_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_sup_tests.erl
@@ -20,16 +20,61 @@ eager crash recovery via `beamtalk_class_monitor`.
 setup() ->
     setup(#{}).
 
+%% In a shared EUnit node an earlier suite may have run
+%% `application:ensure_all_started(beamtalk_runtime)` and left the app
+%% running — then beamtalk_class_sup and beamtalk_class_monitor are already
+%% registered as beamtalk_runtime_sup children. Adopt the running sup
+%% (start_child works the same either way), and swap the app's monitor out
+%% via supervisor:terminate_child so each fixture gets a fresh monitor with
+%% its own budget opts; teardown restores it via supervisor:restart_child.
 setup(MonitorOpts) ->
     beamtalk_class_registry:ensure_pg_started(),
     beamtalk_class_registry:ensure_hierarchy_table(),
     beamtalk_class_registry:ensure_module_table(),
     beamtalk_class_registry:ensure_pid_table(),
-    {ok, SupPid} = beamtalk_class_sup:start_link(),
+    {SupPid, SupOwned} =
+        case whereis(beamtalk_class_sup) of
+            undefined ->
+                {ok, P} = beamtalk_class_sup:start_link(),
+                {P, true};
+            P ->
+                {P, false}
+        end,
+    RestoreMonitor = displace_registered_monitor(),
     {ok, MonPid} = beamtalk_class_monitor:start_link(MonitorOpts),
-    #{sup => SupPid, monitor => MonPid}.
+    #{sup => SupPid, sup_owned => SupOwned, monitor => MonPid, restore_monitor => RestoreMonitor}.
 
-teardown(#{sup := SupPid, monitor := MonPid}) ->
+%% Clear the beamtalk_class_monitor registered name so the fixture can start
+%% its own. Returns true when the displaced monitor was the runtime app's
+%% supervised child (teardown must restart_child it).
+displace_registered_monitor() ->
+    case whereis(beamtalk_class_monitor) of
+        undefined ->
+            false;
+        Pid ->
+            case whereis(beamtalk_runtime_sup) of
+                undefined ->
+                    stop_if_alive(Pid),
+                    false;
+                _ ->
+                    case supervisor:terminate_child(beamtalk_runtime_sup, beamtalk_class_monitor) of
+                        ok ->
+                            true;
+                        {error, _} ->
+                            %% Registered but not the app's child (leaked from
+                            %% another suite) — stop it directly.
+                            stop_if_alive(Pid),
+                            false
+                    end
+            end
+    end.
+
+teardown(#{
+    sup := SupPid,
+    sup_owned := SupOwned,
+    monitor := MonPid,
+    restore_monitor := RestoreMonitor
+}) ->
     %% Stop the monitor FIRST so class cleanup below cannot trigger eager
     %% restarts, then stop this module's classes gracefully, then the sup.
     %% Leaving either registered would change the routing behaviour of every
@@ -58,7 +103,14 @@ teardown(#{sup := SupPid, monitor := MonPid}) ->
             _:_ -> []
         end
     ),
-    stop_if_alive(SupPid),
+    case SupOwned of
+        true -> stop_if_alive(SupPid);
+        false -> ok
+    end,
+    case RestoreMonitor of
+        true -> catch supervisor:restart_child(beamtalk_runtime_sup, beamtalk_class_monitor);
+        false -> ok
+    end,
     ok.
 
 stop_if_alive(Pid) when is_pid(Pid) ->
@@ -276,17 +328,47 @@ restart_budget_test_() ->
 fallback_without_sup_test_() ->
     {setup,
         fun() ->
-            %% No supervisor / monitor here — the standalone-EUnit context.
+            %% The fixture needs beamtalk_class_sup to be ABSENT. If a prior
+            %% suite left the runtime app running, carve its class_sup out via
+            %% supervisor:terminate_child (restored in teardown); a leaked
+            %% standalone sup is stopped directly.
             beamtalk_class_registry:ensure_pg_started(),
             beamtalk_class_registry:ensure_hierarchy_table(),
             beamtalk_class_registry:ensure_module_table(),
             beamtalk_class_registry:ensure_pid_table(),
-            ok
+            case whereis(beamtalk_class_sup) of
+                undefined ->
+                    false;
+                SupPid ->
+                    case whereis(beamtalk_runtime_sup) of
+                        undefined ->
+                            stop_if_alive(SupPid),
+                            false;
+                        _ ->
+                            case
+                                supervisor:terminate_child(
+                                    beamtalk_runtime_sup, beamtalk_class_sup
+                                )
+                            of
+                                ok ->
+                                    true;
+                                {error, _} ->
+                                    stop_if_alive(SupPid),
+                                    false
+                            end
+                    end
+            end
         end,
-        fun(_) ->
+        fun(RestoreSup) ->
             case beamtalk_class_registry:whereis_class('SupTest3236G') of
                 undefined -> ok;
                 P -> stop_if_alive(P)
+            end,
+            case RestoreSup of
+                true ->
+                    catch supervisor:restart_child(beamtalk_runtime_sup, beamtalk_class_sup);
+                false ->
+                    ok
             end
         end,
         fun(_) ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_sup_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_sup_tests.erl
@@ -1,0 +1,288 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+%%% **DDD Context:** Object System Context
+
+-module(beamtalk_class_sup_tests).
+
+-moduledoc """
+EUnit tests for BT-3236: class gen_servers under `beamtalk_class_sup` with
+eager crash recovery via `beamtalk_class_monitor`.
+""".
+-include_lib("eunit/include/eunit.hrl").
+
+%% Custom logger handler callback (see capture_log/2 tests).
+-export([log/2]).
+
+%%====================================================================
+%% Setup/Teardown
+%%====================================================================
+
+setup() ->
+    setup(#{}).
+
+setup(MonitorOpts) ->
+    beamtalk_class_registry:ensure_pg_started(),
+    beamtalk_class_registry:ensure_hierarchy_table(),
+    beamtalk_class_registry:ensure_module_table(),
+    beamtalk_class_registry:ensure_pid_table(),
+    {ok, SupPid} = beamtalk_class_sup:start_link(),
+    {ok, MonPid} = beamtalk_class_monitor:start_link(MonitorOpts),
+    #{sup => SupPid, monitor => MonPid}.
+
+teardown(#{sup := SupPid, monitor := MonPid}) ->
+    %% Stop the monitor FIRST so class cleanup below cannot trigger eager
+    %% restarts, then stop each remaining class gracefully, then the sup.
+    %% Leaving either registered would change the routing behaviour of every
+    %% test module that runs after this one in the same VM.
+    stop_if_alive(MonPid),
+    lists:foreach(
+        fun(Pid) -> stop_if_alive(Pid) end,
+        try
+            pg:get_members(beamtalk_classes)
+        catch
+            _:_ -> []
+        end
+    ),
+    stop_if_alive(SupPid),
+    ok.
+
+stop_if_alive(Pid) when is_pid(Pid) ->
+    case is_process_alive(Pid) of
+        true ->
+            MRef = erlang:monitor(process, Pid),
+            (try
+                gen_server:stop(Pid)
+            catch
+                _:_ -> exit(Pid, kill)
+            end),
+            receive
+                {'DOWN', MRef, process, Pid, _} -> ok
+            after 2000 -> ok
+            end;
+        false ->
+            ok
+    end;
+stop_if_alive(_) ->
+    ok.
+
+minimal_class_info() ->
+    #{superclass => none, methods => #{}, class_methods => #{}}.
+
+wait_until(Fun) ->
+    wait_until(Fun, 100).
+
+wait_until(_Fun, 0) ->
+    timeout;
+wait_until(Fun, Retries) ->
+    case Fun() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(50),
+            wait_until(Fun, Retries - 1)
+    end.
+
+kill_and_wait(Pid) ->
+    MRef = erlang:monitor(process, Pid),
+    exit(Pid, kill),
+    receive
+        {'DOWN', MRef, process, Pid, _} -> ok
+    after 5000 -> ?assert(false)
+    end.
+
+%%====================================================================
+%% Logger capture handler (log/2 is the handler callback)
+%%====================================================================
+
+log(#{msg := Msg, level := Level}, #{config := #{test_pid := TestPid}}) ->
+    TestPid ! {captured_log, Level, Msg},
+    ok.
+
+add_capture_handler() ->
+    %% The rebar3 eunit node's primary logger level filters warnings out, so
+    %% lower it for the duration of the capture (restored in
+    %% remove_capture_handler/1).
+    #{level := OldLevel} = logger:get_primary_config(),
+    ok = logger:set_primary_config(level, warning),
+    ok = logger:add_handler(
+        bt3236_capture,
+        ?MODULE,
+        #{config => #{test_pid => self()}, level => warning}
+    ),
+    OldLevel.
+
+remove_capture_handler(OldLevel) ->
+    _ = logger:remove_handler(bt3236_capture),
+    _ = logger:set_primary_config(level, OldLevel),
+    %% Drain any queued captures so a later test in this process starts clean.
+    drain_captures().
+
+drain_captures() ->
+    receive
+        {captured_log, _, _} -> drain_captures()
+    after 0 -> ok
+    end.
+
+restart_warning_received() ->
+    receive
+        {captured_log, warning, {Fmt, _Args}} when is_list(Fmt) ->
+            case string:find(Fmt, "auto-restarted") of
+                nomatch -> restart_warning_received();
+                _ -> true
+            end;
+        {captured_log, _, _} ->
+            restart_warning_received()
+    after 0 -> false
+    end.
+
+%%====================================================================
+%% Tests
+%%====================================================================
+
+supervised_start_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            {"class process starts as a child of beamtalk_class_sup", fun() ->
+                {ok, Pid} = beamtalk_object_class:start('SupTest3236A', minimal_class_info()),
+                Children = [P || {_, P, _, _} <- supervisor:which_children(beamtalk_class_sup)],
+                ?assert(lists:member(Pid, Children)),
+                ?assertEqual(Pid, beamtalk_class_registry:whereis_class('SupTest3236A'))
+            end},
+            {"already_started contract is preserved through the supervisor", fun() ->
+                {ok, Pid} = beamtalk_object_class:start('SupTest3236B', minimal_class_info()),
+                ?assertEqual(
+                    {error, {already_started, Pid}},
+                    beamtalk_object_class:start('SupTest3236B', minimal_class_info())
+                )
+            end}
+        ]
+    end}.
+
+eager_restart_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            {"killed class process is eagerly restarted without a message send",
+                {timeout, 30, fun() ->
+                    OldLevel = add_capture_handler(),
+                    try
+                    {ok, OldPid} = beamtalk_object_class:start(
+                        'SupTest3236C', minimal_class_info()
+                    ),
+                    kill_and_wait(OldPid),
+                    %% No send to the class here — the monitor's 'DOWN' handler
+                    %% must bring it back on its own.
+                    ?assertEqual(
+                        ok,
+                        wait_until(fun() ->
+                            case beamtalk_class_registry:whereis_class('SupTest3236C') of
+                                undefined -> false;
+                                NewPid -> NewPid =/= OldPid
+                            end
+                        end)
+                    ),
+                    NewPid = beamtalk_class_registry:whereis_class('SupTest3236C'),
+                    %% Re-registered in the pid reverse index and pg group.
+                    ?assertEqual(
+                        {ok, 'SupTest3236C'},
+                        beamtalk_class_registry:class_name_for_pid(NewPid)
+                    ),
+                    ?assert(lists:member(NewPid, pg:get_members(beamtalk_classes))),
+                    %% The restarted child is supervised again.
+                    Children = [
+                        P
+                     || {_, P, _, _} <- supervisor:which_children(beamtalk_class_sup)
+                    ],
+                    ?assert(lists:member(NewPid, Children)),
+                    %% restart_class's warning about dropped hot patches /
+                    %% class-var state was logged.
+                        ?assertEqual(
+                            ok, wait_until(fun restart_warning_received/0)
+                        )
+                    after
+                        remove_capture_handler(OldLevel)
+                    end
+                end}}
+        ]
+    end}.
+
+deliberate_stop_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            {"gen_server:stop does not trigger a restart", fun() ->
+                {ok, Pid} = beamtalk_object_class:start('SupTest3236D', minimal_class_info()),
+                gen_server:stop(Pid),
+                %% Give the monitor time to (wrongly) act, then assert it didn't.
+                timer:sleep(300),
+                ?assertEqual(undefined, beamtalk_class_registry:whereis_class('SupTest3236D'))
+            end}
+        ]
+    end}.
+
+restart_budget_test_() ->
+    {setup, fun() -> setup(#{max_restarts => 1, window_ms => 60000}) end, fun teardown/1, fun(
+        _
+    ) ->
+        [
+            {"crash-looping class is dropped after the budget, others unaffected",
+                {timeout, 30, fun() ->
+                {ok, PidA} = beamtalk_object_class:start('SupTest3236E', minimal_class_info()),
+                {ok, PidB} = beamtalk_object_class:start('SupTest3236F', minimal_class_info()),
+                %% First crash: within budget → eagerly restarted.
+                kill_and_wait(PidA),
+                ?assertEqual(
+                    ok,
+                    wait_until(fun() ->
+                        case beamtalk_class_registry:whereis_class('SupTest3236E') of
+                            undefined -> false;
+                            P -> P =/= PidA
+                        end
+                    end)
+                ),
+                Pid2 = beamtalk_class_registry:whereis_class('SupTest3236E'),
+                %% Second crash inside the window: budget exhausted → stays down.
+                kill_and_wait(Pid2),
+                timer:sleep(300),
+                ?assertEqual(undefined, beamtalk_class_registry:whereis_class('SupTest3236E')),
+                %% The budget is per class: an unrelated class still restarts.
+                kill_and_wait(PidB),
+                ?assertEqual(
+                    ok,
+                    wait_until(fun() ->
+                        case beamtalk_class_registry:whereis_class('SupTest3236F') of
+                            undefined -> false;
+                            P -> P =/= PidB
+                        end
+                    end)
+                )
+                end}}
+        ]
+    end}.
+
+fallback_without_sup_test_() ->
+    {setup,
+        fun() ->
+            %% No supervisor / monitor here — the standalone-EUnit context.
+            beamtalk_class_registry:ensure_pg_started(),
+            beamtalk_class_registry:ensure_hierarchy_table(),
+            beamtalk_class_registry:ensure_module_table(),
+            beamtalk_class_registry:ensure_pid_table(),
+            ok
+        end,
+        fun(_) ->
+            case beamtalk_class_registry:whereis_class('SupTest3236G') of
+                undefined -> ok;
+                P -> stop_if_alive(P)
+            end
+        end,
+        fun(_) ->
+            [
+                {"start/2 still works when beamtalk_class_sup is not running", fun() ->
+                    ?assertEqual(undefined, whereis(beamtalk_class_sup)),
+                    {ok, Pid} = beamtalk_object_class:start(
+                        'SupTest3236G', minimal_class_info()
+                    ),
+                    ?assert(is_process_alive(Pid)),
+                    ?assertEqual(Pid, beamtalk_class_registry:whereis_class('SupTest3236G'))
+                end}
+            ]
+        end}.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_sup_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_sup_tests.erl
@@ -165,36 +165,36 @@ eager_restart_test_() ->
                 {timeout, 30, fun() ->
                     OldLevel = add_capture_handler(),
                     try
-                    {ok, OldPid} = beamtalk_object_class:start(
-                        'SupTest3236C', minimal_class_info()
-                    ),
-                    kill_and_wait(OldPid),
-                    %% No send to the class here — the monitor's 'DOWN' handler
-                    %% must bring it back on its own.
-                    ?assertEqual(
-                        ok,
-                        wait_until(fun() ->
-                            case beamtalk_class_registry:whereis_class('SupTest3236C') of
-                                undefined -> false;
-                                NewPid -> NewPid =/= OldPid
-                            end
-                        end)
-                    ),
-                    NewPid = beamtalk_class_registry:whereis_class('SupTest3236C'),
-                    %% Re-registered in the pid reverse index and pg group.
-                    ?assertEqual(
-                        {ok, 'SupTest3236C'},
-                        beamtalk_class_registry:class_name_for_pid(NewPid)
-                    ),
-                    ?assert(lists:member(NewPid, pg:get_members(beamtalk_classes))),
-                    %% The restarted child is supervised again.
-                    Children = [
-                        P
-                     || {_, P, _, _} <- supervisor:which_children(beamtalk_class_sup)
-                    ],
-                    ?assert(lists:member(NewPid, Children)),
-                    %% restart_class's warning about dropped hot patches /
-                    %% class-var state was logged.
+                        {ok, OldPid} = beamtalk_object_class:start(
+                            'SupTest3236C', minimal_class_info()
+                        ),
+                        kill_and_wait(OldPid),
+                        %% No send to the class here — the monitor's 'DOWN' handler
+                        %% must bring it back on its own.
+                        ?assertEqual(
+                            ok,
+                            wait_until(fun() ->
+                                case beamtalk_class_registry:whereis_class('SupTest3236C') of
+                                    undefined -> false;
+                                    NewPid -> NewPid =/= OldPid
+                                end
+                            end)
+                        ),
+                        NewPid = beamtalk_class_registry:whereis_class('SupTest3236C'),
+                        %% Re-registered in the pid reverse index and pg group.
+                        ?assertEqual(
+                            {ok, 'SupTest3236C'},
+                            beamtalk_class_registry:class_name_for_pid(NewPid)
+                        ),
+                        ?assert(lists:member(NewPid, pg:get_members(beamtalk_classes))),
+                        %% The restarted child is supervised again.
+                        Children = [
+                            P
+                         || {_, P, _, _} <- supervisor:which_children(beamtalk_class_sup)
+                        ],
+                        ?assert(lists:member(NewPid, Children)),
+                        %% restart_class's warning about dropped hot patches /
+                        %% class-var state was logged.
                         ?assertEqual(
                             ok, wait_until(fun restart_warning_received/0)
                         )
@@ -225,35 +225,35 @@ restart_budget_test_() ->
         [
             {"crash-looping class is dropped after the budget, others unaffected",
                 {timeout, 30, fun() ->
-                {ok, PidA} = beamtalk_object_class:start('SupTest3236E', minimal_class_info()),
-                {ok, PidB} = beamtalk_object_class:start('SupTest3236F', minimal_class_info()),
-                %% First crash: within budget → eagerly restarted.
-                kill_and_wait(PidA),
-                ?assertEqual(
-                    ok,
-                    wait_until(fun() ->
-                        case beamtalk_class_registry:whereis_class('SupTest3236E') of
-                            undefined -> false;
-                            P -> P =/= PidA
-                        end
-                    end)
-                ),
-                Pid2 = beamtalk_class_registry:whereis_class('SupTest3236E'),
-                %% Second crash inside the window: budget exhausted → stays down.
-                kill_and_wait(Pid2),
-                timer:sleep(300),
-                ?assertEqual(undefined, beamtalk_class_registry:whereis_class('SupTest3236E')),
-                %% The budget is per class: an unrelated class still restarts.
-                kill_and_wait(PidB),
-                ?assertEqual(
-                    ok,
-                    wait_until(fun() ->
-                        case beamtalk_class_registry:whereis_class('SupTest3236F') of
-                            undefined -> false;
-                            P -> P =/= PidB
-                        end
-                    end)
-                )
+                    {ok, PidA} = beamtalk_object_class:start('SupTest3236E', minimal_class_info()),
+                    {ok, PidB} = beamtalk_object_class:start('SupTest3236F', minimal_class_info()),
+                    %% First crash: within budget → eagerly restarted.
+                    kill_and_wait(PidA),
+                    ?assertEqual(
+                        ok,
+                        wait_until(fun() ->
+                            case beamtalk_class_registry:whereis_class('SupTest3236E') of
+                                undefined -> false;
+                                P -> P =/= PidA
+                            end
+                        end)
+                    ),
+                    Pid2 = beamtalk_class_registry:whereis_class('SupTest3236E'),
+                    %% Second crash inside the window: budget exhausted → stays down.
+                    kill_and_wait(Pid2),
+                    timer:sleep(300),
+                    ?assertEqual(undefined, beamtalk_class_registry:whereis_class('SupTest3236E')),
+                    %% The budget is per class: an unrelated class still restarts.
+                    kill_and_wait(PidB),
+                    ?assertEqual(
+                        ok,
+                        wait_until(fun() ->
+                            case beamtalk_class_registry:whereis_class('SupTest3236F') of
+                                undefined -> false;
+                                P -> P =/= PidB
+                            end
+                        end)
+                    )
                 end}}
         ]
     end}.

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_process_navigation_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_process_navigation_tests.erl
@@ -225,6 +225,8 @@ infra_deny_list_contents_test() ->
     ?assert(sets:is_element(beamtalk_xref, DenyList)),
     ?assert(sets:is_element(beamtalk_workspace_changelog, DenyList)),
     ?assert(sets:is_element(beamtalk_runtime_sup, DenyList)),
+    ?assert(sets:is_element(beamtalk_class_sup, DenyList)),
+    ?assert(sets:is_element(beamtalk_class_monitor, DenyList)),
     ?assertNot(sets:is_element(some_user_actor, DenyList)).
 
 is_infra_predicate_test() ->
@@ -294,7 +296,9 @@ deny_list_parity_test() ->
         beamtalk_object_instances,
         beamtalk_trace_store,
         beamtalk_subprocess_sup,
-        beamtalk_reactive_subprocess_sup
+        beamtalk_reactive_subprocess_sup,
+        beamtalk_class_sup,
+        beamtalk_class_monitor
     ],
     lists:foreach(
         fun(Name) ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_runtime_sup_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_runtime_sup_tests.erl
@@ -34,10 +34,10 @@ supervisor_intensity_test() ->
 children_count_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    %% Should have exactly 10 children: xref, bootstrap, announcements, stdlib,
-    %% object_instances, subprocess_sup, reactive_subprocess_sup, trace_store,
-    %% object_watch, file_handle_registry
-    ?assertEqual(10, length(ChildSpecs)).
+    %% Should have exactly 12 children: xref, class_sup, class_monitor,
+    %% bootstrap, announcements, stdlib, object_instances, subprocess_sup,
+    %% reactive_subprocess_sup, trace_store, object_watch, file_handle_registry
+    ?assertEqual(12, length(ChildSpecs)).
 
 children_ids_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
@@ -46,6 +46,8 @@ children_ids_test() ->
     %% stdlib, object_instances, subprocess_sup, reactive_subprocess_sup, trace_store
     Ids = [maps:get(id, Spec) || Spec <- ChildSpecs],
     ?assert(lists:member(beamtalk_xref, Ids)),
+    ?assert(lists:member(beamtalk_class_sup, Ids)),
+    ?assert(lists:member(beamtalk_class_monitor, Ids)),
     ?assert(lists:member(beamtalk_bootstrap, Ids)),
     ?assert(lists:member(beamtalk_announcements, Ids)),
     ?assert(lists:member(beamtalk_stdlib, Ids)),
@@ -60,12 +62,26 @@ children_ids_test() ->
 children_are_workers_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    %% xref (worker), bootstrap, announcements, stdlib, object_instances are workers;
-    %% subprocess_sup and reactive_subprocess_sup are supervisors; trace_store,
-    %% object_watch, and file_handle_registry are workers.
+    %% xref (worker); class_sup (supervisor, BT-3236); class_monitor, bootstrap,
+    %% announcements, stdlib, object_instances are workers; subprocess_sup and
+    %% reactive_subprocess_sup are supervisors; trace_store, object_watch, and
+    %% file_handle_registry are workers.
     Types = [maps:get(type, Spec) || Spec <- ChildSpecs],
     ?assertEqual(
-        [worker, worker, worker, worker, worker, supervisor, supervisor, worker, worker, worker],
+        [
+            worker,
+            supervisor,
+            worker,
+            worker,
+            worker,
+            worker,
+            worker,
+            supervisor,
+            supervisor,
+            worker,
+            worker,
+            worker
+        ],
         Types
     ).
 
@@ -75,7 +91,7 @@ children_are_permanent_test() ->
     %% All children should have permanent restart
     RestartTypes = [maps:get(restart, Spec) || Spec <- ChildSpecs],
     ?assertEqual(
-        lists:duplicate(10, permanent),
+        lists:duplicate(12, permanent),
         RestartTypes
     ).
 
@@ -94,6 +110,8 @@ children_ordered_correctly_test() ->
     ?assertEqual(
         [
             beamtalk_xref,
+            beamtalk_class_sup,
+            beamtalk_class_monitor,
             beamtalk_bootstrap,
             beamtalk_announcements,
             beamtalk_stdlib,
@@ -108,6 +126,12 @@ children_ordered_correctly_test() ->
     ).
 
 %%% Child specifications tests
+
+%%% Look a child spec up by id — position-independent, so adding a new
+%%% child to beamtalk_runtime_sup does not break every spec test below.
+child_spec(Id, ChildSpecs) ->
+    [Spec] = [S || S <- ChildSpecs, maps:get(id, S) =:= Id],
+    Spec.
 
 xref_child_spec_test() ->
     %% ADR 0087: beamtalk_xref MUST be the first non-pg child.
@@ -124,18 +148,7 @@ xref_child_spec_test() ->
 bootstrap_child_spec_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    [
-        _XrefSpec,
-        BootstrapSpec,
-        _AnnouncementsSpec,
-        _StdlibSpec,
-        _InstancesSpec,
-        _SubprocessSupSpec,
-        _ReactiveSupSpec,
-        _TraceStoreSpec,
-        _ObjectWatchSpec,
-        _FileHandleRegistrySpec
-    ] = ChildSpecs,
+    BootstrapSpec = child_spec(beamtalk_bootstrap, ChildSpecs),
     ?assertEqual(beamtalk_bootstrap, maps:get(id, BootstrapSpec)),
     ?assertEqual({beamtalk_bootstrap, start_link, []}, maps:get(start, BootstrapSpec)),
     ?assertEqual(permanent, maps:get(restart, BootstrapSpec)),
@@ -146,18 +159,7 @@ bootstrap_child_spec_test() ->
 instances_child_spec_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    [
-        _XrefSpec,
-        _BootstrapSpec,
-        _AnnouncementsSpec,
-        _StdlibSpec,
-        InstancesSpec,
-        _SubprocessSupSpec,
-        _ReactiveSupSpec,
-        _TraceStoreSpec,
-        _ObjectWatchSpec,
-        _FileHandleRegistrySpec
-    ] = ChildSpecs,
+    InstancesSpec = child_spec(beamtalk_object_instances, ChildSpecs),
     ?assertEqual(beamtalk_object_instances, maps:get(id, InstancesSpec)),
     ?assertEqual({beamtalk_object_instances, start_link, []}, maps:get(start, InstancesSpec)),
     ?assertEqual(permanent, maps:get(restart, InstancesSpec)),
@@ -168,18 +170,7 @@ instances_child_spec_test() ->
 stdlib_child_spec_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    [
-        _XrefSpec,
-        _BootstrapSpec,
-        _AnnouncementsSpec,
-        StdlibSpec,
-        _InstancesSpec,
-        _SubprocessSupSpec,
-        _ReactiveSupSpec,
-        _TraceStoreSpec,
-        _ObjectWatchSpec,
-        _FileHandleRegistrySpec
-    ] = ChildSpecs,
+    StdlibSpec = child_spec(beamtalk_stdlib, ChildSpecs),
     ?assertEqual(beamtalk_stdlib, maps:get(id, StdlibSpec)),
     ?assertEqual({beamtalk_stdlib, start_link, []}, maps:get(start, StdlibSpec)),
     ?assertEqual(permanent, maps:get(restart, StdlibSpec)),
@@ -190,18 +181,7 @@ stdlib_child_spec_test() ->
 subprocess_sup_child_spec_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    [
-        _XrefSpec,
-        _BootstrapSpec,
-        _AnnouncementsSpec,
-        _StdlibSpec,
-        _InstancesSpec,
-        SubprocessSupSpec,
-        _ReactiveSupSpec,
-        _TraceStoreSpec,
-        _ObjectWatchSpec,
-        _FileHandleRegistrySpec
-    ] = ChildSpecs,
+    SubprocessSupSpec = child_spec(beamtalk_subprocess_sup, ChildSpecs),
     ?assertEqual(beamtalk_subprocess_sup, maps:get(id, SubprocessSupSpec)),
     ?assertEqual({beamtalk_subprocess_sup, start_link, []}, maps:get(start, SubprocessSupSpec)),
     ?assertEqual(permanent, maps:get(restart, SubprocessSupSpec)),
@@ -212,18 +192,7 @@ subprocess_sup_child_spec_test() ->
 reactive_subprocess_sup_child_spec_test() ->
     {ok, {_SupFlags, ChildSpecs}} = beamtalk_runtime_sup:init([]),
 
-    [
-        _XrefSpec,
-        _BootstrapSpec,
-        _AnnouncementsSpec,
-        _StdlibSpec,
-        _InstancesSpec,
-        _SubprocessSupSpec,
-        ReactiveSupSpec,
-        _TraceStoreSpec,
-        _ObjectWatchSpec,
-        _FileHandleRegistrySpec
-    ] = ChildSpecs,
+    ReactiveSupSpec = child_spec(beamtalk_reactive_subprocess_sup, ChildSpecs),
     ?assertEqual(beamtalk_reactive_subprocess_sup, maps:get(id, ReactiveSupSpec)),
     ?assertEqual(
         {beamtalk_reactive_subprocess_sup, start_link, []}, maps:get(start, ReactiveSupSpec)
@@ -237,7 +206,9 @@ reactive_subprocess_sup_child_spec_test() ->
 
 init_returns_proper_format_test() ->
     Result = beamtalk_runtime_sup:init([]),
-    ?assertMatch({ok, {#{strategy := one_for_one}, [_, _, _, _, _, _, _, _, _, _]}}, Result).
+    ?assertMatch(
+        {ok, {#{strategy := one_for_one}, [_, _, _, _, _, _, _, _, _, _, _, _]}}, Result
+    ).
 
 %%% Behavioral tests
 
@@ -270,6 +241,8 @@ all_children_alive_test() ->
         %% Verify each child has correct ID and is alive
         ExpectedIds = [
             beamtalk_xref,
+            beamtalk_class_sup,
+            beamtalk_class_monitor,
             beamtalk_bootstrap,
             beamtalk_announcements,
             beamtalk_stdlib,


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-3236

## Summary

Class gen_servers were started unlinked (`gen_server:start`) outside any supervision tree, with only lazy caller-driven crash recovery (BT-1768). This puts them under a real supervisor and adds eager crash recovery:

- **`beamtalk_class_sup`** — `simple_one_for_one`, `temporary` children. OTP auto-restart is deliberately not used: it would replay stale `ClassInfo` after hot reloads, and restart-intensity escalation would take down every class at once.
- **`beamtalk_class_monitor`** — owns restart policy instead: on abnormal `'DOWN'` it eagerly rebuilds via the existing `beamtalk_class_registry:restart_class/1` (ETS + `__beamtalk_meta/0`), with a per-class restart budget (3 per 30s) so one crash-looping class never affects others. Deliberate stops (`normal`/`shutdown`/`noproc`) are never restarted. Survives its own restart by re-adopting watched classes from `pg`.
- **`beamtalk_object_class:start/2`** routes through the supervisor when running; documented unlinked fallback for standalone EUnit suites (warns if it ever fires in a live release).
- **Removal safety**: `classRemoveFromSystemByName` now `unwatch`es before killing actors — actors are linked to their class process (pre-existing, filed as BT-3243), so removal kills propagate and eager restart would otherwise resurrect the class mid-removal.
- `beamtalk_class_sup`/`beamtalk_class_monitor` added to the process-navigation infra deny-list; lazy `class_send_with_recovery/3` kept as fallback.

## Testing

- New `beamtalk_class_sup_tests`: supervised start, `already_started` contract, eager restart without a send (incl. restart-warning log capture and registry/pg re-registration), deliberate-stop no-restart, per-class budget give-up, unwatch, monitor-restart re-adoption, unsupervised fallback.
- `beamtalk_runtime_sup_tests` child-spec tests refactored to id-lookup (position-independent) and updated for the two new children.
- Full runtime EUnit at exact parity with main (same 5 pre-existing shared-VM interference failures on both); stdlib 233/233, BUnit 3305 passed/0 failed, REPL-protocol e2e green, dialyzer clean.

Adversarial review (fresh Opus subagent) drove the hardening commit: synchronous watch arming, noproc classification, monitor crash-resilience, durable restart budget, removal race fix. Follow-ups filed: BT-3243 (actor↔class link), BT-3241 (unrelated flaky broker test found while running CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)