### PR TITLE
Remove duplicate parse_json/1 from beamtalk_repl_protocol

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_repl_protocol.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_repl_protocol.erl
@@ -82,7 +82,7 @@ eval expression.
 -spec decode(binary()) -> {ok, protocol_msg()} | {error, term()}.
 decode(Data) when is_binary(Data) ->
     Trimmed = string:trim(Data),
-    case parse_json(Trimmed) of
+    case beamtalk_repl_json:parse_json(Trimmed) of
         {ok, Map} when is_map(Map) ->
             decode_map(Map);
         {ok, _NonMap} ->
@@ -638,16 +638,6 @@ base_response(#protocol_msg{id = Id, session = Session}) ->
     case Session of
         undefined -> M1;
         _ -> M1#{<<"session">> => Session}
-    end.
-
--doc "Parse a JSON binary into a decoded term.".
--spec parse_json(binary()) -> {ok, term()} | {error, term()}.
-parse_json(Data) ->
-    try
-        Decoded = json:decode(Data),
-        {ok, Decoded}
-    catch
-        _:_ -> {error, not_json}
     end.
 
 -doc "Add output field to response map only when non-empty.".


### PR DESCRIPTION
## Summary

`beamtalk_repl_protocol` defined a private `parse_json/1` that was a strictly worse duplicate of the canonical `beamtalk_repl_json:parse_json/1`. Both modules live in the same OTP application (`beamtalk_workspace`), so there was no dependency barrier justifying the copy.

The private copy used a bare `_:_` catch with no logging, silently discarding error metadata. The canonical version in `beamtalk_repl_json` uses `?LOG_DEBUG` with structured fields (`class`, `reason`, `stack`, `data`, `domain`) — giving operators a diagnostic trail when JSON parsing fails.

This violates Architecture Principles §6 (Shared-Leaf-Module Pattern).

## Changes

- `runtime/apps/beamtalk_workspace/src/beamtalk_repl_protocol.erl`: the single call site at line 85 now delegates to `beamtalk_repl_json:parse_json/1`; the private `parse_json/1` definition (10 lines: `-doc`, `-spec`, and function body) is deleted

No behaviour change for callers — same `{ok, Map}` / `{error, not_json}` return shapes. `just ci` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C22bctSVVY4JB1EWgyNRJt)_