### PR TITLE
AI-curate method-category dividers across the stdlib (BT-2626)

### DIFF
--- a/crates/beamtalk-core/src/source_analysis/corpus_test_support.rs
+++ b/crates/beamtalk-core/src/source_analysis/corpus_test_support.rs
@@ -1,0 +1,77 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared corpus-walking helpers for `.bt` corpus tests.
+//!
+//! Multiple corpus test suites need "every `.bt` file under `stdlib/src` and
+//! `examples/`" — the byte-span round-trip proof
+//! ([`super::method_span_corpus_tests`], ADR 0082 Phase 0) and the
+//! method-category divider validation
+//! ([`super::method_category_corpus_tests`], BT-2626) both walk the same
+//! corpus. This module is the single place that knows where the corpus lives
+//! and how to walk it, so the two suites can't drift on what "the corpus"
+//! means (see `docs/development/architecture-principles.md` § Duplication &
+//! the Shared-Leaf-Module Pattern).
+
+use std::path::{Path, PathBuf};
+
+/// Returns the repository root (`CARGO_MANIFEST_DIR/../..`).
+pub(super) fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/")
+        .parent()
+        .expect("repo root")
+        .to_path_buf()
+}
+
+/// Recursively collects every `.bt` file under `dir`.
+fn collect_bt_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.filter_map(Result::ok).map(|e| e.path()).collect();
+    // Deterministic order for stable test output.
+    entries.sort();
+    for path in entries {
+        if path.is_dir() {
+            collect_bt_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "bt") {
+            out.push(path);
+        }
+    }
+}
+
+/// The corpus directories: every `.bt` file lives under one of these.
+pub(super) fn corpus_dirs() -> [PathBuf; 2] {
+    let root = repo_root();
+    [root.join("stdlib/src"), root.join("examples")]
+}
+
+/// Whether the corpus directories are present in this checkout.
+///
+/// They are absent when the crate is built from a source distribution or a
+/// partial checkout that omits the workspace `stdlib/` and `examples/` trees. In
+/// that case the corpus tests skip rather than hard-fail (a present-but-
+/// unreadable *file*, by contrast, is always a hard failure).
+pub(super) fn corpus_present() -> bool {
+    corpus_dirs().iter().any(|dir| dir.is_dir())
+}
+
+/// Gathers the whole corpus: every `.bt` file under `stdlib/src` and `examples`.
+pub(super) fn corpus_files() -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    for dir in corpus_dirs() {
+        collect_bt_files(&dir, &mut files);
+    }
+    files
+}
+
+/// Reads a corpus file, hard-failing (with the path + error) if it is present
+/// but cannot be read. Unlike skipping an absent *directory*, an unreadable file
+/// that the walk already discovered must never be silently ignored — that would
+/// let a corpus proof go false-green.
+pub(super) fn read_corpus_file(path: &Path) -> String {
+    std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("could not read corpus file {}: {e}", path.display()))
+}

--- a/crates/beamtalk-core/src/source_analysis/method_category_corpus_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/method_category_corpus_tests.rs
@@ -1,0 +1,176 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! Corpus-wide validation for `// === Name ===` method-category dividers
+//! (BT-2601's recognizer, exercised here at BT-2626's stdlib-wide curation
+//! scale).
+//!
+//! [`method_category`](super::method_category) documents two silent-failure
+//! modes that a hand-written (or AI-curated) divider can fall into with no
+//! diagnostic anywhere in the pipeline:
+//!
+//! 1. **A near-miss divider is not diagnosed.** `=== Name ====` (mismatched
+//!    run lengths), `== Name ==` (too short), or a `///`/`/* */` divider-
+//!    shaped comment all silently fail to parse and fall back to an ordinary
+//!    leading comment — the methods below are silently absorbed into
+//!    whichever category was already open. `fmt-check-beamtalk` and the
+//!    byte-span round-trip test ([`super::method_span_corpus_tests`]) both
+//!    treat comments as opaque trivia, so neither one would catch this.
+//! 2. **A divider with nothing but non-method declarations after it** would
+//!    register as a named category with zero methods — a heading with
+//!    nothing under it.
+//!
+//! This suite proves neither happens anywhere in the corpus, checked against
+//! the real recognizer ([`parse_divider_name`], [`categorize_methods`]) —
+//! not a reimplementation of the rule — so it can't silently drift from what
+//! the LSP outline/cockpit/REPL actually do. It complements (does not
+//! replace) BT-3240's proposed editor-time lint: this is the regression gate
+//! that keeps the corpus itself honest.
+
+use crate::source_analysis::corpus_test_support::{corpus_files, corpus_present, read_corpus_file};
+use crate::source_analysis::method_category::{categorize_methods, parse_divider_name};
+use crate::source_analysis::{lex_with_eof, parse};
+
+/// Returns the divider-candidate text (the comment body after `//`) if `line`
+/// is shaped like someone attempting a `// === Name ===` divider: a plain
+/// `//` line comment (never `///`/`//!`) whose trimmed body has a non-empty
+/// run of `=` at both the start and the end, with *some* non-`=` content
+/// strictly between them.
+///
+/// That last clause is what excludes the older, unrelated pure-border banner
+/// line (`// ===...===`, all `=`, no name) some example files use as part of
+/// a 3-line `border`/`HEADING`/`border` convention — [`parse_divider_name`]
+/// deliberately doesn't recognize that shape either, so it must not count as
+/// a "near miss" here. Anything this function *does* flag is exactly the
+/// shape a `// === Name ===` divider takes, valid or not — so every hit must
+/// parse via [`parse_divider_name`], or it's a silently-broken divider.
+fn divider_attempt(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix("//")?;
+    // Exclude `///` doc comments and `//!` module docs — never dividers, and
+    // doc-comment example snippets (fenced ```beamtalk blocks showing a
+    // divider) are themselves `///`-prefixed line-by-line, so this also
+    // keeps embedded examples out of the raw scan for free.
+    if rest.starts_with('/') || rest.starts_with('!') {
+        return None;
+    }
+    let body = rest.trim_end_matches(['\r', '\n']);
+    let content = body.trim();
+    let chars: Vec<char> = content.chars().collect();
+    let left_len = chars.iter().take_while(|&&c| c == '=').count();
+    if left_len == 0 {
+        return None;
+    }
+    let right_len = chars.iter().rev().take_while(|&&c| c == '=').count();
+    if right_len == 0 {
+        return None;
+    }
+    if left_len + right_len >= chars.len() {
+        // Pure border line (entirely `=`, or the two runs overlap/touch) —
+        // the unrelated 3-line banner convention, not a divider attempt.
+        return None;
+    }
+    Some(body)
+}
+
+/// No divider-shaped comment anywhere in the corpus fails to parse as a
+/// valid divider. A hit here means a `// === Name ===` attempt has a typo
+/// (mismatched `=` run lengths, too short) that would silently vanish from
+/// the LSP outline instead of erroring.
+#[test]
+fn corpus_has_no_near_miss_dividers() {
+    if !corpus_present() {
+        return;
+    }
+    let files = corpus_files();
+    let mut near_misses: Vec<String> = Vec::new();
+    let mut valid_dividers = 0usize;
+
+    for path in &files {
+        let source = read_corpus_file(path);
+        for (idx, line) in source.lines().enumerate() {
+            let Some(body) = divider_attempt(line) else {
+                continue;
+            };
+            if parse_divider_name(body).is_some() {
+                valid_dividers += 1;
+            } else {
+                near_misses.push(format!(
+                    "{}:{}: divider-shaped comment does not parse as a valid \
+                     divider: {:?}",
+                    path.display(),
+                    idx + 1,
+                    line.trim()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        near_misses.is_empty(),
+        "found {} near-miss divider(s) in the corpus (valid `=` run on both \
+         sides, but not recognized by parse_divider_name — see \
+         method_category.rs's near-miss documentation):\n{}",
+        near_misses.len(),
+        near_misses.join("\n")
+    );
+
+    // Sanity: BT-2626 put several hundred real dividers into the stdlib. If
+    // this drops to near zero, the raw scan (or the corpus walk) silently
+    // broke rather than the corpus actually losing its dividers.
+    assert!(
+        valid_dividers > 100,
+        "expected >100 valid dividers across the corpus, found \
+         {valid_dividers} — the scan may have silently failed"
+    );
+}
+
+/// Every named category [`categorize_methods`] produces across the corpus
+/// contains at least one method. A named category with zero methods is a
+/// divider that precedes only non-method declarations (or nothing) before
+/// the next divider/EOF — a heading rendered with nothing under it.
+#[test]
+fn corpus_has_no_empty_named_categories() {
+    if !corpus_present() {
+        return;
+    }
+    let files = corpus_files();
+    let mut empty: Vec<String> = Vec::new();
+    let mut named_categories = 0usize;
+
+    for path in &files {
+        let source = read_corpus_file(path);
+        let tokens = lex_with_eof(&source);
+        let (module, _diags) = parse(tokens);
+
+        for class_def in &module.classes {
+            for category in categorize_methods(class_def, &source) {
+                let Some(name) = &category.name else {
+                    continue;
+                };
+                named_categories += 1;
+                if category.methods.is_empty() {
+                    empty.push(format!(
+                        "{}: {}::{name:?} has no methods",
+                        path.display(),
+                        class_def.name.name
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        empty.is_empty(),
+        "found {} named categor{} with zero methods:\n{}",
+        empty.len(),
+        if empty.len() == 1 { "y" } else { "ies" },
+        empty.join("\n")
+    );
+
+    assert!(
+        named_categories > 100,
+        "expected >100 named categories across the corpus, found \
+         {named_categories} — the walk may have silently failed"
+    );
+}

--- a/crates/beamtalk-core/src/source_analysis/method_span_corpus_tests.rs
+++ b/crates/beamtalk-core/src/source_analysis/method_span_corpus_tests.rs
@@ -24,72 +24,11 @@
 //! if the resolver returned a wrong or sloppy span.
 
 use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
 
 use crate::ast::Module;
+use crate::source_analysis::corpus_test_support::{corpus_files, corpus_present, read_corpus_file};
 use crate::source_analysis::method_span::{MethodSide, resolve_in_module};
 use crate::source_analysis::{Span, lex_with_eof, parse};
-
-/// Returns the repository root (`CARGO_MANIFEST_DIR/../..`).
-fn repo_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("crates/")
-        .parent()
-        .expect("repo root")
-        .to_path_buf()
-}
-
-/// Recursively collects every `.bt` file under `dir`.
-fn collect_bt_files(dir: &Path, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    let mut entries: Vec<_> = entries.filter_map(Result::ok).map(|e| e.path()).collect();
-    // Deterministic order for stable test output.
-    entries.sort();
-    for path in entries {
-        if path.is_dir() {
-            collect_bt_files(&path, out);
-        } else if path.extension().is_some_and(|ext| ext == "bt") {
-            out.push(path);
-        }
-    }
-}
-
-/// The corpus directories: every `.bt` file lives under one of these.
-fn corpus_dirs() -> [PathBuf; 2] {
-    let root = repo_root();
-    [root.join("stdlib/src"), root.join("examples")]
-}
-
-/// Whether the corpus directories are present in this checkout.
-///
-/// They are absent when the crate is built from a source distribution or a
-/// partial checkout that omits the workspace `stdlib/` and `examples/` trees. In
-/// that case the corpus tests skip rather than hard-fail (a present-but-
-/// unreadable *file*, by contrast, is always a hard failure).
-fn corpus_present() -> bool {
-    corpus_dirs().iter().any(|dir| dir.is_dir())
-}
-
-/// Gathers the whole corpus: every `.bt` file under `stdlib/src` and `examples`.
-fn corpus_files() -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    for dir in corpus_dirs() {
-        collect_bt_files(&dir, &mut files);
-    }
-    files
-}
-
-/// Reads a corpus file, hard-failing (with the path + error) if it is present
-/// but cannot be read. Unlike skipping an absent *directory*, an unreadable file
-/// that the walk already discovered must never be silently ignored — that would
-/// let the round-trip proof go false-green.
-fn read_corpus_file(path: &Path) -> String {
-    std::fs::read_to_string(path)
-        .unwrap_or_else(|e| panic!("could not read corpus file {}: {e}", path.display()))
-}
 
 /// One method to resolve, identified the way a caller would: by class name,
 /// canonical selector string, and side.

--- a/crates/beamtalk-core/src/source_analysis/mod.rs
+++ b/crates/beamtalk-core/src/source_analysis/mod.rs
@@ -50,6 +50,15 @@ mod token;
 #[cfg(test)]
 mod lexer_property_tests;
 
+// Shared `.bt` corpus-walking helpers for the corpus test suites below.
+#[cfg(test)]
+mod corpus_test_support;
+
+// Corpus-wide divider validation for method categories (BT-2601 recognizer,
+// BT-2626 stdlib-wide curation).
+#[cfg(test)]
+mod method_category_corpus_tests;
+
 // Corpus round-trip validation for the byte-span resolver (ADR 0082, Phase 0).
 #[cfg(test)]
 mod method_span_corpus_tests;

--- a/stdlib/src/AnnouncementNavigation.bt
+++ b/stdlib/src/AnnouncementNavigation.bt
@@ -38,6 +38,8 @@
 /// ```
 sealed typed Object subclass: AnnouncementNavigation
 
+  // === Class Methods — Construction ===
+
   /// A navigation over the singleton system bus (`SystemAnnouncer current`) —
   /// the `default` scope, the one feed for everything the system emits.
   ///
@@ -59,6 +61,8 @@ sealed typed Object subclass: AnnouncementNavigation
   /// ```
   class of: anAnnouncer :: Announcer -> AnnouncementNavigation =>
     (Erlang beamtalk_announcements) navigationFor: anAnnouncer
+
+  // === Instance Methods — Querying ===
 
   /// A read-only snapshot of every live subscription on the navigated announcer,
   /// as immutable `SubscriptionNode` records. Re-call to refresh.

--- a/stdlib/src/Announcer.bt
+++ b/stdlib/src/Announcer.bt
@@ -47,6 +47,8 @@ typed Object subclass: Announcer
   /// ```
   class new -> Announcer => (Erlang beamtalk_announcements) newAnnouncer
 
+  // === Subscribing ===
+
   // Left as bare `Block` (not `Block(Object, Object)`): the event's actual
   // runtime type is whatever `aClass` names (and its subclasses), not a
   // fixed static bound. Parameterizing to `Object` would reject legitimate
@@ -98,6 +100,8 @@ typed Object subclass: Announcer
       class: aClass
       handler: aBlock
 
+  // === Announcing ===
+
   /// Announce an event asynchronously (fire-and-forget). Delivers to every
   /// subscriber of the event's class or any ancestor (MRO matching).
   ///
@@ -129,6 +133,8 @@ typed Object subclass: Announcer
       announceAndWaitOn: self
       event: anEvent
       timeout: ms
+
+  // === Managing subscriptions ===
 
   /// Remove all subscriptions held by `receiver` on this announcer.
   ///

--- a/stdlib/src/Array.bt
+++ b/stdlib/src/Array.bt
@@ -40,6 +40,8 @@ sealed typed Collection(E) subclass: Array(E)
   /// ```
   class new: elements :: List(E) -> Array(E) => self withAll: elements
 
+  // === Accessing ===
+
   /// Number of elements in the array.
   ///
   /// ## Examples
@@ -109,6 +111,8 @@ sealed typed Collection(E) subclass: Array(E)
   /// ```
   includes: element :: E -> Boolean => @primitive
 
+  // === Enumerating ===
+
   /// Iterate over each element, evaluating `block` with each one.
   ///
   /// ## Examples
@@ -117,8 +121,12 @@ sealed typed Collection(E) subclass: Array(E)
   /// ```
   do: block :: Block(E, Object) -> Nil => @primitive
 
+  // === Conversions ===
+
   /// An Array is already an Array — identity override of `Collection>>asArray`.
   asArray -> Array(E) => self
+
+  // === Transforming ===
 
   /// Map a block over the array, returning a new Array.
   ///
@@ -143,6 +151,8 @@ sealed typed Collection(E) subclass: Array(E)
   /// #[1, 2, 3] inject: 0 into: [:acc :x | acc + x]   // => 6
   /// ```
   inject: initial :: A into: block :: Block(A, E, A) -> A => @primitive
+
+  // === Printing ===
 
   /// Return a developer-readable string representation.
   ///

--- a/stdlib/src/AtomicCounter.bt
+++ b/stdlib/src/AtomicCounter.bt
@@ -54,6 +54,8 @@ typed Object subclass: AtomicCounter native: beamtalk_atomic_counter
   /// ```
   class sealed named: name :: Symbol -> AtomicCounter => self delegate
 
+  // === Incrementing & Decrementing ===
+
   /// Atomically add 1. Returns the new value.
   ///
   /// ## Examples
@@ -85,6 +87,8 @@ typed Object subclass: AtomicCounter native: beamtalk_atomic_counter
   /// c decrementBy: 3    // => -3
   /// ```
   decrementBy: n :: Integer -> Integer => self delegate
+
+  // === Accessing & Lifecycle ===
 
   // `value` stays inline FFI (not `self delegate`, ADR 0101 / BT-2731): the
   // unary `value` selector is intercepted by block-evaluation codegen (BT-1260),

--- a/stdlib/src/Bag.bt
+++ b/stdlib/src/Bag.bt
@@ -125,6 +125,8 @@ typed Collection(E) subclass: Bag(E)
   /// A Bag is already a Bag — identity override of `Collection>>asBag`.
   asBag -> Bag(E) => self
 
+  // === Printing ===
+
   /// Return a developer-readable string representation.
   ///
   /// ## Examples

--- a/stdlib/src/Bag.bt
+++ b/stdlib/src/Bag.bt
@@ -31,6 +31,8 @@ typed Collection(E) subclass: Bag(E)
   class withAll: list :: List(E) -> Bag(E) =>
     list inject: Bag new into: [:bag :elem | bag add: elem]
 
+  // === Accessing ===
+
   /// Total number of element occurrences (sum of all counts).
   ///
   /// ## Examples
@@ -58,6 +60,8 @@ typed Collection(E) subclass: Bag(E)
   /// (Bag withAll: #(1, 2)) includes: 3   // => false
   /// ```
   includes: element :: E -> Boolean => (self occurrencesOf: element) > 0
+
+  // === Adding & Removing ===
 
   /// Return a new bag with one more occurrence of `element`.
   ///
@@ -103,6 +107,8 @@ typed Collection(E) subclass: Bag(E)
         ]
       ]
 
+  // === Enumerating ===
+
   /// Iterate over each element once per occurrence.
   ///
   /// ## Examples
@@ -113,6 +119,8 @@ typed Collection(E) subclass: Bag(E)
     self.counts doWithKey: [:elem :count |
       count timesRepeat: [block value: elem]
     ]
+
+  // === Converting ===
 
   /// A Bag is already a Bag — identity override of `Collection>>asBag`.
   asBag -> Bag(E) => self

--- a/stdlib/src/BeamtalkInterface.bt
+++ b/stdlib/src/BeamtalkInterface.bt
@@ -33,6 +33,8 @@ sealed typed Object subclass: BeamtalkInterface
   class current: instance :: BeamtalkInterface -> BeamtalkInterface =>
     self.current := instance
 
+  // === Class registry ===
+
   /// Return a list of all registered classes as class objects.
   ///
   /// ## Examples
@@ -57,6 +59,8 @@ sealed typed Object subclass: BeamtalkInterface
   /// Beamtalk globals
   /// ```
   globals -> Dictionary => (Erlang beamtalk_interface) globals
+
+  // === Help and documentation ===
 
   /// Show class documentation: name, superclass, and method signatures.
   /// Accepts a Class reference, a Symbol class name, or a String class name.
@@ -124,7 +128,7 @@ sealed typed Object subclass: BeamtalkInterface
   @expect type
   version -> String => (Erlang beamtalk_interface) version
 
-  // --- Logging configuration (delegates to beamtalk_logging_config) ---
+  // === Logging configuration (delegates to beamtalk_logging_config) ===
 
   /// Return the current OTP primary log level as a singleton symbol
   /// (e.g. `#debug`, `#info`, or the `#all`/`#none` sentinels).

--- a/stdlib/src/Behaviour.bt
+++ b/stdlib/src/Behaviour.bt
@@ -24,7 +24,7 @@
 /// ```
 abstract Object subclass: Behaviour
 
-  // --- Identity ---
+  // === Naming ===
 
   /// Return the name of the receiver (class or metaclass) as a Symbol.
   ///
@@ -42,7 +42,7 @@ abstract Object subclass: Behaviour
   /// ```
   sealed name -> Symbol => @primitive "className"
 
-  // --- Method lookup ---
+  // === Method lookup ===
 
   /// Look up a method by selector, returning a CompiledMethod object,
   /// or nil if the selector is not found in the method dictionary.
@@ -59,7 +59,7 @@ abstract Object subclass: Behaviour
   sealed >> aSelector :: Symbol -> CompiledMethod | Nil =>
     @primitive "methodLookup"
 
-  // --- Hierarchy queries ---
+  // === Hierarchy queries ===
 
   /// Return the superclass of the receiver as a class object, or nil for roots.
   ///
@@ -154,7 +154,7 @@ abstract Object subclass: Behaviour
   sealed includesBehaviour: aBehaviour :: Behaviour -> Boolean =>
     self == aBehaviour ifTrue: [true] ifFalse: [self inheritsFrom: aBehaviour]
 
-  // --- Method dictionary ---
+  // === Method dictionary ===
 
   /// Return selectors defined on this class (not inherited).
   ///
@@ -214,7 +214,7 @@ abstract Object subclass: Behaviour
       c includesSelector: selector
     ] ifNone: [nil]
 
-  // --- Instance variable queries ---
+  // === Instance variable queries ===
 
   /// Return the names of fields declared in this class (not inherited).
   ///
@@ -252,7 +252,7 @@ abstract Object subclass: Behaviour
   /// ```
   sealed allClassVarNames -> List(Symbol) => @primitive "classAllClassVarNames"
 
-  // --- Documentation (ADR 0033) ---
+  // === Documentation (ADR 0033) ===
 
   /// Return the class documentation string, or nil if none set.
   ///
@@ -292,7 +292,7 @@ abstract Object subclass: Behaviour
   sealed docForMethod: aSelector :: Symbol -> String | Nil =>
     @primitive "classDocForMethod"
 
-  // --- Identity ---
+  // === Type predicates ===
 
   /// Test whether this is a Behaviour (class-describing object).
   ///
@@ -320,7 +320,7 @@ abstract Object subclass: Behaviour
   /// ```
   sealed isMetaclass -> Boolean => false
 
-  // --- Protocol queries (ADR 0068 Phase 2c) ---
+  // === Protocol queries (ADR 0068 Phase 2c) ===
 
   /// Test whether instances of the receiver conform to a protocol.
   ///
@@ -345,7 +345,7 @@ abstract Object subclass: Behaviour
   /// ```
   sealed protocols -> List(Symbol) => @primitive "classProtocols"
 
-  // --- Source file and reload (ADR 0040 Phase 2) ---
+  // === Source file and reload (ADR 0040 Phase 2) ===
 
   /// Return the path of the source file this class was compiled from, or nil.
   ///
@@ -374,7 +374,7 @@ abstract Object subclass: Behaviour
   /// ```
   sealed reload -> Behaviour => @primitive "classReload"
 
-  // --- Live method editing (ADR 0082 Phase 1) ---
+  // === Live method editing (ADR 0082 Phase 1) ===
 
   /// Compile a method from a source body String and install it in this class,
   /// attempting to record a **durable** ChangeLog entry (ADR 0082).
@@ -453,7 +453,7 @@ abstract Object subclass: Behaviour
   sealed precheckCompile: aSelector :: Symbol source: aSource :: String -> Dictionary =>
     @primitive "classPrecheckCompileSource"
 
-  // --- Method removal (ADR 0112) ---
+  // === Method removal (ADR 0112) ===
 
   /// Remove `aSelector` from the receiver, raising if it is not defined
   /// locally or as an extension.
@@ -506,7 +506,7 @@ abstract Object subclass: Behaviour
   sealed removeSelector: aSelector :: Symbol ifAbsent: absentBlock :: Block(T) -> Behaviour | T =>
     @primitive "classRemoveSelectorIfAbsent"
 
-  // --- Class removal ---
+  // === Class removal ===
 
   /// Remove this class from the system, cleaning up all associated state.
   ///

--- a/stdlib/src/Binary.bt
+++ b/stdlib/src/Binary.bt
@@ -18,9 +18,7 @@
 /// ```
 sealed typed Collection subclass: Binary
 
-  // ═══════════════════════════════════════════════════════════════════
-  // Class methods
-  // ═══════════════════════════════════════════════════════════════════
+  // === Class methods ===
 
   /// Serialize any value to a binary (class method).
   ///
@@ -124,9 +122,7 @@ sealed typed Collection subclass: Binary
   class sealed fromHex: str :: String -> Result(Binary, Error) =>
     (Erlang beamtalk_binary) fromHex: str
 
-  // ═══════════════════════════════════════════════════════════════════
-  // Collection subclass-responsibility methods
-  // ═══════════════════════════════════════════════════════════════════
+  // === Collection subclass-responsibility methods ===
 
   /// Return the byte count of this binary.
   ///
@@ -161,9 +157,7 @@ sealed typed Collection subclass: Binary
   /// ```
   printString -> String => @primitive
 
-  // ═══════════════════════════════════════════════════════════════════
-  // Byte-level access
-  // ═══════════════════════════════════════════════════════════════════
+  // === Byte-level access ===
 
   /// Return the byte value (0-255) at the given 1-based index.
   ///
@@ -197,9 +191,7 @@ sealed typed Collection subclass: Binary
   /// ```
   byteSize -> Integer => @primitive
 
-  // ═══════════════════════════════════════════════════════════════════
-  // Slicing and concatenation
-  // ═══════════════════════════════════════════════════════════════════
+  // === Slicing and concatenation ===
 
   /// Return a zero-copy slice of this binary.
   ///
@@ -220,9 +212,7 @@ sealed typed Collection subclass: Binary
   /// ```
   concat: other :: Binary -> Binary => @primitive
 
-  // ═══════════════════════════════════════════════════════════════════
-  // Conversion
-  // ═══════════════════════════════════════════════════════════════════
+  // === Conversion ===
 
   /// Convert this binary to a list of byte integers (0-255).
   ///
@@ -253,9 +243,7 @@ sealed typed Collection subclass: Binary
   /// ```
   asStringUnchecked -> String => @primitive
 
-  // ═══════════════════════════════════════════════════════════════════
-  // Encoding
-  // ═══════════════════════════════════════════════════════════════════
+  // === Encoding ===
 
   /// Encode as a standard (RFC 4648 §4) base64 string, with `=` padding.
   ///

--- a/stdlib/src/BindingsView.bt
+++ b/stdlib/src/BindingsView.bt
@@ -107,6 +107,8 @@ sealed typed Object subclass: BindingsView native: beamtalk_session_primitives
   /// ```
   size -> Integer => self delegate
 
+  // === Enumerating ===
+
   /// Iterate over each value, evaluating `block` with each one (matches
   /// `Dictionary do:`, which iterates values).
   ///
@@ -115,6 +117,8 @@ sealed typed Object subclass: BindingsView native: beamtalk_session_primitives
   /// Session current bindings do: [:v | Transcript show: v printString]
   /// ```
   do: block :: Block(Object, Object) -> Nil => self values do: block
+
+  // === Printing ===
 
   /// Return a string representation rendered like a `Dictionary`, so REPL
   /// output stays familiar.

--- a/stdlib/src/Block.bt
+++ b/stdlib/src/Block.bt
@@ -50,6 +50,8 @@ sealed typed Object subclass: Block
   value: arg1 :: Object value: arg2 :: Object value: arg3 :: Object =>
     @intrinsic blockValue3
 
+  // === Control Flow ===
+
   /// Repeatedly evaluate `bodyBlock` while the receiver evaluates to true.
   ///
   /// ## Examples
@@ -89,6 +91,8 @@ sealed typed Object subclass: Block
   /// [File readAll: "data.txt"] ensure: [Transcript show: "done"]
   /// ```
   ensure: cleanupBlock :: Block(R) => @intrinsic ensure
+
+  // === Introspection ===
 
   /// Return the number of arguments the block expects.
   ///

--- a/stdlib/src/ChangeEntry.bt
+++ b/stdlib/src/ChangeEntry.bt
@@ -111,6 +111,8 @@ sealed typed Value subclass: ChangeEntry
   /// classes that have no on-disk source.
   sourceFile -> String | Nil => self.sourceFile
 
+  // === Restart-state flags (ADR 0082) ===
+
   /// Whether the entry is orphaned — its prev_source no longer matches disk
   /// after a workspace restart, so the patch can no longer be reconciled.
   ///
@@ -151,6 +153,8 @@ sealed typed Value subclass: ChangeEntry
   /// ```
   isClean -> Boolean => self.clean
 
+  // === Diff and change kind ===
+
   /// The net change this entry represents, as a unified diff (on-disk →
   /// in-memory), or nil when the entry is clean or the diff could not be
   /// computed (ADR 0082, BT-2575). Each line is prefixed `  ` (unchanged),
@@ -170,6 +174,8 @@ sealed typed Value subclass: ChangeEntry
 
   /// Whether this entry removed a class (`removeFromSystem`, ADR 0113).
   isRemoveClass -> Boolean => self.kind =:= #'remove-class'
+
+  // === Printing ===
 
   /// Developer-readable representation, e.g. "Counter>>increment",
   /// "Counter (new-class)", or "Counter (remove-class)".

--- a/stdlib/src/ChangeLog.bt
+++ b/stdlib/src/ChangeLog.bt
@@ -52,6 +52,8 @@ sealed typed Value subclass: ChangeLog
   /// ```
   allEntries -> List(ChangeEntry) => self.entries
 
+  // === Querying ===
+
   /// The number of active (live, re-appliable) changes.
   ///
   /// ## Examples
@@ -77,6 +79,8 @@ sealed typed Value subclass: ChangeLog
   /// Workspace changes notEmpty   // => false
   /// ```
   notEmpty -> Boolean => self isEmpty not
+
+  // === Enumerating ===
 
   /// Iterate over each active entry, evaluating `block` with it.
   ///
@@ -118,6 +122,8 @@ sealed typed Value subclass: ChangeLog
     // (beamtalk_workspace_changelog:dirtyMethods/0), matching the declared
     // return type.
     (Erlang beamtalk_workspace_changelog) dirtyMethods
+
+  // === Mutating ===
 
   /// Re-install the prior body of `anEntry`'s method, undoing the patch
   /// (ADR 0082 Phase 4).
@@ -202,6 +208,8 @@ sealed typed Value subclass: ChangeLog
   /// ```
   flushKinds: kinds :: Object confirmDestructive: confirmDestructive :: Boolean -> Object =>
     (Erlang beamtalk_workspace_interface_primitives) changeLogFlushKinds: kinds confirmDestructive: confirmDestructive
+
+  // === Printing ===
 
   /// Developer-readable representation, e.g. "ChangeLog with 2 entries".
   ///

--- a/stdlib/src/Character.bt
+++ b/stdlib/src/Character.bt
@@ -23,6 +23,8 @@ sealed typed Integer subclass: Character
   /// ```
   class sealed value: codepoint :: Integer -> Character => @primitive
 
+  // === Comparing ===
+
   /// Test strict equality with another character.
   ///
   /// ## Examples
@@ -82,6 +84,8 @@ sealed typed Integer subclass: Character
   /// ```
   >= other :: Character -> Boolean => @primitive
 
+  // === Converting ===
+
   /// Return the Unicode codepoint as an integer.
   ///
   /// ## Examples
@@ -106,6 +110,8 @@ sealed typed Integer subclass: Character
   /// ```
   printString -> String => @primitive
 
+  // === Hashing ===
+
   /// Return a hash value for the character.
   ///
   /// ## Examples
@@ -113,6 +119,8 @@ sealed typed Integer subclass: Character
   /// $A hash
   /// ```
   hash -> Integer => @primitive
+
+  // === Testing ===
 
   /// Test if the character is a Unicode letter.
   ///
@@ -158,6 +166,8 @@ sealed typed Integer subclass: Character
   /// $a isWhitespace          // => false
   /// ```
   isWhitespace -> Boolean => @primitive
+
+  // === Case conversion ===
 
   /// Convert to uppercase.
   ///

--- a/stdlib/src/Class.bt
+++ b/stdlib/src/Class.bt
@@ -42,6 +42,8 @@ sealed typed Behaviour subclass: Class
   /// ```
   sealed class -> Metaclass => @primitive "classClass"
 
+  // === Constructing Subclasses ===
+
   /// Return a new ClassBuilder for creating a subclass of the receiver.
   ///
   /// The builder is a short-lived Actor that accumulates class configuration

--- a/stdlib/src/ClassBuilder.bt
+++ b/stdlib/src/ClassBuilder.bt
@@ -58,6 +58,8 @@ typed Actor subclass: ClassBuilder
   /// ```
   superclass: aClass :: Object -> Object => self.superclassRef := aClass
 
+  // === Bulk configuration (used by codegen) ===
+
   /// Set all fields at once (used by codegen).
   ///
   /// ## Examples
@@ -246,6 +248,8 @@ typed Actor subclass: ClassBuilder
   isConstructible: aBoolean :: Boolean -> Boolean =>
     self.isConstructible := aBoolean
 
+  // === Incremental mutation (browser use case) ===
+
   /// Add a single field with a default value.
   ///
   /// ## Examples
@@ -326,6 +330,8 @@ typed Actor subclass: ClassBuilder
   removeClassMethod: aSelector :: Symbol -> Dictionary =>
     self.classMethods := self.classMethods removeKey: aSelector
 
+  // === Modifiers and native linkage ===
+
   /// Apply a class modifier (#abstract, #sealed, #typed, #internal).
   ///
   /// ## Examples
@@ -346,6 +352,8 @@ typed Actor subclass: ClassBuilder
   /// ```
   native: anErlangModule :: Symbol -> Symbol =>
     self.backingModule := anErlangModule
+
+  // === Registration ===
 
   /// Register the class with the runtime and return the new class object.
   /// Stops the builder process after registration — the builder is

--- a/stdlib/src/CompiledMethod.bt
+++ b/stdlib/src/CompiledMethod.bt
@@ -14,6 +14,8 @@
 /// ```
 sealed typed Value subclass: CompiledMethod
 
+  // ===== Instance Methods — Accessors =====
+
   /// Return the method selector as a symbol.
   ///
   /// ## Examples
@@ -46,6 +48,8 @@ sealed typed Value subclass: CompiledMethod
   /// (Integer >> #abs) argumentCount // => 0
   /// ```
   argumentCount -> Integer => @primitive
+
+  // ===== Instance Methods — Conversions =====
 
   /// Return a developer-readable string representation.
   ///

--- a/stdlib/src/Console.bt
+++ b/stdlib/src/Console.bt
@@ -97,6 +97,8 @@ sealed typed Object subclass: Console native: beamtalk_console
   /// ```
   class sealed flush -> Nil => self delegate
 
+  // === Reading Input ===
+
   /// Read one line from stdin, with the trailing newline stripped.
   ///
   /// Returns the line as a `String`, or `nil` at end of input (including a

--- a/stdlib/src/Dictionary.bt
+++ b/stdlib/src/Dictionary.bt
@@ -105,6 +105,8 @@ sealed typed Collection(V) subclass: Dictionary(K, V)
   /// ```
   includes: value :: V -> Boolean => @primitive
 
+  // === Enumerating ===
+
   /// Iterate over each value, evaluating `block` with each one.
   ///
   /// ## Examples
@@ -144,6 +146,8 @@ sealed typed Collection(V) subclass: Dictionary(K, V)
   /// #{#a => 1} keysAndValuesDo: [:k :v | Transcript show: k]
   /// ```
   keysAndValuesDo: block :: Block(K, V, Object) -> Nil => self doWithKey: block
+
+  // === Printing ===
 
   /// Return a string representation using Beamtalk syntax.
   ///

--- a/stdlib/src/Digest.bt
+++ b/stdlib/src/Digest.bt
@@ -21,6 +21,8 @@
 /// ```
 sealed typed Object subclass: Digest
 
+  // === Hashing ===
+
   /// SHA-256 digest (32 bytes) of `input`.
   ///
   /// ## Examples
@@ -53,6 +55,8 @@ sealed typed Object subclass: Digest
   /// ```
   class sealed md5: input :: String | Binary -> Binary =>
     (Erlang beamtalk_digest) md5: input
+
+  // === HMAC ===
 
   /// HMAC-SHA256 message authentication code of `input` using `key`.
   ///

--- a/stdlib/src/Ets.bt
+++ b/stdlib/src/Ets.bt
@@ -67,6 +67,8 @@ typed Object subclass: Ets(K, V) native: beamtalk_ets
   class sealed new: name :: Symbol type: tableType :: EtsTableType -> Ets =>
     self delegate
 
+  // === Class-side lookup ===
+
   /// Look up an existing named ETS table (class method).
   ///
   /// Returns an `Ets` instance if a table with the given name exists.
@@ -103,6 +105,8 @@ typed Object subclass: Ets(K, V) native: beamtalk_ets
   /// ```
   class sealed newOrExisting: name :: Symbol type: tableType :: EtsTableType -> Ets =>
     self delegate
+
+  // === Accessing ===
 
   /// Look up a key. Returns the value, or `nil` if the key is absent.
   ///
@@ -185,6 +189,8 @@ typed Object subclass: Ets(K, V) native: beamtalk_ets
   /// cache size    // => 3
   /// ```
   size -> Integer => (Erlang beamtalk_ets) tableSize: self
+
+  // === Destroying ===
 
   /// Destroy the table, freeing all memory. Returns `nil`.
   ///

--- a/stdlib/src/Exception.bt
+++ b/stdlib/src/Exception.bt
@@ -69,6 +69,8 @@ Object subclass: Exception
   class sealed signalKind: kind :: ExceptionKind class: cls :: Symbol selector: sel :: Symbol hint: hint :: String -> Never =>
     @primitive "classSignalKind:class:selector:hint:"
 
+  // === Accessing ===
+
   /// Return the error message string.
   ///
   /// ## Examples
@@ -109,6 +111,8 @@ Object subclass: Exception
   /// ```
   errorClass -> String => @primitive
 
+  // === Printing ===
+
   /// Return a developer-readable string representation of the error.
   ///
   /// ## Examples
@@ -116,6 +120,8 @@ Object subclass: Exception
   /// [42 unknownMsg] on: Exception do: [:e | e printString]
   /// ```
   printString -> String => @primitive
+
+  // === Stack trace ===
 
   /// Return the stack trace as a list of StackFrame objects.
   ///
@@ -127,6 +133,8 @@ Object subclass: Exception
   /// [1 / 0] on: Exception do: [:e | e stackTrace]
   /// ```
   stackTrace -> List(StackFrame) => @primitive
+
+  // === Raising ===
 
   /// Raise this exception.
   ///

--- a/stdlib/src/False.bt
+++ b/stdlib/src/False.bt
@@ -14,6 +14,8 @@
 /// ```
 sealed Boolean subclass: False
 
+  // === Control flow ===
+
   /// If true, evaluate `trueBlock`; otherwise evaluate `falseBlock`. Returns `falseBlock` result.
   ///
   /// ## Examples
@@ -47,6 +49,8 @@ sealed Boolean subclass: False
   /// ```
   not -> Boolean => true
 
+  // === Predicates ===
+
   /// Returns false.
   ///
   /// ## Examples
@@ -62,6 +66,8 @@ sealed Boolean subclass: False
   /// false isFalse              // => true
   /// ```
   isFalse -> Boolean => true
+
+  // === Display ===
 
   /// Return a developer-readable string representation.
   ///

--- a/stdlib/src/File.bt
+++ b/stdlib/src/File.bt
@@ -32,6 +32,8 @@ typed Object subclass: File native: beamtalk_file
   /// ```
   class sealed exists: path :: String -> Boolean => self delegate
 
+  // === Reading and writing files ===
+
   /// Read the entire contents of a file as a string (class method).
   ///
   /// Returns `Result ok: contents` on success, or `Result error: err` on failure.
@@ -86,6 +88,8 @@ typed Object subclass: File native: beamtalk_file
   /// ```
   class sealed appendBinary: path :: String contents: binary :: Binary -> Result(Nil, Error) =>
     self delegate
+
+  // === Streaming and handles ===
 
   /// Return a lazy Stream of lines from a file (class method).
   ///
@@ -184,6 +188,8 @@ typed Object subclass: File native: beamtalk_file
   class sealed open: path :: String mode: mode :: Symbol do: block :: Block(FileHandle, R) -> Result(R, Error) =>
     self delegate
 
+  // === Metadata ===
+
   /// Get the last modification time of a file (class method).
   ///
   /// Returns `Result ok: DateTime` on success, or `Result error: err` if the
@@ -211,6 +217,8 @@ typed Object subclass: File native: beamtalk_file
   /// File isFile: "test.txt"   // => true or false
   /// ```
   class sealed isFile: path :: String -> Boolean => self delegate
+
+  // === Directory operations ===
 
   /// Create a directory (class method). Error if the parent does not exist.
   ///
@@ -243,6 +251,8 @@ typed Object subclass: File native: beamtalk_file
   class sealed listDirectory: path :: String -> Result(List(String), Error) =>
     self delegate
 
+  // === Deleting and renaming ===
+
   /// Delete a file or empty directory (class method).
   ///
   /// Returns `Result ok: nil` on success, or `Result error: err` on failure.
@@ -273,6 +283,8 @@ typed Object subclass: File native: beamtalk_file
   /// ```
   class sealed rename: from :: String to: to :: String -> Result(Nil, Error) =>
     self delegate
+
+  // === Paths and diagnostics ===
 
   /// Resolve a relative path to its absolute path (class method).
   ///

--- a/stdlib/src/FileHandle.bt
+++ b/stdlib/src/FileHandle.bt
@@ -86,6 +86,8 @@ sealed typed Object subclass: FileHandle
   readAll -> Result(Binary, Error) =>
     (Erlang beamtalk_file_handle) readAll: self
 
+  // === Writing ===
+
   /// Write a String or Binary at the current position.
   ///
   /// On a handle opened `#append`, writes always land at end-of-file
@@ -108,6 +110,8 @@ sealed typed Object subclass: FileHandle
   /// ```
   writeLine: data :: String | Binary -> Result(Nil, Error) =>
     (Erlang beamtalk_file_handle) writeLine: self data: data
+
+  // === Positioning ===
 
   /// Current byte offset from the start of the file.
   ///
@@ -132,6 +136,8 @@ sealed typed Object subclass: FileHandle
   /// ```
   seek: offset :: Integer -> Result(Integer, Error) =>
     (Erlang beamtalk_file_handle) seek: self to: offset
+
+  // === Lifecycle ===
 
   /// Push buffered writes to the operating system.
   ///

--- a/stdlib/src/Float.bt
+++ b/stdlib/src/Float.bt
@@ -48,6 +48,8 @@ sealed typed Number subclass: Float
   class infinity -> Float =>
     self error: "BEAM does not support IEEE 754 infinity"
 
+  // === Arithmetic ===
+
   /// Add a number to the receiver.
   ///
   /// ## Examples
@@ -79,6 +81,8 @@ sealed typed Number subclass: Float
   /// 10.0 / 4.0       // => 2.5
   /// ```
   / other :: Number -> Float => @primitive
+
+  // === Comparison ===
 
   /// Test strict equality with another number.
   ///
@@ -143,6 +147,8 @@ sealed typed Number subclass: Float
   /// ```
   >= other :: Number -> Boolean => @primitive
 
+  // === Sign and magnitude ===
+
   /// Negate the receiver.
   ///
   /// ## Examples
@@ -181,6 +187,8 @@ sealed typed Number subclass: Float
   /// if `other` is the larger value, the result carries its runtime type.
   max: other :: Number -> Number =>
     (self > other) ifTrue: [self] ifFalse: [other]
+
+  // === Rounding ===
 
   /// Round to the nearest integer.
   ///
@@ -241,6 +249,8 @@ sealed typed Number subclass: Float
   truncateTo: quantum :: Number -> Number =>
     (self / quantum) truncated * quantum
 
+  // === Testing / predicates ===
+
   /// Always returns false. BEAM has no NaN representation.
   ///
   /// ## Examples
@@ -265,6 +275,8 @@ sealed typed Number subclass: Float
   /// 1.0 isZero       // => false
   /// ```
   isZero -> Boolean => self =:= 0.0
+
+  // === Conversion ===
 
   /// Convert the receiver to an integer (truncates).
   ///

--- a/stdlib/src/Float.bt
+++ b/stdlib/src/Float.bt
@@ -224,6 +224,8 @@ sealed typed Number subclass: Float
   /// ```
   truncated -> Integer => @primitive
 
+  // === Powers ===
+
   /// The receiver multiplied by itself.
   ///
   /// ## Examples
@@ -231,6 +233,8 @@ sealed typed Number subclass: Float
   /// 2.5 squared      // => 6.25
   /// ```
   squared -> Float => self * self
+
+  // === Rounding to a quantum ===
 
   /// Round to the nearest multiple of `quantum`.
   ///

--- a/stdlib/src/Inspector.bt
+++ b/stdlib/src/Inspector.bt
@@ -64,6 +64,8 @@ sealed typed Object subclass: Inspector
   class on: anObject :: Object -> Inspector =>
     (Erlang beamtalk_inspector) on: anObject
 
+  // === Accessing ===
+
   /// The inspected object — the value itself, or, for an actor, the captured
   /// state snapshot.
   ///
@@ -123,6 +125,8 @@ sealed typed Object subclass: Inspector
   /// `#collection` cursor. Keeps `size` pure Beamtalk.
   internal sizeOfCollection -> Integer =>
     (Erlang beamtalk_inspector) sizeOf: self
+
+  // === Navigating ===
 
   /// Drill into one field by name, returning a child `Inspector` cursor on that
   /// field's value (ADR 0095 §1).
@@ -226,6 +230,8 @@ sealed typed Object subclass: Inspector
   /// ci refresh fields              // a fresh cursor at T1 (root actor re-fetched)
   /// ```
   refresh -> Inspector => (Erlang beamtalk_inspector) refresh: self
+
+  // === Printing and converting ===
 
   /// An indented text tree of the cursor and its immediate fields, one level
   /// deep (ADR 0095 §7). The REPL default.

--- a/stdlib/src/InspectorField.bt
+++ b/stdlib/src/InspectorField.bt
@@ -51,6 +51,8 @@ sealed typed Value subclass: InspectorField
   /// ```
   isLeaf -> Boolean => self drillable not
 
+  // === Printing ===
+
   /// Human-readable one-line description, e.g.
   /// `#InspectorField<x: 3>` or `#InspectorField<status: #unavailable>`.
   ///

--- a/stdlib/src/Integer.bt
+++ b/stdlib/src/Integer.bt
@@ -19,6 +19,8 @@
 /// ```
 sealed typed Number subclass: Integer
 
+  // === Arithmetic ===
+
   /// Add an integer to the receiver.
   ///
   /// ## Examples
@@ -89,6 +91,8 @@ sealed typed Number subclass: Integer
   /// ```
   ** other :: Number -> Integer => @primitive
 
+  // === Comparison ===
+
   /// Test strict equality with another integer.
   ///
   /// ## Examples
@@ -152,6 +156,8 @@ sealed typed Number subclass: Integer
   /// ```
   >= other :: Number -> Boolean => @primitive
 
+  // === Sign and magnitude ===
+
   /// Negate the receiver.
   ///
   /// ## Examples
@@ -169,6 +175,8 @@ sealed typed Number subclass: Integer
   /// 7 abs         // => 7
   /// ```
   abs -> Integer => (self < 0) ifTrue: [self negated] ifFalse: [self]
+
+  // === Rounding ===
 
   /// Round to the nearest integer. Identity for Integer.
   ///
@@ -248,6 +256,8 @@ sealed typed Number subclass: Integer
   truncateTo: quantum :: Number -> Number =>
     (self / quantum) truncated * quantum
 
+  // === Testing / predicates ===
+
   /// Test if the receiver is even.
   ///
   /// ## Examples
@@ -265,6 +275,8 @@ sealed typed Number subclass: Integer
   /// 4 isOdd       // => false
   /// ```
   isOdd -> Boolean => (self % 2) /= 0
+
+  // === Min and max ===
 
   /// Return the smaller of the receiver and `other`.
   ///
@@ -289,6 +301,8 @@ sealed typed Number subclass: Integer
   /// if `other` is the larger value, the result carries its runtime type.
   max: other :: Number -> Number =>
     (self > other) ifTrue: [self] ifFalse: [other]
+
+  // === Iteration ===
 
   /// Evaluate `block` the receiver number of times.
   ///
@@ -336,6 +350,8 @@ sealed typed Number subclass: Integer
       ]
       ifFalse: [nil]
 
+  // === Interval construction ===
+
   /// Return an Interval from the receiver to `stop` with step 1.
   ///
   /// ## Examples
@@ -356,6 +372,8 @@ sealed typed Number subclass: Integer
   to: stop :: Integer by: step :: Integer -> Interval =>
     step =:= 0 ifTrue: [self error: "Interval step cannot be zero"]
     Interval new: #{#from => self, #to => stop, #step => step}
+
+  // === Conversion & printing ===
 
   /// Convert the receiver to a Float.
   ///
@@ -380,6 +398,8 @@ sealed typed Number subclass: Integer
   /// 42 printString  // => "42"
   /// ```
   printString -> String => @primitive
+
+  // === Bitwise operations ===
 
   /// Bitwise AND with another integer.
   ///
@@ -422,6 +442,8 @@ sealed typed Number subclass: Integer
   /// ```
   bitNot -> Integer => @primitive
 
+  // === Number theory ===
+
   /// Factorial of the receiver. Raises an error for negative integers.
   ///
   /// ## Examples
@@ -456,6 +478,8 @@ sealed typed Number subclass: Integer
   lcm: other :: Integer -> Integer =>
     g := self gcd: other
     g =:= 0 ifTrue: [0] ifFalse: [(self abs div: g) * other abs]
+
+  // === Codepoint predicates ===
 
   /// Test if the codepoint is a Unicode letter.
   ///

--- a/stdlib/src/Integer.bt
+++ b/stdlib/src/Integer.bt
@@ -226,6 +226,8 @@ sealed typed Number subclass: Integer
   /// ```
   truncated -> Integer => self
 
+  // === Powers ===
+
   /// The receiver multiplied by itself.
   ///
   /// ## Examples
@@ -234,6 +236,8 @@ sealed typed Number subclass: Integer
   /// -3 squared       // => 9
   /// ```
   squared -> Integer => self * self
+
+  // === Rounding to a quantum ===
 
   /// Round to the nearest multiple of `quantum`.
   ///

--- a/stdlib/src/Interval.bt
+++ b/stdlib/src/Interval.bt
@@ -48,6 +48,8 @@ typed Collection subclass: Interval
       by: self.step
       do: block
 
+  // === Accessing ===
+
   /// Return the element at the given 1-based index.
   ///
   /// Raises `index_out_of_bounds` for any index outside `1..self size` —
@@ -99,6 +101,8 @@ typed Collection subclass: Interval
       (Erlang beamtalk_collection) raiseEmpty: #Interval selector: #last
     ] ifFalse: [self.from + ((self size - 1) * self.step)]
 
+  // === Conversions ===
+
   /// Materialise the interval into a `List` of its elements (ADR 0095 §6 — the
   /// canonical large-collection example `(1 to: 100000) asList`).
   ///
@@ -116,6 +120,8 @@ typed Collection subclass: Interval
       from: self.from
       to: self.to
       by: self.step
+
+  // === Printing ===
 
   /// Return a developer-readable string representation.
   ///

--- a/stdlib/src/List.bt
+++ b/stdlib/src/List.bt
@@ -38,6 +38,8 @@ sealed typed Collection(E) subclass: List(E)
   /// ```
   class new: elements :: List(E) -> List(E) => self withAll: elements
 
+  // === Accessing ===
+
   /// Number of elements in the list.
   ///
   /// ## Examples
@@ -122,6 +124,8 @@ sealed typed Collection(E) subclass: List(E)
   /// ```
   includes: item :: E -> Boolean => @primitive
 
+  // === Sorting and reordering ===
+
   /// Sort the list in ascending order.
   ///
   /// ## Examples
@@ -160,6 +164,8 @@ sealed typed Collection(E) subclass: List(E)
   /// ```
   unique -> List(E) => @primitive
 
+  // === Searching ===
+
   /// Find the first element for which `block` returns true.
   ///
   /// Raises `not_found` if no element matches — the return type is `E`, so
@@ -189,6 +195,8 @@ sealed typed Collection(E) subclass: List(E)
   /// ```
   detect: block :: Block(E, Boolean) ifNone: default :: Block(Object) -> E | Object =>
     @primitive
+
+  // === Enumerating ===
 
   /// Iterate over each element, evaluating `block` with each one.
   ///
@@ -233,6 +241,8 @@ sealed typed Collection(E) subclass: List(E)
   /// #(1, 2, 3) inject: 0 into: [:sum :x | sum + x]   // => 6
   /// ```
   inject: initial :: A into: block :: Block(A, E, A) -> A => @primitive
+
+  // === Slicing, flattening, and aggregation ===
 
   /// Return the first `n` elements.
   ///
@@ -290,6 +300,8 @@ sealed typed Collection(E) subclass: List(E)
   /// ```
   allSatisfy: block :: Block(E, Boolean) -> Boolean => @primitive
 
+  // === Concatenation and printing ===
+
   /// Concatenate two lists.
   ///
   /// ## Examples
@@ -305,6 +317,8 @@ sealed typed Collection(E) subclass: List(E)
   /// #(1, 2, 3) printString           // => "#(1, 2, 3)"
   /// ```
   printString -> String => @primitive
+
+  // === Slicing and index search ===
 
   /// Return a subsequence from `start` to `end` (1-based, inclusive).
   ///
@@ -340,6 +354,8 @@ sealed typed Collection(E) subclass: List(E)
 
   // `eachWithIndex:` is inherited from Collection (pure-BT, built on inject:into:).
 
+  // === Combining and partitioning ===
+
   /// Combine two lists element-wise into a list of pairs.
   ///
   /// ## Examples
@@ -365,6 +381,8 @@ sealed typed Collection(E) subclass: List(E)
   /// ```
   partition: block :: Block(E, Boolean) -> Dictionary(String, List(E)) =>
     @primitive
+
+  // === Conditional slicing and construction ===
 
   /// Take elements from the front while `block` returns true.
   ///
@@ -406,6 +424,8 @@ sealed typed Collection(E) subclass: List(E)
   /// #(1, 2) add: 3                   // => #(1, 2, 3)
   /// ```
   add: item :: E -> List(E) => @primitive
+
+  // === Streams, sampling, and joining ===
 
   /// Return a lazy Stream over the list elements.
   ///

--- a/stdlib/src/List.bt
+++ b/stdlib/src/List.bt
@@ -206,9 +206,13 @@ sealed typed Collection(E) subclass: List(E)
   /// ```
   do: block :: Block(E, Object) -> Nil => @primitive
 
+  // === Conversions ===
+
   /// A List is already a List — identity override of `Collection>>asList`
   /// that avoids rebuilding via the generic `do:`-fold.
   asList -> List(E) => self
+
+  // === Enumerating ===
 
   /// Collect results of evaluating `block` on each element.
   ///

--- a/stdlib/src/Logger.bt
+++ b/stdlib/src/Logger.bt
@@ -21,6 +21,8 @@
 /// ```
 sealed typed Object subclass: Logger
 
+  // === Info ===
+
   /// Log a message at info level.
   ///
   /// ## Examples
@@ -39,6 +41,8 @@ sealed typed Object subclass: Logger
   /// ```
   class sealed info: message :: String metadata: meta :: Dictionary -> Nil =>
     @intrinsic loggerInfoMeta
+
+  // === Warning ===
 
   /// Log a message at warning level.
   ///
@@ -59,6 +63,8 @@ sealed typed Object subclass: Logger
   class sealed warn: message :: String metadata: meta :: Dictionary -> Nil =>
     @intrinsic loggerWarnMeta
 
+  // === Error ===
+
   /// Log a message at error level.
   ///
   /// ## Examples
@@ -77,6 +83,8 @@ sealed typed Object subclass: Logger
   /// ```
   class sealed error: message :: String metadata: meta :: Dictionary -> Nil =>
     @intrinsic loggerErrorMeta
+
+  // === Debug ===
 
   /// Log a message at debug level.
   ///

--- a/stdlib/src/Metaclass.bt
+++ b/stdlib/src/Metaclass.bt
@@ -24,7 +24,7 @@
 /// ```
 sealed typed Class subclass: Metaclass
 
-  // --- Constructor guard ---
+  // === Constructor guard ===
 
   /// Raises an error — metaclasses cannot be constructed directly.
   ///
@@ -36,7 +36,7 @@ sealed typed Class subclass: Metaclass
   /// ```
   class sealed new => @primitive "metaclassNew"
 
-  // --- Identity predicates ---
+  // === Identity predicates ===
 
   /// Test whether this is a metaclass. Always true for Metaclass instances.
   ///
@@ -62,7 +62,7 @@ sealed typed Class subclass: Metaclass
   /// ```
   sealed isMetaclass -> Boolean => true
 
-  // --- Metaclass protocol ---
+  // === Metaclass protocol ===
 
   /// Return the class that this metaclass describes.
   ///
@@ -102,7 +102,7 @@ sealed typed Class subclass: Metaclass
   /// ```
   sealed superclass => @primitive "metaclassSuperclass"
 
-  // --- Method introspection ---
+  // === Method introspection ===
 
   /// Return all selectors callable on the described class object (class-side + Behaviour protocol).
   ///
@@ -119,7 +119,7 @@ sealed typed Class subclass: Metaclass
   /// ```
   sealed allMethods -> List(Symbol) => @primitive "metaclassAllMethods"
 
-  // --- Class-side method introspection ---
+  // === Class-side method introspection ===
 
   /// Return all class-side selectors of the described class (includes inherited).
   ///
@@ -147,7 +147,7 @@ sealed typed Class subclass: Metaclass
   sealed classIncludesSelector: selector -> Boolean =>
     @primitive "metaclassIncludesSelector"
 
-  // --- Package reflection (ADR 0070 Phase 5) ---
+  // === Package reflection (ADR 0070 Phase 5) ===
 
   /// Return the name of the package that owns the described class.
   ///

--- a/stdlib/src/Object.bt
+++ b/stdlib/src/Object.bt
@@ -33,6 +33,8 @@ ProtoObject subclass: Object
   /// ```
   class -> Self class => @intrinsic "class"
 
+  // === Nil testing ===
+
   /// Test if the receiver is nil. Returns false for all objects except nil.
   ///
   /// ## Examples
@@ -114,6 +116,8 @@ ProtoObject subclass: Object
   ifNotNil: notNilBlock :: Block ifNil: _nilBlock :: Block =>
     notNilBlock value: self
 
+  // === Printing and inspecting ===
+
   /// Return the developer-readable (Debug) string representation.
   ///
   /// `printString` is the **Debug** protocol (ADR 0094): the self-describing,
@@ -181,6 +185,8 @@ ProtoObject subclass: Object
   /// ```
   inspect -> Inspector => Inspector on: self
 
+  // === Identity and equality ===
+
   /// Return the receiver itself. Useful for cascading side effects.
   ///
   /// ## Examples
@@ -237,6 +243,8 @@ ProtoObject subclass: Object
   /// ```
   equals: other :: Object -> Boolean => self =:= other
 
+  // === Reflection ===
+
   /// Test if the receiver responds to the given selector.
   ///
   /// ## Examples
@@ -286,6 +294,8 @@ ProtoObject subclass: Object
   sealed perform: selector :: Symbol withArguments: args :: List =>
     @intrinsic dynamicSendWithArgs
 
+  // === Abstract method markers ===
+
   /// Raise an error indicating this method must be overridden by a subclass.
   ///
   /// ## Examples
@@ -305,6 +315,8 @@ ProtoObject subclass: Object
   /// self notImplemented
   /// ```
   notImplemented -> Never => self error: "Method not yet implemented"
+
+  // === Transcript output ===
 
   /// Send aValue to the current transcript without a trailing newline.
   ///
@@ -329,6 +341,8 @@ ProtoObject subclass: Object
   showCr: aValue :: Printable -> Self =>
     TranscriptStream current ifNotNil: [:t | t show: aValue; cr]
     self
+
+  // === Class testing and errors ===
 
   /// Test if the receiver is an instance of aClass or any of its subclasses.
   ///

--- a/stdlib/src/Object.bt
+++ b/stdlib/src/Object.bt
@@ -342,7 +342,7 @@ ProtoObject subclass: Object
     TranscriptStream current ifNotNil: [:t | t show: aValue; cr]
     self
 
-  // === Class testing and errors ===
+  // === Type testing ===
 
   /// Test if the receiver is an instance of aClass or any of its subclasses.
   ///
@@ -366,6 +366,8 @@ ProtoObject subclass: Object
   /// ```
   isKindOf: aClass :: Behaviour -> Boolean =>
     self class includesBehaviour: aClass
+
+  // === Error handling & dispatch ===
 
   /// Raise an error with the given message.
   ///

--- a/stdlib/src/Pid.bt
+++ b/stdlib/src/Pid.bt
@@ -34,6 +34,8 @@ sealed typed Object subclass: Pid
   /// ```
   printString -> String => self asString
 
+  // === Comparison ===
+
   /// Test strict equality with another pid.
   ///
   /// ## Examples
@@ -60,6 +62,8 @@ sealed typed Object subclass: Pid
 
   /// Return a hash value for the pid.
   hash -> Integer => @primitive
+
+  // === Process Control ===
 
   /// Test if the process referred to by this pid is alive.
   ///

--- a/stdlib/src/Port.bt
+++ b/stdlib/src/Port.bt
@@ -17,6 +17,8 @@
 /// ```
 sealed typed Object subclass: Port
 
+  // === Conversions ===
+
   /// Convert the port to a readable string representation.
   ///
   /// ## Examples
@@ -32,6 +34,8 @@ sealed typed Object subclass: Port
   /// port printString       // => "#Port<0.5>"
   /// ```
   printString -> String => self asString
+
+  // === Comparison ===
 
   /// Test strict equality with another port.
   ///

--- a/stdlib/src/ProcessNavigation.bt
+++ b/stdlib/src/ProcessNavigation.bt
@@ -66,6 +66,8 @@ typed Value subclass: ProcessNavigation
   class internal systemSnapshot -> List(SupervisionNode) =>
     (Erlang beamtalk_process_navigation) system_snapshot
 
+  // === Subtree Construction ===
+
   /// A navigation over the subtree rooted at `aRoot` — a `Supervisor` handle or
   /// a raw `Pid`.
   ///
@@ -92,6 +94,8 @@ typed Value subclass: ProcessNavigation
   /// snapshot rooted at `aRoot`. Keeps `from:` pure Beamtalk.
   class internal snapshotFrom: aRoot :: Supervisor | Pid -> Result(List(SupervisionNode), Error) =>
     (Erlang beamtalk_process_navigation) from: aRoot
+
+  // === Accessing ===
 
   /// The navigable `SupervisionTree` snapshot for this navigation.
   ///

--- a/stdlib/src/Program.bt
+++ b/stdlib/src/Program.bt
@@ -19,6 +19,8 @@
 /// ```
 sealed typed Object subclass: Program native: beamtalk_program
 
+  // === Accessors ===
+
   /// The invoked program's name as a `String`.
   ///
   /// Under a packaged escript it is the invoked filename; under `beamtalk run`
@@ -36,6 +38,8 @@ sealed typed Object subclass: Program native: beamtalk_program
   /// // => "beamtalk"
   /// ```
   class sealed commandName -> String => self delegate
+
+  // === Exiting ===
 
   /// End this program with status 0 — the job-level, safe exit. Does not return.
   ///

--- a/stdlib/src/ProtoObject.bt
+++ b/stdlib/src/ProtoObject.bt
@@ -58,6 +58,8 @@ abstract nil subclass: ProtoObject
   /// ```
   =/= other :: ProtoObject -> Boolean => @intrinsic "=/="
 
+  // === Reflection ===
+
   /// Return the class of the receiver.
   ///
   /// ## Examples
@@ -75,6 +77,8 @@ abstract nil subclass: ProtoObject
   /// ```
   doesNotUnderstand: selector args: arguments =>
     @intrinsic "doesNotUnderstand:args:"
+
+  // === Dynamic Messaging ===
 
   /// Send a message dynamically with an arguments list.
   ///

--- a/stdlib/src/Queue.bt
+++ b/stdlib/src/Queue.bt
@@ -31,6 +31,8 @@ typed Value subclass: Queue native: beamtalk_queue
   /// ```
   class sealed new -> Queue => self delegate
 
+  // === Queue Operations ===
+
   /// Add an element to the back of the queue. Returns a new Queue.
   ///
   /// O(1) amortised.
@@ -62,6 +64,8 @@ typed Value subclass: Queue native: beamtalk_queue
   /// front := q peek    // => first element
   /// ```
   peek -> Object => self delegate
+
+  // === Inspecting ===
 
   /// Return `true` if the queue contains no elements.
   ///

--- a/stdlib/src/Random.bt
+++ b/stdlib/src/Random.bt
@@ -56,6 +56,8 @@ sealed typed Value subclass: Random native: beamtalk_random
   /// ```
   class sealed nextInteger: max :: Integer -> Integer => self delegate
 
+  // === Instance Construction ===
+
   /// Create a new Random instance with an auto-generated seed.
   ///
   /// The instance has its own isolated random state.
@@ -79,6 +81,8 @@ sealed typed Value subclass: Random native: beamtalk_random
   /// ```
   class sealed seed: seed :: Integer -> Random => self delegate
 
+  // === Display ===
+
   /// Return a display string. Overrides the default structural Value form
   /// because the instance holds an opaque internal `rand` generator state
   /// that is not meaningful (or safe) to render field-by-field.
@@ -88,6 +92,8 @@ sealed typed Value subclass: Random native: beamtalk_random
   /// Random new printString       // => "Random"
   /// ```
   printString -> String => self class name asString
+
+  // === Instance-Side Generation ===
 
   /// Return a random float from the instance state.
   ///

--- a/stdlib/src/ReactiveSubprocess.bt
+++ b/stdlib/src/ReactiveSubprocess.bt
@@ -84,6 +84,8 @@ typed Actor subclass: ReactiveSubprocess native: beamtalk_reactive_subprocess
       dir: dir
       notify: notify
 
+  // === Instance Protocol ===
+
   /// Write a line to the subprocess's stdin (appends newline).
   ///
   /// ## Examples

--- a/stdlib/src/Reference.bt
+++ b/stdlib/src/Reference.bt
@@ -34,6 +34,8 @@ sealed typed Object subclass: Reference
   /// ```
   printString -> String => self asString
 
+  // === Comparison ===
+
   /// Test strict equality with another reference.
   ///
   /// ## Examples
@@ -57,6 +59,8 @@ sealed typed Object subclass: Reference
   /// ref1 /= ref2          // => true
   /// ```
   /= other -> Boolean => @primitive
+
+  // === Monitoring & Hashing ===
 
   /// Cancel a monitor associated with this reference.
   ///

--- a/stdlib/src/Regex.bt
+++ b/stdlib/src/Regex.bt
@@ -21,6 +21,8 @@
 /// ```
 sealed typed Value subclass: Regex native: beamtalk_regex
 
+  // ===== Class Methods — Construction =====
+
   /// Use 'Regex from: pattern' to create a Regex.
   class new: _ :: Object -> Object =>
     self error: "Use 'Regex from: pattern' to create a Regex"
@@ -44,6 +46,8 @@ sealed typed Value subclass: Regex native: beamtalk_regex
   class sealed from: pattern :: String options: opts :: List(Symbol) -> Result(Regex, Error) =>
     self delegate
 
+  // ===== Instance Methods — Accessors =====
+
   /// Return the original pattern source string.
   ///
   /// ## Examples
@@ -51,6 +55,8 @@ sealed typed Value subclass: Regex native: beamtalk_regex
   /// (Regex from: "[0-9]+") source              // => "[0-9]+"
   /// ```
   source -> String => self delegate
+
+  // ===== Instance Methods — Display =====
 
   /// Human-readable representation: Regex(pattern).
   ///

--- a/stdlib/src/Set.bt
+++ b/stdlib/src/Set.bt
@@ -40,6 +40,8 @@ sealed typed Collection(E) subclass: Set(E)
   /// ```
   class new: elements :: List(E) -> Set(E) => self withAll: elements
 
+  // === Accessing ===
+
   /// Number of elements in the set.
   ///
   /// ## Examples
@@ -82,6 +84,8 @@ sealed typed Collection(E) subclass: Set(E)
   /// ```
   remove: element :: E -> Set(E) => @primitive
 
+  // === Set operations ===
+
   /// Return a new set with elements from both sets.
   ///
   /// ## Examples
@@ -114,6 +118,8 @@ sealed typed Collection(E) subclass: Set(E)
   /// ```
   isSubsetOf: other :: Set(E) -> Boolean => @primitive
 
+  // === Conversions ===
+
   /// Convert the set to a list of elements.
   ///
   /// Perf override of `Collection>>asList`: converts directly from the
@@ -136,6 +142,8 @@ sealed typed Collection(E) subclass: Set(E)
   /// ```
   fromList: list :: List -> Set(E) => @primitive
 
+  // === Enumerating ===
+
   /// Iterate over each element, evaluating `block` with each one.
   ///
   /// ## Examples
@@ -144,6 +152,8 @@ sealed typed Collection(E) subclass: Set(E)
   /// ```
   do: block :: Block(E, Object) -> Nil => @primitive
 
+  // === Printing ===
+
   /// Return a developer-readable string representation.
   ///
   /// ## Examples
@@ -151,6 +161,8 @@ sealed typed Collection(E) subclass: Set(E)
   /// Set new printString
   /// ```
   printString -> String => @primitive
+
+  // === Streaming ===
 
   /// Return a lazy Stream over the set elements.
   ///

--- a/stdlib/src/StackFrame.bt
+++ b/stdlib/src/StackFrame.bt
@@ -75,6 +75,8 @@ typed Value subclass: StackFrame
   /// ```
   file -> String | Nil => @primitive
 
+  // === Printing ===
+
   /// Return a human-readable string representation.
   ///
   /// ## Examples

--- a/stdlib/src/Stream.bt
+++ b/stdlib/src/Stream.bt
@@ -48,6 +48,8 @@ sealed typed Object subclass: Stream(E) native: beamtalk_stream
   /// ```
   class sealed on: collection :: Object -> Stream(E) => self delegate
 
+  // === Lazy operations ===
+
   /// Filter elements matching predicate (lazy).
   ///
   /// ## Examples
@@ -79,6 +81,8 @@ sealed typed Object subclass: Stream(E) native: beamtalk_stream
   /// ((Stream on: #(1, 2, 3, 4, 5)) drop: 2) asList  // => #(3, 4, 5)
   /// ```
   drop: count :: Integer -> Stream(E) => self delegate
+
+  // === Terminal operations ===
 
   /// Return first N elements as a List (terminal).
   ///
@@ -156,6 +160,8 @@ sealed typed Object subclass: Stream(E) native: beamtalk_stream
   /// (Stream on: #(1, 2, 3)) allSatisfy: [:n | n > 0]  // => true
   /// ```
   allSatisfy: predicate :: Block(E, Boolean) -> Boolean => self delegate
+
+  // === Printing ===
 
   /// Return a developer-readable string showing pipeline structure.
   ///

--- a/stdlib/src/String.bt
+++ b/stdlib/src/String.bt
@@ -57,6 +57,8 @@ sealed typed Binary subclass: String
   /// ```
   class fromIolist: iolist -> String => @primitive
 
+  // === Comparison and concatenation ===
+
   /// Test strict equality with another string.
   ///
   /// ## Examples
@@ -140,6 +142,8 @@ sealed typed Binary subclass: String
   /// ```
   , other :: String -> String => @primitive
 
+  // === Length and access ===
+
   /// Number of grapheme clusters in the string.
   ///
   /// ## Examples
@@ -191,6 +195,8 @@ sealed typed Binary subclass: String
   /// "hello" last         // => "o"
   /// ```
   last -> String => @primitive
+
+  // === Case and trimming ===
 
   /// Convert all characters to uppercase.
   ///
@@ -248,6 +254,8 @@ sealed typed Binary subclass: String
   /// ```
   reverse -> String => @primitive
 
+  // === Searching ===
+
   /// Test if the receiver contains a substring.
   ///
   /// ## Examples
@@ -283,6 +291,8 @@ sealed typed Binary subclass: String
   /// "hello" indexOf: "xyz"      // => nil
   /// ```
   indexOf: substring :: String -> Integer | Nil => @primitive
+
+  // === Splitting and repeating ===
 
   /// Split the string by a separator.
   ///
@@ -324,6 +334,8 @@ sealed typed Binary subclass: String
   /// ```
   words -> List(String) => @primitive
 
+  // === Replacing and slicing ===
+
   /// Replace all occurrences of `old` with `new`.
   ///
   /// ## Examples
@@ -356,6 +368,8 @@ sealed typed Binary subclass: String
   /// ```
   drop: n :: Integer -> String => @primitive
 
+  // === Padding ===
+
   /// Left-pad the string to the given width with spaces.
   ///
   /// ## Examples
@@ -387,6 +401,8 @@ sealed typed Binary subclass: String
   /// "hi" padRight: 5 with: "0"  // => "hi000"
   /// ```
   padRight: width :: Integer with: char :: String -> String => @primitive
+
+  // === Testing and conversion ===
 
   /// Test if the string is empty.
   ///
@@ -465,6 +481,8 @@ sealed typed Binary subclass: String
   /// ```
   asList -> List(String) => @primitive
 
+  // === Enumerating ===
+
   /// Iterate over each grapheme cluster, evaluating `block` with each one.
   ///
   /// ## Examples
@@ -511,6 +529,8 @@ sealed typed Binary subclass: String
   /// ("hello" stream) take: 3         // => #("h", "e", "l")
   /// ```
   stream -> Stream(String) => @primitive
+
+  // === Regular expressions ===
 
   /// Test if the string matches a regular expression pattern.
   /// Accepts a String pattern or compiled Regex object.
@@ -571,6 +591,8 @@ sealed typed Binary subclass: String
   /// ```
   splitRegex: pattern -> List(String) => @primitive
 
+  // === Printing ===
+
   /// Return a developer-readable string representation (with surrounding quotes).
   /// Embedded double-quote characters are doubled (Beamtalk string literal convention).
   ///
@@ -596,9 +618,7 @@ sealed typed Binary subclass: String
   /// ```
   displayString -> String => self
 
-  // ═══════════════════════════════════════════════════════════════════
-  // URL encoding
-  // ═══════════════════════════════════════════════════════════════════
+  // === URL encoding ===
 
   /// Percent-encode characters outside the URL-safe unreserved set
   /// (RFC 3986 §2.3: letters, digits, `-`, `.`, `_`, `~`).

--- a/stdlib/src/Subprocess.bt
+++ b/stdlib/src/Subprocess.bt
@@ -74,6 +74,8 @@ typed Actor subclass: Subprocess native: beamtalk_subprocess
         }
       ]
 
+  // === Writing ===
+
   /// Write a line to the subprocess's stdin (appends newline).
   ///
   /// ## Examples
@@ -81,6 +83,8 @@ typed Actor subclass: Subprocess native: beamtalk_subprocess
   /// agent writeLine: "{\"jsonrpc\":\"2.0\",\"method\":\"ping\"}"
   /// ```
   writeLine: data :: String -> Nil => self delegate
+
+  // === Reading ===
 
   /// Read one line from stdout. Blocks until a line is available. Returns nil at EOF.
   ///
@@ -129,6 +133,8 @@ typed Actor subclass: Subprocess native: beamtalk_subprocess
   /// agent stderrLines do: [:line | Transcript show: line]
   /// ```
   stderrLines -> Stream(String) => self delegate
+
+  // === Lifecycle ===
 
   /// Get the exit code. Returns nil if the subprocess is still running.
   ///

--- a/stdlib/src/SubscriptionNode.bt
+++ b/stdlib/src/SubscriptionNode.bt
@@ -51,6 +51,8 @@ sealed typed Value subclass: SubscriptionNode
   /// ```
   isSend -> Boolean => self handlerKind == #send
 
+  // === Printing ===
+
   /// Human-readable description, e.g.
   /// `#SubscriptionNode<PriceChanged #do #Pid<0.132.0>>` or, for a one-shot,
   /// `#SubscriptionNode<ActorSpawned #doOnce #Pid<0.200.0>>`.

--- a/stdlib/src/SupervisionNode.bt
+++ b/stdlib/src/SupervisionNode.bt
@@ -64,6 +64,8 @@ typed Value subclass: SupervisionNode native: beamtalk_process_navigation
   isBeamtalk -> Boolean =>
     (self kind == #beamtalkActor) or: [self kind == #beamtalkSupervisor]
 
+  // === Navigation ===
+
   /// The snapshot children of this node (supervisors only; `#()` otherwise).
   ///
   /// Resolved from the shared sibling set captured at snapshot time, so it
@@ -93,6 +95,8 @@ typed Value subclass: SupervisionNode native: beamtalk_process_navigation
   /// node parentPid   // => a Pid | nil
   /// ```
   parentPid -> Pid | Nil => self delegate
+
+  // === Supervisor configuration ===
 
   /// The configured OTP restart strategy (`#oneForOne`, `#simpleOneForOne`, …)
   /// for a Beamtalk supervisor node, or `nil` for actors and foreign processes.
@@ -124,6 +128,8 @@ typed Value subclass: SupervisionNode native: beamtalk_process_navigation
   /// ```
   truncated -> Boolean => self delegate
 
+  // === Live status ===
+
   /// Lazily fetch this node's live OTP status (ADR 0092 §5).
   ///
   /// Issues a timeout-guarded `sys:get_status` against the node's pid *at call
@@ -143,6 +149,8 @@ typed Value subclass: SupervisionNode native: beamtalk_process_navigation
   /// (ADR 0101 / BT-2731).
   status -> Dictionary | Nil =>
     (Erlang beamtalk_process_navigation) status: self pid
+
+  // === Printing ===
 
   /// Human-readable description, e.g. `#SupervisionNode<#beamtalkActor Counter
   /// #Pid<0.132.0>>` or, for a supervisor, `#SupervisionNode<#beamtalkSupervisor

--- a/stdlib/src/SupervisionNode.bt
+++ b/stdlib/src/SupervisionNode.bt
@@ -118,6 +118,8 @@ typed Value subclass: SupervisionNode native: beamtalk_process_navigation
   /// ```
   restartIntensity -> Dictionary | Nil => self delegate
 
+  // === Snapshot integrity ===
+
   /// Whether this supervisor's children were truncated by the snapshot child cap
   /// (a large `simpleOneForOne` pool, ADR 0092 §Constraints 1). When `true`,
   /// `children` is empty but `childCount` still reports the live total.

--- a/stdlib/src/SupervisionTree.bt
+++ b/stdlib/src/SupervisionTree.bt
@@ -55,6 +55,8 @@ typed Value subclass: SupervisionTree
   root -> SupervisionNode | Nil =>
     (Erlang beamtalk_process_navigation) rootOf: self flatNodes
 
+  // === Querying ===
+
   /// Total number of nodes in the snapshot.
   ///
   /// ## Examples
@@ -70,6 +72,8 @@ typed Value subclass: SupervisionTree
   /// tree isEmpty   // => false
   /// ```
   isEmpty -> Boolean => self flatNodes isEmpty
+
+  // === Enumerating ===
 
   /// Pre-order walk: evaluate `aBlock` for every node in the snapshot.
   ///
@@ -139,6 +143,8 @@ typed Value subclass: SupervisionTree
   findClass: aClass :: Class -> List(SupervisionNode) =>
     self nodes select: [:node | node behaviourClass == aClass]
 
+  // === Converting ===
+
   /// A serialisable form of the snapshot — one `Dictionary` per node carrying
   /// its identity, kind, class, child count, and parent linkage (adjacency).
   ///
@@ -169,6 +175,8 @@ typed Value subclass: SupervisionTree
           ] ifFalse: [n parentPid asString])
         }
       ]
+
+  // === Printing ===
 
   /// Human-readable summary, e.g. `#SupervisionTree<6 nodes, root: #AppSup>` or
   /// `#SupervisionTree<empty>`.

--- a/stdlib/src/Symbol.bt
+++ b/stdlib/src/Symbol.bt
@@ -34,6 +34,8 @@ sealed typed Object subclass: Symbol
   /// ```
   asAtom -> Symbol => @primitive
 
+  // === Printing ===
+
   /// Return a developer-readable string representation (with `#` prefix).
   ///
   /// ## Examples
@@ -41,6 +43,8 @@ sealed typed Object subclass: Symbol
   /// #hello printString     // => "#hello"
   /// ```
   printString -> String => @primitive
+
+  // === Comparison ===
 
   /// Test strict equality with another symbol.
   ///
@@ -68,6 +72,8 @@ sealed typed Object subclass: Symbol
   /// #hello /= #hello       // => false
   /// ```
   /= other :: Symbol -> Boolean => @primitive
+
+  // === Display & Hashing ===
 
   /// Return a user-facing string representation without the `#` prefix.
   ///

--- a/stdlib/src/System.bt
+++ b/stdlib/src/System.bt
@@ -77,6 +77,8 @@ sealed typed Object subclass: System native: beamtalk_system
   /// ```
   class sealed unsetEnv: name :: String -> Boolean => self delegate
 
+  // === Platform and process info ===
+
   /// Return the OS platform name: "linux", "darwin", or "win32".
   ///
   /// ## Examples
@@ -142,6 +144,8 @@ sealed typed Object subclass: System native: beamtalk_system
   /// // => _
   /// ```
   class sealed uniqueId -> Integer => self delegate
+
+  // === Halting the VM ===
 
   /// Halt the whole VM with status 0 — the nuclear, whole-node option.
   /// Does not return.

--- a/stdlib/src/SystemAnnouncer.bt
+++ b/stdlib/src/SystemAnnouncer.bt
@@ -33,6 +33,8 @@ sealed Announcer subclass: SystemAnnouncer
   class current -> SystemAnnouncer =>
     (Erlang beamtalk_announcements) systemAnnouncer
 
+  // === Prohibited operations ===
+
   /// PROHIBITED on SystemAnnouncer — raises UnsupportedOperation.
   /// The system bus is async-only (ADR 0093 §1).
   announceAndWait: anEvent :: Announcement -> Nil =>

--- a/stdlib/src/SystemNavigation.bt
+++ b/stdlib/src/SystemNavigation.bt
@@ -28,6 +28,8 @@
 /// ```
 sealed typed Object subclass: SystemNavigation
 
+  // ===== Class Methods — Construction =====
+
   /// Return a navigation query rooted at the default scope (all loaded
   /// classes in the workspace's class registry).
   ///
@@ -40,6 +42,8 @@ sealed typed Object subclass: SystemNavigation
     // class instantiation path). ADR 0083 models this in the type checker, so
     // no `@expect dnu` suppression is needed.
     self new
+
+  // ===== Class Registry Overview =====
 
   /// Snapshot of the class registry visible to this navigation query.
   ///
@@ -108,6 +112,8 @@ sealed typed Object subclass: SystemNavigation
       c includesSelector: #doesNotUnderstand:args:
     ]
     handlers sort: [:a :b | a name asString < b name asString]
+
+  // ===== Package & Extension Ownership Queries =====
 
   /// Return the packages (ADR 0070) that contribute extension methods (ADR 0066)
   /// to `aClass` — answers "who extends class X?".
@@ -259,6 +265,8 @@ sealed typed Object subclass: SystemNavigation
     Package named: pkgName
     pkgName
 
+  // ===== Implementors Of (ADR 0087) =====
+
   /// Return all classes that locally define the given selector.
   ///
   /// Searches both instance-side and class-side definitions:
@@ -326,6 +334,8 @@ sealed typed Object subclass: SystemNavigation
     ]) collect: [:c | c class]
     indexImpls ++ fallbackInstance ++ fallbackClassSide
 
+  // ===== Outgoing Calls (messagesSentBy:) =====
+
   /// Return the message sends that occur in the body of `aMethod` — the
   /// outgoing-call set of a single method, the dual of `sendersOf:`.
   ///
@@ -383,6 +393,8 @@ sealed typed Object subclass: SystemNavigation
           acc
         ] ifFalse: [acc add: #{#selector => sentSel, #line => line}]
       ]
+
+  // ===== Senders Of (ADR 0087) & Site-Record Helpers =====
 
   /// Return a collection of call sites that send the given selector.
   ///
@@ -559,6 +571,8 @@ sealed typed Object subclass: SystemNavigation
       into: [:acc :line |
         acc add: #{#class => aClass, #selector => methodSel, #line => line}
       ]
+
+  // ===== Announcement Emission Queries (ADR 0093 §7 / BT-2475) =====
 
   /// Return the distinct `Announcement` subclasses that `aClass` statically
   /// emits — the publisher-side dual of `AnnouncementNavigation` (ADR 0093 §7,
@@ -786,6 +800,8 @@ sealed typed Object subclass: SystemNavigation
     @expect dnu
     targetNames includes: extClass name
 
+  // ===== References To (ADR 0087) =====
+
   /// Return a collection of references to the given class.
   ///
   /// Each result is a Dictionary with three keys:
@@ -939,6 +955,8 @@ sealed typed Object subclass: SystemNavigation
       into: [:acc :line |
         acc add: #{#class => ownerClass, #selector => methodSel, #line => line}
       ]
+
+  // ===== Field Reader/Writer Queries =====
 
   /// Return a collection of methods that READ the named field.
   ///
@@ -1121,6 +1139,8 @@ sealed typed Object subclass: SystemNavigation
       into: [:acc :line |
         acc add: #{#class => ownerClass, #selector => methodSel, #line => line}
       ]
+
+  // ===== Erlang FFI Call-Site Queries =====
 
   /// Return a collection of the Erlang FFI call sites that invoke the named
   /// Erlang function across the loaded class registry.
@@ -1316,6 +1336,8 @@ sealed typed Object subclass: SystemNavigation
           ]
       ]
 
+  // ===== Source-Text Search (methodsMatching:) =====
+
   /// Return a collection of `{class, selector}` records for every method
   /// whose source text matches `aRegex`.
   ///
@@ -1410,6 +1432,8 @@ sealed typed Object subclass: SystemNavigation
               ]
           ]
       ]
+
+  // ===== Selector Search (selectorsMatching:) =====
 
   /// Return a sorted, deduplicated list of selectors whose name contains
   /// `aPattern` (case-insensitive substring match).
@@ -1548,6 +1572,8 @@ sealed typed Object subclass: SystemNavigation
     rawEntries := self extensionEntriesFor: classTag
     rawEntries collect: [:entry | entry at: 1]
 
+  // ===== Shared Extension-Body Scan Helpers =====
+
   /// Append senders of `aSelector` found in every extension method source
   /// (ADR 0066 / BT-2196) to `result`. Returns the (possibly extended) result.
   ///
@@ -1632,6 +1658,8 @@ sealed typed Object subclass: SystemNavigation
           acc add: #{#class => extClass, #selector => extSelector}
         ] ifFalse: [acc]
       ]
+
+  // ===== Unimplemented Selectors (typo finder, ADR 0087 / BT-2303) =====
 
   /// Return a List of every selector that is *sent* somewhere in the loaded
   /// class registry but *defined* nowhere — the classic Smalltalk typo-finder.
@@ -2060,6 +2088,8 @@ sealed typed Object subclass: SystemNavigation
   resolveExtensionClass: classTag :: Symbol -> Object =>
     resolved := self findClass: classTag
     resolved isNil ifTrue: [classTag] ifFalse: [resolved]
+
+  // ===== Unused Selectors (dead-method finder, ADR 0087 / BT-2303) =====
 
   /// Return a List of dead-method *candidates* — selectors that are DEFINED on
   /// some class but SENT nowhere in the loaded class registry. The conservative

--- a/stdlib/src/TestCase.bt
+++ b/stdlib/src/TestCase.bt
@@ -61,6 +61,8 @@ Value subclass: TestCase
   /// ```
   class serial -> Boolean => false
 
+  // === Fixture lifecycle ===
+
   /// Prepare the test fixture. Called before each test method.
   /// Override in subclasses to set up shared state or resources.
   ///
@@ -103,6 +105,8 @@ Value subclass: TestCase
   /// The test runner injects the fixture value into the instance map
   /// before each test method runs.
   suiteFixture => (Erlang beamtalk_test_case) suiteFixture: self
+
+  // === Assertions ===
 
   /// Assert that `condition` is true, failing the test if it is false.
   ///
@@ -161,6 +165,8 @@ Value subclass: TestCase
   should: block :: Block raise: errorKind :: Symbol -> Nil =>
     (Erlang beamtalk_test_case) should: block raise: errorKind
 
+  // === Failing and skipping ===
+
   /// Fail the test immediately with the given `message`.
   ///
   /// ## Examples
@@ -187,6 +193,8 @@ Value subclass: TestCase
   /// Equivalent to `self skip: ""`. The test is counted as skipped, not
   /// failed. Use `^` to exit the test method early after calling this.
   skip -> Nil => self skip: ""
+
+  // === Result assertions ===
 
   /// Assert that `result` is a successful Result and return its value.
   ///

--- a/stdlib/src/TestResult.bt
+++ b/stdlib/src/TestResult.bt
@@ -65,6 +65,8 @@ typed Object subclass: TestResult native: beamtalk_test_runner
   /// ```
   failures -> List => self delegate
 
+  // === Reporting ===
+
   /// True if all tests passed (i.e. `failed` is zero).
   ///
   /// ## Examples

--- a/stdlib/src/TimeoutProxy.bt
+++ b/stdlib/src/TimeoutProxy.bt
@@ -44,11 +44,15 @@ typed Actor subclass: TimeoutProxy
   state: target :: Actor | Nil = nil
   state: timeoutMs :: Timeout = 5000
 
+  // === Configuration ===
+
   /// Set the target actor to forward messages to.
   setTarget: newTarget :: Actor -> Actor => self.target := newTarget
 
   /// Set the timeout in milliseconds (or `#infinity`).
   setTimeoutMs: ms :: Timeout -> Timeout => self.timeoutMs := ms
+
+  // === Forwarding ===
 
   /// Forward all unknown messages to the target with the configured timeout.
   ///

--- a/stdlib/src/TranscriptStream.bt
+++ b/stdlib/src/TranscriptStream.bt
@@ -17,6 +17,8 @@
 typed Actor subclass: TranscriptStream native: beamtalk_transcript_stream
   classState: current :: TranscriptStream | Nil = nil
 
+  // === Class-side Singleton ===
+
   /// Return the current singleton instance (nil before workspace bootstrap).
   class current -> TranscriptStream => self.current
 
@@ -26,6 +28,8 @@ typed Actor subclass: TranscriptStream native: beamtalk_transcript_stream
 
   /// Clear the current singleton instance (reset to nil).
   class resetCurrent -> Nil => self.current := nil
+
+  // === Writing ===
 
   /// Write a value to the transcript.
   ///
@@ -44,6 +48,8 @@ typed Actor subclass: TranscriptStream native: beamtalk_transcript_stream
   /// ```
   cr -> Nil => self delegate
 
+  // === Subscriptions ===
+
   /// Subscribe the calling process to receive transcript output.
   ///
   /// ## Examples
@@ -59,6 +65,8 @@ typed Actor subclass: TranscriptStream native: beamtalk_transcript_stream
   /// Transcript unsubscribe
   /// ```
   unsubscribe -> Nil => self delegate
+
+  // === Buffer ===
 
   /// Return recent transcript entries as a list.
   ///

--- a/stdlib/src/True.bt
+++ b/stdlib/src/True.bt
@@ -14,6 +14,8 @@
 /// ```
 sealed Boolean subclass: True
 
+  // === Control flow ===
+
   /// If true, evaluate `trueBlock`; otherwise evaluate `falseBlock`. Returns `trueBlock` result.
   ///
   /// ## Examples
@@ -47,6 +49,8 @@ sealed Boolean subclass: True
   /// ```
   not -> Boolean => false
 
+  // === Predicates ===
+
   /// Returns true.
   ///
   /// ## Examples
@@ -62,6 +66,8 @@ sealed Boolean subclass: True
   /// true isFalse               // => false
   /// ```
   isFalse -> Boolean => false
+
+  // === Display ===
 
   /// Return a developer-readable string representation.
   ///

--- a/stdlib/src/Tuple.bt
+++ b/stdlib/src/Tuple.bt
@@ -60,6 +60,8 @@ sealed typed Collection subclass: Tuple
   /// ```
   class new: elements :: List -> Tuple => self withAll: elements
 
+  // === Accessing ===
+
   /// Number of elements in the tuple.
   ///
   /// ## Examples
@@ -75,6 +77,8 @@ sealed typed Collection subclass: Tuple
   /// result at: 2   // => the value from an {ok, Value} tuple
   /// ```
   at: index :: Integer => @primitive
+
+  // === Result protocol ===
 
   /// Test if the tuple represents an `{'ok', _}` result.
   ///
@@ -125,6 +129,8 @@ sealed typed Collection subclass: Tuple
   unwrapOrElse: block :: Block(Object) -> Object =>
     self isOk ifTrue: [self at: 2] ifFalse: [block value]
 
+  // === Converting ===
+
   /// Convert the tuple to its string representation.
   ///
   /// ## Examples
@@ -140,6 +146,8 @@ sealed typed Collection subclass: Tuple
   /// result printString   // => "{ok,42}"
   /// ```
   printString -> String => self asString
+
+  // === Enumerating ===
 
   /// Iterate over each element, evaluating `block` with each one.
   ///

--- a/stdlib/src/UndefinedObject.bt
+++ b/stdlib/src/UndefinedObject.bt
@@ -30,6 +30,8 @@ sealed Object subclass: UndefinedObject
   /// ```
   notNil -> Boolean => false
 
+  // === Conditional Evaluation ===
+
   /// Evaluate `nilBlock` since the receiver is nil.
   ///
   /// ## Examples
@@ -72,6 +74,8 @@ sealed Object subclass: UndefinedObject
   ifNotNil: _notNilBlock :: Block(R) ifNil: nilBlock :: Block(R) -> R =>
     nilBlock value
 
+  // === Copying ===
+
   /// Return self. nil is immutable and unique.
   ///
   /// ## Examples
@@ -95,6 +99,8 @@ sealed Object subclass: UndefinedObject
   /// nil shallowCopy             // => nil
   /// ```
   shallowCopy -> Nil => self
+
+  // === Display ===
 
   /// Return a developer-readable string representation.
   ///

--- a/stdlib/src/Value.bt
+++ b/stdlib/src/Value.bt
@@ -64,6 +64,8 @@ Object subclass: Value
   /// ```
   class sealed new: initArgs -> Self => @intrinsic basicNewWith
 
+  // === Printing ===
+
   /// Return a developer-readable string representation showing fields.
   ///
   /// Produces `ClassName(field: value, ...)` via the canonical structural

--- a/stdlib/src/WorkspaceInterface.bt
+++ b/stdlib/src/WorkspaceInterface.bt
@@ -28,6 +28,8 @@ sealed typed Object subclass: WorkspaceInterface
   /// Return the current singleton instance.
   class current -> WorkspaceInterface => self.current
 
+  // === Actors and processes ===
+
   /// Return a list of all live actors as object references.
   ///
   /// ## Examples
@@ -76,6 +78,8 @@ sealed typed Object subclass: WorkspaceInterface
   /// ```
   actorsOf: aClass :: Class -> List(Actor) =>
     self actors select: [:a | a class includesBehaviour: aClass]
+
+  // === Classes and bindings ===
 
   /// Return a list of loaded user classes with source file info.
   ///
@@ -148,6 +152,8 @@ sealed typed Object subclass: WorkspaceInterface
   sessions -> List(Session) =>
     (Erlang beamtalk_workspace_interface_primitives) sessions
 
+  // === Sync and change tracking ===
+
   /// Sync the project: incrementally compile all changed files.
   ///
   /// Scans the current working directory for a `beamtalk.toml` project
@@ -188,6 +194,8 @@ sealed typed Object subclass: WorkspaceInterface
     // result as ChangeLog, matching the declared return type.
     (Erlang beamtalk_workspace_changelog) changeLog
 
+  // === Loading and creating classes ===
+
   /// Compile and load a .bt file, registering the class.
   /// Returns a List of loaded class objects (empty if none resolved).
   /// Returns a structured error if path is not a String or the file cannot be loaded.
@@ -220,6 +228,8 @@ sealed typed Object subclass: WorkspaceInterface
   /// ```
   newClass: source :: String at: path :: String -> List(Behaviour) =>
     (Erlang beamtalk_workspace_interface_primitives) newClass: source at: path
+
+  // === Flushing changes to disk ===
 
   /// Flush every pending durable Tier 1 change to disk (ADR 0082 Phase 2;
   /// destructive tiering ADR 0113 Phase 2).
@@ -316,6 +326,8 @@ sealed typed Object subclass: WorkspaceInterface
   flushIncludingDestructive -> Object =>
     (Erlang beamtalk_workspace_interface_primitives) flushIncludingDestructive
 
+  // === Rechecking and testing ===
+
   /// Whole-image re-check (ADR 0105 Phase 3): re-check every live class the
   /// workspace has a recorded source for, not just the dependents of one
   /// changed selector.
@@ -355,6 +367,8 @@ sealed typed Object subclass: WorkspaceInterface
   /// ```
   test: testClass :: Class -> TestResult => TestRunner run: testClass
 
+  // === Namespace bindings ===
+
   /// Register a value in the workspace namespace under a given name.
   /// Subsequent REPL evals can reference the value by name.
   /// Raises an error if name exists in Beamtalk globals (system name conflict).
@@ -376,6 +390,8 @@ sealed typed Object subclass: WorkspaceInterface
   /// ```
   unbind: bindingName :: Symbol -> Nil =>
     (Erlang beamtalk_workspace_interface_primitives) unbind: bindingName
+
+  // === Supervision ===
 
   /// Return the OTP application root supervisor, or nil if not configured.
   ///
@@ -431,6 +447,8 @@ sealed typed Object subclass: WorkspaceInterface
   /// ```
   supervisors -> List =>
     (Erlang beamtalk_workspace_interface_primitives) supervisors
+
+  // === Settings ===
 
   /// Read the `autoflush` workspace setting (ADR 0082 Phase 4).
   ///


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-2626

One-time, AI-curated pass adding/normalizing `// === Name ===` section dividers grouping methods across the stdlib, feeding BT-2601's method-category recognizer (LSP outline, cockpit, REPL grouping).

- Added or normalized dividers in ~64 stdlib classes (68 files touched counting the two new/edited Rust test files), covering the large majority of non-trivial classes. Small single-purpose classes (event/error/data carriers, classes with 1-4 homogeneous methods) were deliberately left ungrouped per the issue's acceptance criteria.
- Upgraded a handful of pre-existing non-conforming dividers (the older `// --- Name ---` style and 3-line `═══`/heading/`═══` banners) to the compliant single-line `// === Name ===` format so they actually register with the recognizer.
- Comment-only: verified programmatically that every changed line in the diff is blank or a `//` comment — no method body, signature, or ordering was touched.
- Adversarial review (fresh Opus pass) found six methods sitting under a divider that didn't describe them (e.g. `squared` under "Rounding" in Integer.bt/Float.bt); fixed each via divider insertion/rename only, never reordering.
- Closed a real coverage gap the review surfaced: added two new corpus tests (`method_category_corpus_tests.rs`) that check every stdlib+examples divider against the real recognizer — `corpus_has_no_near_miss_dividers` (catches typos like mismatched `=` run lengths that silently vanish from the outline today) and `corpus_has_no_empty_named_categories`. Extracted the shared corpus-walking helpers into `corpus_test_support.rs` rather than duplicating them from `method_span_corpus_tests.rs`.

## Test plan

- [x] `just fmt-check-beamtalk` — clean
- [x] `cargo test -p beamtalk-core corpus_methods_round_trip_byte_identical` — 100% round-trip preserved
- [x] New: `cargo test -p beamtalk-core corpus_` — 8/8 passing, including the two new divider-validation tests
- [x] `just test-stdlib` — 233/233
- [x] `just test-bunit` — 3305/3307 passed, 0 failed (2 pre-existing skips, unrelated)
- [x] `just test-runtime` — 7647 tests, 0 failures
- [x] `just test-metamorphic` — 520/520
- [x] `just verify-threaded-ir` — no invariant violations
- [x] `just lint`, `just check-corpus`, `just check-generated-builtins`, `just check-surface-drift` — all clean
- [x] Full Rust workspace test suite (`cargo test --all-targets`, run single-threaded to rule out an unrelated pre-existing port-contention flake in `beamtalk-desktop-broker`) — 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)