### PR TITLE
Desktop (Tauri) launcher: default workspace filter to "running" (BT-3246)

### DIFF
--- a/desktop/ui/index.html
+++ b/desktop/ui/index.html
@@ -47,7 +47,10 @@
       </div>
 
       <p id="workspace-filter-empty" class="status" hidden>
-        No workspaces match this filter.
+        <span id="workspace-filter-empty-message">No workspaces match this filter.</span>
+        <button id="workspace-filter-empty-show-all" class="filter-empty-show-all" hidden>
+          Show all
+        </button>
       </p>
 
       <ul id="workspace-list" hidden></ul>

--- a/desktop/ui/main.js
+++ b/desktop/ui/main.js
@@ -27,6 +27,12 @@ const workspaceFiltersEl = document.getElementById("workspace-filters");
 const workspaceFilterEmptyEl = document.getElementById(
   "workspace-filter-empty",
 );
+const workspaceFilterEmptyMessageEl = document.getElementById(
+  "workspace-filter-empty-message",
+);
+const workspaceFilterEmptyShowAllButton = document.getElementById(
+  "workspace-filter-empty-show-all",
+);
 const filterButtons = [...document.querySelectorAll(".filter-button")];
 const quitButton = document.getElementById("quit-button");
 const logsButton = document.getElementById("logs-button");
@@ -41,10 +47,12 @@ const attachProgress = new Map();
 // attached workspaces the post-attach monitor has flagged as unhealthy.
 const connectionBadges = new Map();
 
-// "all" | "running" | "stopped" (BT-3230) — persists across refreshes
-// (a periodic `runRefresh()` re-applies it to the freshly fetched list
-// rather than resetting to "all") until the user picks a different one.
-let currentFilter = "all";
+// "all" | "running" | "stopped" (BT-3230) — defaults to "running" (BT-3246)
+// since attaching to an already-running workspace is the common case on
+// app open; persists across refreshes (a periodic `runRefresh()` re-applies
+// it to the freshly fetched list rather than resetting to the default)
+// until the user picks a different one.
+let currentFilter = "running";
 // The last full (unfiltered) workspace list `render()` saw — filter button
 // clicks re-render from this directly rather than re-invoking
 // `list_workspaces`, so switching filters is instant and never races a
@@ -86,6 +94,14 @@ function setFilter(filter) {
 for (const button of filterButtons) {
   button.addEventListener("click", () => setFilter(button.dataset.filter));
 }
+// BT-3246: the default "running" filter can land on an empty list when
+// every discoverable workspace happens to be stopped — the empty-state
+// message rendered by `updateFilterEmptyMessage` offers this as an escape
+// hatch back to the unfiltered view rather than leaving the user stuck
+// looking at "No workspaces match this filter" with no obvious next step.
+workspaceFilterEmptyShowAllButton.addEventListener("click", () =>
+  setFilter("all"),
+);
 setFilter(currentFilter);
 
 // BT-3225: launcher-side log lines (backend `tracing` events), fed by the
@@ -227,9 +243,37 @@ function renderWorkspaceListForCurrentFilter() {
     return;
   }
   const visible = lastWorkspaces.filter(matchesFilter);
-  workspaceFilterEmptyEl.hidden = visible.length > 0;
-  workspaceListEl.hidden = visible.length === 0;
+  const isEmpty = visible.length === 0;
+  workspaceFilterEmptyEl.hidden = !isEmpty;
+  workspaceListEl.hidden = isEmpty;
+  if (isEmpty) {
+    updateFilterEmptyMessage();
+  }
   reconcileWorkspaceList(visible);
+}
+
+// Fill in `workspaceFilterEmptyEl` for the case `renderWorkspaceListForCurrentFilter`
+// just found zero rows matching `currentFilter`. BT-3246: since "running" is
+// now the *default* filter (not a choice the user necessarily made), landing
+// here with stopped-but-not-running workspaces present needs an explicit
+// way back to seeing them, not just a generic "nothing matches" — the
+// "Show all" button covers that; every other empty case (an explicit
+// "stopped" filter with nothing stopped, or "all" somehow empty despite
+// `lastWorkspaces` being non-empty, which can only be a transient render
+// race) falls back to the original generic message with no escape hatch,
+// since there's no other filter to usefully suggest.
+function updateFilterEmptyMessage() {
+  if (currentFilter === "running") {
+    const stoppedCount = lastWorkspaces.filter((w) => !w.alive).length;
+    if (stoppedCount > 0) {
+      const plural = stoppedCount === 1 ? "workspace" : "workspaces";
+      workspaceFilterEmptyMessageEl.textContent = `No running workspaces — ${stoppedCount} stopped ${plural}.`;
+      workspaceFilterEmptyShowAllButton.hidden = false;
+      return;
+    }
+  }
+  workspaceFilterEmptyMessageEl.textContent = "No workspaces match this filter.";
+  workspaceFilterEmptyShowAllButton.hidden = true;
 }
 
 // Update `workspaceListEl` to match `workspaces` by reusing existing row

--- a/desktop/ui/style.css
+++ b/desktop/ui/style.css
@@ -97,6 +97,19 @@ main {
   border-color: var(--accent);
 }
 
+/* BT-3246: inline "Show all" affordance inside the filter-empty message
+   (e.g. "No running workspaces — 2 stopped workspaces.") — styled small and
+   understated like `.filter-button` rather than the bold solid `button`
+   default, since it's a secondary escape hatch next to a status line, not
+   a primary action. */
+.filter-empty-show-all {
+  background: transparent;
+  color: var(--accent);
+  border-color: var(--border);
+  padding: 0.15rem 0.5rem;
+  font-size: 0.8rem;
+}
+
 .workspace-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Defaults the Tauri desktop launcher's workspace picker to the **Running** filter on app open, instead of **All** — attaching to an already-running workspace is the common case, and mixing stopped/dead images into the default view added noise.
- Adds a "Show all" affordance to the filter-empty state so landing on zero running workspaces (with stopped ones present) isn't a dead end — shows "No running workspaces — N stopped workspace(s)." with a button back to the unfiltered view.
- A user-chosen filter still persists across refreshes within the session (existing BT-3230 contract) — only the *default* changed.
- Updated the doc comment at `desktop/ui/main.js` describing the filter contract.

## Changes
- `desktop/ui/main.js`: `currentFilter` now defaults to `"running"`; added `updateFilterEmptyMessage()` to special-case the running-but-nothing-running empty state with a stopped-count message and a "Show all" button wired to `setFilter("all")`.
- `desktop/ui/index.html`: filter-empty message now has a dedicated `<span>` plus a hidden "Show all" `<button>`.
- `desktop/ui/style.css`: small, understated styling for the new `.filter-empty-show-all` button, matching the existing `.filter-button` look.

Linear: https://linear.app/beamtalk/issue/BT-3246

## Test plan
- [x] `node --check desktop/ui/main.js` — syntax valid
- [x] Manual trace of `renderWorkspaceListForCurrentFilter` / `updateFilterEmptyMessage` for the running/stopped/all filter combinations, including the zero-running-with-stopped-present case
- [x] Pre-push hooks passed: clippy, Rust/Erlang/Beamtalk/Elixir formatting, Dialyzer, Biome lint/format
- [x] Desktop UI has no existing JS test harness (vanilla JS, no build step per ADR 0097) and is out of scope for `docs/development/surface-parity.md` (native shell, not a REPL/CLI/MCP/LSP surface) — full repo-wide `just ci` will run in GitHub Actions CI as usual

🤖 Generated with [Claude Code](https://claude.com/claude-code)