### PR TITLE
Actors spawned via a class no longer link to the class gen_server (BT-3243)

### DIFF
--- a/runtime/apps/beamtalk_runtime/include/beamtalk.hrl
+++ b/runtime/apps/beamtalk_runtime/include/beamtalk.hrl
@@ -138,6 +138,27 @@
 %% that Rust test fails.
 -define(BT_CLASS_VARS_SHADOW_KEY_ATOM, '$bt_class_vars_shadow').
 
+%% @doc BT-3243 (supervisor-restart follow-up): process-dictionary key marking
+%% "this process is currently executing a `withClassMethod:` child's factory
+%% method on behalf of `beamtalk_supervisor:start_child_via_class_method/4`,
+%% running directly in the real OTP supervisor process (no process boundary
+%% in between — see that function's `put/2` of this key)".
+%%
+%% `beamtalk_actor:safe_spawn/2` and
+%% `beamtalk_class_instantiation:do_class_self_named_spawn/6` check this key
+%% to decide whether a `self spawn`/`self spawnWith:`/`self spawnAs:`/
+%% `self spawnWith:as:` inside the class method must stay LINKED (this key
+%% present — the link is the supervisor's restart mechanism) or must be
+%% unlinked (key absent — the more common case of a class method running
+%% inside the class's own gen_server, or a plain unsupervised spawn, where a
+%% link would incorrectly tie the new actor's lifetime to the caller; see
+%% BT-3243). Deliberately a *dedicated* key, not `beamtalk_class_name` /
+%% `beamtalk_class_module` (also set by `start_child_via_class_method/4`,
+%% but *also* set by every class gen_server's own `init/1` via
+%% `beamtalk_object_class.erl` — so their presence alone cannot distinguish
+%% "inside a real supervisor" from "inside a class's own gen_server").
+-define(BT_SUPERVISOR_SPAWN_CONTEXT_KEY, '$bt_supervisor_spawn_context').
+
 %% @doc BT-3022/BT-3199: is `T` an in-flight `^` non-local return signal?
 %%
 %% Codegen throws the state-carrying 4-tuple `{'$bt_nlr', Token, Value,

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
@@ -92,26 +92,40 @@ so it runs for ALL spawn paths — direct, supervised, and named.
 | Module:spawn/0,1 | gen_server:start → init/1 (unlinked, BT-3243) | Batch/tests | Yes |
 | REPL spawn | Module:spawn/0,1 + register_spawned/4 | REPL | Yes |
 | class_send → spawn | erlang:apply(Module, spawn, Args) | Runtime | Yes |
-| self spawnAs:/spawnWith:as: | safe_spawn_named/3, unlinked after (BT-3243) | Class method | Yes |
+| self spawn/spawnWith: | safe_spawn/2, unlinked (or linked if inside a `withClassMethod:` supervisor factory — BT-3243 follow-up) | Class method | Yes |
+| self spawnAs:/spawnWith:as: | safe_spawn_named/3, unlinked after (or stays linked, same exception) (BT-3243) | Class method | Yes |
 | withName: supervisor child | safe_spawn_named/3 → gen_server:start_link → init/1 | Supervised | Yes |
-| Supervisor child (unnamed) | start_link/1 → gen_server:start_link → init/1 | Supervised | Yes |
+| Supervisor child (unnamed, plain spawn/spawnWith:) | start_link/1 → gen_server:start_link → init/1 | Supervised | Yes |
+| withClassMethod: supervisor child | start_child_via_class_method/4 → factory's `self spawn`/`spawnWith:`/`spawnAs:`/`spawnWith:as:` → safe_spawn/2 or safe_spawn_named/3, linked | Supervised | Yes |
 | dynamic_object | gen_server:start_link(?MODULE, ...) | Internal | No (by design) |
 
 BT-3243: unnamed `Module:spawn/0,1` (via `beamtalk_actor:safe_spawn/2`)
-spawns unlinked — the caller (which can be a class gen_server for dynamic
-dispatch, or a class method body for `self spawn`) is never linked to the
-actor it creates, so killing the actor cannot take the caller down with it.
-`safe_spawn_named/3` (`spawnAs:`/`spawnWith:as:`) stays linked, because it
-doubles as the real OTP supervisor child MFA for `SupervisionSpec
-withName:` children (ADR 0079/BT-1990) — that link is the restart
-mechanism, not a bug. Its own `self`-send risk (a class method's `self
-spawnAs:` running inside the class gen_server) is fixed by unlinking right
-after the spawn succeeds — see
-`beamtalk_class_instantiation:do_class_self_named_spawn/6`. The unnamed
-`Supervisor child` path — real OTP supervision via
-`beamtalk_supervisor:start_child_via_class_method/4` calling
-`Module:start_link/1` directly — links to the supervisor, never to a class
-process, so it was never part of this bug.
+spawns unlinked in the common case — the caller (which can be a class
+gen_server for dynamic dispatch, or a class method body for `self spawn`)
+is never linked to the actor it creates, so killing the actor cannot take
+the caller down with it. `safe_spawn_named/3` (`spawnAs:`/`spawnWith:as:`)
+stays linked, because it doubles as the real OTP supervisor child MFA for
+`SupervisionSpec withName:` children (ADR 0079/BT-1990) — that link is the
+restart mechanism, not a bug. Its own `self`-send risk (a class method's
+`self spawnAs:` running inside the class gen_server) is fixed by unlinking
+right after the spawn succeeds — see
+`beamtalk_class_instantiation:do_class_self_named_spawn/6`. A plain
+(non-`withClassMethod:`) unnamed `Supervisor child` — real OTP supervision
+via `beamtalk_supervisor:spec_to_otp/1` calling `Module:start_link/1`
+directly — links to the supervisor without ever going through
+`safe_spawn/2`, so it was never part of this bug.
+
+BT-3243 supervisor-restart follow-up: `SupervisionSpec withClassMethod:`
+children (BT-1862) are the exception — their factory method runs directly
+inside the real supervisor process
+(`beamtalk_supervisor:start_child_via_class_method/4`), so a plain
+`self spawn`/`self spawnWith:`/`self spawnAs:`/`self spawnWith:as:` call
+inside that factory *does* need the link, or OTP restart silently breaks
+(the supervisor never sees the child exit). `start_child_via_class_method/4`
+marks that context in the process dictionary
+(`?BT_SUPERVISOR_SPAWN_CONTEXT_KEY`) so `safe_spawn/2` and
+`do_class_self_named_spawn/6` can tell it apart from the ordinary
+class-gen-server case and keep the link instead of severing it.
 
 Key invariant: `initialize` dispatch lives in generated `init/1`, not
 in `spawn/0,1`. This ensures supervised children also run initialize.
@@ -375,16 +389,16 @@ await_initialize(Pid) ->
     end.
 
 -doc """
-BT-1541 / BT-3243: Spawn an actor, unlinked, with initialize synchronization.
+BT-1541 / BT-3243: Spawn an actor, with initialize synchronization.
 
 Handles the full spawn sequence:
-1. Call gen_server:start (unlinked — see BT-3243 rationale below)
+1. Choose linked vs unlinked start (see BT-3243 rationale below)
 2. If start succeeds, wait for handle_continue (initialize) to complete
 3. Return {ok, Pid} or {error, Reason}
 
 BT-3243: Deliberately uses `gen_server:start/3` (unlinked), not
-`gen_server:start_link/3`. `spawn`/`spawnWith:` can run from inside a class
-gen_server's `{spawn, _}` handler (dynamic dispatch,
+`gen_server:start_link/3`, in the common case. `spawn`/`spawnWith:` can run
+from inside a class gen_server's `{spawn, _}` handler (dynamic dispatch,
 `beamtalk_class_instantiation:handle_spawn/4`) or a class method body
 executing in the class's own process (`self spawn` /
 `class_self_spawn/3,4`) — either way, this function's caller is whatever
@@ -397,21 +411,47 @@ when an actor dies (the REPL actor registry, `onExit:`, etc.) already uses
 `erlang:monitor/2`, never the link, so dropping the link changes nothing
 for those consumers.
 
-Unlike `safe_spawn_named/3` (see its doc), this arity is never used as a
-real OTP supervisor child start MFA — supervised unnamed workers start via
-`Module:start_link/1` directly (`beamtalk_supervisor:spec_to_otp/1`) — so
-there is no competing linked use case to preserve here.
+BT-3243 supervisor-restart follow-up: there IS a competing linked use case
+after all — `SupervisionSpec withClassMethod:` children (BT-1862). A
+`withClassMethod:` factory's body runs directly inside the real OTP
+supervisor process via `beamtalk_supervisor:start_child_via_class_method/4`
+→ `call_class_method_direct` → `erlang:apply/3` (no process boundary), so if
+the factory calls plain `self spawn`/`self spawnWith:`, this function's
+caller really is the supervisor — unlinking there would silently defeat OTP
+restart. `start_child_via_class_method/4` marks that context by setting
+`?BT_SUPERVISOR_SPAWN_CONTEXT_KEY` in the process dictionary before invoking
+the factory; since every hop in between is a plain synchronous call in the
+same process (no `spawn`/`erlang:apply` to a different process, no message
+send-and-receive), the key is still visible here. When it is set, this
+delegates to `safe_spawn_linked/2` instead, staying linked exactly like
+`safe_spawn_named/3` already does for the named-child case.
 
 This consolidates the await_initialize logic so generated spawn
 functions stay simple.
 """.
 -spec safe_spawn(module(), map()) -> {ok, pid()} | {error, term()}.
 safe_spawn(Module, InitArgs) ->
-    case gen_server:start(Module, InitArgs, []) of
-        {ok, Pid} -> await_initialize_or_kill_unlinked(Pid);
-        {error, Reason} -> {error, Reason};
-        ignore -> {error, ignore}
+    case get(?BT_SUPERVISOR_SPAWN_CONTEXT_KEY) of
+        true ->
+            safe_spawn_linked(Module, InitArgs);
+        _ ->
+            case gen_server:start(Module, InitArgs, []) of
+                {ok, Pid} -> await_initialize_or_kill_unlinked(Pid);
+                {error, Reason} -> {error, Reason};
+                ignore -> {error, ignore}
+            end
     end.
+
+-doc """
+BT-3243 supervisor-restart follow-up: spawn an actor **linked**, with
+trap_exit + initialize synchronization, for the one `safe_spawn/2` case that
+needs the link — a `withClassMethod:` supervisor child's factory calling
+plain `self spawn`/`self spawnWith:` (see `safe_spawn/2`'s doc). Shares the
+trap_exit dance with `safe_spawn_named/3` via `start_link_and_await/1`.
+""".
+-spec safe_spawn_linked(module(), map()) -> {ok, pid()} | {error, term()}.
+safe_spawn_linked(Module, InitArgs) ->
+    start_link_and_await(fun() -> gen_server:start_link(Module, InitArgs, []) end).
 
 -doc """
 BT-1987: Spawn a named actor with trap_exit + initialize synchronization.
@@ -422,11 +462,11 @@ Handles the full spawn sequence:
 3. If start_link succeeds, wait for handle_continue (initialize) to complete
 4. Restore trap_exit and return {ok, Pid} or {error, Reason}
 
-BT-3243: Unlike `safe_spawn/2` (unnamed), this stays **linked**
-(`gen_server:start_link/4`, with the original trap_exit dance) — it is the
-shared implementation behind both `spawnAs:`/`spawnWith:as:` *and* the real
-OTP supervisor child MFA that `beamtalk_supervisor:spec_to_otp/1` builds
-for `SupervisionSpec withName:` children (ADR 0079/BT-1990:
+BT-3243: Unlike `safe_spawn/2` (unnamed) in its common case, this stays
+**linked** (`gen_server:start_link/4`, with the original trap_exit dance) —
+it is the shared implementation behind both `spawnAs:`/`spawnWith:as:` *and*
+the real OTP supervisor child MFA that `beamtalk_supervisor:spec_to_otp/1`
+builds for `SupervisionSpec withName:` children (ADR 0079/BT-1990:
 `{beamtalk_actor, spawnAs, [Name, Module]}` / `[Name, Module, InitArgs]`
 literally names this function as the start callback). That link is not the
 BT-3243 bug — it is exactly the OTP contract a real supervisor relies on to
@@ -437,12 +477,28 @@ The BT-3243 risk this shares — a class method's `self spawnAs:` /
 `self spawnWith:as:` running inside the class gen_server and linking the
 new actor to it — is fixed at that specific call site instead: see
 `beamtalk_class_instantiation:do_class_self_named_spawn/6`, which unlinks
-immediately after a successful spawn.
+immediately after a successful spawn *unless* it detects the
+`withClassMethod:`-supervisor context via
+`?BT_SUPERVISOR_SPAWN_CONTEXT_KEY`, in which case it stays linked for the
+same reason `safe_spawn_linked/2` above does.
 """.
 -spec safe_spawn_named(atom(), module(), map()) -> {ok, pid()} | {error, term()}.
 safe_spawn_named(Name, Module, InitArgs) when is_atom(Name) ->
+    start_link_and_await(fun() -> gen_server:start_link({local, Name}, Module, InitArgs, []) end).
+
+-doc """
+Shared linked-start + trap_exit + await_initialize dance for
+`safe_spawn_named/3` and `safe_spawn_linked/2`. `StartFun` performs the
+actual `gen_server:start_link/3,4` call (parametrized so the two callers can
+each pass their own registration shape) and is invoked exactly once, with
+`trap_exit` already set, so a crash during `initialize` delivers an `'EXIT'`
+message here instead of taking this process down.
+""".
+-spec start_link_and_await(fun(() -> {ok, pid()} | {error, term()} | ignore)) ->
+    {ok, pid()} | {error, term()}.
+start_link_and_await(StartFun) ->
     OldTrap = erlang:process_flag(trap_exit, true),
-    Result = gen_server:start_link({local, Name}, Module, InitArgs, []),
+    Result = StartFun(),
     case Result of
         {ok, Pid} ->
             case await_initialize(Pid) of

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_actor.erl
@@ -89,11 +89,29 @@ so it runs for ALL spawn paths — direct, supervised, and named.
 
 | Path | Entry | Context | Initialize? |
 |------|-------|---------|-------------|
-| Module:spawn/0,1 | gen_server:start_link → init/1 | Batch/tests | Yes |
+| Module:spawn/0,1 | gen_server:start → init/1 (unlinked, BT-3243) | Batch/tests | Yes |
 | REPL spawn | Module:spawn/0,1 + register_spawned/4 | REPL | Yes |
 | class_send → spawn | erlang:apply(Module, spawn, Args) | Runtime | Yes |
-| Supervisor child | start_link/1 → gen_server:start_link → init/1 | Supervised | Yes |
+| self spawnAs:/spawnWith:as: | safe_spawn_named/3, unlinked after (BT-3243) | Class method | Yes |
+| withName: supervisor child | safe_spawn_named/3 → gen_server:start_link → init/1 | Supervised | Yes |
+| Supervisor child (unnamed) | start_link/1 → gen_server:start_link → init/1 | Supervised | Yes |
 | dynamic_object | gen_server:start_link(?MODULE, ...) | Internal | No (by design) |
+
+BT-3243: unnamed `Module:spawn/0,1` (via `beamtalk_actor:safe_spawn/2`)
+spawns unlinked — the caller (which can be a class gen_server for dynamic
+dispatch, or a class method body for `self spawn`) is never linked to the
+actor it creates, so killing the actor cannot take the caller down with it.
+`safe_spawn_named/3` (`spawnAs:`/`spawnWith:as:`) stays linked, because it
+doubles as the real OTP supervisor child MFA for `SupervisionSpec
+withName:` children (ADR 0079/BT-1990) — that link is the restart
+mechanism, not a bug. Its own `self`-send risk (a class method's `self
+spawnAs:` running inside the class gen_server) is fixed by unlinking right
+after the spawn succeeds — see
+`beamtalk_class_instantiation:do_class_self_named_spawn/6`. The unnamed
+`Supervisor child` path — real OTP supervision via
+`beamtalk_supervisor:start_child_via_class_method/4` calling
+`Module:start_link/1` directly — links to the supervisor, never to a class
+process, so it was never part of this bug.
 
 Key invariant: `initialize` dispatch lives in generated `init/1`, not
 in `spawn/0,1`. This ensures supervised children also run initialize.
@@ -357,44 +375,74 @@ await_initialize(Pid) ->
     end.
 
 -doc """
-BT-1541: Spawn an actor with trap_exit + initialize synchronization.
+BT-1541 / BT-3243: Spawn an actor, unlinked, with initialize synchronization.
 
 Handles the full spawn sequence:
-1. Trap exits so a failed start_link or handle_continue doesn't kill caller
-2. Call gen_server:start_link
-3. If start_link succeeds, wait for handle_continue (initialize) to complete
-4. Restore trap_exit and return {ok, Pid} or {error, Reason}
+1. Call gen_server:start (unlinked — see BT-3243 rationale below)
+2. If start succeeds, wait for handle_continue (initialize) to complete
+3. Return {ok, Pid} or {error, Reason}
 
-This consolidates the trap_exit/await_initialize logic so generated spawn
+BT-3243: Deliberately uses `gen_server:start/3` (unlinked), not
+`gen_server:start_link/3`. `spawn`/`spawnWith:` can run from inside a class
+gen_server's `{spawn, _}` handler (dynamic dispatch,
+`beamtalk_class_instantiation:handle_spawn/4`) or a class method body
+executing in the class's own process (`self spawn` /
+`class_self_spawn/3,4`) — either way, this function's caller is whatever
+process is evaluating the spawn expression, which linking would tie the
+new actor's lifetime to. A link there meant `exit(ActorPid, kill)` — used
+by REPL actor cleanup and `classRemoveFromSystemByName`'s actor teardown —
+took the caller down with it (e.g. the class gen_server, silently losing
+class vars and hot-patched methods). Lifecycle tracking that needs to know
+when an actor dies (the REPL actor registry, `onExit:`, etc.) already uses
+`erlang:monitor/2`, never the link, so dropping the link changes nothing
+for those consumers.
+
+Unlike `safe_spawn_named/3` (see its doc), this arity is never used as a
+real OTP supervisor child start MFA — supervised unnamed workers start via
+`Module:start_link/1` directly (`beamtalk_supervisor:spec_to_otp/1`) — so
+there is no competing linked use case to preserve here.
+
+This consolidates the await_initialize logic so generated spawn
 functions stay simple.
 """.
 -spec safe_spawn(module(), map()) -> {ok, pid()} | {error, term()}.
 safe_spawn(Module, InitArgs) ->
-    safe_spawn_internal(undefined, Module, InitArgs).
+    case gen_server:start(Module, InitArgs, []) of
+        {ok, Pid} -> await_initialize_or_kill_unlinked(Pid);
+        {error, Reason} -> {error, Reason};
+        ignore -> {error, ignore}
+    end.
 
 -doc """
 BT-1987: Spawn a named actor with trap_exit + initialize synchronization.
 
-Same contract as `safe_spawn/2` but registers the actor under `Name`
-via `gen_server:start_link({local, Name}, ...)`. Reuses the same
-initialize-synchronization machinery so callers see `{ok, Pid}` only
-after `handle_continue(initialize, _)` has completed.
+Handles the full spawn sequence:
+1. Trap exits so a failed start_link or handle_continue doesn't kill caller
+2. Call gen_server:start_link({local, Name}, ...)
+3. If start_link succeeds, wait for handle_continue (initialize) to complete
+4. Restore trap_exit and return {ok, Pid} or {error, Reason}
+
+BT-3243: Unlike `safe_spawn/2` (unnamed), this stays **linked**
+(`gen_server:start_link/4`, with the original trap_exit dance) — it is the
+shared implementation behind both `spawnAs:`/`spawnWith:as:` *and* the real
+OTP supervisor child MFA that `beamtalk_supervisor:spec_to_otp/1` builds
+for `SupervisionSpec withName:` children (ADR 0079/BT-1990:
+`{beamtalk_actor, spawnAs, [Name, Module]}` / `[Name, Module, InitArgs]`
+literally names this function as the start callback). That link is not the
+BT-3243 bug — it is exactly the OTP contract a real supervisor relies on to
+detect the child's exit and restart it; removing it would silently break
+supervised named-actor restart (see `beamtalk_supervisor_tests:supervisor_restart_re_registers_name_test/0`).
+
+The BT-3243 risk this shares — a class method's `self spawnAs:` /
+`self spawnWith:as:` running inside the class gen_server and linking the
+new actor to it — is fixed at that specific call site instead: see
+`beamtalk_class_instantiation:do_class_self_named_spawn/6`, which unlinks
+immediately after a successful spawn.
 """.
 -spec safe_spawn_named(atom(), module(), map()) -> {ok, pid()} | {error, term()}.
 safe_spawn_named(Name, Module, InitArgs) when is_atom(Name) ->
-    safe_spawn_internal({local, Name}, Module, InitArgs).
-
--spec safe_spawn_internal(undefined | {local, atom()}, module(), term()) ->
-    {ok, pid()} | {error, term()}.
-safe_spawn_internal(ServerName, Module, InitArgs) ->
     OldTrap = erlang:process_flag(trap_exit, true),
-    Result =
-        case ServerName of
-            undefined ->
-                gen_server:start_link(Module, InitArgs, []);
-            {local, _} = SN ->
-                gen_server:start_link(SN, Module, InitArgs, [])
-        end,
+    Result = gen_server:start_link({local, Name}, Module, InitArgs, []),
     case Result of
         {ok, Pid} ->
             case await_initialize(Pid) of
@@ -419,6 +467,26 @@ safe_spawn_internal(ServerName, Module, InitArgs) ->
         ignore ->
             erlang:process_flag(trap_exit, OldTrap),
             {error, ignore}
+    end.
+
+-doc """
+Shared await_initialize + force-kill-on-timeout tail for the unlinked
+`safe_spawn/2` path (BT-3243). No link exists to fall back on for an
+'EXIT' message on the force-kill path, so this monitors explicitly to
+deterministically observe termination before returning.
+""".
+-spec await_initialize_or_kill_unlinked(pid()) -> {ok, pid()} | {error, term()}.
+await_initialize_or_kill_unlinked(Pid) ->
+    case await_initialize(Pid) of
+        ok ->
+            {ok, Pid};
+        {error, Reason} ->
+            MonRef = erlang:monitor(process, Pid),
+            exit(Pid, kill),
+            receive
+                {'DOWN', MonRef, process, Pid, _} -> ok
+            end,
+            {error, Reason}
     end.
 
 %%% Message Send Helpers

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_behaviour_intrinsics.erl
@@ -623,12 +623,15 @@ classRemoveFromSystemByName(ClassName) ->
                             ClassNameBin = atom_to_binary(ClassName, utf8),
                             RemovalSnapshot = capture_class_removal_snapshot(ClassNameBin),
                             %% BT-3236: stop eager crash recovery for this
-                            %% class BEFORE killing its actors — actors are
-                            %% linked to the class gen_server, so the kills
-                            %% below can take the class process down with
-                            %% reason 'killed', which the monitor would
-                            %% otherwise classify as a crash and resurrect
-                            %% mid-removal.
+                            %% class BEFORE killing its actors. BT-3243
+                            %% removed the link that used to exist between an
+                            %% actor and its class gen_server, so the kills
+                            %% below can no longer take the class process
+                            %% down with them — this unwatch is now defense
+                            %% in depth against any other crash/kill landing
+                            %% on the class process during the removal
+                            %% window, which the monitor would otherwise
+                            %% classify as a crash and resurrect mid-removal.
                             beamtalk_class_monitor:unwatch(ClassName),
                             %% Stop live actors of this class
                             stop_class_actors(ClassName),

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_instantiation.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_instantiation.erl
@@ -499,19 +499,34 @@ do_class_self_named_spawn(ClassName, Module, IsAbstract0, InitArgs, Name, Select
             %% BT-3243: beamtalk_actor:'spawnAs'/3 (safe_spawn_named) always
             %% links — it doubles as the real OTP supervisor child MFA for
             %% named children (ADR 0079/BT-1990), where that link is the
-            %% restart mechanism. For *this* call site, the caller is a
-            %% class method body executing `self spawnAs:`/
-            %% `self spawnWith:as:` (normally the class's own gen_server
-            %% process, per CLAUDE.md's "Blocks into class methods" rule) —
+            %% restart mechanism. For *this* call site, the caller is
+            %% normally a class method body executing `self spawnAs:`/
+            %% `self spawnWith:as:` inside the class's own gen_server
+            %% process (per CLAUDE.md's "Blocks into class methods" rule) —
             %% not a supervisor, so the link must not survive: a later kill
             %% of the actor must not take the class process down with it.
             %% Sever it immediately; by the time `'spawnAs'/3` returns
             %% `{ok, Pid}` its own await_initialize has already confirmed
             %% the actor started and initialized, so no risk window remains
             %% to protect against.
+            %%
+            %% BT-3243 supervisor-restart follow-up: the exception is a
+            %% `SupervisionSpec withClassMethod:` child (BT-1862) whose
+            %% factory calls `self spawnAs:`/`self spawnWith:as:` — that body
+            %% runs directly inside the real OTP supervisor process via
+            %% `beamtalk_supervisor:start_child_via_class_method/4` (no
+            %% process boundary in between), so unlinking here would break
+            %% the supervisor's restart mechanism exactly like it would for
+            %% plain `self spawn`/`self spawnWith:` (see
+            %% `beamtalk_actor:safe_spawn/2`'s doc). That function marks the
+            %% context via `?BT_SUPERVISOR_SPAWN_CONTEXT_KEY`; only unlink
+            %% when it is absent.
             case beamtalk_actor:'spawnAs'(Name, Module, InitArgs) of
                 {ok, Pid} ->
-                    unlink(Pid),
+                    case get(?BT_SUPERVISOR_SPAWN_CONTEXT_KEY) of
+                        true -> ok;
+                        _ -> unlink(Pid)
+                    end,
                     beamtalk_result:from_tagged_tuple(
                         {ok, #beamtalk_object{
                             class = ClassName,

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_instantiation.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_instantiation.erl
@@ -496,8 +496,22 @@ do_class_self_named_spawn(ClassName, Module, IsAbstract0, InitArgs, Name, Select
                 {error, abstract_class_error(ClassName, Selector)}
             );
         false ->
+            %% BT-3243: beamtalk_actor:'spawnAs'/3 (safe_spawn_named) always
+            %% links — it doubles as the real OTP supervisor child MFA for
+            %% named children (ADR 0079/BT-1990), where that link is the
+            %% restart mechanism. For *this* call site, the caller is a
+            %% class method body executing `self spawnAs:`/
+            %% `self spawnWith:as:` (normally the class's own gen_server
+            %% process, per CLAUDE.md's "Blocks into class methods" rule) —
+            %% not a supervisor, so the link must not survive: a later kill
+            %% of the actor must not take the class process down with it.
+            %% Sever it immediately; by the time `'spawnAs'/3` returns
+            %% `{ok, Pid}` its own await_initialize has already confirmed
+            %% the actor started and initialized, so no risk window remains
+            %% to protect against.
             case beamtalk_actor:'spawnAs'(Name, Module, InitArgs) of
                 {ok, Pid} ->
+                    unlink(Pid),
                     beamtalk_result:from_tagged_tuple(
                         {ok, #beamtalk_object{
                             class = ClassName,

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_class_monitor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_class_monitor.erl
@@ -99,12 +99,19 @@ watch(ClassName, Pid) ->
 Stop monitoring `ClassName` ahead of deliberate removal.
 
 `classRemoveFromSystemByName/1` kills the class's live actors before
-stopping the class gen_server, and actors are linked to their class process
-(spawned via `gen_server:start_link` inside the class's `{spawn, _}`
-handler) — so the kill propagates and the class dies with reason `killed`,
-which would otherwise be classified as a crash and eagerly resurrected
-mid-removal. Synchronous (a cast could lose the race against the 'DOWN'
-delivery); a no-op when the monitor is not running.
+stopping the class gen_server itself (`gen_server:stop/1`, reason
+`normal`/`shutdown`). BT-3243 removed the link that used to exist between an
+actor and the class process it was spawned through: dynamic-dispatch
+`{spawn, _}` and `self spawn`/`self spawnWith:` now spawn unlinked
+(`beamtalk_actor:safe_spawn/2` uses `gen_server:start/3`, not
+`start_link/3`), and `self spawnAs:`/`self spawnWith:as:` unlink
+immediately after a successful spawn (`beamtalk_class_instantiation:do_class_self_named_spawn/6`)
+— so an actor kill can no longer take the class process down with it. This
+unwatch stays as defense in depth against the class's own deliberate stop
+racing eager recovery (a kill/crash landing on the class process itself,
+from any other source, in the removal window). Synchronous (a cast could
+lose the race
+against the 'DOWN' delivery); a no-op when the monitor is not running.
 """.
 -spec unwatch(atom()) -> ok.
 unwatch(ClassName) ->

--- a/runtime/apps/beamtalk_runtime/src/beamtalk_supervisor.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_supervisor.erl
@@ -791,6 +791,24 @@ identity from the process dictionary (e.g. `handle_class_self_call/1`'s
 deadlock-diagnostic hint) when the class method runs correctly in the
 supervisor process instead of the class's own gen_server.
 
+BT-3243 (supervisor-restart follow-up): `?BT_SUPERVISOR_SPAWN_CONTEXT_KEY` is
+also set here (and only here). Unlike `beamtalk_class_name`/
+`beamtalk_class_module` — which `beamtalk_object_class`'s `init/1` *also*
+sets, in the class's own gen_server process — this key is exclusive to this
+function, so `beamtalk_actor:safe_spawn/2` and
+`beamtalk_class_instantiation:do_class_self_named_spawn/6` can check it to
+tell "running a supervised child's factory in the real supervisor process"
+(stay linked — that link is the restart mechanism) apart from "running a
+class method inside the class's own gen_server, or a plain unsupervised
+spawn" (unlink — the original BT-3243 fix). This is a plain process
+dictionary read with no process boundary crossed between here and
+`safe_spawn/2`: `call_class_method_direct` below reaches the class method via
+`erlang:apply/3`, and the compiled `self spawn`/`self spawnWith:` body
+reaches `safe_spawn/2` via further direct calls
+(`beamtalk_class_instantiation:handle_spawn/4` → `erlang:apply(Module,
+spawn, Args)` → the generated `spawn/1` wrapper) — all synchronous, same
+process, so the key set here is still visible when `safe_spawn/2` checks it.
+
 BT-3106: `beamtalk_class_is_abstract` is deliberately **not** seeded here.
 `self spawnWith:`/`self spawnAs:`/`self spawnWith:as:` in a compiled class
 method resolve `is_abstract` by class name via
@@ -818,6 +836,14 @@ start_child_via_class_method(ClassName, Module, Selector, Args) ->
     %% excluded — see the doc comment above (BT-3106).
     put(beamtalk_class_name, ClassName),
     put(beamtalk_class_module, Module),
+    %% BT-3243 (supervisor-restart follow-up): mark this process as running a
+    %% withClassMethod: child's factory directly in the real OTP supervisor
+    %% process, so that any `self spawn`/`self spawnWith:`/`self spawnAs:`/
+    %% `self spawnWith:as:` the factory calls (beamtalk_actor:safe_spawn/2,
+    %% beamtalk_class_instantiation:do_class_self_named_spawn/6) stays linked
+    %% to us instead of unlinking — the link is what lets us, the supervisor,
+    %% detect the child's exit and restart it. See ?BT_SUPERVISOR_SPAWN_CONTEXT_KEY.
+    put(?BT_SUPERVISOR_SPAWN_CONTEXT_KEY, true),
     try
         ClassSelf = make_init_class_self(ClassName, Module),
         ClassVars = #{},
@@ -851,7 +877,8 @@ start_child_via_class_method(ClassName, Module, Selector, Args) ->
         end
     after
         erase(beamtalk_class_name),
-        erase(beamtalk_class_module)
+        erase(beamtalk_class_module),
+        erase(?BT_SUPERVISOR_SPAWN_CONTEXT_KEY)
     end.
 
 -doc """

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
@@ -1947,6 +1947,29 @@ safe_spawn_named_still_links_caller_test() ->
     ?assert(lists:member(Pid, CallerLinks)),
     gen_server:stop(Pid).
 
+safe_spawn_links_caller_when_supervisor_spawn_context_set_test() ->
+    %% BT-3243 supervisor-restart follow-up: when
+    %% beamtalk_supervisor:start_child_via_class_method/4 is on the call
+    %% stack (a `SupervisionSpec withClassMethod:` child's factory calling
+    %% plain `self spawn`/`self spawnWith:`), it marks the process
+    %% dictionary with ?BT_SUPERVISOR_SPAWN_CONTEXT_KEY so safe_spawn/2
+    %% knows this caller really is the OTP supervisor process — unlike the
+    %% common case tested by safe_spawn_does_not_link_caller_test/0 above,
+    %% the link here must survive so the supervisor can detect the child's
+    %% exit and restart it.
+    put(?BT_SUPERVISOR_SPAWN_CONTEXT_KEY, true),
+    try
+        {ok, Pid} = beamtalk_actor:safe_spawn(test_counter, #{init_count => 0}),
+        {links, CallerLinks} = process_info(self(), links),
+        {links, ActorLinks} = process_info(Pid, links),
+        ?assert(lists:member(Pid, CallerLinks)),
+        ?assert(lists:member(self(), ActorLinks)),
+        unlink(Pid),
+        gen_server:stop(Pid)
+    after
+        erase(?BT_SUPERVISOR_SPAWN_CONTEXT_KEY)
+    end.
+
 unregister_if_alive(Name) ->
     case erlang:whereis(Name) of
         undefined -> ok;

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_actor_tests.erl
@@ -1920,6 +1920,39 @@ safe_spawn_success_test() ->
     ?assert(is_process_alive(Pid)),
     gen_server:stop(Pid).
 
+safe_spawn_does_not_link_caller_test() ->
+    %% BT-3243: safe_spawn/2 must not link the spawned actor to its caller —
+    %% gen_server:start/3, not gen_server:start_link/3. A killed actor must
+    %% never be able to take its spawner down via a process link.
+    {ok, Pid} = beamtalk_actor:safe_spawn(test_counter, #{init_count => 0}),
+    {links, CallerLinks} = process_info(self(), links),
+    {links, ActorLinks} = process_info(Pid, links),
+    ?assertNot(lists:member(Pid, CallerLinks)),
+    ?assertNot(lists:member(self(), ActorLinks)),
+    gen_server:stop(Pid).
+
+safe_spawn_named_still_links_caller_test() ->
+    %% BT-3243: unlike safe_spawn/2 (unnamed), safe_spawn_named/3
+    %% (spawnAs:/spawnWith:as:) deliberately STAYS linked — it doubles as
+    %% the real OTP supervisor child MFA for named children
+    %% (beamtalk_supervisor:spec_to_otp/1, ADR 0079/BT-1990), where the
+    %% link is the restart mechanism. Its own self-spawnAs: risk (a class
+    %% method linking the actor to the class gen_server it runs in) is
+    %% fixed by unlinking at that call site instead — see
+    %% beamtalk_class_instantiation_tests:test_class_self_spawn_as_success/0.
+    Name = bt_3243_named_actor_test,
+    unregister_if_alive(Name),
+    {ok, Pid} = beamtalk_actor:'spawnAs'(Name, test_counter, #{init_count => 0}),
+    {links, CallerLinks} = process_info(self(), links),
+    ?assert(lists:member(Pid, CallerLinks)),
+    gen_server:stop(Pid).
+
+unregister_if_alive(Name) ->
+    case erlang:whereis(Name) of
+        undefined -> ok;
+        Pid when is_pid(Pid) -> catch gen_server:stop(Pid)
+    end.
+
 await_initialize_preserves_full_stop_reason_test() ->
     %% When handle_continue returns {stop, {error, function_clause}, State},
     %% await_initialize must return {error, {error, function_clause}} — not

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_behaviour_intrinsics_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_behaviour_intrinsics_tests.erl
@@ -2513,6 +2513,83 @@ stop_class_actors_with_registry_test_() ->
     end}.
 
 %%% ============================================================================
+%%% BT-3243: classRemoveFromSystemByName with a real class-spawned live actor
+%%% ============================================================================
+
+%% Unlike stop_class_actors_with_registry_test_ above (a bare `spawn/1` fun,
+%% never linked to anything), this spawns the actor *through* the class
+%% gen_server's real `{spawn, _}` handler — `erlang:apply(Module, spawn, [])`
+%% inside `handle_call({spawn, _}, ...)` — which is exactly how the BT-3243
+%% link used to form (`beamtalk_actor:safe_spawn/2` ran with the class
+%% gen_server as `self()`, and `gen_server:start_link` linked it to the new
+%% actor). Before the fix, `stop_class_actors/1`'s kill below would take the
+%% class process down too, and the unconditional `gen_server:stop(ClassPid)`
+%% a few lines later in `classRemoveFromSystemByName/1` would then crash
+%% this test with `noproc` instead of returning cleanly.
+classremovefromsystembyname_with_class_spawned_actor_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            ?_test(begin
+                %% A disposable class module whose own `spawn/0` delegates to
+                %% the stable `test_class_actor` fixture as the actor's
+                %% backing gen_server — so `code:delete/1` below only ever
+                %% unloads this throwaway module, never a shared test fixture.
+                ModAtom = bt_3243_removable_class_mod,
+                Forms = parse_forms([
+                    "-module(" ++ atom_to_list(ModAtom) ++ ").",
+                    "-export([spawn/0]).",
+                    "spawn() -> beamtalk_actor:safe_spawn(test_class_actor, #{})."
+                ]),
+                {ok, ModAtom, Bin} = compile:forms(Forms, [return_errors]),
+                {module, ModAtom} = code:load_binary(
+                    ModAtom, "bt_3243_removable_class_mod.erl", Bin
+                ),
+                ClassName = 'BT3243LiveActorClass',
+                ClassInfo = #{
+                    name => ClassName,
+                    module => ModAtom,
+                    superclass => none,
+                    instance_methods => #{},
+                    class_methods => #{}
+                },
+                {ok, ClassPid} = beamtalk_object_class:start(ClassName, ClassInfo),
+
+                %% Real spawn through the class gen_server's own process.
+                {ok, #beamtalk_object{pid = ActorPid}} =
+                    gen_server:call(ClassPid, {spawn, []}),
+                ?assert(is_process_alive(ActorPid)),
+
+                Registry = spawn(fun() -> stub_registry_loop(ClassName, ActorPid) end),
+                register(beamtalk_actor_registry, Registry),
+                try
+                    ?assertEqual(
+                        nil,
+                        beamtalk_behaviour_intrinsics:classRemoveFromSystemByName(ClassName)
+                    ),
+                    ?assertEqual(undefined, beamtalk_class_registry:whereis_class(ClassName)),
+                    ?assertNot(is_process_alive(ActorPid))
+                after
+                    catch unregister(beamtalk_actor_registry),
+                    catch exit(Registry, kill),
+                    catch exit(ActorPid, kill)
+                end
+            end)
+        ]
+    end}.
+
+%% Parse a list of complete top-level Erlang source forms (each ending in
+%% `.`) into abstract forms suitable for compile:forms/2.
+parse_forms(SourceLines) ->
+    lists:map(
+        fun(Line) ->
+            {ok, Tokens, _} = erl_scan:string(Line),
+            {ok, Form} = erl_parse:parse_form(Tokens),
+            Form
+        end,
+        SourceLines
+    ).
+
+%%% ============================================================================
 %%% walk_hierarchy/3 — max depth cycle guard
 %%% ============================================================================
 

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_instantiation_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_instantiation_tests.erl
@@ -34,6 +34,10 @@ instantiation_test_() ->
             {"spawn with too many args returns type_error", fun test_spawn_too_many_args/0},
             {"spawn with no args succeeds", fun test_spawn_no_args/0},
             {"spawn with one arg (spawnWith:) succeeds", fun test_spawn_with_arg/0},
+            %% BT-3243: actor spawned via the class gen_server must not be
+            %% linked to it — killing the actor must not kill the class.
+            {"killing an actor spawned via the class gen_server leaves the class alive",
+                fun test_kill_actor_spawned_via_class_survives_class/0},
             %% handle_new tests
             {"new compiled class delegates to module", fun test_new_compiled/0},
             {"new compiled non-constructible class", fun test_new_compiled_non_constructible/0},
@@ -159,6 +163,34 @@ test_spawn_with_arg() ->
     ?assertMatch({ok, #beamtalk_object{class = 'Counter'}}, Result),
     {ok, Obj} = Result,
     gen_server:stop(Obj#beamtalk_object.pid).
+
+test_kill_actor_spawned_via_class_survives_class() ->
+    %% BT-3243: handle_spawn/4 runs *inside* the class gen_server process
+    %% when reached via the {spawn, Args} dynamic-dispatch handler — the
+    %% exact scenario the bug report describes. Before the fix, safe_spawn
+    %% used gen_server:start_link, linking the new actor to the class
+    %% process; exit(ActorPid, kill) then propagated over that link and
+    %% killed the class gen_server too (losing class vars / hot patches).
+    ok = ensure_counter_loaded(),
+    CounterPid = beamtalk_class_registry:whereis_class('Counter'),
+    {ok, #beamtalk_object{pid = ActorPid} = Obj} = gen_server:call(CounterPid, {spawn, []}),
+    ?assertEqual('Counter', Obj#beamtalk_object.class),
+    ?assert(is_process_alive(ActorPid)),
+    ?assert(is_process_alive(CounterPid)),
+
+    MonRef = erlang:monitor(process, ActorPid),
+    exit(ActorPid, kill),
+    receive
+        {'DOWN', MonRef, process, ActorPid, _Reason} -> ok
+    after 5000 ->
+        error(actor_kill_timeout)
+    end,
+
+    %% The class process must not merely be alive — it must still be a
+    %% functioning gen_server (not a zombie mid-crash), so this call must
+    %% succeed synchronously.
+    ?assert(is_process_alive(CounterPid)),
+    ?assertEqual('Counter', gen_server:call(CounterPid, class_name)).
 
 %%====================================================================
 %% handle_new tests (dynamic classes)
@@ -427,6 +459,14 @@ test_class_self_spawn_as_success() ->
     ),
     #{'okValue' := Obj} = Result,
     ?assert(erlang:whereis(Name) =/= undefined),
+    %% BT-3243: beamtalk_actor:'spawnAs'/3 (safe_spawn_named) always links —
+    %% it doubles as the real OTP supervisor child MFA for named children
+    %% (ADR 0079/BT-1990). do_class_self_named_spawn/6 must sever that link
+    %% right after a successful `self spawnAs:`, since the caller here (this
+    %% test process, standing in for a class method body) is not a
+    %% supervisor — a later kill of the actor must not take it down too.
+    {links, CallerLinks} = process_info(self(), links),
+    ?assertNot(lists:member(Obj#beamtalk_object.pid, CallerLinks)),
     gen_server:stop(Obj#beamtalk_object.pid).
 
 test_class_self_spawn_as_reserved() ->

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_class_instantiation_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_class_instantiation_tests.erl
@@ -85,6 +85,9 @@ instantiation_test_() ->
                 fun test_class_self_spawn_as_success/0},
             {"class_self_spawn_as returns Result error for reserved name",
                 fun test_class_self_spawn_as_reserved/0},
+            %% BT-3243 supervisor-restart follow-up
+            {"class_self_spawn_as stays linked when the supervisor-spawn context is set",
+                fun test_class_self_spawn_as_stays_linked_in_supervisor_context/0},
             {"class_self_spawn_as returns Result error for abstract class",
                 fun test_class_self_spawn_as_abstract/0},
             {"class_self_spawn_with returns Result ok with init args applied",
@@ -468,6 +471,36 @@ test_class_self_spawn_as_success() ->
     {links, CallerLinks} = process_info(self(), links),
     ?assertNot(lists:member(Obj#beamtalk_object.pid, CallerLinks)),
     gen_server:stop(Obj#beamtalk_object.pid).
+
+test_class_self_spawn_as_stays_linked_in_supervisor_context() ->
+    %% BT-3243 supervisor-restart follow-up: when
+    %% beamtalk_supervisor:start_child_via_class_method/4 is on the call
+    %% stack (a `SupervisionSpec withClassMethod:` child's factory calling
+    %% `self spawnAs:`/`self spawnWith:as:`), it marks the process
+    %% dictionary with ?BT_SUPERVISOR_SPAWN_CONTEXT_KEY. do_class_self_named_spawn/6
+    %% must NOT unlink in that case — the link is the supervisor's restart
+    %% mechanism — unlike the ordinary case proved by
+    %% test_class_self_spawn_as_success/0 above (no marker set, unlinks).
+    ok = ensure_counter_loaded(),
+    Name = bt3243_self_spawnas_supervisor_context,
+    unregister_if_present(Name),
+    put(?BT_SUPERVISOR_SPAWN_CONTEXT_KEY, true),
+    try
+        Result = beamtalk_class_instantiation:class_self_spawn_as(
+            'Counter', 'bt@counter', false, Name
+        ),
+        ?assertMatch(
+            #{'$beamtalk_class' := 'Result', 'isOk' := true, 'okValue' := #beamtalk_object{}},
+            Result
+        ),
+        #{'okValue' := Obj} = Result,
+        {links, CallerLinks} = process_info(self(), links),
+        ?assert(lists:member(Obj#beamtalk_object.pid, CallerLinks)),
+        unlink(Obj#beamtalk_object.pid),
+        gen_server:stop(Obj#beamtalk_object.pid)
+    after
+        erase(?BT_SUPERVISOR_SPAWN_CONTEXT_KEY)
+    end.
 
 test_class_self_spawn_as_reserved() ->
     ok = ensure_counter_loaded(),

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_supervisor_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_supervisor_tests.erl
@@ -25,6 +25,10 @@ Tests cover:
 - start_child_via_class_method/4: valid return, invalid return, class_var_result
   unwrap, process dictionary cleanup, child linking, supervisor restart,
   supervisor tuple return (BT-1875, BT-1960)
+- start_child_via_class_method/4 supervisor restart through the REAL compiled
+  `self spawn`/`self spawnWith:` and `self spawnAs:`/`self spawnWith:as:`
+  call chains (not a gen_server:start_link stand-in) — BT-3243 supervisor-
+  restart follow-up
 - ensure_root_table idempotent creation (BT-1960)
 - startLink/1 success, already_started, and error paths (BT-1980)
 - terminateChild/2 class path + terminateChild:class:/:child: aliases (BT-1980)
@@ -64,6 +68,17 @@ Tests cover:
     class_returnWrapped/2,
     class_returnSupervisor/2,
     start_link_fake_child/0
+]).
+
+%% BT-3243 supervisor-restart follow-up: fake class methods that route through
+%% the REAL compiled `self spawn`/`self spawnWith:`/`self spawnAs:`/
+%% `self spawnWith:as:` runtime entry points (beamtalk_class_instantiation:
+%% class_self_spawn/3, class_self_spawn_as/4) instead of a `gen_server:start_link`
+%% stand-in — see start_child_via_class_method_real_self_spawn_supervisor_restart_test/0
+%% and start_child_via_class_method_real_self_spawn_as_supervisor_restart_test/0.
+-export([
+    'class_createViaSpawn:value:'/4,
+    'class_createNamedViaSpawn:value:'/4
 ]).
 
 %% BT-3106: Fake class method that self-sends `new`, mirroring the codegen
@@ -859,6 +874,33 @@ class_returnSupervisor(_ClassSelf, _ClassVars) ->
     {ok, Pid} = start_link_fake_child(),
     {beamtalk_supervisor, 'FakeSupervisorChild', ?MODULE, Pid}.
 
+%% BT-3243 supervisor-restart follow-up: fake class method that calls the REAL
+%% compiled `self spawn`/`self spawnWith:` entry point
+%% (beamtalk_class_instantiation:class_self_spawn/3 — exactly what codegen
+%% emits for those forms inside a class method body), targeting
+%% `test_class_actor` — a generated-actor-shaped fixture whose own `spawn/0,1`
+%% delegates to `beamtalk_actor:safe_spawn/2`, the function this PR's fix
+%% touches. Unlike `'class_create:value:'/4` above (a `gen_server:start_link`
+%% stand-in), this exercises the actual production call chain end to end.
+'class_createViaSpawn:value:'(_ClassSelf, _ClassVars, _Name, _Value) ->
+    beamtalk_class_instantiation:class_self_spawn('BT3243RealSpawnChild', test_class_actor, []).
+
+%% BT-3243 supervisor-restart follow-up: same idea, but for the named-spawn
+%% path — the REAL `self spawnAs:` entry point
+%% (beamtalk_class_instantiation:class_self_spawn_as/4). `class_self_spawn_as/4`
+%% returns a Result tagged map (matching the `Result(Self, Error)` return
+%% type real `startAs:`-style factories declare — see
+%% stdlib/test/fixtures/named_factory_actor.bt), so — exactly like a real
+%% compiled factory calling `.unwrap` on it before returning — this unwraps
+%% the ok value to hand `start_child_via_class_method/4` the bare actor
+%% object it expects.
+'class_createNamedViaSpawn:value:'(_ClassSelf, _ClassVars, Name, _Value) ->
+    #{'isOk' := true, 'okValue' := Obj} =
+        beamtalk_class_instantiation:class_self_spawn_as(
+            'BT3243RealNamedSpawnChild', test_class_actor, false, Name
+        ),
+    Obj.
+
 %% BT-3106: Fake class method: self-sends `new`, exactly as codegen's
 %% `try_instantiation_intrinsic` lowers `self new` inside a class method body —
 %% `beamtalk_class_instantiation:class_self_new(ClassName, Module, Args)` with
@@ -1053,6 +1095,121 @@ start_child_via_class_method_supervisor_restart_test() ->
         end
     after
         cleanup_fake_class('BT1875Restart', FakeClassPid)
+    end.
+
+start_child_via_class_method_real_self_spawn_supervisor_restart_test() ->
+    %% BT-3243 supervisor-restart follow-up: the review-bot-flagged gap.
+    %% start_child_via_class_method_supervisor_restart_test/0 above only
+    %% proves restart works when the fake class method calls
+    %% gen_server:start_link directly — a stand-in, not the real `self
+    %% spawn`/`self spawnWith:` path. This test instead routes through the
+    %% ACTUAL compiled runtime call chain: 'class_createViaSpawn:value:'/4 →
+    %% beamtalk_class_instantiation:class_self_spawn/3 →
+    %% beamtalk_class_instantiation:handle_spawn/4 →
+    %% test_class_actor:spawn/0 → beamtalk_actor:safe_spawn/2 — the exact
+    %% function this PR's fix touches. Before the
+    %% ?BT_SUPERVISOR_SPAWN_CONTEXT_KEY fix, safe_spawn/2 always spawned
+    %% unlinked, so the supervisor below would never observe the killed
+    %% child's exit and this test would fail (ChildPid2 =:= ChildPid1,
+    %% or the child simply never restarts).
+    FakeClassPid = setup_fake_class('BT3243RealSpawnRestart'),
+    try
+        ChildSpec = #{
+            id => 'BT3243RealSpawnRestart',
+            start =>
+                {beamtalk_supervisor, start_child_via_class_method, [
+                    'BT3243RealSpawnRestart', ?MODULE, 'class_createViaSpawn:value:', [test, 1]
+                ]},
+            restart => permanent,
+            shutdown => brutal_kill,
+            type => worker,
+            modules => [?MODULE]
+        },
+        SupFlags = #{strategy => one_for_one, intensity => 5, period => 10},
+        {ok, SupPid} = supervisor:start_link(?MODULE, {SupFlags, [ChildSpec]}),
+        try
+            [{_, ChildPid1, _, _}] = supervisor:which_children(SupPid),
+            ?assert(is_pid(ChildPid1)),
+            ?assert(is_process_alive(ChildPid1)),
+
+            Ref = monitor(process, ChildPid1),
+            exit(ChildPid1, kill),
+            receive
+                {'DOWN', Ref, process, ChildPid1, killed} -> ok
+            after 2000 ->
+                error(child_did_not_die)
+            end,
+
+            timer:sleep(100),
+
+            [{_, ChildPid2, _, _}] = supervisor:which_children(SupPid),
+            ?assert(is_pid(ChildPid2)),
+            ?assert(is_process_alive(ChildPid2)),
+            ?assertNotEqual(ChildPid1, ChildPid2)
+        after
+            gen_server:stop(SupPid)
+        end
+    after
+        cleanup_fake_class('BT3243RealSpawnRestart', FakeClassPid)
+    end.
+
+start_child_via_class_method_real_self_spawn_as_supervisor_restart_test() ->
+    %% BT-3243 supervisor-restart follow-up: the review's own suggested test
+    %% only covered `self spawn`/`self spawnWith:` (above); this covers the
+    %% named-spawn sibling path the review also called out —
+    %% `self spawnAs:`/`self spawnWith:as:` inside a `withClassMethod:`
+    %% factory. Routes through the ACTUAL compiled call chain:
+    %% 'class_createNamedViaSpawn:value:'/4 →
+    %% beamtalk_class_instantiation:class_self_spawn_as/4 →
+    %% do_class_self_named_spawn/6 → beamtalk_actor:'spawnAs'/3
+    %% (safe_spawn_named). Before the fix, do_class_self_named_spawn/6
+    %% unconditionally unlinked regardless of caller context, so this
+    %% supervisor would never see the killed child's exit and the test
+    %% would fail.
+    FakeClassPid = setup_fake_class('BT3243RealNamedSpawnRestart'),
+    try
+        ChildSpec = #{
+            id => 'BT3243RealNamedSpawnRestart',
+            start =>
+                {beamtalk_supervisor, start_child_via_class_method, [
+                    'BT3243RealNamedSpawnRestart',
+                    ?MODULE,
+                    'class_createNamedViaSpawn:value:',
+                    [
+                        bt3243_real_named_spawn_restart_child, 1
+                    ]
+                ]},
+            restart => permanent,
+            shutdown => brutal_kill,
+            type => worker,
+            modules => [?MODULE]
+        },
+        SupFlags = #{strategy => one_for_one, intensity => 5, period => 10},
+        {ok, SupPid} = supervisor:start_link(?MODULE, {SupFlags, [ChildSpec]}),
+        try
+            [{_, ChildPid1, _, _}] = supervisor:which_children(SupPid),
+            ?assert(is_pid(ChildPid1)),
+            ?assert(is_process_alive(ChildPid1)),
+
+            Ref = monitor(process, ChildPid1),
+            exit(ChildPid1, kill),
+            receive
+                {'DOWN', Ref, process, ChildPid1, killed} -> ok
+            after 2000 ->
+                error(child_did_not_die)
+            end,
+
+            timer:sleep(100),
+
+            [{_, ChildPid2, _, _}] = supervisor:which_children(SupPid),
+            ?assert(is_pid(ChildPid2)),
+            ?assert(is_process_alive(ChildPid2)),
+            ?assertNotEqual(ChildPid1, ChildPid2)
+        after
+            gen_server:stop(SupPid)
+        end
+    after
+        cleanup_fake_class('BT3243RealNamedSpawnRestart', FakeClassPid)
     end.
 
 start_child_via_class_method_returns_supervisor_tuple_test() ->

--- a/runtime/apps/beamtalk_runtime/test/test_class_actor.erl
+++ b/runtime/apps/beamtalk_runtime/test/test_class_actor.erl
@@ -1,0 +1,58 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(test_class_actor).
+-behaviour(gen_server).
+
+-moduledoc """
+BT-3243: Minimal actor fixture wired the way generated `spawn/0` class
+methods are (`beamtalk_actor:safe_spawn/2`), for tests that need to spawn a
+real actor *through* a class gen_server's `{spawn, _}` handler
+(`beamtalk_class_instantiation:handle_spawn/4` does
+`erlang:apply(Module, spawn, Args)` — this module is that `Module`).
+
+Distinct from `test_counter` (which only exposes `start_link/1` /
+`start/1`, not `spawn/0`) so tests exercising the real class-spawn path
+don't have to reuse the shared `Counter` class fixture, which other test
+suites keep registered for their own duration.
+""".
+
+%% API
+-export([spawn/0, spawn/1]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_cast/2,
+    handle_call/3,
+    handle_info/2,
+    code_change/3,
+    terminate/2
+]).
+
+-doc "Mirrors generated `spawn/0`: beamtalk_actor:safe_spawn/2, unlinked (BT-3243).".
+spawn() ->
+    beamtalk_actor:safe_spawn(?MODULE, #{}).
+
+-doc "Mirrors generated `spawn/1` (spawnWith:).".
+spawn(InitArgs) when is_map(InitArgs) ->
+    beamtalk_actor:safe_spawn(?MODULE, InitArgs).
+
+init(InitArgs) ->
+    beamtalk_actor:init(#{
+        '$beamtalk_class' => 'TestClassActor',
+        '__class_mod__' => ?MODULE,
+        '__methods__' => #{
+            getValue => fun handle_getValue/2
+        },
+        value => maps:get(value, InitArgs, 0)
+    }).
+
+handle_cast(Msg, State) -> beamtalk_actor:handle_cast(Msg, State).
+handle_call(Msg, From, State) -> beamtalk_actor:handle_call(Msg, From, State).
+handle_info(Msg, State) -> beamtalk_actor:handle_info(Msg, State).
+code_change(OldVsn, State, Extra) -> beamtalk_actor:code_change(OldVsn, State, Extra).
+terminate(Reason, State) -> beamtalk_actor:terminate(Reason, State).
+
+handle_getValue([], State) ->
+    {reply, maps:get(value, State), State}.


### PR DESCRIPTION
## Summary

`ClassName spawn` / `self spawn` runs `handle_spawn/4` (or `class_self_spawn`) inside the class's own gen_server process, which called `beamtalk_actor:safe_spawn/2` — and that used `gen_server:start_link`, linking the new actor to whichever process was doing the spawning. When that was the class gen_server, a later `exit(ActorPid, kill)` (REPL actor cleanup, `classRemoveFromSystemByName`'s `stop_class_actors`) propagated over the link and killed the class process too, silently losing class variables and hot-patched methods.

## Fix

Chose **unlink + monitor** over trap_exit, per the acceptance criteria's stated preference, and because `beamtalk_class_monitor` already establishes the precedent (`erlang:monitor/2` for class-process lifecycle tracking) — no reason to introduce a second, inconsistent pattern.

- `beamtalk_actor:safe_spawn/2` (unnamed spawn, backing generated `Module:spawn/0,1`) now uses `gen_server:start/3` — **unlinked**. This is the path `handle_spawn/4` and `self spawn`/`self spawnWith:` go through, and nothing legitimate relied on the link (lifecycle tracking already uses `erlang:monitor/2`).
- `beamtalk_actor:safe_spawn_named/3` (`spawnAs:`/`spawnWith:as:`) **stays linked** via `gen_server:start_link/4` — it turns out to double as the real OTP supervisor child MFA for named children (ADR 0079/BT-1990: `beamtalk_supervisor:spec_to_otp/1` builds `{beamtalk_actor, spawnAs, [Name, Module]}` as a literal child-spec `start` MFA). That link *is* the restart mechanism a real supervisor needs — removing it broke `supervisor_restart_re_registers_name_test` during development (caught by the full-suite run, then fixed by reverting this one arity to its original linked implementation).
- The remaining risk on the named path — `self spawnAs:`/`self spawnWith:as:` executing inside the class gen_server — is fixed at that specific call site: `beamtalk_class_instantiation:do_class_self_named_spawn/6` now calls `unlink(Pid)` immediately after a successful spawn (after `safe_spawn_named`'s own `await_initialize` has already confirmed the actor started cleanly, so there's no remaining risk window).

No changes needed to `beamtalk_object_class.erl` — the class process never trapped exits and doesn't need to.

## Testing

- `beamtalk_class_instantiation_tests:test_kill_actor_spawned_via_class_survives_class/0` — spawns a real actor through `gen_server:call(CounterPid, {spawn, []})` (the exact scenario from the bug report), kills it, and asserts the class process is still alive *and* still a functioning gen_server (not a zombie).
- `beamtalk_behaviour_intrinsics_tests:classremovefromsystembyname_with_class_spawned_actor_test_/0` — spawns an actor through a class gen_server's real `{spawn, _}` handler, then runs `classRemoveFromSystemByName/1` and asserts it completes cleanly (`nil`, no `noproc` crash) with both the class and the actor gone.
- `beamtalk_actor_tests:safe_spawn_does_not_link_caller_test/0` / `safe_spawn_named_still_links_caller_test/0` — direct unit coverage of the two arities' intentionally different linking behavior.
- `beamtalk_class_instantiation_tests:test_class_self_spawn_as_success/0` — extended to assert `self spawnAs:` doesn't leave a link to its caller.
- New fixture `test_class_actor.erl`, mirroring generated `spawn/0` codegen (`beamtalk_actor:safe_spawn/2`) for tests that need to spawn a real actor through a class's `{spawn, _}` handler without touching the shared `Counter` test fixture.

### Commands run
```
cd runtime && rebar3 compile                                    # clean
cd runtime && rebar3 fmt --check                                # clean
cd runtime && rebar3 dialyzer                                   # clean, exit 0
cd runtime && rebar3 eunit --app=beamtalk_runtime                # 2778 tests, 197 failures — identical
                                                                   # failure set to the unmodified baseline
                                                                   # (verified by diffing sorted unique
                                                                   # failing-test-name lists); the app suite
                                                                   # has pre-existing test-isolation flakiness
                                                                   # unrelated to this change
cd runtime && rebar3 eunit --module=beamtalk_supervisor_tests     # 81 tests, 0 failures (the test that
                                                                   # regressed during development, now green)
```
Also ran the full `just ci`-equivalent pre-push hook (Rust, Erlang/Dialyzer, generated-spec validation, formatting, JS/Biome, Elixir) — all green.

## Deviations from acceptance criteria

None. All four criteria are met:
1. Actors are not linked to the class gen_server (unlink + monitor, as preferred) — done for both spawn arities, via two different mechanisms as explained above.
2. `exit(ActorPid, kill)` leaves the class process intact — EUnit test added.
3. `classRemoveFromSystemByName` on a class with live actors completes cleanly without relying on luck — EUnit test added.
4. `safe_spawn_internal`'s initialize-await semantics are preserved — `await_initialize`/`await_initialize_or_kill_unlinked` unchanged in observable behavior for callers.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtpdtrUbzvFVF9CMhYZhaK)_