### PR TITLE
cockpit: icon-only panel-head toggles to fix System Browser overflow (BT-3256)

### DIFF
--- a/editors/liveview/assets/css/app.css
+++ b/editors/liveview/assets/css/app.css
@@ -235,13 +235,24 @@
    height is the thing BT-3247 is about — and `min-width: 0` +
    `text-overflow: ellipsis` degrade a label gracefully instead of silently
    overflowing if a future change ever does force `.seg` narrower than its
-   natural width. It does NOT fix the pre-existing (and pre-dating this fix
+   natural width. It did NOT fix the pre-existing (and pre-dating this fix
    — confirmed still present, and worse, before `.panel-title` existed)
    horizontal deficit: at the 286px default the row's natural content width
-   already exceeds the panel, so `.panel`'s `overflow: hidden` clips a few
-   pixels off the trailing `+`/`×` buttons regardless. That's tracked
-   separately in BT-3256. */
+   already exceeded the panel, so `.panel`'s `overflow: hidden` clipped a few
+   pixels off the trailing `+`/`×` buttons regardless. BT-3256 closed that gap
+   below via `.seg-icon`. */
 .panel-head .seg button { white-space: nowrap; min-width: 0; text-overflow: ellipsis; overflow: hidden; }
+/* BT-3256: icon-only mode/view toggles (Classes/Native/Type-Aliases +
+   Hier/Cats), replacing the BT-3247 comment's tracked horizontal deficit. The
+   text labels moved to `aria-label`/`title` on each button (still exposed to
+   ATs and on hover); the glyph alone needs less horizontal padding than the
+   words it replaces, which is most of what closes the ~119px gap at the
+   286px default. Scoped to `.seg-icon` (not all `.panel-head .seg`) so the
+   still-text-labelled `.actionbar.sb-side .seg` (Instance/Class) and the
+   top-bar `.insp-mode` seg are unaffected. */
+.panel-head .seg-icon button {
+  padding: 2px 6px; font-size: 12px; text-align: center;
+}
 .panel-head .spacer { flex: 1; }
 .panel-head .panel-close {
   border: 0; background: transparent; cursor: pointer; color: var(--faint);

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -8480,7 +8480,7 @@ defmodule BtAttachWeb.WorkspaceLive do
           <button
             :for={
               {view, label, icon} <- [
-                {"hierarchy", "Hierarchy", "▤"},
+                {"hierarchy", "Hierarchy", "≡"},
                 {"category", "Categories", "▦"}
               ]
             }

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -8444,36 +8444,56 @@ defmodule BtAttachWeb.WorkspaceLive do
              own scrollable, filterable browser rather than a collapsed in-tree
              section. Selecting "Native" replaces the class tree body with the
              native-module list (its own origin filter + count). --%>
-        <div class="seg" role="tablist" aria-label="Browser mode">
+        <%!-- BT-3256: icon-only buttons (the seg's text labels were part of the
+             ~119px horizontal deficit at the 286px default — see the BT-3247
+             follow-up comment on `.seg button` above). Each button keeps its
+             full-word `aria-label`/`title` so the meaning that used to be the
+             visible label is still available to screen readers and on hover;
+             only the visible glyph changes. --%>
+        <div class="seg seg-icon" role="tablist" aria-label="Browser mode">
           <button
             :for={
-              {mode, label} <- [
-                {"classes", "Classes"},
-                {"native", "Native"},
-                {"aliases", "Type Aliases"}
+              {mode, label, icon} <- [
+                {"classes", "Classes", "▣"},
+                {"native", "Native", "⚛"},
+                {"aliases", "Type Aliases", "≈"}
               ]
             }
             type="button"
             role="tab"
             class={[to_string(@browser_mode) == mode && "on"]}
             aria-selected={to_string(to_string(@browser_mode) == mode)}
+            aria-label={label}
+            title={label}
             phx-click="browser_mode"
             phx-value-mode={mode}
           >
-            {label}
+            {icon}
           </button>
         </div>
-        <div :if={@browser_mode == :classes} class="seg" role="tablist" aria-label="Class tree view">
+        <div
+          :if={@browser_mode == :classes}
+          class="seg seg-icon"
+          role="tablist"
+          aria-label="Class tree view"
+        >
           <button
-            :for={{view, label} <- [{"hierarchy", "Hier"}, {"category", "Cats"}]}
+            :for={
+              {view, label, icon} <- [
+                {"hierarchy", "Hierarchy", "▤"},
+                {"category", "Categories", "▦"}
+              ]
+            }
             type="button"
             role="tab"
             class={[@browser_view == view && "on"]}
             aria-selected={to_string(@browser_view == view)}
+            aria-label={label}
+            title={label}
             phx-click="browser_view"
             phx-value-view={view}
           >
-            {label}
+            {icon}
           </button>
         </div>
         <%!-- BT-2557: source-origin filter — narrow the tree to project / deps /

--- a/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
@@ -862,6 +862,62 @@ defmodule BtAttachWeb.WorkspaceBrowserTest do
     )
   end
 
+  test "the System Browser panel-head controls fit the column width without clipping at the default width (BT-3256)",
+       %{conn: conn} do
+    conn
+    |> visit("/")
+    |> assert_has(".att-label", text: "attached")
+    |> assert_has("#system-browser .panel-head")
+    # Same font-swap race as BT-3247's test above — measure only once the real
+    # webfont metrics have settled.
+    |> evaluate("document.fonts.ready.then(() => true)")
+    # At the 286px `--browser-w` default with `browser_mode: :classes` (the
+    # default), the panel-head's Classes/Native/Type-Aliases seg + Hier/Cats
+    # seg + source-origin filter + trailing +/× icon buttons needed ~403px
+    # against ~284px available — a ~119px deficit `.panel`'s `overflow:
+    # hidden` clipped silently rather than visibly wrapping or scrolling.
+    # `scrollWidth > clientWidth` is the horizontal counterpart of the
+    # `scrollHeight`/`clientHeight` check BT-3247 used for the vertical case;
+    # BT-3256 fixed it by making the two segs icon-only instead of widening
+    # `--browser-w` (which must stay at its default) or hiding Hier/Cats.
+    |> assert_eventually(
+      "(() => { const h = document.querySelector('#system-browser .panel-head'); return h.scrollWidth <= h.clientWidth; })()",
+      "the System Browser panel-head overflowed its width at the default column width"
+    )
+    # The rightmost controls — the "+" (new class) and "×" (close panel) icon
+    # buttons — are exactly what silently fell (partially or fully) outside
+    # the clipped/clickable area before the fix. Assert both are fully inside
+    # the panel-head's own box, not merely present somewhere in the DOM.
+    |> evaluate(
+      """
+      (() => {
+        const head = document.querySelector('#system-browser .panel-head');
+        const headRect = head.getBoundingClientRect();
+        const fits = (sel) => {
+          const el = head.querySelector(sel);
+          if (!el) return false;
+          const r = el.getBoundingClientRect();
+          return r.width > 0 && r.right <= headRect.right + 0.5;
+        };
+        return fits('.panel-icon') && fits('.panel-close');
+      })()
+      """,
+      fn ok ->
+        assert ok,
+               "the +/× icon buttons are clipped outside the System Browser panel-head"
+      end
+    )
+    # Icon-only toggles (BT-3256) replaced the Classes/Native/Type-Aliases and
+    # Hier/Cats buttons' visible text with a glyph — `aria-label`/`title`
+    # carry the original words so the meaning isn't lost for screen readers
+    # or on hover.
+    |> assert_has("#system-browser .panel-head .seg-icon button[aria-label='Classes']")
+    |> assert_has("#system-browser .panel-head .seg-icon button[aria-label='Native']")
+    |> assert_has("#system-browser .panel-head .seg-icon button[aria-label='Type Aliases']")
+    |> assert_has("#system-browser .panel-head .seg-icon button[aria-label='Hierarchy']")
+    |> assert_has("#system-browser .panel-head .seg-icon button[aria-label='Categories']")
+  end
+
   test "a saved split size is restored on the next load (BT-2576)", %{conn: conn} do
     conn
     |> visit("/")


### PR DESCRIPTION
## Problem

At the default `--browser-w` (286px) with `browser_mode: :classes` (the default), the System Browser panel-head's controls — the Classes/Native/Type-Aliases seg, the Hier/Cats seg, the source-origin filter, and the "+"/"×" icon buttons — need ~403px but only have ~284px available (a ~119px deficit, measured post-BT-3247). `.panel { overflow: hidden }` (app.css:208) clips the excess silently: the rightmost controls (the +/× buttons) can end up partially or fully outside the visible/clickable area with no visual indication.

BT-3247 fixed the *vertical* half of this (title/seg-button wrapping into a second line, overflowing the fixed 30px header) but explicitly left the horizontal deficit tracked here.

## Fix

Icon-only buttons for the two segmented toggles, per the issue's resolved decision:

- **Classes/Native/Type-Aliases seg** → `▣` / `⚛` / `≈`
- **Hier/Cats seg** → `▤` / `▦`

This repo's existing "icon" convention (checked against `.panel-icon`/`.panel-close` and the many single-Unicode-glyph buttons already in `workspace_live.ex` — `⚙` settings gear, `✎` edit, `⚡` runtime badge, `▸`/`▾` carets, etc.) is a single styled glyph character, not a font-icon library or inline SVG sprite — so this follows that same convention rather than introducing a second icon system.

Each icon button keeps `aria-label`/`title` set to the original word ("Classes", "Native", "Type Aliases", "Hierarchy", "Categories") so the accessible name and hover tooltip are unchanged — only the visible glyph is smaller.

CSS: a new `.panel-head .seg-icon button` rule (smaller padding + font-size) scoped to a `.seg-icon` modifier class added to just these two `<div class="seg">` toggles, so the still-text-labelled `.actionbar.sb-side .seg` (Instance/Class footer toggle) and the top-bar `.insp-mode` (Dock/Float) seg are untouched.

Rough width math: the old text buttons (`Classes`/`Native`/`Type Aliases`/`Hier`/`Cats`) at 10.5px font + 8px horizontal padding summed to roughly ~295px; the new single-glyph buttons at 12px font + 6px padding sum to roughly ~120px — a ~175px reduction, comfortably closing the ~119px deficit without needing to also icon-ify the source-origin filter (the issue's named next escalation), widen `--browser-w`, or hide Hier/Cats.

`--browser-w` is untouched (stays at its current default) and Hier/Cats remains visible (not hidden) — per the issue's explicit constraints.

## Files changed

- `editors/liveview/assets/css/app.css` — new `.seg-icon` rule; updated the BT-3247 comment above it to reflect that BT-3256 now closes the gap it flagged.
- `editors/liveview/lib/bt_attach_web/live/workspace_live.ex` — the two `<div class="seg">` toggles in the System Browser panel-head (around line 8447/8466) now render a glyph + `aria-label`/`title` instead of the text label; each `{mode/view, label}` tuple grew a third `icon` element.
- `editors/liveview/test/bt_attach_web/workspace_browser_test.exs` — new test `"the System Browser panel-head controls fit the column width without clipping at the default width (BT-3256)"`, added right after the existing BT-3247 test it extends the pattern of. It asserts:
  1. `panel-head.scrollWidth <= clientWidth` at the 286px default (the horizontal counterpart of BT-3247's `scrollHeight === clientHeight` check).
  2. The `.panel-icon` (+) and `.panel-close` (×) buttons' bounding rects are fully inside the panel-head's own bounding rect (not just present in the DOM — the actual clipping symptom from the issue).
  3. Each icon button carries the correct `aria-label` (`Classes`, `Native`, `Type Aliases`, `Hierarchy`, `Categories`).

  The existing BT-3247 test (title-wrap / `seg button` `white-space: nowrap` / narrowed-column ellipsis) is untouched.

## Validation

- `mix compile --warnings-as-errors` — clean.
- `mix format --check-formatted` on both changed `.ex` files — clean.
- Manual diff review confirms only the three intended files changed (no stray debug artifacts committed).

### Playwright e2e — could not get a clean run in this sandbox; root-caused as pre-existing, unrelated to this change

I was not able to get `mix test test/bt_attach_web/workspace_browser_test.exs --only playwright` to pass in this session's sandboxed environment — every test in the file, including the new BT-3256 test, fails identically with `visit("/") → TimeoutError: Timeout 10000ms exceeded`, i.e. the very first navigation in each test times out before any of my assertions run.

I spent real effort isolating whether this was caused by my change vs. the environment, since the orchestrating session was independently seeing the same symptom from a concurrent, unrelated Playwright run on the same shared port and initially attributed it to port contention:

- Re-ran cleanly with the port free and a dedicated workspace: same 35/35 failures, identical `visit("/")` timeout signature.
- **Control test**: `git stash`ed all three of my changes back to a pristine `origin/main` checkout and re-ran the single pre-existing, unmodified BT-3247 test (`workspace_browser_test.exs:813`) alone, against a workspace with a free port. It failed with the exact same `Timeout 10000ms exceeded` at `visit("/")`. This is airtight: the failure reproduces on code this PR never touched, so it cannot be a regression from this change.
- Direct investigation with a standalone Playwright script (same `assets/node_modules/playwright` install) against the manually-started endpoint showed the raw page navigation itself succeeds fine (LiveView mounts, console shows `phx-... mount`/`update` events) when using the correct `Origin` (`http://localhost:4002`, matching `config.exs`'s `url: [host: "localhost"]`) — so the app itself is healthy and reachable. The specific mechanism by which `phoenix_test_playwright`'s `visit/3` → `Frame.goto` hangs for the full configured 10s timeout in this particular sandbox (proxy/TLS-interception environment) wasn't something I was able to fully pin down in the time available; it appears to be an infra/harness issue specific to this ephemeral session, not the application or this diff.

**What's unverified as a result:** the actual live-DOM `scrollWidth <= clientWidth` measurement and the on-screen appearance of the new glyphs have not been confirmed by a passing automated browser test in this session. I'm confident in the fix based on the CSS math above (the old vs. new button-width sums) and careful reading of the existing icon-button styling this follows, but a green CI run of `liveview-e2e.yml` (a normal, non-sandboxed environment) is the real confirmation this PR still needs before merge.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QtpdtrUbzvFVF9CMhYZhaK)_