### PR TITLE
desktop: embed Windows manifest into test targets too (BT-3253)

### DIFF
--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -2,5 +2,71 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fn main() {
-    tauri_build::build()
+    tauri_build::build();
+
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc")
+    {
+        embed_manifest_for_tests();
+    }
+}
+
+/// Workaround for a confirmed `tauri-build` limitation (BT-3253): on
+/// Windows, `tauri_build::build()` compiles a `.res` resource file —
+/// including a manifest declaring a dependency on Common Controls v6,
+/// needed because `tauri`'s default `common-controls-v6` feature pulls in
+/// native Win32 UI code (menus, dialogs, tray icons via `muda`/`wry`) that
+/// only resolves against the WinSxS-redirected v6 `comctl32.dll`, not the
+/// old in-box one. But `tauri-build` links that resource via
+/// `WindowsResource::compile()`, which (through the `embed-resource` crate)
+/// emits `cargo:rustc-link-arg-bins=...` — and per Cargo's own documented
+/// behavior, the `-bins` suffix scopes a linker arg to this crate's
+/// `[[bin]]` target only, never to `[[test]]` targets. A `[[test]]` binary
+/// that exercises the same native Win32 code path (as
+/// `tests/menu_main_thread.rs` does, calling `menu::build` for real against
+/// `tauri::test::mock_app()`) then crashes at process startup with
+/// `STATUS_ENTRYPOINT_NOT_FOUND`: the OS loader resolves `comctl32.dll` to
+/// the unmanifested old version, which is missing symbols (e.g.
+/// `SetWindowSubclass`) that only the v6 DLL exports — a load-time failure,
+/// before any test code runs.
+///
+/// This is not specific to this crate: `tauri` itself hits the identical
+/// failure in its own test suite, tracked upstream as
+/// <https://github.com/tauri-apps/tauri/issues/13419> and
+/// <https://github.com/orgs/tauri-apps/discussions/11179>, and works around
+/// it in its own `build.rs` with the exact technique mirrored here — see
+/// `embed_manifest_for_tests` at
+/// <https://github.com/tauri-apps/tauri/blob/dev/crates/tauri/build.rs>
+/// (added for <https://github.com/tauri-apps/tauri/pull/4383>). Rather than
+/// another `.res` compile, it invokes the MSVC linker's own
+/// manifest-embedding switches directly, scoped with `cargo`'s
+/// `-tests`-suffixed directive so this never touches the `[[bin]]` target's
+/// already-working, tauri-build-managed manifest:
+///
+/// - `/MANIFEST:EMBED` — embed a manifest resource in the linked binary.
+/// - `/MANIFESTINPUT:<path>` — the manifest content to embed (vendored
+///   locally as `windows-app-manifest.xml`, kept identical to tauri-build's
+///   own default so the test binary gets the same Common Controls v6
+///   declaration as the shipped `[[bin]]`).
+/// - `/WX` — fail the link (rather than silently no-op) if `link.exe` can't
+///   honor these, so a future toolchain change surfaces here instead of as
+///   a mystery Windows-only test crash again.
+///
+/// MSVC-only (guarded above) because `/MANIFEST:EMBED`/`/MANIFESTINPUT:`
+/// are `link.exe` switches, not something `rust-lld`/`gnu-ld` understand;
+/// this repo's Windows CI lane uses the default `x86_64-pc-windows-msvc`
+/// host toolchain (no `windows-gnu` target is built anywhere), so the
+/// `windows-gnu` case is simply out of scope rather than silently broken.
+fn embed_manifest_for_tests() {
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo");
+    let manifest = std::path::Path::new(&manifest_dir).join("windows-app-manifest.xml");
+
+    println!("cargo:rerun-if-changed={}", manifest.display());
+    println!("cargo:rustc-link-arg-tests=/MANIFEST:EMBED");
+    println!(
+        "cargo:rustc-link-arg-tests=/MANIFESTINPUT:{}",
+        manifest.display()
+    );
+    println!("cargo:rustc-link-arg-tests=/WX");
 }

--- a/desktop/src-tauri/tests/menu_main_thread.rs
+++ b/desktop/src-tauri/tests/menu_main_thread.rs
@@ -33,32 +33,44 @@
 //! (the "no duplicate implementations" rule doesn't apply to the compiler
 //! including one file twice).
 //!
-//! macOS-only: `menu::build` is itself only ever *called* on macOS in
-//! production (`main.rs`'s `.menu(menu::build)` is
-//! `#[cfg(target_os = "macos")]`-gated — see `menu.rs`'s module doc for why:
-//! Tauri never auto-installs a menu on Windows/Linux, so this app never
-//! builds one there either), so scoping this test's real assertions to the
-//! same platform matches what actually ships. That scoping also happens to
-//! route around a real, separately-tracked Windows limitation: an earlier
-//! version of this test ran unconditionally and crashed the compiled
-//! `menu_main_thread.exe` at process startup on `windows-2022` CI with
-//! `STATUS_ENTRYPOINT_NOT_FOUND` — an OS-loader symbol-resolution failure,
-//! not a test assertion, and it happened before any test code executed at
-//! all (see BT-3253 for the investigation and leading theory: `tauri-build`'s
-//! Windows resource/manifest linking likely only reaches the crate's
-//! `[[bin]]` target, not arbitrary `[[test]]` targets, so `muda`'s native
-//! Win32 menu-construction code — genuinely exercised here, unlike in any
-//! other test in this crate — can't resolve a symbol it expects). The same
-//! run's `test-desktop (macos-latest)` and `test-desktop (ubuntu-latest)`
-//! both passed; macOS is the only platform this needs to run on regardless,
-//! so BT-3253 is a test-infra follow-up, not a blocker for this file.
+//! Runs on every platform, not just macOS: `menu::build` itself is
+//! `Runtime`-generic with no `#[cfg(target_os = "macos")]` gating around the
+//! "Window" submenu or [`menu::CLOSE_WINDOW_ITEM_ID`] this test asserts on
+//! (see `menu.rs`'s `build` — only a few *other* items in the menu, e.g. the
+//! macOS app-name submenu, are platform-gated). The fact that `main.rs`
+//! itself only *calls* `menu::build` under `#[cfg(target_os = "macos")]`
+//! (Tauri never auto-installs a menu on Windows/Linux, so this app doesn't
+//! build one there either — see `menu.rs`'s module doc) doesn't make the
+//! function's own correctness a macOS-only concern; exercising it here on
+//! every platform is strictly more coverage of genuinely shared code, not
+//! scope creep.
+//!
+//! This file previously *did* gate its real assertions to
+//! `#[cfg(target_os = "macos")]`, purely as a workaround: an earlier,
+//! unconditional version crashed the compiled `menu_main_thread.exe` at
+//! process startup on `windows-2022` CI with `STATUS_ENTRYPOINT_NOT_FOUND` —
+//! an OS-loader symbol-resolution failure, before any test code ran at all.
+//! BT-3253 tracked that down to a confirmed `tauri-build` limitation (not
+//! ruled out — confirmed, both by reading `tauri-build`/`tauri-winres`
+//! source and by finding the identical failure already reported upstream:
+//! <https://github.com/tauri-apps/tauri/issues/13419>,
+//! <https://github.com/orgs/tauri-apps/discussions/11179>): the Windows
+//! resource `tauri_build::build()` compiles — which embeds the Common
+//! Controls v6 manifest `tauri`'s `common-controls-v6` feature needs for its
+//! native Win32 UI code — is linked via `cargo:rustc-link-arg-bins=...`,
+//! which (per Cargo's own documented behavior) only reaches this crate's
+//! `[[bin]]` target, never a `[[test]]` target. Without that manifest, the
+//! OS loader resolves `comctl32.dll` to the old in-box version, which is
+//! missing symbols (e.g. `SetWindowSubclass`) the v6 DLL exports — exactly
+//! matching the observed crash. `build.rs`'s `embed_manifest_for_tests` now
+//! embeds that same manifest into `[[test]]` targets too (mirroring the
+//! identical fix `tauri` itself uses in its own test suite), which is what
+//! makes running this file's real assertions on Windows possible at all.
 
-#[cfg(target_os = "macos")]
 #[path = "../src/menu.rs"]
 #[allow(dead_code, unused_imports)]
 mod menu;
 
-#[cfg(target_os = "macos")]
 fn main() {
     let app = tauri::test::mock_app();
     let built = menu::build(app.handle()).expect("menu should build against a mock app");
@@ -88,11 +100,3 @@ fn main() {
 
     println!("menu_main_thread: ok");
 }
-
-// Non-macOS: `menu::build` is never called in production here (see the
-// module doc above), and — for Windows specifically — actually calling it
-// from this harness=false binary is the exact thing BT-3253 tracks as
-// broken. Trivially succeed rather than omitting the `[[test]]` target
-// outright, so `cargo test`'s target list stays identical across platforms.
-#[cfg(not(target_os = "macos"))]
-fn main() {}

--- a/desktop/src-tauri/tests/menu_main_thread.rs
+++ b/desktop/src-tauri/tests/menu_main_thread.rs
@@ -46,11 +46,12 @@
 //! scope creep.
 //!
 //! This file previously *did* gate its real assertions to
-//! `#[cfg(target_os = "macos")]`, purely as a workaround: an earlier,
-//! unconditional version crashed the compiled `menu_main_thread.exe` at
-//! process startup on `windows-2022` CI with `STATUS_ENTRYPOINT_NOT_FOUND` —
-//! an OS-loader symbol-resolution failure, before any test code ran at all.
-//! BT-3253 tracked that down to a confirmed `tauri-build` limitation (not
+//! `#[cfg(target_os = "macos")]`, purely as a workaround (BT-3253): an
+//! earlier, unconditional version crashed the compiled
+//! `menu_main_thread.exe` at process startup on `windows-2022` CI with
+//! `STATUS_ENTRYPOINT_NOT_FOUND` — an OS-loader symbol-resolution failure,
+//! before any test code ran at all. BT-3253 tracked that down to a
+//! confirmed `tauri-build` limitation (not
 //! ruled out — confirmed, both by reading `tauri-build`/`tauri-winres`
 //! source and by finding the identical failure already reported upstream:
 //! <https://github.com/tauri-apps/tauri/issues/13419>,

--- a/desktop/src-tauri/tests/windows_manifest.rs
+++ b/desktop/src-tauri/tests/windows_manifest.rs
@@ -7,10 +7,20 @@
 //! Common Controls v6 dependency the production `[[bin]]` target gets from
 //! `tauri_build::build()`. That's a "keep in sync" claim with nothing
 //! enforcing it — a future `tauri-build` version bump could change its
-//! default manifest without this vendored copy noticing. Runs on every
-//! platform (it's a static content check, not the Windows-only linker
-//! embedding itself) so a silent desync is caught by ordinary `cargo test`,
-//! not just a Windows CI run.
+//! default manifest without this vendored copy noticing.
+//!
+//! This is a floor check, not a real sync check: it only confirms the
+//! vendored copy still declares Common Controls v6.0.0.0, the one thing
+//! `embed_manifest_for_tests` actually needs from it. It can't catch
+//! `tauri-build` reshaping its manifest in other ways (a changed
+//! `publicKeyToken`, an added `dpiAware`/`trustInfo` entry, ...) while
+//! leaving that dependency intact — that class of drift needs a real diff
+//! against `tauri-build`'s current default, which this doesn't attempt.
+//! Runs on every platform (it's a static content check, not the
+//! Windows-only linker embedding itself), so at least the failure mode
+//! that matters — the vendored copy silently losing what
+//! `common-controls-v6` needs — is caught by ordinary `cargo test`, not
+//! just a Windows CI run.
 
 #[test]
 fn vendored_manifest_declares_common_controls_v6() {

--- a/desktop/src-tauri/tests/windows_manifest.rs
+++ b/desktop/src-tauri/tests/windows_manifest.rs
@@ -1,0 +1,34 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+//! BT-3253 review follow-up: `windows-app-manifest.xml` is a vendored copy
+//! of `tauri-build`'s own default Windows manifest, asserted (in both
+//! `build.rs`'s and this file's own doc comments) to declare the same
+//! Common Controls v6 dependency the production `[[bin]]` target gets from
+//! `tauri_build::build()`. That's a "keep in sync" claim with nothing
+//! enforcing it — a future `tauri-build` version bump could change its
+//! default manifest without this vendored copy noticing. Runs on every
+//! platform (it's a static content check, not the Windows-only linker
+//! embedding itself) so a silent desync is caught by ordinary `cargo test`,
+//! not just a Windows CI run.
+
+#[test]
+fn vendored_manifest_declares_common_controls_v6() {
+    let manifest = include_str!("../windows-app-manifest.xml");
+
+    assert!(
+        manifest.contains("Microsoft.Windows.Common-Controls"),
+        "vendored windows-app-manifest.xml no longer declares a dependency on \
+         Microsoft.Windows.Common-Controls — re-diff against tauri-build's own \
+         default manifest (tauri-build-<version>/src/windows-app-manifest.xml) \
+         after any tauri-build version bump; see build.rs's embed_manifest_for_tests \
+         doc comment for why this file must match it"
+    );
+    assert!(
+        manifest.contains(r#"version="6.0.0.0""#),
+        "vendored windows-app-manifest.xml's Common-Controls dependency no longer \
+         pins version 6.0.0.0 — that's the specific version whose WinSxS-redirected \
+         comctl32.dll exports the symbols (e.g. SetWindowSubclass) this fix exists \
+         to make available to [[test]] targets"
+    );
+}

--- a/desktop/src-tauri/windows-app-manifest.xml
+++ b/desktop/src-tauri/windows-app-manifest.xml
@@ -1,0 +1,33 @@
+<!--
+  Copyright 2026 James Casey
+  SPDX-License-Identifier: Apache-2.0
+
+  Vendored copy of tauri-build's default Windows application manifest
+  (tauri-build-2.6.3/src/windows-app-manifest.xml), which `tauri_build::build()`
+  already embeds into this crate's `[[bin]]` target via `WindowsResource`
+  (since `build.rs` never overrides `WindowsAttributes::app_manifest`, so
+  tauri-build's own default applies). `build.rs` embeds this same file a
+  second time, scoped to `[[test]]` targets only, via the MSVC linker's
+  `/MANIFEST:EMBED` + `/MANIFESTINPUT:` switches — see `embed_manifest_for_tests`
+  in `build.rs` for why, and BT-3253 for the investigation this addresses.
+
+  Keeping this file's content identical to tauri-build's default is
+  intentional: it must declare the same Common Controls v6 dependency the
+  production binary gets, or a test binary could still exercise a
+  differently-manifested (or unmanifested) code path than what actually
+  ships.
+-->
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>


### PR DESCRIPTION
## BT-3253: Windows `harness=false` tests that build real Tauri menus crash with `STATUS_ENTRYPOINT_NOT_FOUND`

### Investigation

Confirmed the `common-controls-v6` manifest-scoping theory from the issue, both by reading source and by finding the identical bug already reported and fixed upstream:

- `tauri-build-2.6.3/src/lib.rs` calls the **unscoped** `WindowsResource::compile()` (not `compile_for(binaries)`).
- `tauri-winres-0.3.6`'s `compile()` calls `embed_resource::compile(rc, NONE)`, which emits `cargo:rustc-link-arg-bins={out_file}` — per Cargo's documented behavior, the `-bins` suffix scopes that linker arg to this crate's `[[bin]]` target **only**, never to `[[test]]` targets.
- The manifest content tauri-build embeds by default (`tauri-build-2.6.3/src/windows-app-manifest.xml`) declares a dependency on `Microsoft.Windows.Common-Controls` v6.0.0.0 — needed because `tauri`'s default `common-controls-v6` feature (`muda/common-controls-v6`, etc.) pulls in native Win32 UI code that only resolves against the WinSxS-redirected v6 `comctl32.dll`. Without the manifest, the OS loader resolves `comctl32.dll` to the old in-box version, which is missing symbols (e.g. `SetWindowSubclass`) only the v6 DLL exports — a load-time failure matching `STATUS_ENTRYPOINT_NOT_FOUND` exactly.
- This is a known upstream limitation, not specific to this crate: `tauri` itself hits the identical failure in its own test suite — [tauri-apps/tauri#13419](https://github.com/tauri-apps/tauri/issues/13419), [tauri-apps/tauri discussion #11179](https://github.com/orgs/tauri-apps/discussions/11179) — and works around it in its own `build.rs` via an `embed_manifest_for_tests` helper, added for [tauri-apps/tauri#4383](https://github.com/tauri-apps/tauri/pull/4383).

### Fix (option a)

`desktop/src-tauri/build.rs` now mirrors tauri's own upstream workaround: on `windows`+`msvc`, it embeds a locally-vendored copy of the same manifest (`desktop/src-tauri/windows-app-manifest.xml`, identical content to tauri-build's default) via the MSVC linker's `/MANIFEST:EMBED` + `/MANIFESTINPUT:` switches, scoped with Cargo's `-tests`-suffixed link-arg directive (`cargo:rustc-link-arg-tests=...`) so it's purely additive — it never touches the `[[bin]]` target's existing, already-working tauri-build-managed manifest.

`tests/menu_main_thread.rs`'s `#[cfg(target_os = "macos")]` gate (added as a workaround in BT-3244) is lifted: `menu::build` is `Runtime`-generic with no macOS-only code around what the test actually asserts on (the "Window" submenu's custom close-item), so running it on every platform is strictly more coverage now that the crash is addressed, not scope creep.

### Confidence / what's unverified

I have no Windows machine — **`test-desktop (windows-2022)` CI is the real test of this fix**, not my local run. My confidence is moderate-to-high: the mechanism is confirmed via source + a known, upstream-fixed instance of the exact same bug, and the fix mirrors tauri's own accepted solution almost verbatim. The one thing I can't verify locally is whether `/WX` (turning linker warnings into errors, matching upstream's own choice) could interact badly with some other dependency's build script also touching `-tests` link args — if Windows CI fails, that's the first thing I'd look at relaxing.

### Validation (Linux, this sandbox)

- `cargo build` — passes, same pre-existing dead-code warnings as before (macOS-only call site).
- `cargo test --locked` — all 19 unit tests + `menu_main_thread` integration test pass.
- `cargo clippy --all-targets -- -D warnings` — same pre-existing dead-code errors as origin/main (confirmed pre-existing per a sibling issue's investigation, not introduced here); no new findings.
- `cargo fmt --all -- --check` — clean.
- Repo's pre-push hook (full `just ci`-equivalent lint/build/test sweep) — passed.

On Linux, `build.rs`'s new Windows-only branch never executes, so this only proves no regression to the existing (already-passing) macOS/Linux behavior — the Windows path is exactly what CI needs to confirm.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QtpdtrUbzvFVF9CMhYZhaK)_