### PR TITLE
Cockpit: fix System Browser panel-head title wrap/overflow (BT-3247)

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -222,6 +222,26 @@
    intrinsic-content floor) but never wraps, truncating with an ellipsis
    instead once the column is narrowed via the splitter. */
 .panel-head .panel-title { flex: 1 1 auto; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* BT-3247 (follow-up): `.seg` (the Classes/Native/Type-Aliases + Hier/Cats
+   toggles) looked non-shrinkable but was actually a default flex item
+   (flex-shrink: 1) whose `<button>`s had no `white-space` override — once
+   `.panel-title` was squeezed to its floor there was still a width deficit
+   at the 286px default (BT-3256: the mode/view segs + source select + icon
+   buttons simultaneously visible in the default :classes browser_mode
+   already exceed the 266px content box, title or no title), and the
+   flexbox shrink algorithm pushed the rest onto `.seg`, wrapping a button's
+   label onto a second line and overflowing the head the same way the title
+   used to. `white-space: nowrap` stops that internal wrap — the header's
+   height is the thing BT-3247 is about — and `min-width: 0` +
+   `text-overflow: ellipsis` degrade a label gracefully instead of silently
+   overflowing if a future change ever does force `.seg` narrower than its
+   natural width. It does NOT fix the pre-existing (and pre-dating this fix
+   — confirmed still present, and worse, before `.panel-title` existed)
+   horizontal deficit: at the 286px default the row's natural content width
+   already exceeds the panel, so `.panel`'s `overflow: hidden` clips a few
+   pixels off the trailing `+`/`×` buttons regardless. That's tracked
+   separately in BT-3256. */
+.panel-head .seg button { white-space: nowrap; min-width: 0; text-overflow: ellipsis; overflow: hidden; }
 .panel-head .spacer { flex: 1; }
 .panel-head .panel-close {
   border: 0; background: transparent; cursor: pointer; color: var(--faint);

--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -215,6 +215,13 @@
   color: var(--muted);
 }
 .panel-head .count { color: var(--faint); font-weight: 500; letter-spacing: 0; text-transform: none; white-space: nowrap; flex: none; }
+/* BT-3247: the title used to be a bare text node — the only shrinkable flex
+   item in `.panel-head` — so it wrapped to two lines under pressure from the
+   mode/view segs and source select, overflowing the fixed 30px header. Give
+   it its own flex item that can shrink (min-width: 0 removes the text's
+   intrinsic-content floor) but never wraps, truncating with an ellipsis
+   instead once the column is narrowed via the splitter. */
+.panel-head .panel-title { flex: 1 1 auto; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .panel-head .spacer { flex: 1; }
 .panel-head .panel-close {
   border: 0; background: transparent; cursor: pointer; color: var(--faint);

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -8086,7 +8086,7 @@ defmodule BtAttachWeb.WorkspaceLive do
       phx-hook="TweaksPanel"
       data-tweaks-defaults={Jason.encode!(@defaults)}
     >
-      <div class="panel-head">Tweaks</div>
+      <div class="panel-head"><span class="panel-title">Tweaks</span></div>
       <div class="panel-body">
         <%!-- Theme → data-theme on <html> (whole palette swap) --%>
         <div class="twk-row">
@@ -8236,7 +8236,7 @@ defmodule BtAttachWeb.WorkspaceLive do
     ~H"""
     <div id="system-browser" class="panel">
       <div class="panel-head">
-        System Browser <span class="spacer"></span>
+        <span class="panel-title">System Browser</span> <span class="spacer"></span>
         <%!-- BT-2656: Classes | Native panel-mode toggle. Native (Erlang) modules
              are a distinct namespace from Beamtalk classes, so they live in their
              own scrollable, filterable browser rather than a collapsed in-tree
@@ -8753,11 +8753,13 @@ defmodule BtAttachWeb.WorkspaceLive do
     ~H"""
     <div class="panel">
       <div class="panel-head">
-        <%= if @selected_class do %>
-          {if @browser_side == "class", do: @selected_class <> " class", else: @selected_class}
-        <% else %>
-          Protocols &amp; Methods
-        <% end %>
+        <span class="panel-title">
+          <%= if @selected_class do %>
+            {if @browser_side == "class", do: @selected_class <> " class", else: @selected_class}
+          <% else %>
+            Protocols &amp; Methods
+          <% end %>
+        </span>
         <span class="spacer"></span>
         <span :if={@selected_class} class="count">{@total_methods} methods</span>
       </div>
@@ -10781,7 +10783,7 @@ defmodule BtAttachWeb.WorkspaceLive do
               <div class="right-split">
                 <div id="bindings-panel" class="panel bindings-panel">
                   <div class="panel-head">
-                    Bindings <span class="spacer"></span>
+                    <span class="panel-title">Bindings</span> <span class="spacer"></span>
                     <span class="count">{length(@bindings)} in session</span>
                   </div>
                   <div class="panel-body">
@@ -10853,7 +10855,7 @@ defmodule BtAttachWeb.WorkspaceLive do
 
                 <div id="inspector-panel" class="panel insp inspector-panel">
                   <div class="panel-head">
-                    Inspector <span class="spacer"></span>
+                    <span class="panel-title">Inspector</span> <span class="spacer"></span>
                     <%!-- Freeze toggle (BT-2492, spike `iw-freeze`): live tracking
                          subscribes to the object's change stream and flashes
                          changed fields; freezing holds the current snapshot. Shown
@@ -11027,7 +11029,7 @@ defmodule BtAttachWeb.WorkspaceLive do
           <div class="cockpit" style="grid-template-columns: minmax(0, 1fr);">
             <div class="col">
               <div class="panel" style="flex:1;">
-                <div class="panel-head">Workspace</div>
+                <div class="panel-head"><span class="panel-title">Workspace</span></div>
                 <div class="panel-body">
                   <%= if @error do %>
                     <div class="io-block err">

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -8753,7 +8753,19 @@ defmodule BtAttachWeb.WorkspaceLive do
     ~H"""
     <div class="panel">
       <div class="panel-head">
-        <span class="panel-title">
+        <%!-- BT-3247 review nit: the title can now ellipsis-truncate at a
+             narrow `--browser-w`, so give it a `title=` attribute (same text
+             as the rendered content) — a hover reveals the full class name
+             even once the visible label is cut short. --%>
+        <span
+          class="panel-title"
+          title={
+            if @selected_class,
+              do:
+                if(@browser_side == "class", do: @selected_class <> " class", else: @selected_class),
+              else: "Protocols & Methods"
+          }
+        >
           <%= if @selected_class do %>
             {if @browser_side == "class", do: @selected_class <> " class", else: @selected_class}
           <% else %>

--- a/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
@@ -816,13 +816,33 @@ defmodule BtAttachWeb.WorkspaceBrowserTest do
     |> visit("/")
     |> assert_has(".att-label", text: "attached")
     |> assert_has("#col-gutter-left")
+    # Wait for the UI webfont (Hanken Grotesk, loaded from Google Fonts —
+    # `root.html.heex`) to finish loading before measuring: while it's still
+    # loading the fallback stack renders wider/narrower text, which would
+    # make this assertion race the font swap instead of testing the fix.
+    |> evaluate("document.fonts.ready.then(() => true)")
     # Default width (286px): the title used to be a bare text node — the only
     # shrinkable flex item in `.panel-head` — so it wrapped to two lines under
     # pressure from the mode/view segs + source select, overflowing the fixed
-    # 30px header. `scrollHeight === clientHeight` fails the moment it wraps.
+    # 30px header. `scrollHeight === clientHeight` fails the moment anything
+    # in the row wraps to a second line.
     |> assert_eventually(
       "(() => { const h = document.querySelector('#system-browser .panel-head'); return h.scrollHeight === h.clientHeight; })()",
       "the System Browser panel-head overflowed its height at the default column width"
+    )
+    # Regression guard for the follow-up half of the same bug (found while
+    # fixing this one): once the title stopped absorbing the row's width
+    # deficit, the flexbox shrink algorithm pushed it onto the Classes/
+    # Native/Type-Aliases `.seg` toggle next, wrapping a button's own label
+    # onto a second line — same overflow, different element. `white-space:
+    # nowrap` on `.seg button` is what stops that; assert it directly so a
+    # regression here fails fast instead of racing `assert_eventually`'s 3s
+    # window. (The row's remaining HORIZONTAL deficit at this width — the
+    # trailing icon buttons losing a few px to `.panel`'s `overflow: hidden`
+    # — is a separate, pre-existing issue tracked in BT-3256, not this one.)
+    |> evaluate(
+      "getComputedStyle(document.querySelector('#system-browser .panel-head .seg button')).whiteSpace",
+      fn v -> assert v == "nowrap", "seg buttons should never wrap, got #{inspect(v)}" end
     )
     # Narrow the column well past the point that used to force a wrap (286px
     # default down toward the 160px floor, data-min on #col-gutter-left) — the

--- a/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
@@ -810,6 +810,38 @@ defmodule BtAttachWeb.WorkspaceBrowserTest do
     end)
   end
 
+  test "the System Browser panel-head title stays on one line at any column width (BT-3247)",
+       %{conn: conn} do
+    conn
+    |> visit("/")
+    |> assert_has(".att-label", text: "attached")
+    |> assert_has("#col-gutter-left")
+    # Default width (286px): the title used to be a bare text node — the only
+    # shrinkable flex item in `.panel-head` — so it wrapped to two lines under
+    # pressure from the mode/view segs + source select, overflowing the fixed
+    # 30px header. `scrollHeight === clientHeight` fails the moment it wraps.
+    |> assert_eventually(
+      "(() => { const h = document.querySelector('#system-browser .panel-head'); return h.scrollHeight === h.clientHeight; })()",
+      "the System Browser panel-head overflowed its height at the default column width"
+    )
+    # Narrow the column well past the point that used to force a wrap (286px
+    # default down toward the 160px floor, data-min on #col-gutter-left) — the
+    # title must truncate with an ellipsis instead of wrapping the head.
+    |> drag_split("col-gutter-left", -150, 0)
+    |> assert_eventually(
+      "document.querySelector('.cockpit > .col').offsetWidth < 200",
+      "dragging the left column gutter left did not narrow the System Browser column"
+    )
+    |> assert_eventually(
+      "(() => { const h = document.querySelector('#system-browser .panel-head'); return h.scrollHeight === h.clientHeight; })()",
+      "the System Browser panel-head overflowed its height at a narrowed column width"
+    )
+    |> evaluate(
+      "getComputedStyle(document.querySelector('#system-browser .panel-title')).whiteSpace",
+      fn v -> assert v == "nowrap", "the panel title should never wrap, got #{inspect(v)}" end
+    )
+  end
+
   test "a saved split size is restored on the next load (BT-2576)", %{conn: conn} do
     conn
     |> visit("/")


### PR DESCRIPTION
## Summary

- The cockpit's `.panel-head` title (e.g. "System Browser") was a bare text node — the only shrinkable flex item in the header row — so under pressure from the mode/view segmented controls and source `<select>` in the 286px browser column it wrapped to two lines and overflowed the fixed 30px header.
- Wraps each panel-head title in a `.panel-title` span with `min-width: 0`, `white-space: nowrap`, `overflow: hidden`, `text-overflow: ellipsis` so it truncates instead of wrapping, at any splitter width.
- Applied to all six bare-text `.panel-head` titles so they can't regress the same way: Tweaks, System Browser, Protocols & Methods, Bindings, Inspector, Workspace.
- Added a Playwright e2e regression test asserting the System Browser panel-head never overflows its height, at both the default column width and after narrowing it toward the 160px floor.

## Test plan

- [x] `just build && just clippy && just fmt-check` — all pass
- [x] `just test` — Rust + stdlib + BUnit + runtime suite passes
- [x] `mix format --check-formatted` / `mix compile --warnings-as-errors` / `mix test` (509 passed) in `editors/liveview`
- [x] New Playwright case added covering the fix (tagged `:workspace`/`:playwright`, runs in the `liveview-e2e` CI lane)

Linear: https://linear.app/beamtalk/issue/BT-3247

🤖 Generated with [Claude Code](https://claude.com/claude-code)