### PR TITLE
test: add unit tests for pid_liveness::is_process_alive (0% → ~91%)

### DIFF
--- a/crates/beamtalk-cli/src/pid_liveness.rs
+++ b/crates/beamtalk-cli/src/pid_liveness.rs
@@ -62,7 +62,7 @@ mod tests {
     #[test]
     fn nonexistent_pid_is_not_alive() {
         // PID 4_194_304 (4M) fits in i32 but no system ever has this many processes.
-        // kill(pid, 0) returns ESRCH, so the EPERM check on line 28 returns false.
+        // kill(pid, 0) returns ESRCH, so the EPERM fallback returns false.
         assert!(!is_process_alive(4_194_304));
     }
 

--- a/crates/beamtalk-cli/src/pid_liveness.rs
+++ b/crates/beamtalk-cli/src/pid_liveness.rs
@@ -48,3 +48,28 @@ pub fn is_process_alive(pid: u32) -> bool {
         ok != FALSE && exit_code == STILL_ACTIVE as u32
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_process_is_alive() {
+        // The current process is always alive — this exercises the kill(pid,0)==0 → true branch.
+        assert!(is_process_alive(std::process::id()));
+    }
+
+    #[test]
+    fn nonexistent_pid_is_not_alive() {
+        // PID 4_194_304 (4M) fits in i32 but no system ever has this many processes.
+        // kill(pid, 0) returns ESRCH, so the EPERM check on line 28 returns false.
+        assert!(!is_process_alive(4_194_304));
+    }
+
+    #[test]
+    fn pid_u32_overflow_is_not_alive() {
+        // u32::MAX cannot be converted to i32, so the early `return false` on the
+        // i32::try_from branch fires before any syscall.
+        assert!(!is_process_alive(u32::MAX));
+    }
+}


### PR DESCRIPTION
## Summary

`crates/beamtalk-cli/src/pid_liveness.rs` had **0% coverage** (0/11 executable lines) despite being actively called in production — workspace process management (`workspace/process.rs`), the CLI test helper (`tests/cli_common/mod.rs`), and the desktop broker (`desktop-broker/reap.rs`). The gap existed because only integration paths exercise it and those paths are skipped in the coverage build.

This PR adds three deterministic unit tests covering all reachable Unix branches:

| Test | Branch exercised |
|---|---|
| `current_process_is_alive` | `kill(pid, 0) == 0 → return true` |
| `nonexistent_pid_is_not_alive` | `ESRCH → EPERM check → false` |
| `pid_u32_overflow_is_not_alive` | `i32::try_from` overflow `→ return false` |

The EPERM branch (process exists but owned by another user) is unreachable without root privileges and is pre-existing documented scope-out.

## Files changed

- `crates/beamtalk-cli/src/pid_liveness.rs` — added `#[cfg(test)] mod tests` block (+25 lines)

## Test plan

- [x] `cargo test -p beamtalk-cli pid_liveness` — 3/3 pass
- [x] `cargo clippy -p beamtalk-cli -- -D warnings` — clean
- [x] Pre-push hooks (clippy, dialyzer, fmt, build) — all pass
- [x] Pre-existing integration test failures (`cli_doctor`, `cli_test::test_passes_for_passing_suite`) confirmed on unmodified `main` — not introduced by this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2fvrmpZetzJU5qzY8TBaN)_