### PR TITLE
test: extract setUp and tighten assertions in TestRunnerTest

### DIFF
--- a/crates/beamtalk-examples/corpus.json
+++ b/crates/beamtalk-examples/corpus.json
@@ -31010,6 +31010,7 @@
         "mutation",
         "object",
         "set",
+        "setUp",
         "string conversion",
         "subclassing",
         "testResultDuration",
@@ -31024,7 +31025,7 @@
         "toString",
         "to_string"
       ],
-      "source": "// BUnit tests for TestRunner and TestResult (BT-762)\n\nTestCase subclass: TestRunnerTest\n\n  testResultTotal =>\n    result := TestRunner run: SampleTestCase\n    self assert: result total equals: 2\n\n  testResultPassed =>\n    result := TestRunner run: SampleTestCase\n    self assert: result passed equals: 2\n\n  testResultFailed =>\n    result := TestRunner run: SampleTestCase\n    self assert: result failed equals: 0\n\n  testResultHasPassed =>\n    result := TestRunner run: SampleTestCase\n    self assert: result hasPassed\n\n  testResultSummary =>\n    result := TestRunner run: SampleTestCase\n    self deny: (result summary == nil)\n\n  testResultDuration =>\n    result := TestRunner run: SampleTestCase\n    self assert: (result duration >= 0.0)\n\n  testResultPrintString =>\n    result := TestRunner run: SampleTestCase\n    self deny: (result printString == nil)\n\n  testResultFailuresEmpty =>\n    result := TestRunner run: SampleTestCase\n    self assert: result failures equals: #()",
+      "source": "// BUnit tests for TestRunner and TestResult (BT-762)\n\nTestCase subclass: TestRunnerTest\n\n  setUp => self.result := TestRunner run: SampleTestCase\n\n  testResultTotal => self assert: self.result total equals: 2\n\n  testResultPassed => self assert: self.result passed equals: 2\n\n  testResultFailed => self assert: self.result failed equals: 0\n\n  testResultHasPassed => self assert: self.result hasPassed\n\n  testResultSummary => self assert: self.result summary class equals: String\n\n  testResultDuration => self assert: (self.result duration >= 0.0)\n\n  testResultPrintString =>\n    self assert: self.result printString class equals: String\n\n  testResultFailuresEmpty => self assert: self.result failures equals: #()",
       "explanation": "BUnit tests for TestRunner and TestResult (BT-762)"
     },
     {

--- a/stdlib/test/test_runner_test.bt
+++ b/stdlib/test/test_runner_test.bt
@@ -5,34 +5,21 @@
 
 TestCase subclass: TestRunnerTest
 
-  testResultTotal =>
-    result := TestRunner run: SampleTestCase
-    self assert: result total equals: 2
+  setUp => self.result := TestRunner run: SampleTestCase
 
-  testResultPassed =>
-    result := TestRunner run: SampleTestCase
-    self assert: result passed equals: 2
+  testResultTotal => self assert: self.result total equals: 2
 
-  testResultFailed =>
-    result := TestRunner run: SampleTestCase
-    self assert: result failed equals: 0
+  testResultPassed => self assert: self.result passed equals: 2
 
-  testResultHasPassed =>
-    result := TestRunner run: SampleTestCase
-    self assert: result hasPassed
+  testResultFailed => self assert: self.result failed equals: 0
 
-  testResultSummary =>
-    result := TestRunner run: SampleTestCase
-    self deny: (result summary == nil)
+  testResultHasPassed => self assert: self.result hasPassed
 
-  testResultDuration =>
-    result := TestRunner run: SampleTestCase
-    self assert: (result duration >= 0.0)
+  testResultSummary => self assert: self.result summary class equals: String
+
+  testResultDuration => self assert: (self.result duration >= 0.0)
 
   testResultPrintString =>
-    result := TestRunner run: SampleTestCase
-    self deny: (result printString == nil)
+    self assert: self.result printString class equals: String
 
-  testResultFailuresEmpty =>
-    result := TestRunner run: SampleTestCase
-    self assert: result failures equals: #()
+  testResultFailuresEmpty => self assert: self.result failures equals: #()


### PR DESCRIPTION
## Summary

Nightly test-quality pass — one smelly file found and tightened.

**File:** `stdlib/test/test_runner_test.bt`

**Smells fixed:**

1. **Repeated setup (8/8 test methods):** Every test method began with
   `result := TestRunner run: SampleTestCase`. Extracted into
   `setUp => self.result := TestRunner run: SampleTestCase`, removing 8
   duplicate lines. `TestResult` is immutable so sharing across assertions
   in one test instance is safe.

2. **Loose `deny: nil` assertions (2 methods):**
   - `testResultSummary`: `deny: (result summary == nil)` → `assert: self.result summary class equals: String` — `summary` is typed `-> String` in `TestResult.bt`; checking the class is strictly tighter.
   - `testResultPrintString`: same pattern, same fix.

## Test plan

- [x] `just test-bunit` — 3307 tests, 3305 passed, 0 failed (TestRunnerTest included)
- [x] `just fmt-beamtalk` — no violations after auto-format
- [x] Pre-push lint hook (Dialyzer, erlfmt, clippy, Biome) — all green

---
_Generated by [Claude Code](https://claude.ai/code/session_0126FbA7SncMk9PqyfPgCg3U)_