### PR TITLE
BT-3268: ADR 0114 Phase 1 site-discovery spike

### DIFF
--- a/docs/development/adr-0114-site-discovery-spike-findings.md
+++ b/docs/development/adr-0114-site-discovery-spike-findings.md
@@ -1,0 +1,271 @@
+# ADR 0114 — Phase 1 Site-Discovery Spike Findings (BT-3268)
+
+**Status:** complete
+**Deliverable:** knowledge. Validate (or refute) that `renameTo:`'s planned
+site-discovery mechanism — the union of `SystemNavigation default
+referencesTo: aClass` (ADR 0087) and `beamtalk_class_registry:
+direct_subclasses/1` — is exhaustive against real, compiled code, and measure
+the one known, accepted gap (Constraint 4: `beamtalk_xref:
+build_method_entry/5` hard-codes `references => []` for every live-patched
+method) before any rename primitive is built on top of it.
+
+**Evidence artefacts committed:**
+- `runtime/apps/beamtalk_workspace/test/beamtalk_adr0114_site_discovery_spike_tests.erl`
+  — EUnit harness against the real, compiled stdlib
+  (`beamtalk_test_boot:boot_real_stdlib/1`) plus a primitive-level
+  reproduction of the `build_method_entry/5` gap. `rebar3 eunit --module=
+  beamtalk_adr0114_site_discovery_spike_tests` → **6 tests, 0 failures**.
+  Also green inside the full suite: `rebar3 eunit --app=beamtalk_runtime,
+  beamtalk_workspace,beamtalk_compiler` → **5900 tests, 0 failures**.
+- `stdlib/test/adr_0114_class_builder_live_patch_gap_test.bt` — the gap
+  reproduced end-to-end through `SystemNavigation referencesTo:` against a
+  real `ClassBuilder`-installed method (`just test-bunit
+  test/adr_0114_class_builder_live_patch_gap_test.bt` → passes).
+- `tests/repl-protocol/cases/adr_0114_live_patch_gap.btscript` — checks the
+  two OTHER live-patch surfaces the ADR names (`>>`/`compile:source:` via a
+  prior revision of this file, and `register/5` extensions in the current
+  one) and finds neither actually reproduces the gap end-to-end (both pass
+  cleanly today, asserting the reference IS found) — see finding #3.
+
+## Headline
+
+| # | Question | Verdict | Evidence |
+|---|---|---|---|
+| 1 | Is `direct_subclasses/1` exhaustive for superclass-declaration sites? | **Held** | Exact match against a hand audit of every `Announcement subclass:` (9) and `Error subclass:` (4) declaration in `stdlib/src/*.bt`. |
+| 2 | Is `referencesTo:` exhaustive for body/type/extension references, outside the known gaps? | **Held — with a corrected mental model** | Exact match against a hand audit of `Duration`, once the audit accounted for two behaviours not obvious from reading source alone (below). |
+| 3 | Does the Constraint 4 live-patch gap reproduce via the surfaces the ADR names (`>>`, `compile:source:`, `register/5`)? | **No — corrects the ADR's own text** | All three were tried live. None reproduces the gap through `SystemNavigation referencesTo:`. See finding #3 for the mechanism behind each. |
+| 4 | Is the gap reachable at all through a real, currently-shipped surface? | **Yes — `ClassBuilder` `methodSource:`** | The one surface this spike found that actually hits it, confirmed via `SystemNavigation referencesTo:` end-to-end (not just `build_method_entry/5` in isolation). |
+| 5 | What is the reproduced gap's blast radius? | **The entire `references` channel for the affected method, unconditionally** | Confirmed at both the primitive level (`build_method_entry/5` returns `references => []` for a method with 2 real references) and the `SystemNavigation`-level (the `ClassBuilder` fixture's real reference is completely absent, not partially represented). |
+| 6 | Is the `sends`/`references` asymmetry Constraint 4 highlights real? | **Confirmed at the primitive level; not reproduced through the BT-level `sendersOf:` for the `ClassBuilder` case** | `build_method_entry/5` populates `sends` while hard-coding `references => []` for the identical patched method (EUnit-level, direct). A parallel BUnit-level check that `SystemNavigation sendersOf:` finds the same `ClassBuilder` method's send did **not** pass and was dropped rather than asserted incorrectly — see finding #4 (open question, not resolved by this spike). |
+
+**Single most important implication for Phase 2:** finding #3 is a genuine,
+material correction to the ADR's own Constraint 4 text, not a nuance. The
+ADR states the gap is reachable via "every `>>`/`compile:source:` live
+patch" and calls it "the *everyday* ADR 0082 workflow, not an edge case."
+Measured against the current implementation, **neither of those two named
+surfaces reproduces the gap** — both recompile the whole class through the
+real compiler (a complete, correct `method_xref`) rather than routing
+through `beamtalk_object_class:put_method/3,4` (a repo-wide grep confirms
+zero non-test call sites of that function today). The gap **is** real and
+**is** reachable — via `ClassBuilder` `methodSource:` — but that is a
+narrower, less "everyday" surface than the ADR currently claims. This
+changes the risk characterization Phase 2 should carry forward, even though
+it does not change the recommendation (see §4): the union is still safe to
+build on, and the live-patch gap is still real, but its practical exposure
+in ordinary agent/human workspace editing (which overwhelmingly uses `>>`
+and `compile:source:`) is smaller than the ADR states. The ADR's Constraint
+4 text should be corrected in a follow-up before Phase 2 relies on its
+current wording to scope caller-facing warnings.
+
+---
+
+## 1. `direct_subclasses/1` — exhaustive for the sample
+
+Hand audit method: `grep -n "<Class> subclass:" stdlib/src/*.bt` (109 real,
+compiled stdlib classes), read against the resulting file list to exclude
+comment/doc-string occurrences and generic-type subclass forms of unrelated
+classes.
+
+- `direct_subclasses('Announcement')` — hand audit found exactly 9 direct
+  subclasses (`ActorSpawned`, `ActorStopped`, `BindingChanged`, `ClassLoaded`,
+  `ClassRemoved`, `FlushCompleted`, `ObjectStateChanged`,
+  `SupervisionChildAdded`, `SupervisionChildCrashed`). The real runtime query
+  against the booted stdlib returned exactly this set, sorted.
+- `direct_subclasses('Error')` — hand audit found exactly 4
+  (`BEAMError`, `InstantiationError`, `RuntimeError`, `TypeError`).
+  `ExitError`/`ThrowError` subclass `BEAMError`, not `Error` directly, and
+  were correctly excluded (confirming the query is not accidentally
+  transitive).
+
+No discrepancy in either sample. `direct_subclasses/1` reads a single ETS
+reverse-edge table (`beamtalk_class_metadata:match_subclasses/1`) populated
+at class-registration time from the compiler-parsed class header — there is
+no live-patch analogue for superclass declarations (a class's own
+`subclass:` header cannot be live-patched independently of a full class
+redefinition), so this channel has no equivalent of Constraint 4's gap.
+
+## 2. `referencesTo:` — exhaustive, but two behaviours are easy to
+   under-predict from source alone
+
+The first pass of this spike's `references_to_duration` test hand-counted
+only *other* classes' mentions of `Duration` (8, across `Actor.bt`,
+`DateTime.bt`, `Parallel.bt`, `Timer.bt`) and asserted `length(references_to(
+'Duration')) == 8`. Run against the real booted stdlib, this failed:
+**21**, not 8. Both discrepancies turned out to be `referencesTo:` doing the
+*correct*, exhaustive thing — the hand audit was wrong, not the index:
+
+1. **Self-references count.** `Duration.bt` itself has 13 methods whose own
+   signatures mention `Duration` (7 instance-side comparison/arithmetic
+   operators — `+ - * < <= > >=` — and 6 class-side constructors —
+   `milliseconds: seconds: minutes: hours: days: fromString:`). Every one of
+   these is correctly reported as a site owned by `Duration`. This is not
+   optional for `renameTo:`'s purposes: renaming `Duration` to (say)
+   `TimeSpan` requires rewriting `Duration`'s own `-> Duration` / `::
+   Duration` signature mentions exactly as much as any external caller's.
+   8 + 13 = 21, matching the real result exactly once this was accounted for.
+2. **Same-line multi-occurrence collapse.** `+ other :: Duration -> Duration
+   =>` mentions `Duration` twice on one source line (param type, return
+   type). Both mentions produce identical `#{class => 'Duration', line =>
+   L}` reference-hit records at codegen time; once folded into the xref
+   site shape `#{owner, class_side, method, line, gen}`, the two hits are
+   *identical* tuples, and `beamtalk_xref_references` is an ETS `bag` —
+   which stores at most one copy of an object that is fully identical to an
+   existing one. The result: `Duration>>+` contributes **one** row, not two.
+   This is invisible in the data (nothing is missing — the line/method pair
+   that needs rewriting is still present) but means a naive
+   "count textual occurrences of the class name" prediction will not match
+   `length(references_to(X))` when a method mentions the same class more
+   than once on one line. Verified by contrast: `Actor.bt`'s `withTimeout:`
+   mentions `Duration` on two *different* lines (type annotation, then
+   `isKindOf:`) and correctly produces two separate rows.
+
+Once corrected for both, the hand-audited set (21 exact `{owner, class_side,
+method}` tuples, several with duplicate entries for the two-different-line
+case) matches the real query result exactly — see the test's inline
+commentary for the corrected, line-by-line audit.
+
+**Conclusion:** no unexplained gap. Every real, non-comment mention of the
+sampled classes that a person reading the source would call "a reference"
+is present in the index. The two behaviours above are worth documenting for
+whoever builds Phase 2's rewrite mechanism (the site list is precise, but
+"how many sites" is not the same question as "how many textual mentions"),
+but neither is a correctness defect.
+
+## 3. Live-patch gap (Constraint 4) — which surfaces actually reach it
+
+This is the finding that most changes the picture the ADR paints. All three
+live-patch surfaces Constraint 4 and its doc comments name were checked
+live, in order, against the actual `SystemNavigation referencesTo:` a
+rename would call — not just `build_method_entry/5` in isolation.
+
+### 3a. `>>` and `compile:source:` — do NOT reproduce the gap
+
+First checked via `Counter >> makeTimer -> Timer => Timer after: 999999 do:
+[nil]` against a real loaded class (`Counter`), in the E2E harness. Result:
+`SystemNavigation default referencesTo: Timer` **found** the patch — no gap.
+
+Tracing why: both `>>` (parsed as a standalone `MethodDefinition`,
+`beamtalk_repl_eval:handle_method_definition/4` →
+`beamtalk_repl_loader:reload_method_definition/4`) and `compile:source:`
+(`beamtalk_repl_eval:compile_method/6,7` → `do_compile_method/7` →
+`beamtalk_repl_loader:install_method/9`) converge on the *same* function,
+`install_method_with_source/10`/`recompile_with_method`, which:
+
+1. Merges the patched method's source into the class's full, on-disk source
+   text.
+2. Recompiles the **whole class** via `beamtalk_repl_compiler:
+   compile_method_reload/3` — a full pass through the real Rust compiler,
+   producing a fresh `Binary` with a complete, compiler-computed
+   `method_xref` (references included, exactly like a normal file compile).
+3. Installs it via `code:load_binary/3` and `activate_module/2`, which runs
+   the new module's `register_class/0` — forwarding the *complete* xref
+   payload to `beamtalk_xref`, generation-bumped, same as any ordinary class
+   load or `Behaviour reload`.
+
+**Neither path calls `beamtalk_object_class:put_method/3,4` at all.** A
+repo-wide grep (`grep -rln "object_class:put_method(" apps/*/src`) returns
+zero results outside test files. `build_method_entry/5`'s narrow
+single-method reparse — the function Constraint 4 names — is simply never
+invoked by either surface in the current codebase. This directly
+contradicts the ADR's characterization of `>>`/`compile:source:` as "the
+function every `>>`/`compile:source:` live patch... routes through."
+
+### 3b. `register/5` sourced extensions — do NOT reproduce the gap (but for a different reason)
+
+Checked via `Erlang beamtalk_extensions register: #Counter selector:
+#btAdr0114TimerExt fun: ... source: "spawnTimer -> Timer => Timer after:
+999999 do: [nil]"` (the same FFI shape `workspace_native_api.btscript`
+already uses for its own passing extension coverage). Result:
+`referencesTo: Timer` **found** the extension method — no gap here either.
+
+This time the `build_method_entry/5`-level gap is real and confirmed
+separately (`beamtalk_extensions:index_extension_xref/3` does call
+`build_method_entry/5`, and the EUnit-level test in this spike confirms its
+own such call returns `references => []`) — but `SystemNavigation.bt`'s
+`referencesTo:` implementation compensates for it with a **dedicated,
+unconditional rescan of every registered extension's source**
+(`collectExtensionReferencesFor:into:`, BT-2196), whose own comment says
+why: *"Extensions are not in the index yet, so this scan is
+unconditional."* This rescan runs on every `referencesTo:` call regardless
+of what the xref table says, so the table's empty `references` row for an
+extension method never actually surfaces as a missed reference at the
+`SystemNavigation` level.
+
+### 3c. `ClassBuilder` `methodSource:` — DOES reproduce the gap
+
+Confirmed via `stdlib/test/adr_0114_class_builder_live_patch_gap_test.bt`:
+a class built with `Object classBuilder name: #Adr0114BuilderGapProbe;
+superclass: Object; methods: #{#makeCounter => [:_self | AtomicCounter
+new: #adr0114BuilderProbe]}; register` (a real block-literal method body,
+BT-2246-auto-populated source) is **not** found by `SystemNavigation
+referencesTo: AtomicCounter`, even though its body plainly sends
+`AtomicCounter new: ...`.
+
+Why this one differs from 3a/3b: `beamtalk_class_builder.erl`'s
+`source_map_to_xref/3` calls `build_method_entry/5` with `SourceStatus =
+indexed` (a real source string), so the class ends up **fully indexed** in
+the xref table — unlike an unindexed class, it is never picked up by
+`referencesTo:`'s loaded-but-unindexed fallback scan, and unlike a
+`register/5` extension, there is no compensating unconditional rescan for
+`ClassBuilder`-installed methods. The `references => []` row is the only
+data `referencesTo:` ever consults for this method, so the real reference
+is silently and completely missed.
+
+### Primitive-level confirmation (independent of which surface calls it)
+
+`runtime/apps/beamtalk_workspace/test/beamtalk_adr0114_site_discovery_spike_tests.erl`
+calls `beamtalk_object_class:put_method/4` directly (the function
+`build_method_entry/5` doc-comments as the mechanism, whichever surface
+eventually calls it) with a method carrying two distinct, real references
+to `AtomicCounter` (a return-type annotation and a constructor send).
+`build_method_entry/5` returns `references => []` — confirmed against an
+independent count (the literal `AtomicCounter` substring occurs exactly
+twice in the source, counted without re-running the compiler's own walker)
+— and `references_to('AtomicCounter')` never surfaces the patched class
+afterward. **Blast radius: 100% of that method's real references, not a
+partial miss.** The same method's constructor send *is* correctly indexed
+by `sendersOf:` — the sends/references asymmetry Constraint 4 describes is
+real at this level.
+
+## 4. Open question this spike does not resolve
+
+A BUnit-level check that `SystemNavigation sendersOf: #new:` finds the same
+`ClassBuilder`-method's send (mirroring the EUnit-level `put_method/4`
+result) did not pass in a first attempt and was dropped from the committed
+fixture rather than asserted on faith. This does not affect the core
+`referencesTo:` finding above (§3c stands on its own, confirmed
+independently), but it means the sends/references asymmetry is confirmed at
+the primitive level (§3, EUnit) and not independently re-confirmed at the
+`ClassBuilder`+`SystemNavigation sendersOf:` level. Worth a follow-up
+probe before Phase 3 (`renameSelector:to:`) leans on `ClassBuilder`
+`sendersOf:` completeness specifically — not blocking for this issue, which
+scopes `renameTo:`'s `referencesTo:`/`direct_subclasses:` union only.
+
+## 5. Recommendation for Phase 2
+
+- The `referencesTo:` + `direct_subclasses/1` union is safe to build
+  `renameTo:`'s site discovery on as designed. No fallback to a narrower
+  "definition-only" v1 is indicated by this spike.
+- Phase 2's implementer should be aware of finding #2's two behaviours (self-
+  references count; same-line occurrences collapse to one row) when writing
+  any code that predicts or double-checks a rewrite site count from source
+  text — the site *list* is correct, but is not directly comparable to a
+  naive occurrence count.
+- **The ADR's Constraint 4 text should be corrected**: the live-patch gap is
+  real, but is not reachable via `>>`/`compile:source:` in the current
+  implementation — only via `ClassBuilder` `methodSource:` (and, at the raw
+  primitive level, any future direct caller of
+  `beamtalk_object_class:put_method/3,4`, which nothing currently calls in
+  production). Caller-facing warning copy for `renameTo:` should scope the
+  live-patch caveat to `ClassBuilder`-defined dynamic classes specifically,
+  not to "any class with an unflushed live patch" as the ADR currently
+  implies — the latter overstates the risk for the ordinary `>>`/
+  `compile:source:` workflow, which this spike found to be unaffected.
+
+## References
+
+- ADR: `docs/ADR/0114-class-and-method-rename.md` § Decision, § Constraints
+  4, § Phased rollout Phase 1
+- Related: `docs/ADR/0087-maintained-xref-index-for-system-navigation.md`
+  (`referencesTo:`, `beamtalk_xref:build_method_entry/5`)
+- Issue: BT-3268

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_adr0114_site_discovery_spike_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_adr0114_site_discovery_spike_tests.erl
@@ -99,6 +99,13 @@ corpus_accuracy_test_() ->
 %% ClassLoaded.bt:17, ClassRemoved.bt:17, FlushCompleted.bt:19,
 %% ObjectStateChanged.bt:26, SupervisionChildAdded.bt:18,
 %% SupervisionChildCrashed.bt:17 — nine direct subclasses, no more, no fewer.
+%% Asserted as a subset, not exact equality: this module runs in ordinary
+%% CI, and an unrelated future PR adding another `Announcement subclass:`
+%% declaration must not fail a spike test whose validation purpose (this
+%% hand audit, dated 2026-08-25) is already served — see the Claude review
+%% bot's finding on PR #3519. The hand-audited set must still be present
+%% (that's the actual accuracy check); growth beyond it is expected and
+%% fine.
 direct_subclasses_announcement() ->
     Expected = lists:sort([
         'ActorSpawned',
@@ -112,17 +119,18 @@ direct_subclasses_announcement() ->
         'SupervisionChildCrashed'
     ]),
     Actual = lists:sort(beamtalk_class_registry:direct_subclasses('Announcement')),
-    ?assertEqual(Expected, Actual).
+    ?assert(ordsets:is_subset(ordsets:from_list(Expected), ordsets:from_list(Actual))).
 
 %% Hand audit (`grep -n "Error subclass:" stdlib/src/*.bt`, 2026-08-25):
 %% BEAMError.bt:20, InstantiationError.bt:13, RuntimeError.bt:14,
 %% TypeError.bt:12 — four direct subclasses. `ExitError`/`ThrowError`
 %% subclass `BEAMError`, not `Error` directly, so they are correctly excluded
 %% here (direct_subclasses/1 is not transitive).
+%% Subset, not exact equality — see direct_subclasses_announcement/0's note.
 direct_subclasses_error() ->
     Expected = lists:sort(['BEAMError', 'InstantiationError', 'RuntimeError', 'TypeError']),
     Actual = lists:sort(beamtalk_class_registry:direct_subclasses('Error')),
-    ?assertEqual(Expected, Actual).
+    ?assert(ordsets:is_subset(ordsets:from_list(Expected), ordsets:from_list(Actual))).
 
 %% Hand audit (`grep -n '\bDuration\b' stdlib/src/*.bt`, 2026-08-25, real code
 %% lines only — every other hit is inside a `///` doc comment and must NOT be
@@ -157,9 +165,13 @@ direct_subclasses_error() ->
 %%     (lines 40/49/57/65/73/87 — return-type-only mentions, one row each)
 %%
 %% 21 rows total across 5 owner classes.
+%% Asserted as a subset, not exact equality — see
+%% direct_subclasses_announcement/0's note: a future PR adding a method
+%% elsewhere in the stdlib that mentions `Duration` in its signature must
+%% not fail this spike test. The hand-audited 21-tuple set (this module's
+%% actual accuracy evidence) must still be present in full.
 references_to_duration() ->
     Sites = beamtalk_xref:references_to('Duration'),
-    ?assertEqual(21, length(Sites)),
     OwnerMethodTally = lists:sort([
         {maps:get(owner, S), maps:get(class_side, S), maps:get(method, S)}
      || S <- Sites
@@ -190,7 +202,7 @@ references_to_duration() ->
         {'Duration', true, 'days:'},
         {'Duration', true, 'fromString:'}
     ]),
-    ?assertEqual(ExpectedTally, OwnerMethodTally).
+    ?assert(multiset_subset(ExpectedTally, OwnerMethodTally)).
 
 %%====================================================================
 %% Group 2 — live-patch gap reproduction (ADR 0114 Constraint 4).
@@ -297,3 +309,22 @@ count_occurrences(Pattern, Bin) ->
     case binary:matches(Bin, Pattern) of
         Matches when is_list(Matches) -> length(Matches)
     end.
+
+%% True iff every element of `Expected` occurs in `Actual` at least as many
+%% times (a multiset subset, not a plain set subset — some hand-audited
+%% tuples above are legitimately duplicated, e.g. a method mentioning
+%% `Duration` on two distinct source lines). Used so the corpus-accuracy
+%% tests keep proving the hand audit's evidence is present without failing
+%% when an unrelated future stdlib change adds more of the same shape.
+-spec multiset_subset([term()], [term()]) -> boolean().
+multiset_subset(Expected, Actual) ->
+    ExpectedCounts = tally(Expected),
+    ActualCounts = tally(Actual),
+    maps:fold(
+        fun(Key, Count, Ok) -> Ok andalso Count =< maps:get(Key, ActualCounts, 0) end,
+        true,
+        ExpectedCounts
+    ).
+
+tally(List) ->
+    lists:foldl(fun(X, Acc) -> maps:update_with(X, fun(C) -> C + 1 end, 1, Acc) end, #{}, List).

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_adr0114_site_discovery_spike_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_adr0114_site_discovery_spike_tests.erl
@@ -1,0 +1,299 @@
+%% Copyright 2026 James Casey
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(beamtalk_adr0114_site_discovery_spike_tests).
+
+%%% **DDD Context:** Runtime Context (spike / validation harness)
+
+-moduledoc """
+BT-3268 — ADR 0114 Phase 1 validation spike.
+
+`renameTo:`'s planned site-discovery mechanism (not yet implemented — see ADR
+0114 § Decision) is the union of `SystemNavigation default referencesTo:
+aClass` (ADR 0087) and `beamtalk_class_registry:direct_subclasses/1`. This
+module is the spike the ADR's Phase 1 row calls for: confirm that union is
+exhaustive against real, compiled stdlib code before any rename primitive is
+built on top of it, and measure the one known, accepted gap (Constraint 4 —
+`beamtalk_xref:build_method_entry/5` hard-codes `references => []` for every
+live-patched method).
+
+Two concerns, two groups of tests:
+
+1. **Corpus accuracy** (`corpus_accuracy_test_/0`) — boots the real, compiled
+   stdlib (`beamtalk_test_boot:boot_real_stdlib/1`, the same helper
+   `beamtalk_repl_ops_browse_tests` and `beamtalk_repl_docs_tests` use for a
+   genuinely-compiled-not-hand-written corpus) and runs
+   `beamtalk_class_registry:direct_subclasses/1` /
+   `beamtalk_xref:references_to/1` against a representative sample of real
+   `stdlib/src/*.bt` classes, diffing each result against a reference list
+   computed by hand-reading the actual source (recorded inline in each test's
+   comment, with the exact source lines cited so the audit is independently
+   checkable — not just against a second regex).
+
+2. **Live-patch gap reproduction** (`live_patch_gap_test_/0`) — patches a
+   throwaway dynamic class via `beamtalk_object_class:put_method/4`, one of
+   `beamtalk_xref:build_method_entry/5`'s three real call sites (the other
+   two are `beamtalk_extensions:register/5` and `beamtalk_class_builder.erl`'s
+   `methodSource:` install — see the corrected note below). Confirms
+   `references => []` reproduces exactly as Constraint 4 describes and
+   measures the blast radius on a method carrying two syntactically distinct
+   reference forms (a type annotation and a constructor send) to the same
+   class.
+
+**Spike finding, correcting the ADR's own text:** Constraint 4 states this
+gap is reachable via "every `>>`/`compile:source:` live patch". A live E2E
+check (`tests/repl-protocol/cases/adr_0114_live_patch_gap.btscript`) found
+this is NOT true of the current implementation — both `>>` and
+`compile:source:` route through `beamtalk_repl_loader:install_method/9` /
+`reload_method_definition/4`, which recompile the **whole class** via
+`beamtalk_repl_compiler:compile_method_reload/3` and `code:load_binary/3`,
+producing a complete compiler-computed `method_xref` (references included).
+Neither surface calls `beamtalk_object_class:put_method/3,4` — a repo-wide
+grep confirms zero non-test call sites of that function today. The gap IS
+reachable, confirmed live, via `beamtalk_extensions:register/5` (ADR 0066
+source-bearing extensions) — the `.btscript` fixture above exercises that
+real surface instead. See the findings doc for the full account.
+
+Findings are written up in `docs/development/adr-0114-site-discovery-spike-findings.md`.
+
+No production code changes — this module is test-only, per the issue's scope.
+""".
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% Group 1 — corpus accuracy: referencesTo: / direct_subclasses/1 against
+%% the real, compiled stdlib corpus.
+%%====================================================================
+
+%% Boots the real stdlib once for every test in this generator. Idempotent
+%% and safe alongside other test modules doing the same in this EUnit VM
+%% (`beamtalk_test_boot`'s own moduledoc) — no global process-group wipe here,
+%% unlike `beamtalk_object_class_tests`'s heavier setup/teardown, since this
+%% module must not disturb real stdlib class processes booted for its own or
+%% sibling suites.
+corpus_setup() ->
+    beamtalk_test_boot:boot_real_stdlib('Duration').
+
+corpus_accuracy_test_() ->
+    {setup, fun corpus_setup/0, fun(_) -> ok end, [
+        {
+            "direct_subclasses/1 matches a hand audit of every `Announcement subclass:` "
+            "declaration in stdlib/src/*.bt",
+            fun direct_subclasses_announcement/0
+        },
+        {
+            "direct_subclasses/1 matches a hand audit of every `Error subclass:` "
+            "declaration in stdlib/src/*.bt",
+            fun direct_subclasses_error/0
+        },
+        {
+            "references_to/1 matches a hand audit of every real (non-doc-comment) "
+            "`Duration` mention in stdlib/src/*.bt",
+            fun references_to_duration/0
+        }
+    ]}.
+
+%% Hand audit (`grep -n "Announcement subclass:" stdlib/src/*.bt`, 2026-08-25):
+%% ActorSpawned.bt:18, ActorStopped.bt:17, BindingChanged.bt:26,
+%% ClassLoaded.bt:17, ClassRemoved.bt:17, FlushCompleted.bt:19,
+%% ObjectStateChanged.bt:26, SupervisionChildAdded.bt:18,
+%% SupervisionChildCrashed.bt:17 — nine direct subclasses, no more, no fewer.
+direct_subclasses_announcement() ->
+    Expected = lists:sort([
+        'ActorSpawned',
+        'ActorStopped',
+        'BindingChanged',
+        'ClassLoaded',
+        'ClassRemoved',
+        'FlushCompleted',
+        'ObjectStateChanged',
+        'SupervisionChildAdded',
+        'SupervisionChildCrashed'
+    ]),
+    Actual = lists:sort(beamtalk_class_registry:direct_subclasses('Announcement')),
+    ?assertEqual(Expected, Actual).
+
+%% Hand audit (`grep -n "Error subclass:" stdlib/src/*.bt`, 2026-08-25):
+%% BEAMError.bt:20, InstantiationError.bt:13, RuntimeError.bt:14,
+%% TypeError.bt:12 — four direct subclasses. `ExitError`/`ThrowError`
+%% subclass `BEAMError`, not `Error` directly, so they are correctly excluded
+%% here (direct_subclasses/1 is not transitive).
+direct_subclasses_error() ->
+    Expected = lists:sort(['BEAMError', 'InstantiationError', 'RuntimeError', 'TypeError']),
+    Actual = lists:sort(beamtalk_class_registry:direct_subclasses('Error')),
+    ?assertEqual(Expected, Actual).
+
+%% Hand audit (`grep -n '\bDuration\b' stdlib/src/*.bt`, 2026-08-25, real code
+%% lines only — every other hit is inside a `///` doc comment and must NOT be
+%% indexed, matching `find_references_to_in_source`'s own documented
+%% doc-comment-body-vs-example-code distinction). This audit was corrected
+%% once against a live run (see finding #3 in the write-up): a first pass
+%% counted only *other* classes' mentions of `Duration` (8) and missed that
+%% `referencesTo:` also — correctly — reports a class's own self-references
+%% (`Duration`'s own arithmetic/comparison operators and constructors
+%% mention `Duration` in their own type signatures), which is required for
+%% `renameTo:` to be exhaustive: those signatures need rewriting too.
+%%
+%% Cross-class mentions:
+%%   Actor.bt:294    withTimeout: ms :: Timeout | Duration -> TimeoutProxy =>
+%%   Actor.bt:297      (ms isKindOf: Duration) ifTrue: [ ...            (2 rows: different lines)
+%%   DateTime.bt:255  addDuration: d :: Duration -> DateTime => self delegate
+%%   DateTime.bt:280  - other :: DateTime -> Duration =>
+%%   Parallel.bt:73   class sealed all: ... timeout: ms :: Integer | Duration -> List(Result) =>
+%%   Timer.bt:36/48/58  after:do: / every:do: / sleep: (each `Integer | Duration`)
+%% Self-mentions in Duration.bt itself:
+%%   instance-side: + - < <= > >= * (lines 184/193/225/243/234/252/203 — each
+%%     signature mentions `Duration` in its param and/or return type, but
+%%     ends up as ONE row per method: when both mentions land on the same
+%%     source line, e.g. `+ other :: Duration -> Duration =>`, they produce
+%%     two identical `#{class => 'Duration', line => L}` entries at codegen
+%%     time, which collapse to a single ETS `bag` row keyed on the full
+%%     `{owner, class_side, method, line}` site tuple — a real, minor
+%%     ETS-semantics footgun for anyone hand-predicting a raw occurrence
+%%     count from source, NOT a dropped reference: the site (this line, this
+%%     method) is still correctly present exactly once.)
+%%   class-side: milliseconds: seconds: minutes: hours: days: fromString:
+%%     (lines 40/49/57/65/73/87 — return-type-only mentions, one row each)
+%%
+%% 21 rows total across 5 owner classes.
+references_to_duration() ->
+    Sites = beamtalk_xref:references_to('Duration'),
+    ?assertEqual(21, length(Sites)),
+    OwnerMethodTally = lists:sort([
+        {maps:get(owner, S), maps:get(class_side, S), maps:get(method, S)}
+     || S <- Sites
+    ]),
+    ExpectedTally = lists:sort([
+        %% Cross-class mentions.
+        {'Actor', false, 'withTimeout:'},
+        {'Actor', false, 'withTimeout:'},
+        {'DateTime', false, 'addDuration:'},
+        {'DateTime', false, '-'},
+        {'Parallel', true, 'all:timeout:'},
+        {'Timer', true, 'after:do:'},
+        {'Timer', true, 'every:do:'},
+        {'Timer', true, 'sleep:'},
+        %% Duration's own self-references (instance-side operators).
+        {'Duration', false, '+'},
+        {'Duration', false, '-'},
+        {'Duration', false, '*'},
+        {'Duration', false, '<'},
+        {'Duration', false, '<='},
+        {'Duration', false, '>'},
+        {'Duration', false, '>='},
+        %% Duration's own self-references (class-side constructors).
+        {'Duration', true, 'milliseconds:'},
+        {'Duration', true, 'seconds:'},
+        {'Duration', true, 'minutes:'},
+        {'Duration', true, 'hours:'},
+        {'Duration', true, 'days:'},
+        {'Duration', true, 'fromString:'}
+    ]),
+    ?assertEqual(ExpectedTally, OwnerMethodTally).
+
+%%====================================================================
+%% Group 2 — live-patch gap reproduction (ADR 0114 Constraint 4).
+%%
+%% `AtomicCounter` is a real, always-loaded stdlib class (native-backed,
+%% `stdlib/src/AtomicCounter.bt`) used purely as "some other real class name"
+%% for the patched method to reference — any loaded class name would do.
+%%====================================================================
+
+live_patch_gap_test_() ->
+    {setup, fun live_patch_setup/0, fun live_patch_teardown/1, fun live_patch_gap/1}.
+
+live_patch_setup() ->
+    %% Boots the real runtime (idempotent alongside corpus_setup/0 within the
+    %% same EUnit VM) so `AtomicCounter` is a real, indexed class to reference,
+    %% then spawns one throwaway dynamic class of our own — never touching any
+    %% real stdlib class process, so no global pg/class-registry cleanup is
+    %% needed beyond stopping our own class and purging its own xref rows.
+    ok = beamtalk_test_boot:boot_real_stdlib('AtomicCounter'),
+    %% `beamtalk_xref:build_method_entry/5`'s `sends` channel (used by the
+    %% "send channel does NOT have the same gap" assertion below) walks the
+    %% patched source via `beamtalk_compiler:find_all_sends_in_source/1`,
+    %% which round-trips through `beamtalk_compiler_server` — not started by
+    %% `beamtalk_runtime` alone (`beamtalk_runtime.app.src` does not list
+    %% `beamtalk_compiler` as a dependency). Started explicitly here so this
+    %% test is deterministic in isolation, rather than relying on some other
+    %% suite in the same EUnit VM having started it first.
+    {ok, _} = application:ensure_all_started(beamtalk_compiler),
+    ClassInfo = #{
+        name => 'BT3268LiveFixture',
+        module => bt3268_live_fixture,
+        instance_methods => #{}
+    },
+    {ok, Pid} = beamtalk_object_class:start_link('BT3268LiveFixture', ClassInfo),
+    Pid.
+
+live_patch_teardown(Pid) ->
+    gen_server:stop(Pid),
+    beamtalk_xref:purge_class('BT3268LiveFixture'),
+    ok.
+
+live_patch_gap(Pid) ->
+    %% One method, two syntactically distinct reference forms to the same
+    %% class — a type annotation (return type) and a constructor send —
+    %% mirroring the ADR's own examples of what `referencesTo:` normally
+    %% catches (Decision § "renameTo: rewrites cross-file references").
+    Source =
+        <<
+            "makeCounter -> AtomicCounter =>\n"
+            "  AtomicCounter new: #bt3268LiveFixture"
+        >>,
+    NewFun = fun() -> ok end,
+    ok = beamtalk_object_class:put_method(Pid, makeCounter, NewFun, Source),
+
+    [
+        {
+            "build_method_entry/5 (the function Constraint 4 names) hard-codes "
+            "references => [] for a live-patched method, even though this "
+            "method's source carries two real references to AtomicCounter",
+            fun() ->
+                Entry = beamtalk_xref:build_method_entry(
+                    false, makeCounter, Source, indexed, put_method
+                ),
+                %% Independent count of the real references in the fixture source
+                %% (not derived from the compiler's own walker): the literal
+                %% "AtomicCounter" substring appears exactly twice.
+                ActualReferenceCount = count_occurrences(<<"AtomicCounter">>, Source),
+                ?assertEqual(2, ActualReferenceCount),
+                ?assertEqual([], maps:get(references, Entry))
+            end
+        },
+
+        {
+            "the gap reproduces end-to-end: references_to/1 never surfaces the "
+            "live-patched class as a referencing site for AtomicCounter, "
+            "confirmed against the real runtime index (not just the entry "
+            "builder in isolation)",
+            fun() ->
+                Sites = beamtalk_xref:references_to('AtomicCounter'),
+                OwnedByFixture = [S || S <- Sites, maps:get(owner, S) =:= 'BT3268LiveFixture'],
+                ?assertEqual([], OwnedByFixture)
+            end
+        },
+
+        {
+            "the send channel does NOT have the same gap (ADR 0087's documented "
+            "asymmetry, Constraint 4's contrast with sendersOf:): the "
+            "constructor send's selector IS indexed for the live-patched method",
+            fun() ->
+                Sites = beamtalk_xref:senders_of('new:'),
+                OwnedByFixture = [S || S <- Sites, maps:get(owner, S) =:= 'BT3268LiveFixture'],
+                ?assertEqual(1, length(OwnedByFixture)),
+                [Site] = OwnedByFixture,
+                ?assertEqual(makeCounter, maps:get(method, Site))
+            end
+        }
+    ].
+
+%% Count non-overlapping occurrences of `Pattern` in `Bin` — a plain
+%% substring tally, independent of any compiler/xref machinery, used as the
+%% "actual blast radius" ground truth for the live-patch gap test above.
+-spec count_occurrences(binary(), binary()) -> non_neg_integer().
+count_occurrences(Pattern, Bin) ->
+    case binary:matches(Bin, Pattern) of
+        Matches when is_list(Matches) -> length(Matches)
+    end.

--- a/stdlib/test/adr_0114_class_builder_live_patch_gap_test.bt
+++ b/stdlib/test/adr_0114_class_builder_live_patch_gap_test.bt
@@ -1,0 +1,51 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-3268 (ADR 0114 Phase 1 spike): confirms the referencesTo: live-patch
+// gap Constraint 4 describes reproduces end-to-end via ClassBuilder's
+// `methodSource:` install path — the one real, currently-reachable surface
+// this spike found that actually hits it (see
+// tests/repl-protocol/cases/adr_0114_live_patch_gap.btscript and
+// runtime/apps/beamtalk_workspace/test/beamtalk_adr0114_site_discovery_spike_tests.erl
+// for the two surfaces that do NOT: `>>`/`compile:source:` recompile the
+// whole class with a complete xref, and `register/5` sourced extensions are
+// unconditionally rescanned by SystemNavigation.bt's `referencesTo:` itself
+// (BT-2196), bypassing the xref table's gap entirely).
+//
+// A ClassBuilder class built with a real block-literal method body (BT-2246
+// auto-populates its source from the literal) is fully INDEXED
+// (`beamtalk_class_builder.erl`'s `source_map_to_xref/3` calls
+// `beamtalk_xref:build_method_entry/5` with `SourceStatus = indexed`) — so,
+// unlike a loaded-but-unindexed class, it is never re-scanned by
+// `referencesTo:`'s fallback path either. Its xref row's `references` field
+// is hard-coded `[]` by `build_method_entry/5` (Constraint 4), and nothing
+// compensates for it the way the extension-specific rescan does — so the
+// real reference below is silently missed end-to-end.
+
+TestCase subclass: Adr0114ClassBuilderLivePatchGapTest
+  field: cls = nil
+
+  tearDown => self.cls isNil ifFalse: [self.cls removeFromSystem]
+
+  // The installed method's body is a genuine, real reference to
+  // `AtomicCounter` (a real, always-loaded stdlib class) via a constructor
+  // send — exactly the reference form `referencesTo:` is documented to
+  // catch for an ordinary file-defined method (ADR 0114 Decision section's
+  // own examples). `referencesTo: AtomicCounter` must NOT list this class as
+  // an owner, confirming the gap reproduces exactly as Constraint 4
+  // describes: the whole `references` channel is empty for this live-
+  // installed method, not merely incomplete.
+  testClassBuilderMethodReferenceIsMissedByReferencesTo =>
+    self.cls := Object classBuilder name: #Adr0114BuilderGapProbe;
+      superclass: Object;
+      methods: #{
+        #makeCounter => [:_self | AtomicCounter new: #adr0114BuilderProbe]
+      };
+      register
+    nav := SystemNavigation default
+    refs := nav referencesTo: AtomicCounter
+    owners := refs collect: [:r | r at: #class]
+    // THE GAP: the just-registered class's method plainly references
+    // AtomicCounter, yet it is completely absent from referencesTo:'s
+    // result — not partially represented, absent.
+    self deny: (owners includes: self.cls)

--- a/tests/repl-protocol/cases/adr_0114_live_patch_gap.btscript
+++ b/tests/repl-protocol/cases/adr_0114_live_patch_gap.btscript
@@ -1,0 +1,75 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// E2E test for BT-3268 (ADR 0114 Phase 1 spike): checks which real,
+// currently-reachable live-patch surfaces actually reproduce the
+// referencesTo: gap Constraint 4 describes
+// (`beamtalk_xref:build_method_entry/5` hard-codes `references => []`).
+//
+// SPIKE FINDING, correcting the ADR's own text: Constraint 4 names
+// "every `>>`/`compile:source:` live patch" as reaching this gap. Measured
+// here against the real, currently-reachable surfaces, in order:
+//
+//   1. `>>` / `compile:source:` — do NOT reproduce the gap. Both route
+//      through `beamtalk_repl_loader:install_method/9` /
+//      `reload_method_definition/4`, which recompile the WHOLE class via
+//      `beamtalk_repl_compiler:compile_method_reload/3` + `code:load_binary/3`,
+//      producing a complete compiler-computed `method_xref` (references
+//      included). Neither surface calls `beamtalk_object_class:put_method/3,4`
+//      in the current codebase (a repo-wide grep confirms zero non-test call
+//      sites) — so `build_method_entry/5`'s narrow reparse is never reached.
+//   2. `beamtalk_extensions:register/5` (source-bearing extensions, ADR
+//      0066) — measured below. Also does NOT reproduce the gap end-to-end,
+//      for a different reason: its xref TABLE row genuinely does carry
+//      `references => []` (confirmed at the EUnit level, see
+//      beamtalk_adr0114_site_discovery_spike_tests.erl), but
+//      `SystemNavigation referencesTo:`'s own Beamtalk-level implementation
+//      has a dedicated, UNCONDITIONAL rescan of every registered extension's
+//      source (`collectExtensionReferencesFor:into:`, BT-2196 — "Extensions
+//      are not in the index yet, so this scan is unconditional") that
+//      bypasses the xref table entirely and finds the reference fresh, every
+//      call, regardless of what the index says.
+//   3. `ClassBuilder` `methodSource:` (ADR 0038) — DOES reproduce the gap.
+//      See `stdlib/test/adr_0114_class_builder_live_patch_gap_test.bt` for
+//      that fixture: a ClassBuilder class is fully indexed (no fallback
+//      rescan, unlike extensions) but with `references => []`, so its real
+//      reference is silently missed by `referencesTo:` end-to-end.
+//
+// This script measures case 2 live, against the exact FFI
+// `workspace_native_api.btscript` already uses for its own (passing)
+// register/5 + referencesTo: coverage.
+
+// @load tests/repl-protocol/fixtures/counter.bt
+
+// A block whose behaviour is irrelevant — the extension is never invoked,
+// only its `source:` text is scanned for xref purposes (matching
+// workspace_native_api.btscript's `extRefsFun`/`extRefsSource` pattern).
+extTimerFun := [:a :s | s]
+// => _
+
+extTimerSource := "spawnTimer -> Timer => Timer after: 999999 do: [nil]"
+// => _
+
+Erlang beamtalk_extensions register: #Counter selector: #btAdr0114TimerExt fun: extTimerFun owner: #test source: extTimerSource
+// => Result ok: nil
+
+// NOT a gap: referencesTo: Timer DOES surface this extension method as a
+// site, via the unconditional extension rescan described above — even
+// though the xref TABLE row for this method carries `references => []`.
+((SystemNavigation default referencesTo: Timer) collect: [:r | r at: #selector]) includes: #btAdr0114TimerExt
+// => true
+
+// The sends channel finds it too, via the ordinary (non-extension-special-
+// cased) xref path — sends_from_source/1 re-derives sends for every
+// source-bearing extension.
+((SystemNavigation default sendersOf: #after:do:) collect: [:r | r at: #selector]) includes: #btAdr0114TimerExt
+// => true
+
+// Clean up both ETS tables (mirrors workspace_native_api.btscript's own
+// register/5 cleanup so this fixture leaves no residue for later cases in
+// the shared E2E session).
+Erlang ets delete: #beamtalk_extensions key: #(#Counter, #btAdr0114TimerExt)
+// => true
+
+Erlang ets delete: #beamtalk_extension_sources key: #(#Counter, #btAdr0114TimerExt)
+// => true


### PR DESCRIPTION
## Summary
- Validates that `referencesTo:`/`direct_subclasses/1`'s union is exhaustive for `renameTo:`'s planned site discovery (ADR 0114 Phase 1 spike, BT-3268)
- Measures the Constraint 4 live-patch gap's real blast radius: it's real, but reachable only via `ClassBuilder` `methodSource:` — not via `>>`/`compile:source:` as the ADR's Constraint 4 text currently claims (both fully recompile the class through the real compiler, producing a complete xref)
- Recommendation for Phase 2: the `referencesTo:`/`direct_subclasses/1` union is safe to build on as designed; no fallback to a narrower v1 needed. The ADR's Constraint 4 wording should be corrected in a follow-up.

No production code changes — this is a test/spike issue per its scope.

## Test plan
- [x] `rebar3 eunit --module=beamtalk_adr0114_site_discovery_spike_tests` → 6/6 pass
- [x] `rebar3 eunit --app=beamtalk_runtime,beamtalk_workspace,beamtalk_compiler` → 5900/5900 pass
- [x] BUnit fixture (`adr_0114_class_builder_live_patch_gap_test.bt`) passes
- [x] e2e `.btscript` case passes
- [x] `just fmt` / lints clean on changed files

Part of Epic BT-3267 (ADR 0114). First of 12 sequential issues landing on this epic branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Reae4miRyBSZTm4Mbxiry)_