### PR TITLE
Desktop: give the picker window a CloseRequested handler (BT-3252)

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -16,9 +16,13 @@ desktop/
   src-tauri/          Rust backend (NOT a Cargo workspace member — see below)
     src/
       main.rs          App setup: single-instance plugin, orphan-sweep, state,
-                         OS-level-quit (Cmd-Q/SIGTERM) detach-all cleanup
+                         OS-level-quit (Cmd-Q/SIGTERM) detach-all cleanup, and
+                         (BT-3252) the picker window's own `CloseRequested`
+                         handler — see "Closing the picker" below
       commands.rs       Tauri commands: list_workspaces, attach, detach,
-                         create_workspace, quit
+                         create_workspace, quit (a thin wrapper around
+                         `quit_app`, the detach-all-then-exit path BT-3252's
+                         picker close handler shares with it)
       menu.rs            App-wide menu (BT-3244): swaps the native ⌘/Ctrl+W
                            "Close Window" item for a plain ⇧⌘W one, freeing
                            ⌘/Ctrl+W so the LiveView cockpit's own `mod+w`
@@ -325,8 +329,8 @@ root/sudo access to install them). What that means concretely:
   lower-severity finding (the desktop picker window has no `CloseRequested`
   handler, so closing it — now more directly reachable via the global ⇧⌘W
   binding — can leave the app running with no visible window) was
-  pre-existing, not introduced by this change, and was filed as BT-3252
-  rather than fixed here.
+  pre-existing, not introduced by this change; filed as BT-3252 and fixed
+  there — see "Closing the picker" below.
 
 **Before this ships**, someone with a real Linux/macOS/Windows desktop needs
 to: install the Tauri prerequisites (`https://v2.tauri.app/start/prerequisites/`),
@@ -370,3 +374,54 @@ only — workspace windows (label `ws-<id>`) load the attached front's own
 that (arbitrary, workspace-authored) content cannot invoke any of this app's
 Tauri commands. Detach/quit/window-title updates for those windows are all
 driven from the Rust side, never from JS running inside them.
+
+## Closing the picker (BT-3252)
+
+Unlike each per-workspace window — which `commands::attach_and_open_window`
+gives its own `on_window_event`/`CloseRequested` handler, wired to
+`detach_internal` — the picker (`tauri.conf.json`'s static `"picker"` window)
+had no such handler at all before BT-3252. Since the picker is the app's only
+always-present window, and there is no tray icon, dock-click handler, or
+other affordance to bring it back once gone, closing it (the traffic-light
+button, or — since BT-3244 — the app-wide "Close Window" menu item/⇧⌘W, which
+targets whichever window has OS focus) just destroyed the window with no
+app-level follow-up: if any workspace window was still attached, the app kept
+running with no visible window and no way back in short of killing the
+process from a terminal.
+
+**Decision: closing the picker is treated as equivalent to quitting the whole
+app.** `main.rs`'s `.setup()` registers a `CloseRequested` handler on the
+picker window that calls `commands::quit_app` — the exact same
+detach-every-tracked-workspace-then-exit path the in-app "Quit" button
+(`commands::quit`) and the OS-level-quit `RunEvent::ExitRequested` handler
+already used, not a separate/duplicated implementation. Considered and
+rejected:
+
+- **Recreate/show the picker on the next single-instance relaunch even with
+  no window open.** Would keep the app alive with literally nothing visible
+  and no menu-bar/dock affordance most users would think to use to bring it
+  back — worse discoverability than just quitting, for no real benefit over
+  option (b) below.
+- **Hide instead of destroy (macOS "no visible window, dock icon still
+  works" pattern), revealed again via a dock-click handler.** The most
+  "native-feeling" option, but needs new dock-click-handler and/or tray-icon
+  infrastructure this app has none of today, and would leave every attached
+  workspace's front process running invisibly forever if the user's actual
+  intent in closing the picker was to quit — a real footgun for a feature
+  this app doesn't otherwise need.
+
+Quitting is simplest, most predictable (no hidden windows, no surprising
+still-running state), needs no new UI affordance, and matches what most
+users intuitively expect from closing what looks like the app's main window.
+Reopening the picker is always just relaunching the app from the Dock/
+Finder/CLI, same as day one.
+
+Tested via `commands::quit_cleanup` (the detach-all-and-flush portion of
+`quit_app`, split out from the final `AppHandle::exit` call it can't reach
+under a live event loop): `cargo test -p beamtalk-desktop` (well,
+`cd desktop/src-tauri && cargo test`, since this crate is deliberately not a
+workspace member — see `Cargo.toml`'s header comment) exercises it against
+`tauri::test::mock_app()`. The picker's actual `on_window_event` wiring
+itself is not (and, given `MockRuntime`'s `on_window_event` is a
+never-stores-the-callback stub, cannot be) exercised this way — the same
+pre-existing gap `attach_and_open_window`'s own per-workspace handler has.

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -423,8 +423,15 @@ pub fn detach(
 /// instead" (same source), which is exactly what every caller here wants —
 /// none of them need the "an outside observer can still intercept/cancel
 /// this close" semantics `close()` exists for.
-pub fn detach_internal(
-    app: &AppHandle,
+///
+/// Generic over `R: tauri::Runtime` (not the plain `AppHandle` alias for
+/// `AppHandle<Wry>` every other command in this file uses) purely so
+/// [`quit_cleanup`]'s test can reach this through `tauri::test::mock_app()`'s
+/// `MockRuntime` — matches the same pattern `menu::handle_event` already
+/// uses for the same reason. Every real call site still passes a plain
+/// `AppHandle` (Wry), inferred here without any change at the call site.
+pub fn detach_internal<R: tauri::Runtime>(
+    app: &AppHandle<R>,
     state: &AppState,
     workspace_id: &str,
 ) -> Result<(), String> {
@@ -483,11 +490,45 @@ pub fn get_launcher_logs(limit: Option<usize>) -> Result<Vec<String>, String> {
 }
 
 /// Quit: detach every tracked workspace (kills every front process, not
-/// just the picker), then exit the app.
+/// just the picker), then exit the app. Thin wrapper around [`quit_app`] —
+/// see its doc comment for why the two are split.
 #[tauri::command(async)]
 pub fn quit(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
+    quit_app(&app, &state);
+    Ok(())
+}
+
+/// Shared body of "quit the app": detach every tracked workspace (killing
+/// every front process, not just the picker), flush logs, then exit.
+///
+/// Split out from the `quit` command (rather than left inline there) so
+/// [`quit`] and the picker window's own `CloseRequested` handler
+/// (`main.rs`, BT-3252 — closing the picker is treated as equivalent to
+/// quitting the whole app, since it's the app's only always-present window
+/// and there is no tray icon or other affordance to bring it back once
+/// closed) can both run the exact same path without going through Tauri's
+/// IPC command dispatch, which `#[tauri::command]`-wrapped `quit` is not
+/// otherwise callable outside of.
+pub fn quit_app<R: tauri::Runtime>(app: &AppHandle<R>, state: &AppState) {
+    quit_cleanup(app, state);
+    app.exit(0);
+}
+
+/// The testable part of [`quit_app`]: everything up to, but not including,
+/// `AppHandle::exit`. Split out purely for [`tests::quit_cleanup_runs_cleanly_with_nothing_attached`]
+/// below: `tauri::test::mock_app()`'s `MockRuntime` implements
+/// `on_window_event` as a stub that never stores the callback (so no test
+/// can fire a simulated `CloseRequested` and observe [`quit_app`] get
+/// invoked that way — the same reason `attach_and_open_window`'s own
+/// `CloseRequested` handler has no test today), and separately,
+/// `RuntimeHandle::request_exit` is `unimplemented!()` under `MockRuntime`,
+/// so calling `AppHandle::exit` — even with nothing attached — panics
+/// unconditionally in a test. This function is as close as a test can get
+/// to exercising "the logic the picker's close handler and the Quit button
+/// both run" without hitting either limitation.
+fn quit_cleanup<R: tauri::Runtime>(app: &AppHandle<R>, state: &AppState) {
     tracing::info!("quit requested");
-    detach_all(&app, &state);
+    detach_all(app, state);
     // Best-effort and idempotent (`LoggingGuard::flush` is a `.take()`):
     // flush explicitly here rather than relying solely on `main.rs`'s
     // `RunEvent::ExitRequested` handler, since it's not guaranteed that
@@ -496,8 +537,6 @@ pub fn quit(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
     if let Some(guard) = app.try_state::<Mutex<crate::logging::LoggingGuard>>() {
         guard.lock().unwrap_or_else(|e| e.into_inner()).flush();
     }
-    app.exit(0);
-    Ok(())
 }
 
 /// Detach every tracked workspace (kills every front process). Shared by the
@@ -522,7 +561,7 @@ pub fn quit(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
 /// worst place in this file to do that: it would leak every still-attached
 /// front for the rest of the OS process's life, on the exact path (quit)
 /// meant to guarantee they get killed.
-pub fn detach_all(app: &AppHandle, state: &AppState) {
+pub fn detach_all<R: tauri::Runtime>(app: &AppHandle<R>, state: &AppState) {
     let ids: Vec<String> = locked(&state.children).keys().cloned().collect();
     tracing::info!(count = ids.len(), "detaching all tracked fronts");
     for id in ids {
@@ -756,6 +795,25 @@ fn reflect_connection_state(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn quit_cleanup_runs_cleanly_with_nothing_attached() {
+        // BT-3252: the picker window's own `CloseRequested` handler
+        // (`main.rs`) calls `quit_app`, whose entire body (besides the
+        // final `app.exit(0)` — see `quit_cleanup`'s doc comment for why
+        // that can't be exercised here) is `quit_cleanup`. This is the
+        // closest a test in this crate can get to "invoke the picker's new
+        // close handler and assert it runs the right quit/detach logic"
+        // without a live Tauri runtime: it confirms the shared path the
+        // picker's close and the in-app "Quit" button both now run
+        // (`detach_all` + best-effort log flush) completes without
+        // panicking against a freshly `mock_app()`-backed `AppHandle` and
+        // an `AppState` with nothing attached — the state both start from.
+        let app = tauri::test::mock_app();
+        let state = AppState::new(PathBuf::from("unused-in-this-test"));
+        quit_cleanup(app.handle(), &state);
+    }
 
     #[test]
     fn locked_recovers_from_a_poisoned_mutex() {

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -115,6 +115,46 @@ fn main() {
             tracing::info!(launcher = %launcher.display(), "resolved bt_attach launcher path");
             app.manage(AppState::new(launcher));
             app.manage(Mutex::new(logging_guard));
+
+            // BT-3252: the picker (`tauri.conf.json`'s static `"picker"`
+            // window) is the app's only always-present window and has no
+            // tray icon or other affordance to reopen it — unlike each
+            // per-workspace window (`commands::attach_and_open_window`'s own
+            // `on_window_event`), closing it (traffic-light button, or the
+            // app-wide "Close Window" menu item / ⇧⌘W now that it targets
+            // whichever window has OS focus) previously just destroyed that
+            // window with no app-level follow-up, leaving the app running
+            // invisibly whenever a workspace window was still attached.
+            // Closing the picker is therefore treated as equivalent to
+            // quitting the whole app — the simplest, most predictable
+            // behavior, and consistent with what closing what looks like the
+            // app's main window intuitively does. Reuses `commands::quit`'s
+            // exact detach-all-then-exit path (`quit_app`) rather than
+            // duplicating it, the same way this file's own
+            // `RunEvent::ExitRequested` handler below does for an OS-level
+            // quit.
+            if let Some(picker) = app.get_webview_window("picker") {
+                let app_handle_for_close = app.handle().clone();
+                picker.on_window_event(move |event| {
+                    if let tauri::WindowEvent::CloseRequested { .. } = event {
+                        let state = app_handle_for_close.state::<AppState>();
+                        commands::quit_app(&app_handle_for_close, &state);
+                    }
+                });
+            } else {
+                // Should be unreachable — `tauri.conf.json` declares
+                // `"picker"` as a static window Tauri creates before
+                // `.setup()` runs — but logged rather than assumed, since a
+                // future config change removing/renaming it would otherwise
+                // silently regress back to this issue's exact bug with no
+                // signal at all.
+                tracing::warn!(
+                    "picker window not found during setup; its CloseRequested handler was not \
+                     registered (BT-3252 regression: closing it would leave the app running \
+                     invisibly)"
+                );
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![


### PR DESCRIPTION
## Problem

The picker window (`desktop/src-tauri`, label `"picker"`) is created from static `tauri.conf.json` config and never got an `on_window_event`/`CloseRequested` handler — unlike each per-workspace window, which `commands::attach_and_open_window` explicitly wires up (`detach_internal` on `CloseRequested`).

Closing the picker window (traffic-light button, or — since BT-3244 — the app-wide "Close Window" menu item / ⇧⌘W, which now targets whichever window has OS focus, including the picker) just destroyed that window with no app-level follow-up. If any workspace window was still attached, the app kept running (its event loop still alive) but with no visible window and no way back in: `tauri_plugin_single_instance`'s relaunch handler only does `app.get_webview_window("picker")` → `None` → no-op, and there's no tray icon or other affordance to reopen the picker.

## Decision: (b) — closing the picker is treated as equivalent to quitting the app

Per the issue's three options (recreate-on-relaunch / quit-on-close / hide-and-reveal), I implemented **(b)**: closing the picker now runs the exact same detach-all-then-exit path as the in-app "Quit" button and the OS-level-quit `RunEvent::ExitRequested` handler.

Why (b) over the alternatives:
- **(a) recreate/show on next relaunch** would leave the app alive with nothing visible and no obvious way back — worse discoverability than just quitting, for no real benefit.
- **(c) hide instead of destroy** is the most "native-feeling" macOS pattern, but needs new dock-click-handler/tray-icon infrastructure this app has none of today, and risks leaving every attached workspace's front process running invisibly forever if the user's actual intent was to quit.
- **(b)** is simplest, most predictable (no hidden windows, no surprising still-running state), needs no new UI affordance, and matches what most users intuitively expect from closing what looks like the app's main window. Reopening the picker is always just relaunching the app.

Full reasoning, including the two rejected alternatives, is now documented in `desktop/README.md` under "Closing the picker (BT-3252)".

## Changes

- `desktop/src-tauri/src/main.rs`: `.setup()` now registers a `CloseRequested` handler on the picker window that calls `commands::quit_app` — logs a warning (not a panic) in the near-unreachable case the picker window isn't found at setup time.
- `desktop/src-tauri/src/commands.rs`:
  - Split `quit`'s body into `quit_app` (detach-all + flush + `AppHandle::exit`) so both the `quit` command and the picker's close handler share one implementation rather than duplicating it — matches the existing pattern where `detach_internal` is already shared by `detach`, `quit`'s detach-all, and each workspace window's own close handler.
  - Further split `quit_app` into `quit_cleanup` (everything except the final `AppHandle::exit` call) purely so a test can exercise it against `tauri::test::mock_app()`'s `MockRuntime` — `AppHandle::exit` panics unconditionally there (`request_exit` is `unimplemented!()`).
  - `quit_app`/`quit_cleanup`/`detach_all`/`detach_internal` are now generic over `tauri::Runtime` (matching the existing pattern in `menu.rs`), so the mock-app test can call them without changing any real (Wry) call site.
  - Added `commands::tests::quit_cleanup_runs_cleanly_with_nothing_attached` — the closest a test in this crate can get to "invoke the picker's close handler and assert it runs the right quit/detach logic" without a live Tauri runtime (`MockRuntime::on_window_event` is a stub that never stores the callback, so no test can fire a simulated `CloseRequested` either — the same reason `attach_and_open_window`'s own handler has no test today).
- `desktop/README.md`: documents the decision, the two rejected alternatives, and the file/layout summary.

## Correctness check (adversarial self-review)

Traced through Tauri's actual runtime source (`tauri-runtime-wry`) to confirm no double-run/reentrancy risk:
- `AppHandle::exit()` does trigger `RunEvent::ExitRequested` (confirmed against `tauri-2.11.5/src/app.rs` and the `Message::RequestExit` handling in `tauri-runtime-wry`), so the picker's `CloseRequested` → `quit_app` → `app.exit(0)` will cause `main.rs`'s existing `RunEvent::ExitRequested` handler to run `detach_all`/flush a second time — both are already idempotent (`detach_all` iterates a `Vec` collected from `state.children`, empty after the first pass; `LoggingGuard::flush` is a `.take()`), matching the pre-existing behavior the in-app "Quit" button already exercised.
- `ControlFlow::Exit` (set once `RunEvent::ExitRequested` isn't prevented) ends the winit event loop directly — it does **not** re-dispatch `WindowMessage::Close` per window, so there's no reentrant loop where app-wide exit re-fires the picker's own `CloseRequested` handler.
- `detach_all`/`detach_internal` only ever touch workspace windows (`ws-<id>` labels), never the picker itself, so nothing double-destroys the picker window.

## Test evidence

Ran from `desktop/src-tauri` (after installing this sandbox's missing WebKitGTK/GTK dev packages and a placeholder `dist-liveview/` resource dir, both needed just to get a working local build — see the crate's own README caveat about most sandboxes lacking the Tauri toolchain):

```
$ cargo build
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.72s   # only pre-existing macOS-only-menu.rs dead-code warnings, unrelated to this change

$ cargo test
test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests/menu_main_thread.rs ... (non-macOS no-op, as designed)

$ cargo clippy --all-targets -- -D warnings
# Fails — but diffed the exact error set against origin/main (git stash) and it's byte-for-byte
# identical before/after this change: pre-existing macOS-gated dead_code in menu.rs failing
# under -D warnings on this Linux sandbox (menu::build/handle_event/etc. are only ever *called*
# on macOS). Confirmed this change adds zero new clippy findings.

$ cargo fmt --all -- --check
(clean, no output)
```

The pre-push hook additionally ran the full `just ci` (workspace-wide clippy/fmt/Dialyzer/Elixir-format/lint) — all passed.

## Deviations from the acceptance criteria

None — all three checkboxes are done: decision made and documented (b), `CloseRequested` handler implemented, decision documented in `desktop/README.md`.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QtpdtrUbzvFVF9CMhYZhaK)_