### PR TITLE
Add send_number_coercion/4 to beamtalk_message_dispatch.erl (BT-3262)

### DIFF
--- a/runtime/apps/beamtalk_runtime/src/beamtalk_message_dispatch.erl
+++ b/runtime/apps/beamtalk_runtime/src/beamtalk_message_dispatch.erl
@@ -5,6 +5,8 @@
 
 %%% **DDD Context:** Object System Context
 
+-include("beamtalk.hrl").
+
 -moduledoc """
 Unified message dispatch entry point.
 
@@ -38,16 +40,26 @@ to the normal synchronous path.
 | Class object     | (silently ignored) | ok |
 | Primitive        | (silently ignored) | ok |
 
+### send_number_coercion/4 (sync — returns value) (BT-3262, ADR 0116)
+
+Wraps send/3 for number-on-the-left arithmetic coercion (`5 + aVector`):
+delegates to send/3, and on a `does_not_understand` for the exact
+`Right`/`Selector` this call was for, re-raises it with a hint naming the
+original operator before it reaches the caller. Any other exception
+propagates unchanged.
+
 ## Usage (from generated Core Erlang)
 
 ```erlang
 call 'beamtalk_message_dispatch':'send'(Receiver, 'selector', [Args])
 call 'beamtalk_message_dispatch':'cast'(Receiver, 'selector', [Args])
+call 'beamtalk_message_dispatch':'send_number_coercion'(
+    Right, 'plusFromNumber:', [Left], '+')
 ```
 
 See: ADR 0006 (Unified Method Dispatch), BT-430, ADR 0043 (BT-918)
 """.
--export([send/3, send/4, cast/3]).
+-export([send/3, send/4, cast/3, send_number_coercion/4]).
 
 %% Compiled stdlib modules are generated from Core Erlang.
 %% Dialyzer can't resolve them if stdlib hasn't been built yet.
@@ -195,6 +207,63 @@ cast(Receiver, Selector, Args) ->
         {dead, _ClassName} ->
             %% Dead actor: cast is fire-and-forget, silently ignore
             ok
+    end.
+
+-doc """
+Send a reflected number-on-the-left coercion message, hinting the DNU if the
+reflected method is genuinely missing (ADR 0116 § Dispatch mechanism).
+
+Wraps send/3 for the `<verb>FromNumber:` call sites codegen emits for
+`5 + aVector`-shaped expressions: `Right` is the non-numeric right operand,
+`Selector` the synthesized reflected-method name (e.g. `'plusFromNumber:'`),
+`Args` its argument list (the original left operand), and `OrigOp` the
+original source operator symbol (e.g. `'+'`) used only for the hint text.
+
+On success, returns send/3's result unchanged. On a `does_not_understand`
+whose class and selector match `Right`'s actual class and this exact
+`Selector` — i.e. the reflected method is genuinely absent from `Right`'s
+class — re-raises the same error with a hint naming the original operator,
+so `5 + aThing` fails with something closer to "`Thing` has no
+`plusFromNumber:` — implement it to support `number + Thing` arithmetic"
+than an unexplained DNU referencing a selector the caller never typed.
+
+Any other exception propagates unchanged via erlang:raise/3: a DNU for a
+*different* selector or class (e.g. a bug inside a *present* reflected
+method's own body that itself DNUs on something else), or a non-DNU error
+entirely. `kind` stays `does_not_understand` on the re-raised error — only
+`hint` changes, so `on: RuntimeError do:`/`on: Error do:` catch it exactly
+as before.
+
+A DNU raised via `beamtalk_error:raise/1` is wrapped by
+`beamtalk_exception_handler:wrap/1` into a `#{'$beamtalk_class' := _, error
+:= #beamtalk_error{}}` tagged map *before* being raised (mirroring every
+other DNU in the system, e.g. `raise_class_dnu` in
+beamtalk_class_dispatch.erl) — the catch clause below matches that wrapped
+shape, not the bare record, and the re-raise re-wraps the hinted error the
+same way.
+""".
+-spec send_number_coercion(term(), atom(), list(), atom()) -> term().
+send_number_coercion(Right, Selector, Args, OrigOp) ->
+    RightClass = beamtalk_primitive:class_of(Right),
+    try
+        send(Right, Selector, Args)
+    catch
+        error:#{
+            '$beamtalk_class' := _,
+            error := #beamtalk_error{
+                kind = does_not_understand,
+                class = RightClass,
+                selector = Selector
+            } = Error
+        }:Stack ->
+            Hint = unicode:characters_to_binary(
+                io_lib:format(
+                    "~s has no '~s' — implement it to support 'number ~s ~s' arithmetic",
+                    [RightClass, Selector, OrigOp, RightClass]
+                )
+            ),
+            HintedError = beamtalk_error:with_hint(Error, Hint),
+            erlang:raise(error, beamtalk_exception_handler:wrap(HintedError), Stack)
     end.
 
 -doc """

--- a/runtime/apps/beamtalk_runtime/test/beamtalk_message_dispatch_tests.erl
+++ b/runtime/apps/beamtalk_runtime/test/beamtalk_message_dispatch_tests.erl
@@ -419,3 +419,105 @@ supervisor_generic_dispatch_test() ->
     after
         gen_server:stop(SupPid)
     end.
+
+%% ============================================================================
+%% BT-3262 (ADR 0116): send_number_coercion/4 — DNU hint on missing reflected
+%% method for number-on-the-left arithmetic coercion.
+%% ============================================================================
+
+number_coercion_test_() ->
+    {setup, fun actor_setup/0, fun actor_teardown/1, [
+        {"hint added when the reflected method is genuinely absent",
+            fun number_coercion_hints_missing_method/0},
+        {"DNU inside a present reflected method (unrelated selector) is not rewritten",
+            fun number_coercion_does_not_rewrite_inner_dnu/0},
+        {"a non-DNU exception from inside send/3 passes through unchanged",
+            fun number_coercion_passes_through_non_dnu/0},
+        {"success case: send/3's result is returned unchanged",
+            fun number_coercion_returns_result_on_success/0}
+    ]}.
+
+number_coercion_hints_missing_method() ->
+    %% CoercionActor has no 'timesFromNumber:' method at all — this is the
+    %% genuine "hook missing" case: does_not_understand for the exact
+    %% class+selector send_number_coercion/4 was asked to send, so it gets
+    %% the operator-naming hint attached.
+    {ok, Pid} = test_number_coercion_actor:start_link(),
+    Obj = #beamtalk_object{
+        class = 'CoercionActor', class_mod = test_number_coercion_actor, pid = Pid
+    },
+    try
+        ?assertError(
+            #{
+                '$beamtalk_class' := _,
+                error := #beamtalk_error{
+                    kind = does_not_understand,
+                    class = 'CoercionActor',
+                    selector = 'timesFromNumber:',
+                    hint =
+                        <<"CoercionActor has no 'timesFromNumber:' — implement it to support 'number * CoercionActor' arithmetic"/utf8>>
+                }
+            },
+            beamtalk_message_dispatch:send_number_coercion(
+                Obj, 'timesFromNumber:', [5], '*'
+            )
+        )
+    after
+        gen_server:stop(Pid)
+    end.
+
+number_coercion_does_not_rewrite_inner_dnu() ->
+    %% CoercionActor DOES implement 'plusFromNumber:', but its body sends an
+    %% unrelated selector that itself DNUs. The selector on the propagated
+    %% error ('unrelatedSelector') doesn't match the Selector argument
+    %% ('plusFromNumber:'), so send_number_coercion/4 must not add a hint —
+    %% confirms the class+selector match isn't over-catching.
+    {ok, Pid} = test_number_coercion_actor:start_link(),
+    Obj = #beamtalk_object{
+        class = 'CoercionActor', class_mod = test_number_coercion_actor, pid = Pid
+    },
+    try
+        ?assertError(
+            #{
+                '$beamtalk_class' := _,
+                error := #beamtalk_error{
+                    kind = does_not_understand,
+                    class = 'CoercionActor',
+                    selector = unrelatedSelector,
+                    hint = undefined
+                }
+            },
+            beamtalk_message_dispatch:send_number_coercion(
+                Obj, 'plusFromNumber:', [5], '+'
+            )
+        )
+    after
+        gen_server:stop(Pid)
+    end.
+
+number_coercion_passes_through_non_dnu() ->
+    %% CoercionActor's 'divFromNumber:' is present and raises a non-DNU
+    %% error (instantiation_error). send_number_coercion/4 only catches
+    %% does_not_understand, so this must propagate unchanged.
+    {ok, Pid} = test_number_coercion_actor:start_link(),
+    Obj = #beamtalk_object{
+        class = 'CoercionActor', class_mod = test_number_coercion_actor, pid = Pid
+    },
+    try
+        ?assertError(
+            #{
+                '$beamtalk_class' := _,
+                error := #beamtalk_error{kind = instantiation_error}
+            },
+            beamtalk_message_dispatch:send_number_coercion(
+                Obj, 'divFromNumber:', [5], '/'
+            )
+        )
+    after
+        gen_server:stop(Pid)
+    end.
+
+number_coercion_returns_result_on_success() ->
+    %% On success, send_number_coercion/4 returns send/3's result unchanged.
+    Result = beamtalk_message_dispatch:send_number_coercion(2, '+', [3], '+'),
+    ?assertEqual(5, Result).

--- a/runtime/apps/beamtalk_runtime/test/test_number_coercion_actor.erl
+++ b/runtime/apps/beamtalk_runtime/test/test_number_coercion_actor.erl
@@ -1,0 +1,70 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(test_number_coercion_actor).
+-behaviour(gen_server).
+
+-moduledoc """
+Test actor for beamtalk_message_dispatch:send_number_coercion/4 tests
+(BT-3262, ADR 0116).
+
+Exposes a present `plusFromNumber:`-style reflected method whose own body
+DNUs on an unrelated selector (simulating a bug inside the method, not a
+missing hook) and a present `divFromNumber:` that raises a non-DNU error —
+used to confirm send_number_coercion/4's class+selector match doesn't
+over-catch either case. A selector with no corresponding method at all (e.g.
+`timesFromNumber:`) is left undefined so ordinary dispatch produces a
+genuine "hook missing" does_not_understand.
+""".
+-include("beamtalk.hrl").
+
+%% API
+-export([start_link/0]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_cast/2,
+    handle_call/3,
+    handle_info/2,
+    code_change/3,
+    terminate/2
+]).
+
+%% Method implementations
+-export([
+    'handle_plusFromNumber:'/2,
+    'handle_divFromNumber:'/2
+]).
+
+start_link() ->
+    beamtalk_actor:start_link(?MODULE, []).
+
+init(_Args) ->
+    beamtalk_actor:init(#{
+        '$beamtalk_class' => 'CoercionActor',
+        '__class_mod__' => 'test_number_coercion_actor',
+        '__methods__' => #{
+            'plusFromNumber:' => fun ?MODULE:'handle_plusFromNumber:'/2,
+            'divFromNumber:' => fun ?MODULE:'handle_divFromNumber:'/2
+        }
+    }).
+
+handle_cast(Msg, State) -> beamtalk_actor:handle_cast(Msg, State).
+handle_call(Msg, From, State) -> beamtalk_actor:handle_call(Msg, From, State).
+handle_info(Msg, State) -> beamtalk_actor:handle_info(Msg, State).
+code_change(OldVsn, State, Extra) -> beamtalk_actor:code_change(OldVsn, State, Extra).
+terminate(Reason, State) -> beamtalk_actor:terminate(Reason, State).
+
+%% Present, but its own body sends an unrelated message that DNUs — the
+%% method itself is not missing, something inside it is broken. Used to
+%% confirm send_number_coercion/4 does not rewrite this as "hook missing".
+'handle_plusFromNumber:'([_N], _State) ->
+    Error = beamtalk_error:new(does_not_understand, 'CoercionActor', unrelatedSelector),
+    error(Error).
+
+%% Present, raises a non-DNU error (instantiation_error) — confirms an
+%% unrelated exception kind passes through send_number_coercion/4 unchanged.
+'handle_divFromNumber:'([_N], _State) ->
+    Error = beamtalk_error:new(instantiation_error, 'CoercionActor', 'divFromNumber:'),
+    error(Error).


### PR DESCRIPTION
## Summary

Phase 1 of [ADR 0116](https://github.com/jamesc/beamtalk/blob/main/docs/ADR/0116-number-on-the-left-arithmetic-coercion.md) (double-dispatch coercion for number-on-the-left arithmetic), implementing [BT-3262](https://linear.app/beamtalk/issue/BT-3262/add-send-number-coercion4-to-beamtalk-message-dispatcherl).

Adds `beamtalk_message_dispatch:send_number_coercion/4`, a thin wrapper around `send/3` used by the (not-yet-wired) number-on-the-left arithmetic coercion mechanism (`5 + aVector`). When the reflected coercion method (e.g. `plusFromNumber:`) is genuinely absent on the right operand's class, the resulting `does_not_understand` gets a hint naming the original operator, instead of leaving the caller to decode a synthesized selector name they never typed.

This is pure runtime work with no codegen dependency — nothing calls it yet. Codegen wiring is BT-3263 (Phase 2, blocked on this PR).

## Key changes

- `send_number_coercion/4` added and exported in `beamtalk_message_dispatch.erl`. Calls `send/3` normally; on success returns its result unchanged. On a `does_not_understand` whose class and selector match `Right`'s actual class and the exact `Selector` argument, re-raises the same error with a hint via `beamtalk_error:with_hint/2`. Any other exception (different selector/class, or a non-DNU error) propagates unchanged.
- Correctly handles the real DNU propagation shape (`beamtalk_error:raise/1` → `beamtalk_exception_handler:wrap/1` → wrapped tagged map), not just the bare record.
- Fixed a real bug in the ADR's own literal pseudocode along the way: the em-dash in the hint text can't survive `iolist_to_binary/1` (a codepoint >255 corrupts an iolist silently, with no compiler warning — exactly the class of bug the repo's own `lint-binary-literal-encoding` check, BT-3026, exists to catch). Used `unicode:characters_to_binary/1` instead.
- New dedicated test fixture `test_number_coercion_actor.erl` and 4 EUnit tests: hint added when the reflected method is genuinely absent; a DNU raised *inside* a present reflected method for an unrelated selector is not rewritten; a non-DNU exception passes through unchanged; and the success path returns `send/3`'s result unchanged.

## Test plan

- [x] `just ci-changed` (build, lint incl. dialyzer, Rust tests, Erlang runtime tests, BUnit, stdlib tests, metamorphic tests, corpus check, surface-parity drift) — all clean
- [x] `just test` — 1860/1860 Erlang runtime tests pass (including the 36/36 in `beamtalk_message_dispatch_tests`, 4 new)
- [x] `rebar3 fmt --check` — clean
- [x] Pre-push hook (full CI) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDp1s9rbz3fas625DEV6Y9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDp1s9rbz3fas625DEV6Y9)_