### PR TITLE
refactor: move split_top_level_maps to string_utils shared leaf module

### DIFF
--- a/crates/beamtalk-core/src/semantic_analysis/string_utils.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/string_utils.rs
@@ -79,6 +79,79 @@ pub(crate) fn split_generic_base(type_name: &str) -> (&str, Option<&str>) {
     }
 }
 
+/// Split a string of consecutive Erlang map literals at the top level.
+///
+/// Maps are delimited by `#{…}` with possible nesting (`{…}` also increments
+/// depth). Binary literals (`<<…>>`) are skipped so that `<<",">>` content is
+/// not treated as a separator. Splitting happens when depth returns to zero
+/// after a closing `}`, and any trailing `,` / whitespace before the next map
+/// is consumed. Returns each top-level map as a `&str` slice (inclusive of its
+/// outer braces).
+///
+/// This is the companion scanner to [`split_top_level`] for the Erlang-map
+/// content produced by `beamtalk_spec_reader.erl` — moved here from
+/// `type_checker::native_types` so both map-aware and paren-aware scanners
+/// live in the same shared leaf module.
+///
+/// **References:** ADR 0075; used by `type_checker::native_types`.
+pub(crate) fn split_top_level_maps(input: &str) -> Vec<&str> {
+    let mut result = Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0;
+    let bytes = input.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'#' if i + 1 < bytes.len() && bytes[i + 1] == b'{' => {
+                depth += 1;
+                i += 2;
+            }
+            b'{' => {
+                depth += 1;
+                i += 1;
+            }
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    result.push(&input[start..=i]);
+                    i += 1;
+                    while i < bytes.len()
+                        && (bytes[i] == b',' || bytes[i] == b' ' || bytes[i] == b'\n')
+                    {
+                        i += 1;
+                    }
+                    start = i;
+                    continue;
+                }
+                i += 1;
+            }
+            b'<' if i + 1 < bytes.len() && bytes[i + 1] == b'<' => {
+                i += 2;
+                while i < bytes.len() {
+                    if bytes[i] == b'>' && i + 1 < bytes.len() && bytes[i + 1] == b'>' {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+
+    if start < bytes.len() && depth == 0 {
+        let remainder = input[start..].trim();
+        if !remainder.is_empty() {
+            result.push(remainder);
+        }
+    }
+
+    result
+}
+
 /// Simple edit distance (Levenshtein) for "did you mean" suggestions.
 pub(crate) fn edit_distance(a: &str, b: &str) -> usize {
     let a_chars: Vec<char> = a.chars().collect();
@@ -189,6 +262,50 @@ mod tests {
     #[test]
     fn split_top_level_unbalanced_closing_paren_recovers_immediately() {
         assert_eq!(split_top_level("A), B", ','), vec!["A)", "B"]);
+    }
+
+    // ---- split_top_level_maps ----
+
+    #[test]
+    fn split_top_level_maps_empty() {
+        assert_eq!(split_top_level_maps(""), Vec::<&str>::new());
+    }
+
+    #[test]
+    fn split_top_level_maps_single() {
+        assert_eq!(split_top_level_maps("#{a => 1}"), vec!["#{a => 1}"]);
+    }
+
+    #[test]
+    fn split_top_level_maps_two_maps() {
+        assert_eq!(
+            split_top_level_maps("#{a => 1}, #{b => 2}"),
+            vec!["#{a => 1}", "#{b => 2}"]
+        );
+    }
+
+    #[test]
+    fn split_top_level_maps_nested_map() {
+        assert_eq!(
+            split_top_level_maps("#{a => #{x => 1}}, #{b => 2}"),
+            vec!["#{a => #{x => 1}}", "#{b => 2}"]
+        );
+    }
+
+    #[test]
+    fn split_top_level_maps_binary_literal_not_split() {
+        assert_eq!(
+            split_top_level_maps("#{name => <<\"hello,world\">>}, #{v => 1}"),
+            vec!["#{name => <<\"hello,world\">>}", "#{v => 1}"]
+        );
+    }
+
+    #[test]
+    fn split_top_level_maps_plain_braces_nested() {
+        assert_eq!(
+            split_top_level_maps("#{a => {1, 2}}, #{b => 3}"),
+            vec!["#{a => {1, 2}}", "#{b => 3}"]
+        );
     }
 
     // ---- split_generic_base ----

--- a/crates/beamtalk-core/src/semantic_analysis/type_checker/native_types.rs
+++ b/crates/beamtalk-core/src/semantic_analysis/type_checker/native_types.rs
@@ -34,6 +34,7 @@ use super::type_resolver;
 use super::types::DynamicReason;
 use super::types::{InferredType, TypeProvenance};
 use crate::semantic_analysis::class_hierarchy::DeclaredType;
+use crate::semantic_analysis::string_utils::split_top_level_maps;
 use ecow::EcoString;
 use std::collections::HashMap;
 
@@ -198,72 +199,6 @@ fn parse_erlang_spec_term(term: &str) -> Vec<FunctionSignature> {
         } else {
             seen.insert(key, (result.len(), is_bare));
             result.push(sig);
-        }
-    }
-
-    result
-}
-
-/// Splits a string containing multiple Erlang maps at the top level.
-///
-/// Maps are delimited by `#{...}` with possible nesting. We split on `,#{`
-/// patterns that occur at nesting depth 0.
-fn split_top_level_maps(input: &str) -> Vec<&str> {
-    let mut result = Vec::new();
-    let mut depth = 0;
-    let mut start = 0;
-    let bytes = input.as_bytes();
-    let mut i = 0;
-
-    while i < bytes.len() {
-        match bytes[i] {
-            b'#' if i + 1 < bytes.len() && bytes[i + 1] == b'{' => {
-                depth += 1;
-                i += 2;
-            }
-            b'{' => {
-                depth += 1;
-                i += 1;
-            }
-            b'}' => {
-                depth -= 1;
-                if depth == 0 {
-                    // End of a top-level map
-                    result.push(&input[start..=i]);
-                    // Skip comma and whitespace after the closing brace
-                    i += 1;
-                    while i < bytes.len()
-                        && (bytes[i] == b',' || bytes[i] == b' ' || bytes[i] == b'\n')
-                    {
-                        i += 1;
-                    }
-                    start = i;
-                    continue;
-                }
-                i += 1;
-            }
-            b'<' if i + 1 < bytes.len() && bytes[i + 1] == b'<' => {
-                // Skip binary literal: <<"...">>
-                i += 2;
-                while i < bytes.len() {
-                    if bytes[i] == b'>' && i + 1 < bytes.len() && bytes[i + 1] == b'>' {
-                        i += 2;
-                        break;
-                    }
-                    i += 1;
-                }
-            }
-            _ => {
-                i += 1;
-            }
-        }
-    }
-
-    // If there's remaining content (shouldn't happen for well-formed input)
-    if start < bytes.len() && depth == 0 {
-        let remainder = input[start..].trim();
-        if !remainder.is_empty() {
-            result.push(remainder);
         }
     }
 


### PR DESCRIPTION
## Summary

Moves `split_top_level_maps` from its private location in `type_checker::native_types` into the `semantic_analysis::string_utils` shared-kernel module, where its sibling scanners `split_top_level` and `split_generic_base` already live (BT-3089).

### Why

The function is a general-purpose nesting-aware byte scanner for Erlang map literals — not specific to native-type parsing. Keeping it private in `native_types.rs` made it invisible to any future consumer that needs the same scan, setting up a duplication trap. The `string_utils` module is already established as the designated shared leaf for this class of utility (see `docs/development/architecture-principles.md` §6 — Shared-Leaf-Module Pattern).

### What changed

- **`string_utils.rs`** — adds `pub(crate) fn split_top_level_maps` with a doc comment cross-referencing `split_top_level`, plus 6 unit tests (empty, single map, two maps, nested maps, binary-literal content, plain-brace nesting)
- **`native_types.rs`** — removes the private `split_top_level_maps` definition; adds `use crate::semantic_analysis::string_utils::split_top_level_maps`; the two call sites are unchanged

### Safety

Pure code movement — the function body is identical. All 7,173 Rust unit tests + stdlib/BUnit/runtime suites pass. Pre-push hook (clippy, Dialyzer, fmt, all lints) is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQdUZhGacwwzhJS3quZmsC)_