### PR TITLE
Accept right-operand untyped self.field coercion gap (BT-3266)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/expressions.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/expressions.rs
@@ -513,6 +513,33 @@ fn test_number_coercion_untyped_self_field_right_operand_stays_bare() {
     );
 }
 
+#[test]
+fn test_number_coercion_untyped_self_fields_both_sides_stay_bare() {
+    // BT-3266 (ADR 0116 addendum, decision: accept the gap): this issue's
+    // own literal example, `self.total + self.extra` with both fields
+    // untyped. `receiver_is_statically_numeric` trusts an untyped
+    // `self.<field>` on either side of the operator identically, so this
+    // stays a bare `erlang:'+'` — no guard, no try/catch — exactly like the
+    // single-field-on-the-right case above. Pinned down as documented,
+    // accepted behavior, not asserted as correct.
+    let mut generator = CoreErlangGenerator::new("test");
+    let left = self_field_access("total");
+    let right = self_field_access("extra");
+    let output = generator
+        .generate_binary_op("+", &left, &[right])
+        .unwrap()
+        .to_pretty_string();
+    assert!(
+        !output.contains("try ") && !output.contains("send_number_coercion"),
+        "BT-3266: self.total + self.extra (both untyped) stays on the bare-BIF \
+         path on both operands — got: {output}"
+    );
+    assert!(
+        output.contains("call 'erlang':'+'("),
+        "expected a bare erlang:'+' call; got: {output}"
+    );
+}
+
 // BT-2710: comparison operators (`< > <= >=`) are dispatchable messages. The
 // bare-BIF fast path holds for statically-comparable receivers (numeric / char
 // / string literals, `self` in Integer/Float/Character/String, and

--- a/docs/ADR/0116-number-on-the-left-arithmetic-coercion.md
+++ b/docs/ADR/0116-number-on-the-left-arithmetic-coercion.md
@@ -897,6 +897,65 @@ specific to this ADR's mechanism — noted here because § User Impact
 (Newcomer) already establishes `does_not_understand` as the intended,
 improved failure mode.
 
+## Addendum (2026-08-25): BT-3266 — right-operand untyped `self.<field>` gap, accepted
+
+`receiver_is_statically_numeric` (BT-2709) treats an untyped `self.<field>`
+as statically numeric to keep `self.count := self.count + 1`-shaped counter
+arithmetic on the bare-BIF fast path. § Dispatch mechanism's "Trigger
+condition, refined" deliberately reuses that same predicate, unmodified, to
+gate this ADR's *right*-operand coercion check — so the identical leniency
+reproduces on the right side: `self.total + self.extra` with `extra`
+untyped stays a bare `erlang:'+'`, no guard and no `try`/`catch`, and raw-
+crashes on `badarith` if `extra` ever holds a non-number. BT-3263 code
+review (PR #3515) flagged this as a real, if narrow, gap and filed it as
+BT-3266 rather than folding a fix into that PR.
+
+**Decision: accept the gap as specified; do not diverge the right-operand
+check from the left-operand one.** Concretely, this addendum closes BT-3266
+without a code change to the trigger condition — the codegen already
+matches what's decided here (see "What already shipped" below).
+
+**Rationale:**
+- **Symmetry.** A right-operand-specific stricter check would make
+  `self.a + self.b` guard asymmetrically depending on which side of `+`
+  each field sits — the same untyped field trusted as a left operand and
+  guarded as a right operand at different call sites. That's a more
+  confusing model than "both operands get the same rule," for a gap that's
+  already accepted on the left (§ Consequences, Negative — the `self.
+  <field>`/untyped-param trust boundary bullet already covers exactly this
+  class of risk, just from the left-operand side).
+- **Performance.** Closing the gap taxes precisely the accumulator/counter
+  call shape (`self.total + self.extra`, `self.total + self.count`) that
+  BT-2709 designed the untyped-field leniency around in the first place —
+  paying a guard on every untyped-field read on *either* side of an
+  operator undoes that trade-off for hot self-field arithmetic, not just
+  for the narrow case this issue names.
+- **Scope.** Closing the gap for the right operand only, while leaving the
+  left operand as-is, is the one option this ADR's dispatch mechanism
+  doesn't already support cleanly — it would need `receiver_is_statically_
+  numeric` split into left/right variants, and raises its own unresolved
+  question of whether the left operand should then tighten too for
+  consistency. That's a wider redesign than a follow-up issue's scope, not
+  a decision to make silently inside this addendum.
+- **Blast radius stays the accepted one.** When the trust is wrong, the
+  user-visible outcome is the same `badarith` this ADR's own Negative
+  consequences section already accepts for the left operand — not a new
+  failure mode, just the existing one reachable from one more operand
+  position.
+
+**What already shipped** (landed in BT-3263, commit 871eac5, ahead of this
+addendum): `receiver_is_statically_numeric`'s own doc comment
+(`operators.rs`) names this exact asymmetry and cross-references BT-3266;
+`test_number_coercion_untyped_self_field_right_operand_stays_bare`
+(`codegen/core_erlang/tests/expressions.rs`) pins the current, accepted
+behavior down as a regression test, and a second test using `self.<field>`
+on *both* operands (`self.total + self.extra`, this issue's literal
+example) was added closing out BT-3266's coverage criterion.
+
+If untyped-field arithmetic's silent-badarith risk ever becomes a real
+problem in practice, revisit both operands together as one design pass —
+not the right operand alone.
+
 ## Implementation Tracking
 
 **Parent:** BT-2712 (Phase 4 of BT-2708, already tracked this ADR's spec —
@@ -907,6 +966,7 @@ duplicate Epic)
 - BT-3263 — Wire number-on-the-left coercion into `operators.rs` codegen (Phase 2, codegen; blocked by BT-3262)
 - BT-3264 — BUnit tests for number-on-the-left arithmetic coercion (Phase 3; blocked by BT-3263)
 - BT-3265 — Benchmark + language docs for number-on-the-left arithmetic (Phase 4; blocked by BT-3263)
+- BT-3266 — Right-operand untyped `self.<field>` gap: design decision (accepted, not fixed — see Addendum above)
 
 **Status:** Planned
 


### PR DESCRIPTION
## Summary

BT-3266 was a follow-up from BT-3263 code review (ADR 0116 Phase 2, PR #3515): the number-on-the-left coercion's right-operand gate reuses `receiver_is_statically_numeric` verbatim, so BT-2709's untyped-`self.<field>`-is-numeric leniency (tuned for the left operand's `self.count := self.count + 1` counter pattern) reproduces on the right operand too. `self.total + self.extra` with `extra` untyped still raw-crashes on `badarith` at runtime instead of dispatching to `plusFromNumber:`.

This was a genuine design question, not a mechanical bug: either extend the left operand's leniency to the right operand (current, ADR-literal behavior), or make the right-operand check stricter (a real behavior + perf change with its own open questions about left-operand symmetry).

**Decision: accept the gap.** Diverging the right-operand check from the left-operand one would make `self.a + self.b` guard asymmetrically depending on which side of `+` a field sits, and would tax exactly the hot accumulator call shape the untyped-field leniency exists for. The resulting failure mode (`badarith`) is the same one already accepted for the left operand in ADR 0116 § Consequences, Negative.

Note: the doc-comment callout and a single-field pinning test for this gap were already added preemptively in BT-3263's own commit (871eac5), anticipating this follow-up — this PR formalizes the decision and closes out the remaining coverage.

## Changes

- **`docs/ADR/0116-number-on-the-left-arithmetic-coercion.md`**: added an addendum recording the BT-3266 decision, its rationale, and what already shipped; updated Implementation Tracking to include BT-3266.
- **`crates/beamtalk-core/src/codegen/core_erlang/tests/expressions.rs`**: added `test_number_coercion_untyped_self_fields_both_sides_stay_bare`, a regression test using the issue's literal example (`self.total + self.extra`, both operands untyped `self.<field>`) — closes out the "self.field right operand ... add coverage" acceptance criterion explicitly, alongside the existing single-field-on-the-right test.

## Test plan

- [x] `cargo test -p beamtalk-core --lib codegen::core_erlang::tests::expressions::test_number_coercion` — all 7 coercion tests pass (including the new one)
- [x] `cargo fmt -p beamtalk-core -- --check` — clean
- [x] `just ci-changed` pre-push hooks (clippy, Rust/Erlang/JS/Beamtalk/Elixir formatting, Dialyzer, spec validation) — all passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qiy8cnAudpWo27fSSEfgDo)_