### PR TITLE
beamtalk_test_case BIF-fallback module_info(exports) crashes on real Beamtalk-compiled test classes (BT-3251)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_module_activation.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_module_activation.erl
@@ -42,7 +42,8 @@ source text) are handled via the `on_activate` callback in activation options.
     topo_sort/1,
     extract_source_path/1,
     extract_class_names/1,
-    load_app_from_ebin/1
+    load_app_from_ebin/1,
+    safe_module_exports/1
 ]).
 
 %% Exported for callers that need validation (e.g. workspace_bootstrap backwards compat).
@@ -685,4 +686,62 @@ extract_class_info_from_beam(EbinDir, ModuleName) ->
             end;
         _ ->
             error
+    end.
+
+-doc """
+Read a module's exports without depending on `Module:module_info/1`
+(BT-3242, BT-3251).
+
+Beamtalk's Core Erlang codegen compiles straight to Core Erlang and feeds it
+to `compile:forms(..., [from_core | Opts])` (CLAUDE.md), which never runs the
+abstract-form `sys_pre_expand` compiler pass that auto-injects
+`module_info/0,1`. So every Beamtalk-compiled (`bt@...`) module lacks
+`module_info/1`, and `Module:module_info(exports)` always raises `undef` for
+one.
+
+Tries `erlang:get_module_info/2` first — a BIF that reads the VM's
+already-loaded code table directly, independent of whether the module itself
+exports `module_info/1`. This is the primary path (not merely a fast path)
+because it is the only one of the two that works for a module loaded via
+`code:load_binary/3` with a `Filename` that isn't a real path on the code
+path — e.g. every REPL/System-Browser-defined class (`beamtalk_repl_loader`
+loads each edited class straight from its compiled `Binary`, never writing
+it to disk first) — and because it reads the binary actually resident in the
+VM rather than whatever currently sits at that path on disk, so a hot-reloaded
+class can't return stale exports the way a disk re-read could.
+
+Falls back to `code:get_object_code/1` + `beam_lib:chunks/2` — reading the
+compiled Exports chunk straight from a `.beam` file on the code path — only
+when the module isn't loaded yet (`get_module_info/2` raises `badarg` for
+that case), the same pattern `extract_class_info_from_loaded/1` above uses to
+read the `beamtalk_class` attribute without forcing a load. Returns `[]` when
+neither path resolves the module (not loaded and not on the code path,
+or the Exports chunk can't be read), so callers get an honest "no exports
+found" rather than a crash.
+
+Shared by `beamtalk_repl_ops_browse` (native-delegate callers, BT-3242) and
+`beamtalk_test_case` (BIF-fallback test/lifecycle-method discovery, BT-3251)
+so the read-exports-safely rule has one implementation instead of two copies
+that could drift.
+""".
+-spec safe_module_exports(module()) -> [{atom(), arity()}].
+safe_module_exports(Module) ->
+    try erlang:get_module_info(Module, exports) of
+        Exports -> Exports
+    catch
+        error:badarg -> safe_module_exports_from_object_code(Module)
+    end.
+
+%% @private Fallback for a module that is on the code path but not (yet)
+%% loaded — `erlang:get_module_info/2` only reads already-loaded code.
+-spec safe_module_exports_from_object_code(module()) -> [{atom(), arity()}].
+safe_module_exports_from_object_code(Module) ->
+    case code:get_object_code(Module) of
+        {Module, Beam, _Filename} ->
+            case beam_lib:chunks(Beam, [exports]) of
+                {ok, {Module, [{exports, Exports}]}} -> Exports;
+                _ -> []
+            end;
+        _ ->
+            []
     end.

--- a/runtime/apps/beamtalk_runtime/test_fixtures/README.md
+++ b/runtime/apps/beamtalk_runtime/test_fixtures/README.md
@@ -20,6 +20,7 @@ runtime/apps/beamtalk_runtime/test_fixtures/
 ├── spawner_actor.bt     # Actor-spawns-actor from a compiled method (BT-3093)
 ├── shadow_actor.bt      # Param name shadows an instance var (BT-3093)
 ├── coordinate_actor.bt  # Multiple instance vars, one keyword message (BT-3093)
+├── bif_fallback_test_case.bt  # Real TestCase subclass for the BIF-fallback path (BT-3251)
 └── README.md           # This file
 ```
 
@@ -117,6 +118,38 @@ precedent:
 `counter_module_state/1` doc comment explain what stayed simulated and why
 (the async future-cast protocol tested there has no compiled `.bt` source
 construct that reaches it).
+
+### bif_fallback_test_case.bt (BT-3251)
+
+**Source:** `runtime/apps/beamtalk_runtime/test_fixtures/bif_fallback_test_case.bt`
+**Purpose:** A real, compiled `TestCase` subclass for `beamtalk_test_case`'s
+"BIF fallback" path (`run_all/1`, `run_single/2`, `run_all_structured/1`) —
+the code path used when a test class is run outside a gen_server
+`handle_call` (i.e. NOT via `execute_tests/5`'s `FlatMethods` map). That path
+used to call `Module:module_info(exports)` directly, which always raises
+`undef` on a genuinely Beamtalk-compiled (`bt@...`) module (CLAUDE.md: Core
+Erlang codegen goes through `compile:forms(..., [from_core | Opts])`, which
+never runs the `sys_pre_expand` pass that injects `module_info/0,1`).
+Hand-written `.erl` stubs like `runtime/apps/beamtalk_stdlib/test/bt@tc_stub.erl`
+get `module_info` auto-injected by the ordinary `erlc` pipeline, so they
+can't reproduce the bug — this fixture can.
+
+Has `setUp`/`tearDown` and `setUpOnce`/`tearDownOnce` so the regression test
+(`runtime/apps/beamtalk_stdlib/test/beamtalk_test_case_stdlib_tests.erl`)
+exercises `discover_test_methods_from_module/1`,
+`check_lifecycle_methods/2`, and `check_suite_lifecycle_methods/2` — all
+three BT-3251 call sites — not just method discovery. `setUp`/`setUpOnce`
+set observable state (a field, a suite fixture map) rather than returning
+`nil`, so both test methods assert on it — a `nil`-returning `setUp` is
+rejected by `is_valid_setUp_result/2` and falls back to the pre-setUp
+instance either way, so it wouldn't prove `check_lifecycle_methods/2` (vs.
+`check_suite_lifecycle_methods/2`) actually ran on this path.
+
+**Note:** unlike the other fixtures here (consumed only by
+`beamtalk_codegen_simulation_tests.erl` in `beamtalk_runtime`'s own EUnit
+scope), this fixture's `.beam` is copied into `beamtalk_stdlib`'s test build
+dir instead, since that's the app `beamtalk_test_case` and its regression
+test both live in. See `copy_to_build_dirs/4` in `compile_fixtures.escript`.
 
 ## References
 

--- a/runtime/apps/beamtalk_runtime/test_fixtures/bif_fallback_test_case.bt
+++ b/runtime/apps/beamtalk_runtime/test_fixtures/bif_fallback_test_case.bt
@@ -1,0 +1,35 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-3251: a real TestCase subclass compiled through the actual Beamtalk
+// pipeline (Core Erlang → `compile:forms(..., [from_core | Opts])`, no
+// `module_info/1`) — used to exercise `beamtalk_test_case`'s "BIF fallback"
+// path (`run_all/1`, `run_single/2`, `run_all_structured/1`) against a
+// genuinely compiled module. A hand-written `.erl` test double (like
+// `bt@tc_stub.erl`) gets `module_info` auto-injected by the ordinary erlc
+// pipeline and can't reproduce the bug this fixture was added to catch.
+//
+// setUp and setUpOnce actually set observable state (rather than returning
+// nil) so the regression test can tell `check_lifecycle_methods/2` and
+// `check_suite_lifecycle_methods/2` genuinely ran them on the BIF fallback
+// path, not merely that discovering them didn't crash — a nil-returning
+// setUp is `is_valid_setUp_result/2`-rejected and falls back to the
+// pre-setUp instance either way, so it wouldn't tell the two cases apart.
+TestCase subclass: BifFallbackTestCase
+  field: setUpRan = false
+
+  setUp => self withSetUpRan: true
+
+  tearDown => nil
+
+  setUpOnce => #{#suite => "fixture"}
+
+  tearDownOnce => nil
+
+  testPasses =>
+    self assert: self.setUpRan equals: true
+    self assert: (self suiteFixture at: #suite) equals: "fixture"
+
+  testFails =>
+    self assert: self.setUpRan equals: true
+    self assert: 1 equals: 2

--- a/runtime/apps/beamtalk_runtime/test_fixtures/compile_fixtures.escript
+++ b/runtime/apps/beamtalk_runtime/test_fixtures/compile_fixtures.escript
@@ -91,11 +91,64 @@ main([]) ->
         LocalFixtures
     ),
 
+    %% BT-3251: fixtures needed by beamtalk_stdlib's EUnit scope (a real
+    %% compiled TestCase subclass for beamtalk_test_case's BIF-fallback-path
+    %% regression test), in addition to beamtalk_runtime's. Kept as a
+    %% separate list/app-target pair rather than widening every existing
+    %% LocalFixtures entry's destination, since those are beamtalk_runtime-only.
+    StdlibFixtures = [
+        %% BT-3251 - BIF-fallback (run_all/1 etc.) regression fixture
+        "bif_fallback_test_case"
+    ],
+    lists:foreach(
+        fun(Basename) ->
+            build_local_fixture(
+                Beamtalk, FixturesDir, FixtureBuildDir, RepoRoot, Basename, [
+                    {"test", "beamtalk_stdlib", "ebin"}
+                ]
+            )
+        end,
+        StdlibFixtures
+    ),
+
     ok.
 
 %% @private Compile a `<Basename>.bt` fixture from FixturesDir and copy the
-%% resulting `bt@<Basename>.beam` into every rebar3 test build directory.
+%% resulting `bt@<Basename>.beam` into every rebar3 test build directory for
+%% `beamtalk_runtime`'s `test` dir (the default consumer of this fixtures
+%% directory).
 build_local_fixture(Beamtalk, FixturesDir, FixtureBuildDir, RepoRoot, Basename) ->
+    build_local_fixture(Beamtalk, FixturesDir, FixtureBuildDir, RepoRoot, Basename, [
+        {"*", "beamtalk_runtime", "test"}
+    ]).
+
+%% @private Compile a `<Basename>.bt` fixture from FixturesDir and copy the
+%% resulting `bt@<Basename>.beam` into every rebar3 build directory of each
+%% `{Profile, App, SubDir}` in `Targets` (BT-3251: a fixture consumed by more
+%% than one app's EUnit scope, e.g. beamtalk_stdlib, needs its `.beam` on
+%% that app's code path too).
+%%
+%% SubDir matters: `rebar3 eunit --dir=apps/<App>/test` treats every `.beam`
+%% file already sitting in that app's `test` build dir as a candidate test
+%% suite and probes it for `_test`/`_test_`-suffixed exports — which, for a
+%% genuinely Beamtalk-compiled module, means calling something equivalent to
+%% `Module:module_info(exports)` and hitting the very `undef` this fixture
+%% exists to reproduce, this time inside EUnit's own discovery instead of
+%% the code under test (observed as an EUnit-level `{abort,
+%% {module_not_found, Mod}}` and cascading `cancelled` tests). `ebin` (the
+%% app's normal, non-test compiled code) is also on the VM code path during
+%% `eunit --dir=...` — so `resolve_module/1`'s `code:get_object_code/1` /
+%% `code:ensure_loaded/1` still finds it there — without being inside the
+%% directory EUnit scans for test suites.
+%%
+%% Profile matters too: an `ebin`-targeted fixture must be pinned to the
+%% `test` rebar3 profile, not the `*` wildcard `beamtalk_runtime`'s `test`-dir
+%% fixtures use. `_build/default/lib/<App>/ebin` is exactly what `just
+%% install` copies into the install prefix wholesale, and `*` would also
+%% match it whenever a prior `rebar3 compile`/`build-erlang` run (independent
+%% of this eunit-only pre-hook) already created that directory — silently
+%% shipping an EUnit fixture class into a production install.
+build_local_fixture(Beamtalk, FixturesDir, FixtureBuildDir, RepoRoot, Basename, Targets) ->
     ModuleFile = "bt@" ++ Basename ++ ".beam",
     Src = filename:join([FixturesDir, Basename ++ ".bt"]),
     Beam = filename:join(FixtureBuildDir, ModuleFile),
@@ -111,7 +164,12 @@ build_local_fixture(Beamtalk, FixturesDir, FixtureBuildDir, RepoRoot, Basename) 
                       "  Source:   ~s~n", [Basename, Beam, Beamtalk, Src]),
             halt(1)
     end,
-    copy_to_build_dirs(RepoRoot, Beam, ModuleFile).
+    lists:foreach(
+        fun({Profile, App, SubDir}) ->
+            copy_to_build_dirs(RepoRoot, Beam, ModuleFile, Profile, App, SubDir)
+        end,
+        Targets
+    ).
 
 %% @private Run beamtalk build on a source file.
 %% Uses open_port/spawn_executable to avoid cmd.exe quoting issues on Windows.
@@ -150,19 +208,44 @@ delete_if_exists(Path) ->
         false -> ok
     end.
 
-%% @private Copy a beam file to all rebar3 test build directories.
+%% @private Copy a beam file to all of `beamtalk_runtime`'s rebar3 test build
+%% directories, across every profile (the default consumer of this fixtures
+%% directory).
 copy_to_build_dirs(RepoRoot, SrcFile, FileName) ->
-    Pattern = filename:join([RepoRoot, "runtime", "_build", "*", "lib", "beamtalk_runtime", "test"]),
-    Dirs = filelib:wildcard(Pattern),
-    lists:foreach(fun(Dir) ->
-        Dest = filename:join(Dir, FileName),
-        case file:copy(SrcFile, Dest) of
-            {ok, _BytesCopied} ->
-                ok;
-            {error, Reason} ->
-                io:format(standard_error,
-                          "Failed to copy ~s to ~s: ~p~n",
-                          [SrcFile, Dest, Reason]),
-                halt(1)
-        end
-    end, Dirs).
+    copy_to_build_dirs(RepoRoot, SrcFile, FileName, "*", "beamtalk_runtime", "test").
+
+%% @private Copy a beam file to `App`'s rebar3 `SubDir` build directory under
+%% `Profile` (a literal rebar3 profile name like `"test"`, or `"*"` to match
+%% every profile directory present) (BT-3251: a fixture may be consumed by
+%% more than one app's EUnit scope, and may need to land in `ebin` rather
+%% than `test`, pinned to the `test` profile only — see
+%% `build_local_fixture/6`'s doc for why).
+%%
+%% Fails loudly (rather than silently copying nowhere) when the wildcard
+%% matches no directories — e.g. a mistyped `SubDir`/`App`, or `Profile`
+%% pinned to `"test"` before `rebar3 eunit` has ever created that profile's
+%% `_build` tree — since a fixture that never lands anywhere degrades to
+%% the exact same symptom the bug it exists to catch produces ("No test
+%% methods found in ..."), silently passing instead of failing the build.
+copy_to_build_dirs(RepoRoot, SrcFile, FileName, Profile, App, SubDir) ->
+    Pattern = filename:join([RepoRoot, "runtime", "_build", Profile, "lib", App, SubDir]),
+    case filelib:wildcard(Pattern) of
+        [] ->
+            io:format(standard_error,
+                      "No build directories matched ~s — nowhere to copy ~s~n",
+                      [Pattern, FileName]),
+            halt(1);
+        Dirs ->
+            lists:foreach(fun(Dir) ->
+                Dest = filename:join(Dir, FileName),
+                case file:copy(SrcFile, Dest) of
+                    {ok, _BytesCopied} ->
+                        ok;
+                    {error, Reason} ->
+                        io:format(standard_error,
+                                  "Failed to copy ~s to ~s: ~p~n",
+                                  [SrcFile, Dest, Reason]),
+                        halt(1)
+                end
+            end, Dirs)
+    end.

--- a/runtime/apps/beamtalk_stdlib/src/beamtalk_test_case.erl
+++ b/runtime/apps/beamtalk_stdlib/src/beamtalk_test_case.erl
@@ -686,10 +686,22 @@ discover_test_methods(FlatMethods) ->
     ),
     lists:sort(TestMethods).
 
--doc "Discover test methods from module exports (BIF fallback path).".
+-doc """
+Discover test methods from module exports (BIF fallback path).
+
+BT-3251: uses `beamtalk_module_activation:safe_module_exports/1` rather than
+`Module:module_info(exports)`. `Module` here is a real Beamtalk-compiled
+`bt@`-prefixed test class, and Beamtalk's Core Erlang codegen compiles
+straight to Core Erlang via `compile:forms(..., [from_core | Opts])`
+(CLAUDE.md), which never runs the abstract-form `sys_pre_expand` compiler
+pass that auto-injects `module_info/0,1` — so a compiled test module never
+has `module_info/1`, and calling it here raised an uncaught `undef` for every
+real test class run through the BIF-fallback path (`run_all/1`,
+`run_single/2`, `run_all_structured/1`).
+""".
 -spec discover_test_methods_from_module(atom()) -> [atom()].
 discover_test_methods_from_module(Module) ->
-    Exports = Module:module_info(exports),
+    Exports = beamtalk_module_activation:safe_module_exports(Module),
     TestMethods = lists:filtermap(
         fun({FunName, _Arity}) ->
             case atom_to_list(FunName) of
@@ -743,7 +755,7 @@ resolve_module(ClassName) ->
 Run a single test method with setUp/tearDown lifecycle (BT-440).
 
 FlatMethods is either a map (from gen_server state) or 'none' (BIF fallback).
-When 'none', uses module_info(exports) to check for setUp/tearDown.
+When 'none', uses safe_module_exports/1 (BT-3251) to check for setUp/tearDown.
 Creates fresh instance, runs lifecycle, returns pass/fail.
 tearDown always runs, even if the test fails.
 """.
@@ -855,12 +867,19 @@ run_test_method(_ClassName, Module, MethodName, FlatMethods, SuiteFixture) ->
             {fail, MethodName, SetupMsg}
     end.
 
--doc "Check for setUp/tearDown methods, using FlatMethods map or module exports.".
+-doc """
+Check for setUp/tearDown methods, using FlatMethods map or module exports.
+
+BT-3251: the `none` clause reads exports via
+`beamtalk_module_activation:safe_module_exports/1`, not
+`Module:module_info(exports)` — see `discover_test_methods_from_module/1`
+for why the BIF-fallback path can never rely on `module_info/1`.
+""".
 -spec check_lifecycle_methods(atom(), map() | none) -> {boolean(), boolean()}.
 check_lifecycle_methods(_Module, FlatMethods) when is_map(FlatMethods) ->
     {maps:is_key(setUp, FlatMethods), maps:is_key(tearDown, FlatMethods)};
 check_lifecycle_methods(Module, none) ->
-    Exports = Module:module_info(exports),
+    Exports = beamtalk_module_activation:safe_module_exports(Module),
     {lists:keymember(setUp, 1, Exports), lists:keymember(tearDown, 1, Exports)}.
 
 -doc """
@@ -943,12 +962,19 @@ run_suite_lifecycle(_ClassName, Module, FlatMethods, TestMethods, TestFun) ->
             end
     end.
 
--doc "Check for setUpOnce/tearDownOnce methods (BT-1549).".
+-doc """
+Check for setUpOnce/tearDownOnce methods (BT-1549).
+
+BT-3251: the `none` clause reads exports via
+`beamtalk_module_activation:safe_module_exports/1`, not
+`Module:module_info(exports)` — see `discover_test_methods_from_module/1`
+for why the BIF-fallback path can never rely on `module_info/1`.
+""".
 -spec check_suite_lifecycle_methods(atom(), map() | none) -> {boolean(), boolean()}.
 check_suite_lifecycle_methods(_Module, FlatMethods) when is_map(FlatMethods) ->
     {maps:is_key(setUpOnce, FlatMethods), maps:is_key(tearDownOnce, FlatMethods)};
 check_suite_lifecycle_methods(Module, none) ->
-    Exports = Module:module_info(exports),
+    Exports = beamtalk_module_activation:safe_module_exports(Module),
     {lists:keymember(setUpOnce, 1, Exports), lists:keymember(tearDownOnce, 1, Exports)}.
 
 -doc "Run tearDownOnce, swallowing errors to avoid masking test results (BT-1549).".

--- a/runtime/apps/beamtalk_stdlib/test/beamtalk_test_case_stdlib_tests.erl
+++ b/runtime/apps/beamtalk_stdlib/test/beamtalk_test_case_stdlib_tests.erl
@@ -454,6 +454,82 @@ run_single_structured_fail_test() ->
     ?assertEqual(1, maps:get(failed, Result)).
 
 %%% ============================================================================
+%%% BT-3251 regression: BIF-fallback path against a REAL Beamtalk-compiled
+%%% TestCase subclass — 'bt@bif_fallback_test_case', compiled by
+%%% compile_fixtures.escript from
+%%% runtime/apps/beamtalk_runtime/test_fixtures/bif_fallback_test_case.bt —
+%%% NOT a hand-written .erl stub like bt@tc_stub.erl above.
+%%%
+%%% A hand-written .erl module gets module_info/0,1 auto-injected by the
+%%% ordinary erlc pipeline, so the run_all_with_tests_test() etc. tests above
+%%% never exercised the actual bug: Beamtalk's Core Erlang codegen compiles
+%%% straight to Core Erlang via compile:forms(..., [from_core | Opts])
+%%% (CLAUDE.md), which never runs the sys_pre_expand pass that injects
+%%% module_info/0,1 — so a genuinely compiled bt@ module has no
+%%% module_info/1, and Module:module_info(exports) raised an uncaught undef
+%%% for one. discover_test_methods_from_module/1, check_lifecycle_methods/2,
+%%% and check_suite_lifecycle_methods/2 now go through
+%%% beamtalk_module_activation:safe_module_exports/1 instead, which reads
+%%% the compiled Exports chunk directly and never depends on module_info/1.
+%%%
+%%% BifFallbackTestCase's testPasses/testFails inherit assert:equals: from
+%%% the real TestCase.bt hierarchy, so the class registry must actually be
+%%% booted first — boot_real_stdlib/1 (shared with beamtalk_workspace's
+%%% integration tests, see beamtalk_test_support:beamtalk_test_boot) starts
+%%% beamtalk_runtime and runs beamtalk_stdlib:init/0 before the assertions
+%%% run, the same way a hand-written stub (which needs none of that
+%%% machinery) never had to.
+%%%
+%%% The canary passed to boot_real_stdlib/1 is 'TestCase' itself, NOT
+%%% 'BifFallbackTestCase': the fixture is loaded ad hoc via
+%%% resolve_module/1's own code:ensure_loaded/1 (mirroring how a real BIF
+%%% fallback caller would reach an arbitrary compiled test class), not
+%%% through beamtalk_stdlib:init/0's activation walk — so it never gets a
+%%% live class gen_server process of its own and
+%%% beamtalk_class_registry:whereis_class/1 would never resolve it.
+%%% Waiting on 'TestCase' instead confirms the real ancestor chain
+%%% (TestCase -> Value -> Object -> ProtoObject) that assert:equals: needs
+%%% is loaded and registered before dispatching into the fixture.
+%%% ============================================================================
+
+bif_fallback_setup() ->
+    beamtalk_test_boot:boot_real_stdlib('TestCase').
+
+bif_fallback_bif_path_test_() ->
+    {setup, fun bif_fallback_setup/0, fun(_) -> ok end, [
+        {"run_all/1 discovers + runs both test methods without crashing", fun() ->
+            %% resolve_module('BifFallbackTestCase') -> 'bt@bif_fallback_test_case';
+            %% discover_test_methods_from_module/1 finds testPasses + testFails via
+            %% safe_module_exports/1. Pre-fix, this raised an uncaught `undef`.
+            Result = beamtalk_test_case:run_all('BifFallbackTestCase'),
+            ?assert(is_binary(Result)),
+            ?assertNotEqual(nomatch, binary:match(Result, <<"2 tests, 1 passed, 1 failed">>))
+        end},
+        {"run_single/2 passes a genuinely passing test", fun() ->
+            Result = beamtalk_test_case:run_single('BifFallbackTestCase', testPasses),
+            ?assert(is_binary(Result)),
+            ?assertNotEqual(nomatch, binary:match(Result, <<"1 tests, 1 passed">>))
+        end},
+        {"run_single/2 fails a genuinely failing test", fun() ->
+            Result = beamtalk_test_case:run_single('BifFallbackTestCase', testFails),
+            ?assert(is_binary(Result)),
+            ?assertNotEqual(nomatch, binary:match(Result, <<"1 tests, 0 passed, 1 failed">>))
+        end},
+        {"run_all_structured/1 reports the same pass/fail split", fun() ->
+            %% Exercises check_lifecycle_methods/2 and
+            %% check_suite_lifecycle_methods/2 too (the fixture has
+            %% setUp/tearDown and setUpOnce/tearDownOnce), not just
+            %% discover_test_methods_from_module/1.
+            Result = beamtalk_test_case:run_all_structured('BifFallbackTestCase'),
+            ?assert(is_map(Result)),
+            ?assertEqual('BifFallbackTestCase', maps:get(class, Result)),
+            ?assertEqual(2, maps:get(total, Result)),
+            ?assertEqual(1, maps:get(passed, Result)),
+            ?assertEqual(1, maps:get(failed, Result))
+        end}
+    ]}.
+
+%%% ============================================================================
 %%% extract_error_kind/1 clauses via should_raise/2
 %%%
 %%% extract_error_kind/1 is private but reachable via the public should_raise/2

--- a/runtime/apps/beamtalk_test_support/src/beamtalk_test_boot.erl
+++ b/runtime/apps/beamtalk_test_support/src/beamtalk_test_boot.erl
@@ -1,16 +1,25 @@
 %% Copyright 2026 James Casey
 %% SPDX-License-Identifier: Apache-2.0
 
--module(beamtalk_workspace_test_boot).
+-module(beamtalk_test_boot).
 
-%%% **DDD Context:** REPL Session Context (test support)
+%%% **DDD Context:** Runtime Context (test support)
 
 -moduledoc """
-Shared EUnit fixture: boot the real runtime + stdlib for `beamtalk_workspace`
-integration tests that need a genuinely compiled class (not a hand-written
-`.erl` test double) — e.g. `beamtalk_repl_docs_tests`'s doc-formatting
-integration tests and `beamtalk_repl_ops_browse_tests`'s BT-3242 native-class
-delegate-callers regression test.
+Shared EUnit fixture: boot the real runtime + stdlib for EUnit suites that
+need a genuinely compiled class (not a hand-written `.erl` test double) —
+e.g. `beamtalk_workspace`'s `beamtalk_repl_docs_tests` (doc-formatting
+integration tests) and `beamtalk_repl_ops_browse_tests` (BT-3242 native-class
+delegate-callers regression test), and `beamtalk_stdlib`'s
+`beamtalk_test_case_stdlib_tests` (BT-3251 BIF-fallback-path regression
+test against a real compiled `TestCase` subclass).
+
+BT-3251: originally `beamtalk_workspace_test_boot`, living under
+`beamtalk_workspace/test/` — moved here (mirroring `beamtalk_test_corpus`'s
+precedent, see its `moduledoc` for the "why a standalone app" rationale) once
+`beamtalk_stdlib`'s EUnit suite needed the same boot sequence too. Reaching
+into a peer/dependent app's `test/` tree from another app's suite would
+recreate the duplication `beamtalk_test_support` exists to avoid.
 
 Guarded so it is safe to call from more than one test module in the same
 EUnit VM: `beamtalk_bootstrap:start_link/0` is only invoked when no bootstrap

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_ops_browse.erl
@@ -1323,7 +1323,7 @@ meta_is_native(Meta) ->
 %% selectors are never delegated this way, so they are always `false`.
 -spec is_native_delegate(atom(), boolean(), atom()) -> boolean().
 is_native_delegate(ModName, false, Selector) when is_atom(ModName) ->
-    delegate_exported(safe_module_exports(ModName), Selector);
+    delegate_exported(beamtalk_module_activation:safe_module_exports(ModName), Selector);
 is_native_delegate(_ModName, _ClassSide, _Selector) ->
     false.
 
@@ -1401,7 +1401,7 @@ delegate_rows_for_class_name(ClassName, Module) ->
                 ModName = beamtalk_runtime_api:module_name(Pid),
                 case beamtalk_class_registry:meta_backing_module(native_meta_of(ModName)) of
                     Module ->
-                        Exports = safe_module_exports(ModName),
+                        Exports = beamtalk_module_activation:safe_module_exports(ModName),
                         [delegate_row(ClassName, Sel) || Sel <- self_delegate_selectors(Exports)];
                     _ ->
                         []
@@ -1409,37 +1409,6 @@ delegate_rows_for_class_name(ClassName, Module) ->
         end
     catch
         _:_ -> []
-    end.
-
-%% BT-3242: `ModName:module_info(exports)` is unreliable for a
-%% Beamtalk-compiled module. Beamtalk's Core Erlang codegen compiles straight
-%% to Core Erlang and feeds it to `compile:forms(..., [from_core | Opts])`
-%% (CLAUDE.md), which never runs the abstract-form `sys_pre_expand` compiler
-%% pass that auto-injects `module_info/0,1` — so every Beamtalk-compiled
-%% (`bt@...`) module lacks `module_info/1`, and `ModName:module_info(exports)`
-%% always raised `undef` for one, which this function's old `try/catch`
-%% silently swallowed to `[]`. That made `delegate_callers_of_native_module/1`
-%% return `[]` for every real native-backed class (the bug this fixes), and
-%% `is_native_delegate/3` (the other native-delegate check site) shared the
-%% same blind spot via its own copy of the same catch — now routed through
-%% here instead of duplicating it.
-%%
-%% `beam_lib:chunks/2` reads the compiled Exports chunk straight from the
-%% object code, independent of whether the module exports `module_info` at
-%% all — the same `code:get_object_code/1` + `beam_lib:chunks/2` pattern
-%% `beamtalk_module_activation:extract_class_info_from_loaded/1` already uses
-%% to read a module's `beamtalk_class` attribute without forcing a
-%% `module_info` call.
--spec safe_module_exports(atom()) -> [{atom(), arity()}].
-safe_module_exports(ModName) ->
-    case code:get_object_code(ModName) of
-        {ModName, Beam, _Filename} ->
-            case beam_lib:chunks(Beam, [exports]) of
-                {ok, {ModName, [{exports, Exports}]}} -> Exports;
-                _ -> []
-            end;
-        _ ->
-            []
     end.
 
 %% The `self delegate` instance selectors a facade exposes, recovered from its

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_docs_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_docs_tests.erl
@@ -573,12 +573,14 @@ format_method_doc_metaclass_unknown_test() ->
 %% Integration tests (require running runtime with bootstrap)
 %%====================================================================
 
-%% Boots the real runtime + stdlib via the shared `beamtalk_workspace_test_boot`
+%% Boots the real runtime + stdlib via the shared `beamtalk_test_boot`
 %% fixture (BT-3242: extracted so `beamtalk_repl_ops_browse_tests`'s real-stdlib
 %% delegate-callers regression test doesn't carry a second copy of this same
-%% boot/wait sequence), blocking until `Integer` is registered.
+%% boot/wait sequence; BT-3251: moved into `beamtalk_test_support` once
+%% `beamtalk_stdlib`'s EUnit suite needed the same boot sequence too),
+%% blocking until `Integer` is registered.
 integration_setup() ->
-    beamtalk_workspace_test_boot:boot_real_stdlib('Integer').
+    beamtalk_test_boot:boot_real_stdlib('Integer').
 
 format_class_docs_integer_test_() ->
     {setup, fun integration_setup/0, fun(_) -> ok end, [
@@ -750,7 +752,7 @@ format_class_docs_class_side_test_() ->
 value_synthetic_accessor_docs_test_() ->
     {setup, fun integration_setup/0, fun(_) -> ok end, [
         {"ChangeEntry withSeq: CompiledMethod carries synthetic __doc__/__signature__", fun() ->
-            beamtalk_workspace_test_boot:wait_for_class('ChangeEntry', 50),
+            beamtalk_test_boot:wait_for_class('ChangeEntry', 50),
             ClassPid = beamtalk_class_registry:whereis_class('ChangeEntry'),
             ?assert(is_pid(ClassPid)),
             Method = gen_server:call(ClassPid, {method, 'withSeq:'}, 5000),
@@ -765,7 +767,7 @@ value_synthetic_accessor_docs_test_() ->
             )
         end},
         {"format_method_doc surfaces the synthetic doc + signature for withSeq:", fun() ->
-            beamtalk_workspace_test_boot:wait_for_class('ChangeEntry', 50),
+            beamtalk_test_boot:wait_for_class('ChangeEntry', 50),
             {ok, Result} = beamtalk_repl_docs:format_method_doc(
                 'ChangeEntry', <<"withSeq:">>
             ),
@@ -778,7 +780,7 @@ value_synthetic_accessor_docs_test_() ->
             )
         end},
         {"auto getter (clean) carries a synthetic signature from its slot type", fun() ->
-            beamtalk_workspace_test_boot:wait_for_class('ChangeEntry', 50),
+            beamtalk_test_boot:wait_for_class('ChangeEntry', 50),
             ClassPid = beamtalk_class_registry:whereis_class('ChangeEntry'),
             Method = gen_server:call(ClassPid, {method, clean}, 5000),
             ?assert(is_map(Method)),

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_browse_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_repl_ops_browse_tests.erl
@@ -351,11 +351,13 @@ real_stdlib_delegate_callers_test_() ->
 
 %% Boot the real runtime + stdlib so `Subprocess`'s facade module is loaded from
 %% its real compiled BEAM — not a hand-written test double — and registered as a
-%% live class process. Delegates to the shared `beamtalk_workspace_test_boot`
-%% fixture (same helper `beamtalk_repl_docs_tests`'s integration tests use in this
-%% app's test suite) rather than a second copy of the boot/wait sequence.
+%% live class process. Delegates to the shared `beamtalk_test_boot` (in
+%% `beamtalk_test_support`) fixture (same helper `beamtalk_repl_docs_tests`'s
+%% integration tests use in this app's test suite, and BT-3251's
+%% `beamtalk_stdlib` regression test uses too) rather than a second copy of
+%% the boot/wait sequence.
 real_stdlib_setup() ->
-    beamtalk_workspace_test_boot:boot_real_stdlib('Subprocess').
+    beamtalk_test_boot:boot_real_stdlib('Subprocess').
 
 %%====================================================================
 %% browse-native-modules — enumeration + filter + source-path (BT-2648)

--- a/runtime/rebar.config.script
+++ b/runtime/rebar.config.script
@@ -10,17 +10,25 @@
 %% class was added.
 
 %% Scan the stdlib ebin directory for bt@* BEAM files.
+%%
+%% Two sources, always unioned (not "checked-in dir, else _build fallback"):
+%% `apps/beamtalk_stdlib/ebin` holds the real, `just build-stdlib`-generated
+%% production classes; `_build/*/lib/beamtalk_stdlib/ebin` also picks up
+%% EUnit-only `bt@*` fixtures that compile_fixtures.escript copies there for
+%% suites needing a genuinely Beamtalk-compiled module rather than a
+%% hand-written `.erl` test double (BT-3251) — those have the same "no
+%% abstract code" problem this exclusion exists for, but never land in the
+%% checked-in production ebin dir, so the old either/or logic silently
+%% skipped the `_build` scan whenever production classes already existed
+%% (the common case) and left them unexcluded.
 StdlibEbin = "apps/beamtalk_stdlib/ebin",
 BtModules =
-    case filelib:wildcard(filename:join(StdlibEbin, "bt@*.beam")) of
-        [] ->
-            %% Fallback: check _build directories (rebar3 copies beams there)
-            lists:usort(
-                [list_to_atom(filename:basename(F, ".beam"))
-                 || F <- filelib:wildcard("_build/*/lib/beamtalk_stdlib/ebin/bt@*.beam")]);
-        Files ->
-            [list_to_atom(filename:basename(F, ".beam")) || F <- lists:sort(Files)]
-    end,
+    lists:usort(
+        [list_to_atom(filename:basename(F, ".beam"))
+         || F <-
+             filelib:wildcard(filename:join(StdlibEbin, "bt@*.beam")) ++
+                 filelib:wildcard("_build/*/lib/beamtalk_stdlib/ebin/bt@*.beam")]
+    ),
 
 %% Helper: deep-merge a key into a proplist, preserving other keys.
 SetKey = fun(Key, Value, Proplist) ->


### PR DESCRIPTION
## Summary

Fixes [BT-3251](https://linear.app/beamtalk/issue/BT-3251): `beamtalk_test_case.erl`'s "BIF fallback" path (`run_all/1`, `run_single/2`, `run_all_structured/1` — used to run BUnit tests outside a gen_server `handle_call`, e.g. `MyTestClass runAll` from the REPL) called `Module:module_info(exports)` directly with no try/catch at three call sites. Beamtalk's Core Erlang codegen compiles straight to `compile:forms(..., [from_core | Opts])`, which never runs the `sys_pre_expand` pass that injects `module_info/0,1` — so every real `bt@`-compiled test class raised an uncaught `undef` through this path, worse than the sibling bug fixed in [BT-3242](https://linear.app/beamtalk/issue/BT-3242) (which at least caught the `undef` and degraded to `[]`).

## Changes

- Extracted `safe_module_exports/1` (previously private to `beamtalk_repl_ops_browse.erl`, BT-3242) into the shared `beamtalk_module_activation` module and routed all three BIF-fallback call sites (`discover_test_methods_from_module/1`, `check_lifecycle_methods/2`, `check_suite_lifecycle_methods/2`) through it, eliminating a would-be second copy.
  - The shared function now prefers `erlang:get_module_info/2` — a BIF that reads the VM's already-loaded code table directly, so it works for REPL/System-Browser-defined classes (loaded via `code:load_binary/3` with no real `.beam` on the code path) and never reads stale disk state — falling back to `code:get_object_code/1` + `beam_lib:chunks/2` only when the module isn't loaded yet.
- Added a real compiled `TestCase` subclass fixture (`bif_fallback_test_case.bt`, with `setUp`/`tearDown`/`setUpOnce`/`tearDownOnce` setting observable state, not no-ops) and wired `compile_fixtures.escript` to compile it into `beamtalk_stdlib`'s **test-profile `ebin`** dir specifically — not `beamtalk_runtime`'s `test` dir (which `rebar3 eunit --dir=...` scans as a candidate test-suite directory and would hit the same `undef` inside EUnit's own discovery) and not the `default` profile (which `just install` copies wholesale into the install prefix).
- Extended `rebar.config.script`'s `bt@*` dialyzer/cover exclusion scan to always union the checked-in stdlib `ebin` dir with `_build` fixtures, instead of only falling back to `_build` when the checked-in dir is empty — the old either/or logic silently left EUnit-only fixtures unexcluded whenever real stdlib classes already existed (the common case), and dialyzer hard-failed trying to analyze the from_core-compiled fixture.
- Moved the shared "boot real stdlib" EUnit fixture (`boot_real_stdlib/1`, `wait_for_class/2`) from `beamtalk_workspace/test/` into `beamtalk_test_support` — the pre-existing, dedicated cross-app EUnit-helpers app — since `beamtalk_stdlib`'s suite now needs it too, not just `beamtalk_workspace`'s.
- Added regression tests exercising `run_all/1`, `run_single/2` (pass + fail cases), and `run_all_structured/1` against the real compiled fixture; verified they fail with an uncaught `undef` against the pre-fix code and pass against the fix.

## Test plan

- [x] `just test` — Rust + stdlib + BUnit + runtime tests, all green (5855 + 1841 Erlang EUnit tests, 0 failures)
- [x] New regression tests verified to fail (uncaught `undef`) against the pre-fix code and pass against the fix
- [x] `just build && just clippy && just fmt-check` — all pass
- [x] `just dialyzer` — clean (confirms the fixture is properly excluded and not leaking into the `default` profile)
- [x] Verified from a fully clean `_build` (cold start) — no first-run breakage from the new fixture-copy safety checks
- [x] Pre-push hook (full lint suite) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)