### PR TITLE
LiveView cockpit: workspace-wide keyboard shortcuts — Esc closes editor tab, ⌘/ toggles docs (BT-3245)

### DIFF
--- a/editors/liveview/assets/js/hooks/keyboard_shortcuts.js
+++ b/editors/liveview/assets/js/hooks/keyboard_shortcuts.js
@@ -106,9 +106,11 @@ export const KeyboardShortcuts = {
     const key = ev.key.toLowerCase()
     const chord = isMod(ev) ? "mod+" + key : isPlain(ev) ? key : null
     if (!chord) return
-    if (chord === key && claimedByWindowKeydown(key)) return
     const action = this.bindings[chord]
+    // The `data-scope="window"` hook fires on every keydown anywhere on the
+    // page, so only pay for the DOM scan once a binding actually matches.
     if (!action) return
+    if (chord === key && claimedByWindowKeydown(key)) return
     ev.preventDefault()
 
     if (typeof action !== "string") return

--- a/editors/liveview/assets/js/hooks/keyboard_shortcuts.js
+++ b/editors/liveview/assets/js/hooks/keyboard_shortcuts.js
@@ -15,7 +15,10 @@
 //
 // Events another handler already claimed (`defaultPrevented`) are skipped, so
 // e.g. Escape dismissing CodeMirror's autocomplete or the omni-search popover
-// (both preventDefault) never ALSO fires a bare "escape" binding.
+// (both preventDefault) never ALSO fires a bare "escape" binding. LiveView's
+// own `phx-window-keydown` dismissals never preventDefault, so bare-key chords
+// additionally defer to any mounted `[phx-window-keydown][phx-key]` element
+// claiming the same key (see `claimedByWindowKeydown`).
 //
 // Each value is the action fired when the chord matches; the chord's default
 // browser action (e.g. the Save dialog for ⌘S) is prevented either way:
@@ -49,6 +52,22 @@ function isPlain(ev) {
   // the binding still fires with a stray Shift down (none of the bare keys we
   // bind are shift-sensitive).
   return !ev.metaKey && !ev.ctrlKey && !ev.altKey
+}
+
+function claimedByWindowKeydown(key) {
+  // LiveView surfaces that dismiss on a bare key (the New Class modal, the
+  // Senders/Implementors popover, the settings dropdown) mount an element with
+  // `phx-window-keydown` + `phx-key` only while they are open. Their dismiss
+  // can't be seen via `defaultPrevented` (LiveView never preventDefaults it),
+  // and it can't be checked server-side either: LiveView's own window listener
+  // registered before this hook's, so the dismiss event from the SAME
+  // keystroke is processed first and has already cleared the "is it open"
+  // assign by the time our event arrives. The DOM at keypress time is the
+  // reliable signal — if any mounted element claims this key, the press means
+  // "dismiss that surface", not the bare-key chord.
+  return Array.from(
+    document.querySelectorAll("[phx-window-keydown][phx-key]")
+  ).some((el) => (el.getAttribute("phx-key") || "").toLowerCase() === key)
 }
 
 export const KeyboardShortcuts = {
@@ -87,6 +106,7 @@ export const KeyboardShortcuts = {
     const key = ev.key.toLowerCase()
     const chord = isMod(ev) ? "mod+" + key : isPlain(ev) ? key : null
     if (!chord) return
+    if (chord === key && claimedByWindowKeydown(key)) return
     const action = this.bindings[chord]
     if (!action) return
     ev.preventDefault()

--- a/editors/liveview/assets/js/hooks/keyboard_shortcuts.js
+++ b/editors/liveview/assets/js/hooks/keyboard_shortcuts.js
@@ -7,10 +7,15 @@
 // see `spikes/cockpit-ux-spike/app.jsx`).
 //
 // The bindings are declared on the element as JSON, keyed by the lowercased key
-// with a `mod+` prefix meaning "Cmd on macOS / Ctrl elsewhere":
+// with a `mod+` prefix meaning "Cmd on macOS / Ctrl elsewhere". A key WITHOUT
+// the prefix (e.g. "escape") matches the bare key with no Cmd/Ctrl/Alt held:
 //
 //   <form phx-hook="KeyboardShortcuts" id="..."
-//         data-shortcuts='{"mod+s":"submit","mod+d":"do_it"}'>
+//         data-shortcuts='{"mod+s":"submit","escape":"tab_close_active"}'>
+//
+// Events another handler already claimed (`defaultPrevented`) are skipped, so
+// e.g. Escape dismissing CodeMirror's autocomplete or the omni-search popover
+// (both preventDefault) never ALSO fires a bare "escape" binding.
 //
 // Each value is the action fired when the chord matches; the chord's default
 // browser action (e.g. the Save dialog for ⌘S) is prevented either way:
@@ -37,6 +42,13 @@ function isMod(ev) {
   // require *exactly* one so a user with Ctrl held on macOS still triggers it,
   // but we DO reject Alt/Shift so plain editing chords don't misfire.
   return (ev.metaKey || ev.ctrlKey) && !ev.altKey && !ev.shiftKey
+}
+
+function isPlain(ev) {
+  // A bare-key chord like "escape": no Cmd/Ctrl/Alt held. Shift is allowed so
+  // the binding still fires with a stray Shift down (none of the bare keys we
+  // bind are shift-sensitive).
+  return !ev.metaKey && !ev.ctrlKey && !ev.altKey
 }
 
 export const KeyboardShortcuts = {
@@ -71,8 +83,10 @@ export const KeyboardShortcuts = {
   },
 
   handleKeyDown(ev) {
-    if (!isMod(ev) || !ev.key) return
-    const chord = "mod+" + ev.key.toLowerCase()
+    if (ev.defaultPrevented || !ev.key) return
+    const key = ev.key.toLowerCase()
+    const chord = isMod(ev) ? "mod+" + key : isPlain(ev) ? key : null
+    if (!chord) return
     const action = this.bindings[chord]
     if (!action) return
     ev.preventDefault()

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1565,9 +1565,20 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   # Keyboard chord (Esc in the browser, ⌘W in the desktop shell) closing the
   # focused editor tab — same path as clicking the tab's ✕, including the
-  # silent discard of a dirty tab. No-op when nothing is open.
+  # silent discard of a dirty tab. No-op when nothing is open. While an
+  # Escape-dismissable surface is open (New Class modal, Senders/Implementors
+  # popover, Settings dropdown — all closed via `phx-window-keydown`, which
+  # never `preventDefault`s, so the JS hook cannot tell the key was claimed),
+  # Escape means "dismiss it": bail here so backing out of a modal never also
+  # discards the active tab.
   def handle_event("tab_close_active", _params, socket) do
-    case socket.assigns.active_tab do
+    %{assigns: assigns} = socket
+
+    escape_claimed? =
+      assigns.new_class_open or assigns.show_settings or assigns.nav_popover != nil
+
+    case assigns.active_tab do
+      _ when escape_claimed? -> {:noreply, socket}
       nil -> {:noreply, socket}
       id -> {:noreply, close_tab(socket, id)}
     end

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1567,10 +1567,14 @@ defmodule BtAttachWeb.WorkspaceLive do
   # focused editor tab — same path as clicking the tab's ✕, including the
   # silent discard of a dirty tab. No-op when nothing is open. While an
   # Escape-dismissable surface is open (New Class modal, Senders/Implementors
-  # popover, Settings dropdown — all closed via `phx-window-keydown`, which
-  # never `preventDefault`s, so the JS hook cannot tell the key was claimed),
-  # Escape means "dismiss it": bail here so backing out of a modal never also
-  # discards the active tab.
+  # popover, Settings dropdown), Escape means "dismiss it", never "close the
+  # tab". The PRIMARY defence is client-side (`claimedByWindowKeydown` in
+  # `keyboard_shortcuts.js`): those surfaces mount a `phx-window-keydown`
+  # element only while open, and LiveView's window listener fires before the
+  # hook's, so the same keystroke's dismiss event can reach the server first
+  # and clear these assigns before this handler runs — the guard below is a
+  # best-effort backstop (and the testable contract) for any push that does
+  # arrive while a surface is still open.
   def handle_event("tab_close_active", _params, socket) do
     %{assigns: assigns} = socket
 

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -112,11 +112,14 @@ defmodule BtAttachWeb.WorkspaceLive do
       themed `--t-*` CSS variables still drive the colours. This retired the old
       transparent-textarea-over-`<pre>` overlay (CodeEditor) and the separate
       SelectionTracker hook, both folded into CmEditor.
-    * `KeyboardShortcuts` — maps Cmd/Ctrl chords to actions from a
-      `data-shortcuts` JSON map. The method-editor form binds ⌘S → `submit`
-      (request-submits the form so class/selector/source ride the normal
-      `save_method` `phx-submit`); the Workspace dock binds ⌘D/⌘P/⌘I →
-      `submit:<action>` (BT-2490), riding the eval form's hidden `action` field.
+    * `KeyboardShortcuts` — maps Cmd/Ctrl chords (and bare keys like Escape)
+      to actions from a `data-shortcuts` JSON map. The method-editor form binds
+      ⌘S → `submit` (request-submits the form so class/selector/source ride the
+      normal `save_method` `phx-submit`); the Workspace dock binds ⌘D/⌘P/⌘I →
+      `submit:<action>` (BT-2490), riding the eval form's hidden `action` field;
+      the cockpit root binds Esc/⌘W → `tab_close_active` (close the focused
+      editor tab — ⌘W only reaches the page in the desktop shell, browsers
+      reserve it) and ⌘/ → `toggle_doc` (documentation disclosure).
 
   ## Tweaks panel (BT-2487, epic BT-2482 Phase 1)
 
@@ -1559,6 +1562,16 @@ defmodule BtAttachWeb.WorkspaceLive do
   end
 
   def handle_event("tab_close", _params, socket), do: {:noreply, socket}
+
+  # Keyboard chord (Esc in the browser, ⌘W in the desktop shell) closing the
+  # focused editor tab — same path as clicking the tab's ✕, including the
+  # silent discard of a dirty tab. No-op when nothing is open.
+  def handle_event("tab_close_active", _params, socket) do
+    case socket.assigns.active_tab do
+      nil -> {:noreply, socket}
+      id -> {:noreply, close_tab(socket, id)}
+    end
+  end
 
   # Open a fresh class-definition tab (the spike's "+ def" affordance): a tab
   # whose source is a *class definition* rather than a method body, so saving it
@@ -8946,7 +8959,26 @@ defmodule BtAttachWeb.WorkspaceLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="bt-cockpit">
+    <%!-- Workspace-wide keyboard chords ride the root element so they work no
+         matter which pane has focus (data-scope="window"): Esc closes the
+         focused editor tab (same path as its ✕), ⌘/ toggles the documentation
+         disclosure. "mod+w" is inert in a browser — Cmd/Ctrl+W is on every
+         browser's reserved list and closes the tab before the page sees it —
+         but the desktop (Tauri) webview delivers it once its menu no longer
+         claims ⌘W, giving the native app the real chord. --%>
+    <div
+      class="bt-cockpit"
+      id="workspace-shortcuts"
+      phx-hook="KeyboardShortcuts"
+      data-scope="window"
+      data-shortcuts={
+        Jason.encode!(%{
+          "escape" => "tab_close_active",
+          "mod+w" => "tab_close_active",
+          "mod+/" => "toggle_doc"
+        })
+      }
+    >
       <div class="app">
         <%!-- ── top bar (46px): brand + Attach-topology widget ───────────── --%>
         <div class="topbar">

--- a/editors/liveview/test/bt_attach_web/workspace_keyboard_shortcuts_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_keyboard_shortcuts_test.exs
@@ -1,0 +1,100 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.WorkspaceKeyboardShortcutsTest do
+  @moduledoc """
+  Workspace-wide keyboard chords: the cockpit root carries a
+  window-scoped `KeyboardShortcuts` binding so Esc (and ⌘W in the desktop shell)
+  closes the focused editor tab and ⌘/ toggles the documentation disclosure. The
+  browser-side key handling itself is JS (`keyboard_shortcuts.js`, exercised in
+  the `:playwright` lane); these tests cover the server contract — the rendered
+  `data-shortcuts` map and the `tab_close_active` event the chords push.
+
+  Drives the LiveView against the fully-stubbed workspace client
+  (`BtAttachWeb.StubWorkspaceClient`). No `:workspace` tag, so this runs in the
+  bare `mix test` lane.
+  """
+  use BtAttachWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  setup do
+    Application.put_env(:bt_attach, :workspace_client, BtAttachWeb.StubWorkspaceClient)
+
+    Application.put_env(:bt_attach, :oidc, %{
+      issuer: "https://idp",
+      client_id: "id",
+      redirect_uri: "https://ide/callback",
+      groups_claim: "groups",
+      client_secret: "x",
+      roles: %{"owner" => ["beamtalk-owners"], "observer" => ["beamtalk-observers"]}
+    })
+
+    Application.put_env(:bt_attach, :session_ttl_secs, 3600)
+
+    on_exit(fn ->
+      Application.delete_env(:bt_attach, :workspace_client)
+      Application.delete_env(:bt_attach, :oidc)
+      Application.delete_env(:bt_attach, :session_ttl_secs)
+      BtAttachWeb.StubWorkspaceClient.stop_state(2_000)
+    end)
+
+    {:ok, _} = BtAttachWeb.StubWorkspaceClient.start_state()
+
+    :ok
+  end
+
+  defp owner_conn(conn) do
+    Plug.Test.init_test_session(conn, %{
+      "bt_user" => %{"sub" => "alice", "groups" => ["beamtalk-owners"]},
+      "bt_logged_in_at" => System.system_time(:second)
+    })
+  end
+
+  test "the cockpit root declares the workspace-wide shortcut bindings", %{conn: conn} do
+    {:ok, _view, html} = live(owner_conn(conn), "/")
+
+    # The root element carries the window-scoped KeyboardShortcuts hook with
+    # Esc/⌘W → tab_close_active and ⌘/ → toggle_doc. The JSON rides the DOM
+    # HTML-escaped, so assert on the chord/action substrings.
+    assert html =~ ~s(id="workspace-shortcuts")
+    assert html =~ ~s(phx-hook="KeyboardShortcuts")
+    assert html =~ ~s(data-scope="window")
+    assert html =~ "escape"
+    assert html =~ "mod+w"
+    assert html =~ "mod+/"
+    assert html =~ "tab_close_active"
+    assert html =~ "toggle_doc"
+  end
+
+  test "tab_close_active closes the focused editor tab", %{conn: conn} do
+    {:ok, view, _html} = live(owner_conn(conn), "/")
+
+    html = render_click(view, "browser_open_definition", %{"class" => "Counter"})
+    assert html =~ "Counter ▸ def"
+
+    html = render_click(view, "tab_close_active", %{})
+    refute html =~ "Counter ▸ def"
+  end
+
+  test "tab_close_active closes only the focused tab, refocusing its neighbour", %{conn: conn} do
+    {:ok, view, _html} = live(owner_conn(conn), "/")
+
+    render_click(view, "browser_open_definition", %{"class" => "Counter"})
+    html = render_click(view, "browser_open_definition", %{"class" => "Ledger"})
+    assert html =~ "Counter ▸ def"
+    assert html =~ "Ledger ▸ def"
+
+    # Ledger is the active tab; Esc closes it and Counter survives.
+    html = render_click(view, "tab_close_active", %{})
+    refute html =~ "Ledger ▸ def"
+    assert html =~ "Counter ▸ def"
+  end
+
+  test "tab_close_active with no open tab is a no-op", %{conn: conn} do
+    {:ok, view, _html} = live(owner_conn(conn), "/")
+
+    html = render_click(view, "tab_close_active", %{})
+    assert html =~ ~s(id="workspace-shortcuts")
+  end
+end

--- a/editors/liveview/test/bt_attach_web/workspace_keyboard_shortcuts_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_keyboard_shortcuts_test.exs
@@ -91,6 +91,40 @@ defmodule BtAttachWeb.WorkspaceKeyboardShortcutsTest do
     assert html =~ "Counter ▸ def"
   end
 
+  test "tab_close_active is a no-op while the New Class modal is open", %{conn: conn} do
+    {:ok, view, _html} = live(owner_conn(conn), "/")
+
+    html = render_click(view, "browser_open_definition", %{"class" => "Counter"})
+    assert html =~ "Counter ▸ def"
+
+    # The modal dismisses on Escape via phx-window-keydown, which never
+    # preventDefaults — the same keypress reaches the KeyboardShortcuts hook,
+    # so the server must treat Escape as claimed and keep the tab.
+    render_click(view, "toggle_new_class", %{})
+    html = render_click(view, "tab_close_active", %{})
+    assert html =~ "Counter ▸ def"
+
+    # With the modal closed again, Escape closes the tab as usual.
+    render_click(view, "close_new_class", %{})
+    html = render_click(view, "tab_close_active", %{})
+    refute html =~ "Counter ▸ def"
+  end
+
+  test "tab_close_active is a no-op while the settings dropdown is open", %{conn: conn} do
+    {:ok, view, _html} = live(owner_conn(conn), "/")
+
+    html = render_click(view, "browser_open_definition", %{"class" => "Counter"})
+    assert html =~ "Counter ▸ def"
+
+    render_click(view, "toggle_settings", %{})
+    html = render_click(view, "tab_close_active", %{})
+    assert html =~ "Counter ▸ def"
+
+    render_click(view, "close_settings", %{})
+    html = render_click(view, "tab_close_active", %{})
+    refute html =~ "Counter ▸ def"
+  end
+
   test "tab_close_active with no open tab is a no-op", %{conn: conn} do
     {:ok, view, _html} = live(owner_conn(conn), "/")
 


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-3245

## Summary

Adds the first workspace-wide keyboard chords to the LiveView cockpit. Until now chords were per-form (⌘S save, ⌘D/⌘P/⌘I eval); this adds:

- **Esc** closes the focused editor tab — same path as clicking the tab's ✕ (neighbour refocus, empty state on the last tab). Guarded so an Esc already claimed by CodeMirror autocomplete or the omni-search popover never also closes a tab.
- **⌘/ (Ctrl+/)** toggles the documentation disclosure (`toggle_doc`).
- **mod+W** is bound to close-tab too, but is inert in browsers (Cmd/Ctrl+W is browser-reserved and closes the tab before the page sees it). BT-3244 tracks the desktop (Tauri) menu-accelerator rebind that delivers real ⌘W to the page.

## Key changes

- `keyboard_shortcuts.js` — the hook now accepts bare-key chords (`"escape"`) alongside `mod+` ones, and skips `defaultPrevented` events.
- `workspace_live.ex` — window-scoped bindings on the cockpit root (`#workspace-shortcuts`); new `tab_close_active` event closes `@active_tab` via `close_tab/2`.
- `workspace_keyboard_shortcuts_test.exs` (new) — bindings render, close-active, neighbour refocus, no-tab no-op.

Verified: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix assets.build`, `mix test` (507 passed). No Rust/Erlang files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)