### PR TITLE
test(workspace): cover uncovered dispatch routing arms and revert_side_field binary branches

### DIFF
--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_interface_primitives_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_interface_primitives_tests.erl
@@ -1132,7 +1132,10 @@ changelog_live_test_() ->
         fun flush_filter_via_dispatch/1,
         fun flush_kinds_valid_list_with_empty_log/1,
         fun revert_no_active_entry_raises_state_error/1,
-        fun revert_via_object_keyed_map/1
+        fun revert_via_object_keyed_map/1,
+        fun flush_confirm_destructive_via_dispatch/1,
+        fun flush_including_destructive_via_dispatch/1,
+        fun recheck_image_via_dispatch/1
     ]}.
 
 %% changeLogClear/0 returns nil and is idempotent on an empty log.
@@ -1201,6 +1204,40 @@ flush_filter_via_dispatch(_Ctx) ->
     [
         ?_assert(is_map(Summary)),
         ?_assertEqual(0, maps:get(flushed, Summary))
+    ].
+
+%% dispatch('flush:confirmDestructive:', [Filter, Bool]) routes to flush/2.
+%% Over an empty log the summary has flushed=0 (BT-3456: routing arm coverage).
+flush_confirm_destructive_via_dispatch(_Ctx) ->
+    Summary = beamtalk_workspace_interface_primitives:dispatch(
+        'flush:confirmDestructive:', ['new-class', false], fake_self(self())
+    ),
+    [
+        ?_assert(is_map(Summary)),
+        ?_assertEqual(0, maps:get(flushed, Summary))
+    ].
+
+%% dispatch(flushIncludingDestructive, []) routes to flushIncludingDestructive/0.
+%% Over an empty log the summary has flushed=0 (BT-3456: routing arm coverage).
+flush_including_destructive_via_dispatch(_Ctx) ->
+    Summary = beamtalk_workspace_interface_primitives:dispatch(
+        flushIncludingDestructive, [], fake_self(self())
+    ),
+    [
+        ?_assert(is_map(Summary)),
+        ?_assertEqual(0, maps:get(flushed, Summary))
+    ].
+
+%% dispatch(recheckImage, []) routes to recheckImage/0 → beamtalk_recheck:trigger_image/0.
+%% With no live class sources the result is the empty-findings map (BT-3456).
+recheck_image_via_dispatch(_Ctx) ->
+    Result = beamtalk_workspace_interface_primitives:dispatch(
+        recheckImage, [], fake_self(self())
+    ),
+    [
+        ?_assert(is_map(Result)),
+        ?_assertEqual([], maps:get(findings, Result)),
+        ?_assertEqual(0, maps:get(checked, Result))
     ].
 
 %% changeLogFlushKinds/1 with a valid List of kind Symbols flows through to
@@ -1430,6 +1467,60 @@ start_bare_workspace_sup() ->
 %% supervisor init/1 callback used only by start_bare_workspace_sup/0.
 init(bare_sup) ->
     {ok, {#{strategy => one_for_one, intensity => 1, period => 5}, []}}.
+
+%%====================================================================
+%% dispatch(supervisors, []) routing arm (BT-3456)
+%%
+%% supervisors/0 calls supervisor:which_children/1 on beamtalk_workspace_sup,
+%% so this test starts a bare workspace_sup when none is already running —
+%% mirroring the existing supervisors_returns_list_test/supervisors_empty_*
+%% pattern. The dispatch/3 routing arm was previously exercised only by
+%% supervisors/0's direct callers; this test covers the dispatch path itself.
+%%====================================================================
+
+supervisors_via_dispatch_test() ->
+    Self = fake_self(self()),
+    case whereis(beamtalk_workspace_sup) of
+        undefined ->
+            {ok, SupPid} = start_bare_workspace_sup(),
+            try
+                Result = beamtalk_workspace_interface_primitives:dispatch(
+                    supervisors, [], Self
+                ),
+                ?assert(is_list(Result))
+            after
+                stop_proc(SupPid)
+            end;
+        _ ->
+            Result = beamtalk_workspace_interface_primitives:dispatch(
+                supervisors, [], Self
+            ),
+            ?assert(is_list(Result))
+    end.
+
+%%====================================================================
+%% revert_side_field/1 binary-argument branches (BT-3456)
+%%
+%% revert_side_field/1 is private. The binary <<"instance">> / <<"class">>
+%% arms (LiveView phx-value-side, ADR 0112 BT-3187) are exercised via
+%% revert_method/3, which calls revert_side_field(SideArg) before the
+%% selector-atom lookup. A never-compiled selector makes existing_selector_atom/1
+%% return `error` (pure — no changelog needed), so the test reaches
+%% revert_side_field/1 and returns {error, #beamtalk_error{}} without touching
+%% any gen_server.
+%%====================================================================
+
+revert_side_field_binary_test() ->
+    %% <<"instance">> arm: revert_side_field/1 called before selector lookup.
+    {error, #beamtalk_error{kind = revert_not_possible}} =
+        beamtalk_workspace_interface_primitives:revert_method(
+            <<"NoClass">>, <<"__no_such_selector__">>, <<"instance">>
+        ),
+    %% <<"class">> arm.
+    {error, #beamtalk_error{kind = revert_not_possible}} =
+        beamtalk_workspace_interface_primitives:revert_method(
+            <<"NoClass">>, <<"__no_such_selector__">>, <<"class">>
+        ).
 
 %%====================================================================
 %% safe_existing_atom/1 + class_object_for/1 via changeLogRevert


### PR DESCRIPTION
## Summary

- Add EUnit tests for five previously-uncovered paths in `beamtalk_workspace_interface_primitives` (was 57% line coverage):
  - `dispatch(supervisors, [], Self)` routing arm (line 138-139)
  - `dispatch('flush:confirmDestructive:', [Filter, Bool], Self)` routing arm (lines 148-149)
  - `dispatch(flushIncludingDestructive, [], Self)` routing arm (lines 150-151)
  - `dispatch(recheckImage, [], Self)` routing arm (lines 152-153)
  - `revert_side_field/1` with binary `<<"instance">>` and `<<"class">>` args (lines 558-559), exercised via `revert_method/3` which calls it before the selector-atom lookup

## Test design

The three flush/recheck tests run inside the existing `changelog_live_test_` `foreach` fixture, which provides an isolated changelog + workspace_meta with an empty log. The empty-log path gives deterministic results: `flushed=0` summaries for both flush variants, and `#{findings=>[], checked=>0, stale=>0}` for the recheck.

`dispatch(recheckImage, ...)` delegates to `beamtalk_recheck:trigger_image/0`, which iterates `beamtalk_workspace_meta:all_class_sources/0`. With no classes registered, the loop is empty and the compiler is never invoked — no additional setup needed.

The `supervisors_via_dispatch_test/0` mirrors the existing `supervisors_returns_list_test` pattern: it starts a bare workspace supervisor when one is not already running, since `supervisors/0` calls `supervisor:which_children(beamtalk_workspace_sup)`.

The `revert_side_field_binary_test/0` is a pure-function test: `revert_method/3` calls `revert_side_field(SideArg)` before `existing_selector_atom/1`, so a never-compiled selector reaches the binary clause and returns `{error, #beamtalk_error{}}` without touching any gen_server.

All 99 tests pass locally (0 failures).

---
_Generated by [Claude Code](https://claude.ai/code/session_015e6VsHijpJxNTzB7yNYQ2x)_