### PR TITLE
BT-3269: ChangeLog schema for rename-class/rename-method

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
@@ -60,7 +60,7 @@ Each `changes.jsonl` line is a JSON object with these fields (ADR 0082,
 | `candidate_sites`      | `[{sourceFile,span},...] \| null`                           | ADR 0114 (BT-3269): `"rename-method"`-only — reported, never auto-rewritten senders; no `source_ref`/`prev_source_ref` since nothing here is ever spliced |
 | `intent`               | `"durable"`\|`"ephemeral"`                                  | |
 | `flushable`            | boolean                                                      | true iff in-project source; for `"rename-class"`/`"rename-method"`, true iff every entry in `sites` (never `candidate_sites`) resolves to a flushable file |
-| `not_flushable_reason` | string \| null                                              | `"stdlib"`/`"dynamic"`/`"dependency:<path>"`/`"extension"`; `"rename-class"` is `"dynamic"`\|null only (ADR 0114 refuses stdlib/dependency before any entry exists) |
+| `not_flushable_reason` | string \| null                                              | `"stdlib"`/`"dynamic"`/`"dependency:<path>"`/`"extension"`; `"rename-class"` is `"dynamic"`\|null only (ADR 0114 refuses stdlib/dependency before any entry exists); `"rename-method"` is `"stdlib"`\|`"dynamic"`\|`"dependency:<path>"`\|null — `"extension"` is not reachable there either (ADR 0114 § ChangeLog schema) |
 | `author`               | string                                                       | session/tool id |
 | `author_kind`          | `"human"`\|`"agent"`                                        | audit metadata |
 
@@ -2112,17 +2112,38 @@ sites_from_json(List) when is_list(List) -> [site_from_json(S) || S <- List].
 candidate_site_to_json(#{source_file := SourceFile, span := Span}) ->
     #{<<"sourceFile">> => SourceFile, <<"span">> => span_to_json(Span)}.
 
--spec candidate_site_from_json(map()) -> candidate_site().
+%% Unlike `site_from_json/1`, a `candidate_site()` has no optional-field case
+%% to default (every candidate site always names a real sourceFile/span) —
+%% so a map missing either key is genuinely malformed, not a legitimate
+%% "not applicable" shape. Returns `error` for that case instead of
+%% crashing: `candidate_sites_from_json/1` drops just the malformed element
+%% (logged) rather than letting it propagate up through `entry_from_json/1`
+%% and cost `parse_log/1`'s catch the *entire* ChangeLog line — including
+%% that entry's unrelated `sites`/rename data — over one bad element.
+-spec candidate_site_from_json(map()) -> {ok, candidate_site()} | error.
 candidate_site_from_json(#{<<"sourceFile">> := SourceFile, <<"span">> := Span}) ->
-    #{source_file => SourceFile, span => span_from_json(Span)}.
+    {ok, #{source_file => SourceFile, span => span_from_json(Span)}};
+candidate_site_from_json(Malformed) ->
+    ?LOG_WARNING("Dropping malformed candidate_site (missing sourceFile/span): ~p", [Malformed]),
+    error.
 
 -spec candidate_sites_to_json([candidate_site()] | undefined) -> [map()] | null.
 candidate_sites_to_json(undefined) -> null;
 candidate_sites_to_json(Sites) -> [candidate_site_to_json(S) || S <- Sites].
 
 -spec candidate_sites_from_json([map()] | null) -> [candidate_site()] | undefined.
-candidate_sites_from_json(null) -> undefined;
-candidate_sites_from_json(List) when is_list(List) -> [candidate_site_from_json(S) || S <- List].
+candidate_sites_from_json(null) ->
+    undefined;
+candidate_sites_from_json(List) when is_list(List) ->
+    lists:filtermap(
+        fun(S) ->
+            case candidate_site_from_json(S) of
+                {ok, CandidateSite} -> {true, CandidateSite};
+                error -> false
+            end
+        end,
+        List
+    ).
 
 -spec null_or(binary() | undefined) -> binary() | null.
 null_or(undefined) -> null;

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
@@ -2114,17 +2114,33 @@ candidate_site_to_json(#{source_file := SourceFile, span := Span}) ->
 
 %% Unlike `site_from_json/1`, a `candidate_site()` has no optional-field case
 %% to default (every candidate site always names a real sourceFile/span) —
-%% so a map missing either key is genuinely malformed, not a legitimate
+%% so a missing/invalid key is genuinely malformed, not a legitimate
 %% "not applicable" shape. Returns `error` for that case instead of
 %% crashing: `candidate_sites_from_json/1` drops just the malformed element
 %% (logged) rather than letting it propagate up through `entry_from_json/1`
 %% and cost `parse_log/1`'s catch the *entire* ChangeLog line — including
 %% that entry's unrelated `sites`/rename data — over one bad element.
+%%
+%% Guards against two distinct malformed shapes, not just a missing key:
+%% an explicit `"span": null` (`span_from_json/1` returns `undefined`, which
+%% would otherwise silently violate `candidate_site()`'s non-optional
+%% `span := span()` contract) and a `span` object missing `start`/`end`
+%% (`span_from_json/1` has no fallback clause for that shape and raises
+%% `function_clause` — caught here rather than crashing the whole decode).
 -spec candidate_site_from_json(map()) -> {ok, candidate_site()} | error.
-candidate_site_from_json(#{<<"sourceFile">> := SourceFile, <<"span">> := Span}) ->
-    {ok, #{source_file => SourceFile, span => span_from_json(Span)}};
+candidate_site_from_json(#{<<"sourceFile">> := SourceFile, <<"span">> := Span} = Map) ->
+    try span_from_json(Span) of
+        undefined -> drop_malformed_candidate_site(Map);
+        DecodedSpan -> {ok, #{source_file => SourceFile, span => DecodedSpan}}
+    catch
+        _:_ -> drop_malformed_candidate_site(Map)
+    end;
 candidate_site_from_json(Malformed) ->
-    ?LOG_WARNING("Dropping malformed candidate_site (missing sourceFile/span): ~p", [Malformed]),
+    drop_malformed_candidate_site(Malformed).
+
+-spec drop_malformed_candidate_site(term()) -> error.
+drop_malformed_candidate_site(Malformed) ->
+    ?LOG_WARNING("Dropping malformed candidate_site: ~p", [Malformed]),
     error.
 
 -spec candidate_sites_to_json([candidate_site()] | undefined) -> [map()] | null.

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
@@ -47,15 +47,20 @@ Each `changes.jsonl` line is a JSON object with these fields (ADR 0082,
 | `epoch`                | integer                                                      | bumped each workspace start |
 | `class`                | string                                                       | e.g. `"Counter"` |
 | `selector`             | string \| null                                              | null for `new-class` |
-| `kind`                 | `"instance"`\|`"class"`\|`"new-class"`\|`"remove-method"`\|`"remove-class"` | open enum |
-| `side`                 | `"instance"`\|`"class"`\|null                               | ADR 0112: explicit only for `"remove-method"`; legacy `"instance"`/`"class"`-kind entries derive it from `kind` (`entry_side/1`); always null for `"remove-class"` (BT-3206 — no method-level target) |
-| `source_ref`           | string \| null                                              | null for `"remove-method"`/`"remove-class"` (nothing replaces the deleted text) |
-| `prev_source_ref`      | string \| null                                              | null for `new-class`; the removed class's full prior source for `"remove-class"` (BT-3206) |
-| `sourceFile`           | string \| null                                              | null for stdlib/dynamic |
-| `span`                 | `{start,end}` \| null                                       | null for `new-class` and `"remove-class"` (BT-3206 — no byte range within a whole-file removal); the excised span for `"remove-method"` (BT-2192's future flush-excise step) |
+| `kind`                 | `"instance"`\|`"class"`\|`"new-class"`\|`"remove-method"`\|`"remove-class"`\|`"rename-class"`\|`"rename-method"` | open enum |
+| `side`                 | `"instance"`\|`"class"`\|null                               | ADR 0112: explicit only for `"remove-method"`/`"rename-method"` (ADR 0114, BT-3269); legacy `"instance"`/`"class"`-kind entries derive it from `kind` (`entry_side/1`); always null for `"remove-class"`/`"rename-class"` (BT-3206/BT-3269 — no method-level target) |
+| `source_ref`           | string \| null                                              | null for `"remove-method"`/`"remove-class"`/`"rename-class"`/`"rename-method"` (nothing replaces the deleted text; a multi-site entry's per-site bodies live under `sites` instead) |
+| `prev_source_ref`      | string \| null                                              | null for `new-class`; the removed class's full prior source for `"remove-class"` (BT-3206); null for `"rename-class"`/`"rename-method"` (superseded by `sites`) |
+| `sourceFile`           | string \| null                                              | null for stdlib/dynamic; also null for `"rename-class"`/`"rename-method"` (ambiguous for a multi-file entry — see `sites`) |
+| `span`                 | `{start,end}` \| null                                       | null for `new-class` and `"remove-class"` (BT-3206 — no byte range within a whole-file removal); the excised span for `"remove-method"` (BT-2192's future flush-excise step); null for `"rename-class"`/`"rename-method"` (see `sites`) |
+| `old_class`            | string \| null                                              | ADR 0114 (BT-3269): `"rename-class"`-only — the pre-rename class name |
+| `old_selector`         | string \| null                                              | ADR 0114 (BT-3269): `"rename-method"`-only — the pre-rename selector (`selector` holds the new one) |
+| `old_path`/`new_path`  | string \| null                                              | ADR 0114 (BT-3269): `"rename-class"`-only — the file path before/after a rename that also moves the backing file; null for a dynamic class |
+| `sites`                | `[{sourceFile,span,source_ref,prev_source_ref}\|null,...] \| null` | ADR 0114 (BT-3269): `"rename-class"`/`"rename-method"`-only — `sites[0]` is the definition/declaration site (`null` only for a dynamic class with no backing file), `sites[1..]` are every other rewritten reference |
+| `candidate_sites`      | `[{sourceFile,span},...] \| null`                           | ADR 0114 (BT-3269): `"rename-method"`-only — reported, never auto-rewritten senders; no `source_ref`/`prev_source_ref` since nothing here is ever spliced |
 | `intent`               | `"durable"`\|`"ephemeral"`                                  | |
-| `flushable`            | boolean                                                      | true iff in-project source |
-| `not_flushable_reason` | string \| null                                              | `"stdlib"`/`"dynamic"`/`"dependency:<path>"`/`"extension"` |
+| `flushable`            | boolean                                                      | true iff in-project source; for `"rename-class"`/`"rename-method"`, true iff every entry in `sites` (never `candidate_sites`) resolves to a flushable file |
+| `not_flushable_reason` | string \| null                                              | `"stdlib"`/`"dynamic"`/`"dependency:<path>"`/`"extension"`; `"rename-class"` is `"dynamic"`\|null only (ADR 0114 refuses stdlib/dependency before any entry exists) |
 | `author`               | string                                                       | session/tool id |
 | `author_kind`          | `"human"`\|`"agent"`                                        | audit metadata |
 
@@ -131,7 +136,21 @@ release nodes do not start a workspace, so this code is a no-op there.
     entry_source_ref/1,
     entry_prev_source_ref/1,
     read_source_body/1,
-    read_prev_source_body/1
+    read_prev_source_body/1,
+    %% ADR 0114 (BT-3269).
+    entry_old_class/1,
+    entry_old_selector/1,
+    entry_old_path/1,
+    entry_new_path/1,
+    entry_sites/1,
+    entry_candidate_sites/1
+]).
+
+%% ADR 0114 (BT-3269): shadow-detection and flushability helpers for the
+%% multi-site `'rename-class'`/`'rename-method'` kinds.
+-export([
+    target_key/1,
+    sites_flushable/1
 ]).
 
 %% gen_server callbacks
@@ -162,17 +181,56 @@ release nodes do not start a workspace, so this code is a no-op there.
 %% 0112's method-removal kind (BT-3187). `'class-def'` is ADR 0082's
 %% extension for redefining an *existing* class's whole definition (BT-3248) —
 %% the cockpit `:def` tab's "Compile" action, as opposed to `'new-class'`
-%% (a brand-new class created via `newClass:at:`).
+%% (a brand-new class created via `newClass:at:`). `'rename-class'`/
+%% `'rename-method'` are ADR 0114's `renameTo:`/`renameSelector:to:` kinds
+%% (BT-3269) — the first two kinds whose rewrite spans a *set* of files
+%% (`sites`/`candidate_sites`) rather than one, see those fields' docs below.
 -type kind() ::
-    instance | class | 'new-class' | 'class-def' | 'remove-method' | 'remove-class' | unknown.
+    instance
+    | class
+    | 'new-class'
+    | 'class-def'
+    | 'remove-method'
+    | 'remove-class'
+    | 'rename-class'
+    | 'rename-method'
+    | unknown.
 %% ADR 0112: which method table a `'remove-method'` entry targets. Stored
 %% explicitly only for that kind — legacy `instance`/`class`-kind patch
 %% entries derive their side from `kind` itself (`entry_side/1`), so the field
 %% is additive, not a breaking schema change (ADR 0112 § ChangeLog interaction).
+%% ADR 0114 (BT-3269): `'rename-method'` stores `side` the same explicit way;
+%% `'rename-class'` always has `side = undefined` (null) — a class identity
+%% change has no method-table side.
 -type side() :: instance | class.
 -type intent() :: durable | ephemeral | unknown.
 -type author_kind() :: human | agent | unknown.
 -type span() :: #{start := non_neg_integer(), 'end' := non_neg_integer()}.
+
+%% ADR 0114 (BT-3269): one rewritten reference location in a `'rename-class'`/
+%% `'rename-method'` entry's `sites` list. `source_ref`/`prev_source_ref` name
+%% the recorded pre/post rewrite bodies exactly like the top-level fields do
+%% for a single-file kind (undefined for a site not yet populated with a
+%% recorded body — the site-discovery/rewrite mechanism itself is BT-3270,
+%% out of scope here). A bare `undefined` in place of a `site()` map (rather
+%% than a map with `source_file = undefined`) is the ADR's documented
+%% `sites[0] = null` case: a dynamic (ClassBuilder) class being renamed has no
+%% backing file for its own declaration site to point at.
+-type site() :: #{
+    source_file := binary() | undefined,
+    span := span() | undefined,
+    source_ref := binary() | undefined,
+    prev_source_ref := binary() | undefined
+}.
+
+%% ADR 0114 (BT-3269): one reported-but-never-rewritten sender in a
+%% `'rename-method'` entry's `candidate_sites` list. No `source_ref`/
+%% `prev_source_ref` — nothing here is ever spliced, so there is no prior/new
+%% body to record (ADR 0114 § ChangeLog schema).
+-type candidate_site() :: #{
+    source_file := binary(),
+    span := span()
+}.
 
 %% A ChangeEntry as stored in memory. Bodies are not kept in the record —
 %% only the `source_ref` / `prev_source_ref` filenames — so the ETS footprint
@@ -193,6 +251,31 @@ release nodes do not start a workspace, so this code is a no-op there.
     prev_source_ref :: binary() | undefined,
     source_file :: binary() | undefined,
     span :: span() | undefined,
+    %% ADR 0114 (BT-3269): `'rename-class'`-only — the pre-rename class name.
+    %% `undefined` for every other kind.
+    old_class :: binary() | undefined,
+    %% ADR 0114 (BT-3269): `'rename-method'`-only — the pre-rename selector
+    %% (`selector` itself holds the *new* selector, mirroring how `class`
+    %% holds the *new* name for `'rename-class'`). `undefined` for every
+    %% other kind.
+    old_selector :: binary() | undefined,
+    %% ADR 0114 (BT-3269): `'rename-class'`-only — the file path before/after
+    %% a rename that also moves the backing file (or a pure `Workspace
+    %% moveClass:to:` move). `undefined` for a dynamic class (no backing
+    %% file) and for every other kind.
+    old_path :: binary() | undefined,
+    new_path :: binary() | undefined,
+    %% ADR 0114 (BT-3269): `'rename-class'`/`'rename-method'`-only — the
+    %% multi-site shape neither field above can express: `sites[0]` is always
+    %% the definition/declaration site, `sites[1..]` are every other rewritten
+    %% reference. `undefined` (not `[]`) for every other kind, matching the
+    %% "undefined means not applicable" convention every other optional field
+    %% here already follows.
+    sites :: [site() | undefined] | undefined,
+    %% ADR 0114 (BT-3269): `'rename-method'`-only — the reported, never
+    %% auto-rewritten candidate sender list. `undefined` for every other kind
+    %% (including `'rename-class'`, which has no candidate tier).
+    candidate_sites :: [candidate_site()] | undefined,
     intent :: intent(),
     flushable :: boolean(),
     not_flushable_reason :: binary() | undefined,
@@ -234,10 +317,27 @@ release nodes do not start a workspace, so this code is a no-op there.
     prev_source => binary() | undefined,
     source_file => binary() | undefined,
     span => span() | undefined,
-    not_flushable_reason => binary() | undefined
+    not_flushable_reason => binary() | undefined,
+    %% ADR 0114 (BT-3269): see the matching `#entry{}` fields' docs above.
+    old_class => binary() | undefined,
+    old_selector => binary() | undefined,
+    old_path => binary() | undefined,
+    new_path => binary() | undefined,
+    sites => [site() | undefined] | undefined,
+    candidate_sites => [candidate_site()] | undefined
 }.
 
--export_type([entry/0, append_input/0, kind/0, side/0, intent/0, author_kind/0, span/0]).
+-export_type([
+    entry/0,
+    append_input/0,
+    kind/0,
+    side/0,
+    intent/0,
+    author_kind/0,
+    span/0,
+    site/0,
+    candidate_site/0
+]).
 
 -record(state, {
     %% Absolute path to <workspace>/changes, or undefined in run mode
@@ -748,6 +848,110 @@ shadow_key(#entry{selector = undefined} = E) ->
 shadow_key(E) ->
     {E#entry.class, E#entry.selector, entry_side(E)}.
 
+%%% ----------------------------------------------------------------------------
+%%% Per-site shadow-detection key (ADR 0114, BT-3269)
+%%% ----------------------------------------------------------------------------
+
+-doc """
+Per-site shadow-detection keys for `Entry` (ADR 0114, BT-3269).
+
+Every existing kind targets exactly one file, so `shadow_key/1`'s single
+tuple already identifies "what does this entry patch" unambiguously — that
+is exactly the "does a newer edit replace this entry for the same
+`(class, selector, side)` (or whole-class) target" dirty-view question
+`survivor_seqs/1` answers. A `'rename-class'`/`'rename-method'` entry's
+`sites` list breaks the one-entry-one-target assumption underneath that
+question: renaming `Counter` might rewrite a reference inside `widget.bt`,
+and an *unrelated*, independently issued rename of `Widget` might also
+rewrite a (different) reference inside that very same file. Whole-entry
+keying cannot express "does a newer edit's rewritten location overlap this
+older edit's rewritten location" — that question needs a key per rewritten
+location, not per entry.
+
+Returns one key per site for `'rename-class'`/`'rename-method'` — a `null`
+site (the dynamic-class case, ADR 0114 § ChangeLog schema) is skipped, since
+there is no location to key — and a single-element list wrapping
+`shadow_key/1`'s existing tuple for every other kind, so a caller folding
+over "every target this entry touches" needs no kind-specific branch.
+`candidate_sites` are never included: they are never rewritten (ADR 0114),
+so they have no shadow-detection role.
+
+Each site's key also carries the entry's own rename identity —
+`class`/`old_class` for `'rename-class'`; `class`/`selector`/`old_selector`/
+`side` for `'rename-method'` — alongside the site's own `sourceFile`/`span`,
+so two independent renames that happen to touch the same file are never
+conflated into a false shadow relationship purely because they share a
+file: only a genuinely repeated edit of the *same* rename at the *same*
+location collides.
+
+Exported for the future multi-site rewrite mechanism (BT-3270) and for
+tests. Not yet wired into `survivor_seqs/1`/the `ChangeEntry` `shadowed`
+flag — `'rename-class'`/`'rename-method'` flush and dirty-view integration
+is out of scope for BT-3269 (schema only).
+""".
+-spec target_key(entry()) -> [term()].
+target_key(#entry{kind = 'rename-class'} = E) ->
+    [
+        {'rename-class', E#entry.class, E#entry.old_class, site_location(S)}
+     || S <- sites_or_empty(E), S =/= undefined
+    ];
+target_key(#entry{kind = 'rename-method'} = E) ->
+    [
+        {'rename-method', E#entry.class, E#entry.selector, E#entry.old_selector, entry_side(E),
+            site_location(S)}
+     || S <- sites_or_empty(E), S =/= undefined
+    ];
+target_key(E) ->
+    [shadow_key(E)].
+
+-spec sites_or_empty(#entry{}) -> [site() | undefined].
+sites_or_empty(#entry{sites = undefined}) -> [];
+sites_or_empty(#entry{sites = Sites}) -> Sites.
+
+-spec site_location(site()) -> {binary() | undefined, span() | undefined}.
+site_location(#{source_file := SourceFile, span := Span}) ->
+    {SourceFile, Span}.
+
+-doc """
+Fold per-site flushability verdicts into the single `flushable`/
+`not_flushable_reason` pair a `'rename-class'`/`'rename-method'` ChangeEntry
+records (ADR 0114 § ChangeLog schema): `true` iff every entry in `sites` is
+flushable, `false` with the first non-flushable site's reason otherwise.
+`candidate_sites` are never consulted — flush never writes them, so a
+candidate site being e.g. a stdlib sender must never block an otherwise
+clean rename (ADR 0114 explicitly calls this out: "a single incidental
+stdlib candidate sender would leave the whole rename stuck forever").
+
+Callers classify each site themselves before folding — reusing
+`beamtalk_repl_loader:classify_source_file/1`/`no_source_reason/1` exactly
+as the single-file kinds already do (ADR 0112), rather than this module
+re-deriving that classification, which would duplicate it: this module has
+no class-registry access, and a bare `sourceFile` cannot distinguish
+"stdlib" from "dynamic" the way a class name can (`no_source_reason/1`
+needs `code:which/1` on the class's own module).
+
+Order matters only for which reason is reported when several sites
+disagree: the first non-flushable entry in `Classifications` wins, so
+callers should classify sites in the same order they appear in `sites`
+(definition/declaration site first) for a deterministic, sites[0]-first
+reason.
+""".
+-spec sites_flushable([flushable | {not_flushable, binary()}]) ->
+    {boolean(), binary() | undefined}.
+sites_flushable(Classifications) ->
+    case
+        lists:filtermap(
+            fun
+                (flushable) -> false;
+                ({not_flushable, Reason}) -> {true, Reason}
+            end,
+            Classifications
+        )
+    of
+        [] -> {true, undefined};
+        [Reason | _] -> {false, Reason}
+    end.
+
 -doc """
 Return the dirty methods derived from the *active* entries as a Beamtalk
 Dictionary `#{ClassSymbol => Set(selectorSymbol)}`.
@@ -779,9 +983,12 @@ dirtyMethods() ->
 %% (redefinition of an *existing* class's whole definition, BT-3248) also
 %% carries no selector — it gets its own `#'class-def'` placeholder rather
 %% than reusing `#new-class`, so the dirty view does not misreport a
-%% redefinition as a brand-new class.
+%% redefinition as a brand-new class. `'rename-class'` (ADR 0114, BT-3269)
+%% gets the same treatment for the same reason — it must not be confused
+%% with either a brand-new class or a whole-definition redefinition.
 -spec dirty_selector(#entry{}) -> atom().
 dirty_selector(#entry{kind = 'class-def', selector = undefined}) -> 'class-def';
+dirty_selector(#entry{kind = 'rename-class', selector = undefined}) -> 'rename-class';
 dirty_selector(#entry{selector = undefined}) -> 'new-class';
 dirty_selector(#entry{selector = Sel}) -> binary_to_atom(Sel, utf8).
 
@@ -1077,6 +1284,39 @@ entry_source_ref(#entry{source_ref = V}) -> V.
 -spec entry_prev_source_ref(entry()) -> binary() | undefined.
 entry_prev_source_ref(#entry{prev_source_ref = V}) -> V.
 
+-doc "The pre-rename class name for a `'rename-class'` entry (ADR 0114, BT-3269); `undefined` otherwise.".
+-spec entry_old_class(entry()) -> binary() | undefined.
+entry_old_class(#entry{old_class = V}) -> V.
+
+-doc "The pre-rename selector for a `'rename-method'` entry (ADR 0114, BT-3269); `undefined` otherwise.".
+-spec entry_old_selector(entry()) -> binary() | undefined.
+entry_old_selector(#entry{old_selector = V}) -> V.
+
+-doc "The pre-rename file path for a `'rename-class'` entry (ADR 0114, BT-3269); `undefined` otherwise.".
+-spec entry_old_path(entry()) -> binary() | undefined.
+entry_old_path(#entry{old_path = V}) -> V.
+
+-doc "The post-rename file path for a `'rename-class'` entry (ADR 0114, BT-3269); `undefined` otherwise.".
+-spec entry_new_path(entry()) -> binary() | undefined.
+entry_new_path(#entry{new_path = V}) -> V.
+
+-doc """
+The multi-site rewrite list for a `'rename-class'`/`'rename-method'` entry
+(ADR 0114, BT-3269); `undefined` otherwise. `sites[0]` is always the
+definition/declaration site; a bare `undefined` element (rather than a
+`site()` map) is the dynamic-class "no declaration site" case.
+""".
+-spec entry_sites(entry()) -> [site() | undefined] | undefined.
+entry_sites(#entry{sites = V}) -> V.
+
+-doc """
+The reported-but-never-rewritten candidate sender list for a
+`'rename-method'` entry (ADR 0114, BT-3269); `undefined` otherwise
+(including for `'rename-class'`, which has no candidate tier).
+""".
+-spec entry_candidate_sites(entry()) -> [candidate_site()] | undefined.
+entry_candidate_sites(#entry{candidate_sites = V}) -> V.
+
 -doc """
 Read the patched method body (or full new-class source) recorded for `Entry`
 from `<workspace>/changes/sources/<source_ref>.bt`.
@@ -1216,6 +1456,12 @@ do_append(Input, State) ->
         prev_source_ref = PrevSourceRef,
         source_file = maps:get(source_file, Input, undefined),
         span = maps:get(span, Input, undefined),
+        old_class = maps:get(old_class, Input, undefined),
+        old_selector = maps:get(old_selector, Input, undefined),
+        old_path = maps:get(old_path, Input, undefined),
+        new_path = maps:get(new_path, Input, undefined),
+        sites = maps:get(sites, Input, undefined),
+        candidate_sites = maps:get(candidate_sites, Input, undefined),
         intent = maps:get(intent, Input),
         flushable = maps:get(flushable, Input),
         not_flushable_reason = maps:get(not_flushable_reason, Input, undefined),
@@ -1677,6 +1923,13 @@ entry_to_json(#entry{} = E) ->
         <<"prev_source_ref">> => null_or(E#entry.prev_source_ref),
         <<"sourceFile">> => null_or(E#entry.source_file),
         <<"span">> => span_to_json(E#entry.span),
+        %% ADR 0114 (BT-3269).
+        <<"old_class">> => null_or(E#entry.old_class),
+        <<"old_selector">> => null_or(E#entry.old_selector),
+        <<"old_path">> => null_or(E#entry.old_path),
+        <<"new_path">> => null_or(E#entry.new_path),
+        <<"sites">> => sites_to_json(E#entry.sites),
+        <<"candidate_sites">> => candidate_sites_to_json(E#entry.candidate_sites),
         <<"intent">> => atom_to_binary(E#entry.intent, utf8),
         <<"flushable">> => E#entry.flushable,
         <<"not_flushable_reason">> => null_or(E#entry.not_flushable_reason),
@@ -1706,6 +1959,16 @@ entry_from_json(Line) ->
         prev_source_ref = from_null(maps:get(<<"prev_source_ref">>, Map, null)),
         source_file = from_null(maps:get(<<"sourceFile">>, Map, null)),
         span = span_from_json(maps:get(<<"span">>, Map, null)),
+        %% ADR 0114 (BT-3269): absent in every metadata line written before
+        %% this ADR — `maps:get/3`'s `null` default decodes to `undefined`
+        %% via the same helpers used for every other pre-existing optional
+        %% field, so legacy lines round-trip unchanged.
+        old_class = from_null(maps:get(<<"old_class">>, Map, null)),
+        old_selector = from_null(maps:get(<<"old_selector">>, Map, null)),
+        old_path = from_null(maps:get(<<"old_path">>, Map, null)),
+        new_path = from_null(maps:get(<<"new_path">>, Map, null)),
+        sites = sites_from_json(maps:get(<<"sites">>, Map, null)),
+        candidate_sites = candidate_sites_from_json(maps:get(<<"candidate_sites">>, Map, null)),
         intent = decode_intent(maps:get(<<"intent">>, Map)),
         flushable = maps:get(<<"flushable">>, Map),
         not_flushable_reason = from_null(maps:get(<<"not_flushable_reason">>, Map, null)),
@@ -1737,6 +2000,10 @@ decode_kind(<<"remove-method">>) ->
     'remove-method';
 decode_kind(<<"remove-class">>) ->
     'remove-class';
+decode_kind(<<"rename-class">>) ->
+    'rename-class';
+decode_kind(<<"rename-method">>) ->
+    'rename-method';
 decode_kind(Other) ->
     log_unknown_enum(kind, Other),
     unknown.
@@ -1801,6 +2068,61 @@ span_to_json(#{start := Start, 'end' := End}) -> #{<<"start">> => Start, <<"end"
 -spec span_from_json(map() | null) -> span() | undefined.
 span_from_json(null) -> undefined;
 span_from_json(#{<<"start">> := Start, <<"end">> := End}) -> #{start => Start, 'end' => End}.
+
+%% ADR 0114 (BT-3269): `sites`/`candidate_sites` (de)serialisation. A whole
+%% `sites` list of `null` (rather than an empty array) matches every other
+%% optional field's "absent means not applicable" convention — only
+%% `'rename-class'`/`'rename-method'` entries ever populate it. An individual
+%% `null` *element* inside a present list is the dynamic-class "no
+%% declaration site" case (ADR 0114 § ChangeLog schema), distinct from the
+%% whole-field absence.
+-spec site_to_json(site() | undefined) -> map() | null.
+site_to_json(undefined) ->
+    null;
+site_to_json(#{
+    source_file := SourceFile, span := Span, source_ref := SourceRef, prev_source_ref := PrevRef
+}) ->
+    #{
+        <<"sourceFile">> => null_or(SourceFile),
+        <<"span">> => span_to_json(Span),
+        <<"source_ref">> => null_or(SourceRef),
+        <<"prev_source_ref">> => null_or(PrevRef)
+    }.
+
+-spec site_from_json(map() | null) -> site() | undefined.
+site_from_json(null) ->
+    undefined;
+site_from_json(Map) when is_map(Map) ->
+    #{
+        source_file => from_null(maps:get(<<"sourceFile">>, Map, null)),
+        span => span_from_json(maps:get(<<"span">>, Map, null)),
+        source_ref => from_null(maps:get(<<"source_ref">>, Map, null)),
+        prev_source_ref => from_null(maps:get(<<"prev_source_ref">>, Map, null))
+    }.
+
+-spec sites_to_json([site() | undefined] | undefined) -> [map() | null] | null.
+sites_to_json(undefined) -> null;
+sites_to_json(Sites) -> [site_to_json(S) || S <- Sites].
+
+-spec sites_from_json([map() | null] | null) -> [site() | undefined] | undefined.
+sites_from_json(null) -> undefined;
+sites_from_json(List) when is_list(List) -> [site_from_json(S) || S <- List].
+
+-spec candidate_site_to_json(candidate_site()) -> map().
+candidate_site_to_json(#{source_file := SourceFile, span := Span}) ->
+    #{<<"sourceFile">> => SourceFile, <<"span">> => span_to_json(Span)}.
+
+-spec candidate_site_from_json(map()) -> candidate_site().
+candidate_site_from_json(#{<<"sourceFile">> := SourceFile, <<"span">> := Span}) ->
+    #{source_file => SourceFile, span => span_from_json(Span)}.
+
+-spec candidate_sites_to_json([candidate_site()] | undefined) -> [map()] | null.
+candidate_sites_to_json(undefined) -> null;
+candidate_sites_to_json(Sites) -> [candidate_site_to_json(S) || S <- Sites].
+
+-spec candidate_sites_from_json([map()] | null) -> [candidate_site()] | undefined.
+candidate_sites_from_json(null) -> undefined;
+candidate_sites_from_json(List) when is_list(List) -> [candidate_site_from_json(S) || S <- List].
 
 -spec null_or(binary() | undefined) -> binary() | null.
 null_or(undefined) -> null;

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
@@ -71,7 +71,20 @@ changelog_test_() ->
         fun unknown_cast_is_ignored/1,
         fun unknown_info_is_ignored/1,
         fun code_change_returns_state/1,
-        fun new_class_value_has_nil_source_file/1
+        fun new_class_value_has_nil_source_file/1,
+        %% ADR 0114 (BT-3269): rename-class / rename-method schema
+        fun rename_class_json_round_trip/1,
+        fun rename_method_json_round_trip/1,
+        fun rename_class_entry_accessors_expose_fields/1,
+        fun rename_method_entry_accessors_expose_fields/1,
+        fun rename_class_does_not_shadow_pending_new_class_entry/1,
+        fun dirty_methods_uses_rename_class_placeholder/1,
+        fun change_entries_handles_rename_class_without_crashing/1,
+        fun target_key_single_element_for_ordinary_kind/1,
+        fun target_key_distinct_per_site_for_rename_class/1,
+        fun target_key_distinct_per_site_for_rename_method/1,
+        fun target_key_skips_null_site_for_dynamic_class_rename/1,
+        fun target_key_distinguishes_independent_renames_sharing_a_file/1
     ]}.
 
 %% FFI surface with no gen_server started: must degrade to empty, not crash.
@@ -775,6 +788,201 @@ new_class_value_has_nil_source_file(_Ctx) ->
     ].
 
 %%====================================================================
+%% ADR 0114 (BT-3269): rename-class / rename-method schema
+%%====================================================================
+
+%% JSON round-trip for the new multi-site `'rename-class'` kind, mirroring
+%% `json_round_trip/1`'s existing single-file-kind coverage.
+rename_class_json_round_trip(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(rename_class_input()),
+    [Entry] = beamtalk_workspace_changelog:entries(),
+    Json = beamtalk_workspace_changelog:entry_to_json(Entry),
+    Decoded = beamtalk_workspace_changelog:entry_from_json(Json),
+    Reencoded = beamtalk_workspace_changelog:entry_to_json(Decoded),
+    [
+        ?_assertEqual(Json, Reencoded),
+        ?_assertEqual('rename-class', beamtalk_workspace_changelog:entry_kind(Decoded)),
+        ?_assertEqual(<<"Counter">>, beamtalk_workspace_changelog:entry_old_class(Decoded)),
+        ?_assertEqual(2, length(beamtalk_workspace_changelog:entry_sites(Decoded)))
+    ].
+
+%% JSON round-trip for the new multi-site `'rename-method'` kind, including
+%% `candidate_sites` (which round-trips but is never folded into `sites`).
+rename_method_json_round_trip(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(rename_method_input()),
+    [Entry] = beamtalk_workspace_changelog:entries(),
+    Json = beamtalk_workspace_changelog:entry_to_json(Entry),
+    Decoded = beamtalk_workspace_changelog:entry_from_json(Json),
+    Reencoded = beamtalk_workspace_changelog:entry_to_json(Decoded),
+    [
+        ?_assertEqual(Json, Reencoded),
+        ?_assertEqual('rename-method', beamtalk_workspace_changelog:entry_kind(Decoded)),
+        ?_assertEqual(<<"increment">>, beamtalk_workspace_changelog:entry_old_selector(Decoded)),
+        ?_assertEqual(instance, beamtalk_workspace_changelog:entry_side(Decoded)),
+        ?_assertEqual(2, length(beamtalk_workspace_changelog:entry_sites(Decoded))),
+        ?_assertEqual(1, length(beamtalk_workspace_changelog:entry_candidate_sites(Decoded)))
+    ].
+
+%% All six new accessors expose the fields recorded on append (not just what
+%% survives a JSON round-trip).
+rename_class_entry_accessors_expose_fields(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(rename_class_input()),
+    [Entry] = beamtalk_workspace_changelog:entries(),
+    [
+        ?_assertEqual(<<"Counter">>, beamtalk_workspace_changelog:entry_old_class(Entry)),
+        ?_assertEqual(
+            <<"/proj/src/counter.bt">>, beamtalk_workspace_changelog:entry_old_path(Entry)
+        ),
+        ?_assertEqual(
+            <<"/proj/src/accumulator.bt">>, beamtalk_workspace_changelog:entry_new_path(Entry)
+        ),
+        ?_assertEqual(undefined, beamtalk_workspace_changelog:entry_old_selector(Entry)),
+        ?_assertEqual(undefined, beamtalk_workspace_changelog:entry_candidate_sites(Entry)),
+        ?_assertEqual(undefined, beamtalk_workspace_changelog:entry_side(Entry)),
+        ?_assertEqual(undefined, beamtalk_workspace_changelog:entry_selector(Entry))
+    ].
+
+rename_method_entry_accessors_expose_fields(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(rename_method_input()),
+    [Entry] = beamtalk_workspace_changelog:entries(),
+    [
+        ?_assertEqual(<<"increment">>, beamtalk_workspace_changelog:entry_old_selector(Entry)),
+        ?_assertEqual(<<"incrementBy">>, beamtalk_workspace_changelog:entry_selector(Entry)),
+        ?_assertEqual(instance, beamtalk_workspace_changelog:entry_side(Entry)),
+        ?_assertEqual(undefined, beamtalk_workspace_changelog:entry_old_class(Entry)),
+        ?_assertEqual(undefined, beamtalk_workspace_changelog:entry_old_path(Entry)),
+        ?_assertEqual(1, length(beamtalk_workspace_changelog:entry_candidate_sites(Entry)))
+    ].
+
+%% Regression, mirroring `class_def_entry_does_not_shadow_pending_new_class_entry/1`:
+%% a `'rename-class'` entry (selector = undefined) must not collide on the
+%% shadow key with a `'new-class'` entry for an unrelated pending class —
+%% `shadow_key/1`'s existing kind-tiebreaker for selector-less entries already
+%% covers this without modification, verified here as a regression guard.
+rename_class_does_not_shadow_pending_new_class_entry(_Ctx) ->
+    NewClassInput = #{
+        class => <<"Widget">>,
+        kind => 'new-class',
+        source => <<"Object subclass: Widget\nend\n">>,
+        intent => durable,
+        flushable => true,
+        author => <<"sess-1">>,
+        author_kind => human,
+        source_file => <<"/proj/src/widget.bt">>
+    },
+    {ok, _} = beamtalk_workspace_changelog:append(NewClassInput),
+    {ok, _} = beamtalk_workspace_changelog:append(rename_class_input()),
+    [NewClassEntry, RenameClassEntry] = beamtalk_workspace_changelog:change_entries(),
+    [
+        ?_assertEqual('new-class', maps:get(kind, NewClassEntry)),
+        ?_assertEqual(false, maps:get(shadowed, NewClassEntry)),
+        ?_assertEqual('rename-class', maps:get(kind, RenameClassEntry)),
+        ?_assertEqual(false, maps:get(shadowed, RenameClassEntry))
+    ].
+
+%% dirtyMethods/0 uses a `#'rename-class'` placeholder (not `#'new-class'`) for
+%% a selector-less `'rename-class'` entry, mirroring `'class-def'`'s own
+%% placeholder (BT-3248).
+dirty_methods_uses_rename_class_placeholder(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(rename_class_input()),
+    Dirty = beamtalk_workspace_changelog:dirtyMethods(),
+    Set = maps:get('Accumulator', Dirty),
+    [
+        ?_assertEqual(['rename-class'], maps:get(elements, Set))
+    ].
+
+%% `change_entries/0` (the `Workspace changes` FFI path) must not crash on a
+%% multi-site entry — `method_delta/1`'s catch-all degrades to "no diff"
+%% (BT-3270's rewrite mechanism, not this schema-only issue, will teach it to
+%% do better).
+change_entries_handles_rename_class_without_crashing(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(rename_class_input()),
+    [Entry] = beamtalk_workspace_changelog:change_entries(),
+    [
+        ?_assertEqual('rename-class', maps:get(kind, Entry)),
+        ?_assertEqual(nil, maps:get(selector, Entry)),
+        ?_assertEqual(false, maps:get(clean, Entry)),
+        ?_assertEqual(nil, maps:get(diff, Entry))
+    ].
+
+%% target_key/1: every pre-0114 kind still returns a single-element list
+%% wrapping the existing per-entry shadow key.
+target_key_single_element_for_ordinary_kind(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(durable_input(<<"Counter">>, <<"inc">>)),
+    [Entry] = beamtalk_workspace_changelog:entries(),
+    Keys = beamtalk_workspace_changelog:target_key(Entry),
+    [?_assertEqual(1, length(Keys))].
+
+%% target_key/1: a `'rename-class'` entry yields one distinct key per site.
+target_key_distinct_per_site_for_rename_class(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(rename_class_input()),
+    [Entry] = beamtalk_workspace_changelog:entries(),
+    Keys = beamtalk_workspace_changelog:target_key(Entry),
+    [
+        ?_assertEqual(2, length(Keys)),
+        ?_assertEqual(2, length(lists:usort(Keys)))
+    ].
+
+%% target_key/1: a `'rename-method'` entry yields one distinct key per `sites`
+%% entry — `candidate_sites` are never keyed (they have no shadow-detection
+%% role, since flush never rewrites them).
+target_key_distinct_per_site_for_rename_method(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(rename_method_input()),
+    [Entry] = beamtalk_workspace_changelog:entries(),
+    Keys = beamtalk_workspace_changelog:target_key(Entry),
+    [
+        ?_assertEqual(2, length(Keys)),
+        ?_assertEqual(2, length(lists:usort(Keys)))
+    ].
+
+%% target_key/1: a `null` site (ADR 0114's dynamic-class "no declaration site"
+%% case) contributes no key — only the real site is keyed.
+target_key_skips_null_site_for_dynamic_class_rename(_Ctx) ->
+    DynamicInput = (rename_class_input())#{
+        old_path => undefined,
+        new_path => undefined,
+        sites => [
+            undefined,
+            site_map(<<"/proj/src/widget.bt">>, #{start => 40, 'end' => 55})
+        ]
+    },
+    {ok, _} = beamtalk_workspace_changelog:append(DynamicInput),
+    [Entry] = beamtalk_workspace_changelog:entries(),
+    Keys = beamtalk_workspace_changelog:target_key(Entry),
+    [?_assertEqual(1, length(Keys))].
+
+%% The scenario ADR 0114 explicitly calls out: two independent renames whose
+%% site lists happen to share a reference file must not collide on the same
+%% per-site key (each key also carries the entry's own rename identity, not
+%% just the site's file/span).
+target_key_distinguishes_independent_renames_sharing_a_file(_Ctx) ->
+    RenameCounter = (rename_class_input())#{
+        class => <<"Accumulator">>,
+        old_class => <<"Counter">>,
+        sites => [
+            site_map(<<"/proj/src/accumulator.bt">>, #{start => 0, 'end' => 20}),
+            site_map(<<"/proj/src/widget.bt">>, #{start => 40, 'end' => 55})
+        ]
+    },
+    RenameWidget = (rename_class_input())#{
+        class => <<"Gadget">>,
+        old_class => <<"Widget">>,
+        old_path => <<"/proj/src/widget.bt">>,
+        new_path => <<"/proj/src/gadget.bt">>,
+        sites => [
+            site_map(<<"/proj/src/gadget.bt">>, #{start => 0, 'end' => 18}),
+            %% Same file as RenameCounter's second site, different span.
+            site_map(<<"/proj/src/widget.bt">>, #{start => 60, 'end' => 75})
+        ]
+    },
+    {ok, _} = beamtalk_workspace_changelog:append(RenameCounter),
+    {ok, _} = beamtalk_workspace_changelog:append(RenameWidget),
+    [E1, E2] = beamtalk_workspace_changelog:entries(),
+    Keys1 = beamtalk_workspace_changelog:target_key(E1),
+    Keys2 = beamtalk_workspace_changelog:target_key(E2),
+    [?_assertEqual([], [K || K <- Keys1, lists:member(K, Keys2)])].
+
+%%====================================================================
 %% Restart semantics (separate fixture: stop + restart same workspace)
 %%====================================================================
 
@@ -1087,10 +1295,62 @@ known_kinds_decode_to_atoms() ->
     ClassDef = beamtalk_workspace_changelog:entry_from_json(
         line_json_with(#{<<"kind">> => <<"class-def">>})
     ),
+    %% ADR 0114 (BT-3269).
+    RenameClass = beamtalk_workspace_changelog:entry_from_json(
+        line_json_with(#{<<"kind">> => <<"rename-class">>})
+    ),
+    RenameMethod = beamtalk_workspace_changelog:entry_from_json(
+        line_json_with(#{<<"kind">> => <<"rename-method">>})
+    ),
     ?assertEqual(instance, beamtalk_workspace_changelog:entry_kind(Instance)),
     ?assertEqual(class, beamtalk_workspace_changelog:entry_kind(Class)),
     ?assertEqual('new-class', beamtalk_workspace_changelog:entry_kind(NewClass)),
-    ?assertEqual('class-def', beamtalk_workspace_changelog:entry_kind(ClassDef)).
+    ?assertEqual('class-def', beamtalk_workspace_changelog:entry_kind(ClassDef)),
+    ?assertEqual('rename-class', beamtalk_workspace_changelog:entry_kind(RenameClass)),
+    ?assertEqual('rename-method', beamtalk_workspace_changelog:entry_kind(RenameMethod)).
+
+%%====================================================================
+%% sites_flushable/1 (ADR 0114, BT-3269): pure fold, no gen_server needed
+%%====================================================================
+
+sites_flushable_test_() ->
+    [
+        fun sites_flushable_all_flushable_is_true/0,
+        fun sites_flushable_empty_list_is_true/0,
+        fun sites_flushable_mixed_stdlib_and_project_returns_false_with_reason/0,
+        fun sites_flushable_first_reason_wins_when_multiple_non_flushable/0
+    ].
+
+sites_flushable_all_flushable_is_true() ->
+    ?assertEqual(
+        {true, undefined},
+        beamtalk_workspace_changelog:sites_flushable([flushable, flushable, flushable])
+    ).
+
+sites_flushable_empty_list_is_true() ->
+    ?assertEqual({true, undefined}, beamtalk_workspace_changelog:sites_flushable([])).
+
+%% AC: "flushable computed correctly for a mixed stdlib+project sites list".
+sites_flushable_mixed_stdlib_and_project_returns_false_with_reason() ->
+    ?assertEqual(
+        {false, <<"stdlib">>},
+        beamtalk_workspace_changelog:sites_flushable([
+            flushable,
+            {not_flushable, <<"stdlib">>},
+            flushable
+        ])
+    ).
+
+%% Deterministic ordering: the first non-flushable classification wins,
+%% matching sites[0]-first append order.
+sites_flushable_first_reason_wins_when_multiple_non_flushable() ->
+    ?assertEqual(
+        {false, <<"dynamic">>},
+        beamtalk_workspace_changelog:sites_flushable([
+            {not_flushable, <<"dynamic">>},
+            {not_flushable, <<"dependency:/dep/foo.bt">>}
+        ])
+    ).
 
 %%====================================================================
 %% Table-absent guards (no gen_server started)
@@ -1156,6 +1416,62 @@ durable_input(Class, Selector) ->
         author_kind => human,
         source_file => <<"/proj/src/counter.bt">>,
         span => #{start => 0, 'end' => 10}
+    }.
+
+%%====================================================================
+%% ADR 0114 (BT-3269) helpers: rename-class / rename-method fixtures
+%%====================================================================
+
+%% A `site()` map with no recorded source_ref/prev_source_ref — schema-only,
+%% no site-discovery/rewrite mechanism exists yet (BT-3270).
+site_map(SourceFile, Span) ->
+    #{
+        source_file => SourceFile,
+        span => Span,
+        source_ref => undefined,
+        prev_source_ref => undefined
+    }.
+
+%% A minimal, valid `'rename-class'` append_input: two sites — the class's own
+%% (post-rename) declaration and one foreign reference in another file.
+rename_class_input() ->
+    #{
+        class => <<"Accumulator">>,
+        kind => 'rename-class',
+        old_class => <<"Counter">>,
+        old_path => <<"/proj/src/counter.bt">>,
+        new_path => <<"/proj/src/accumulator.bt">>,
+        sites => [
+            site_map(<<"/proj/src/accumulator.bt">>, #{start => 0, 'end' => 20}),
+            site_map(<<"/proj/src/widget.bt">>, #{start => 40, 'end' => 55})
+        ],
+        intent => durable,
+        flushable => true,
+        author => <<"sess-1">>,
+        author_kind => human
+    }.
+
+%% A minimal, valid `'rename-method'` append_input: definition site + one
+%% confirmed self/super sender site, plus one reported (never rewritten)
+%% candidate sender.
+rename_method_input() ->
+    #{
+        class => <<"Counter">>,
+        selector => <<"incrementBy">>,
+        old_selector => <<"increment">>,
+        kind => 'rename-method',
+        side => instance,
+        sites => [
+            site_map(<<"/proj/src/counter.bt">>, #{start => 10, 'end' => 30}),
+            site_map(<<"/proj/src/sub_counter.bt">>, #{start => 5, 'end' => 25})
+        ],
+        candidate_sites => [
+            #{source_file => <<"/proj/src/timer.bt">>, span => #{start => 2, 'end' => 12}}
+        ],
+        intent => durable,
+        flushable => true,
+        author => <<"sess-1">>,
+        author_kind => agent
     }.
 
 %% Create an isolated workspace: a unique id + a temp HOME so the changelog

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
@@ -824,10 +824,12 @@ rename_method_json_round_trip(_Ctx) ->
         ?_assertEqual(1, length(beamtalk_workspace_changelog:entry_candidate_sites(Decoded)))
     ].
 
-%% A malformed `candidate_sites` element (missing `span`) must not cost the
-%% whole ChangeLog line: `entry_from_json/1` should drop just that element
-%% (logged, per review feedback on PR #3521) and decode everything else —
-%% including `sites`/rename data — intact.
+%% Three distinct malformed `candidate_sites` shapes (missing `span`,
+%% present-but-`null` `span`, and a `span` object missing `end`) must not
+%% cost the whole ChangeLog line: `entry_from_json/1` should drop each
+%% malformed element (logged, per review feedback on PR #3521) and decode
+%% everything else — including `sites`/rename data and the one well-formed
+%% candidate site — intact.
 rename_method_decode_drops_malformed_candidate_site(_Ctx) ->
     {ok, _} = beamtalk_workspace_changelog:append(rename_method_input()),
     [Entry] = beamtalk_workspace_changelog:entries(),
@@ -836,6 +838,8 @@ rename_method_decode_drops_malformed_candidate_site(_Ctx) ->
     Corrupted = Map#{
         <<"candidate_sites">> => [
             #{<<"sourceFile">> => <<"/proj/src/timer.bt">>},
+            #{<<"sourceFile">> => <<"/proj/src/timer2.bt">>, <<"span">> => null},
+            #{<<"sourceFile">> => <<"/proj/src/timer3.bt">>, <<"span">> => #{<<"start">> => 1}},
             #{
                 <<"sourceFile">> => <<"/proj/src/other.bt">>,
                 <<"span">> => #{

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_changelog_tests.erl
@@ -75,6 +75,7 @@ changelog_test_() ->
         %% ADR 0114 (BT-3269): rename-class / rename-method schema
         fun rename_class_json_round_trip/1,
         fun rename_method_json_round_trip/1,
+        fun rename_method_decode_drops_malformed_candidate_site/1,
         fun rename_class_entry_accessors_expose_fields/1,
         fun rename_method_entry_accessors_expose_fields/1,
         fun rename_class_does_not_shadow_pending_new_class_entry/1,
@@ -819,6 +820,35 @@ rename_method_json_round_trip(_Ctx) ->
         ?_assertEqual('rename-method', beamtalk_workspace_changelog:entry_kind(Decoded)),
         ?_assertEqual(<<"increment">>, beamtalk_workspace_changelog:entry_old_selector(Decoded)),
         ?_assertEqual(instance, beamtalk_workspace_changelog:entry_side(Decoded)),
+        ?_assertEqual(2, length(beamtalk_workspace_changelog:entry_sites(Decoded))),
+        ?_assertEqual(1, length(beamtalk_workspace_changelog:entry_candidate_sites(Decoded)))
+    ].
+
+%% A malformed `candidate_sites` element (missing `span`) must not cost the
+%% whole ChangeLog line: `entry_from_json/1` should drop just that element
+%% (logged, per review feedback on PR #3521) and decode everything else —
+%% including `sites`/rename data — intact.
+rename_method_decode_drops_malformed_candidate_site(_Ctx) ->
+    {ok, _} = beamtalk_workspace_changelog:append(rename_method_input()),
+    [Entry] = beamtalk_workspace_changelog:entries(),
+    Json = beamtalk_workspace_changelog:entry_to_json(Entry),
+    Map = json:decode(Json),
+    Corrupted = Map#{
+        <<"candidate_sites">> => [
+            #{<<"sourceFile">> => <<"/proj/src/timer.bt">>},
+            #{
+                <<"sourceFile">> => <<"/proj/src/other.bt">>,
+                <<"span">> => #{
+                    <<"start">> => 1, <<"end">> => 2
+                }
+            }
+        ]
+    },
+    CorruptedJson = json:encode(Corrupted),
+    Decoded = beamtalk_workspace_changelog:entry_from_json(iolist_to_binary(CorruptedJson)),
+    [
+        ?_assertEqual('rename-method', beamtalk_workspace_changelog:entry_kind(Decoded)),
+        ?_assertEqual(<<"increment">>, beamtalk_workspace_changelog:entry_old_selector(Decoded)),
         ?_assertEqual(2, length(beamtalk_workspace_changelog:entry_sites(Decoded))),
         ?_assertEqual(1, length(beamtalk_workspace_changelog:entry_candidate_sites(Decoded)))
     ].


### PR DESCRIPTION
## Summary
- Extends `beamtalk_workspace_changelog`'s `kind` enum with ADR 0114's two multi-site shapes: `rename-class` (`old_class`/`old_path`/`new_path`/`sites`) and `rename-method` (`old_selector`/`side`/`sites`/`candidate_sites`)
- Reuses the existing `class`/`selector` fields to hold the *new* name/selector, matching every other kind's convention, rather than adding redundant `new_class`/`new_selector` fields
- Adds `target_key/1`, a per-site shadow-detection key (the existing `shadow_key/1` stays per-entry, which breaks down once one entry's rewrite spans a set of files — two independent renames could touch overlapping reference files)
- Adds `sites_flushable/1` implementing the "true iff every site in `sites` is flushable, never blocked by a `candidate_sites` entry" rule ADR 0114 specifies

Schema only, per issue scope — site-discovery and the rewrite mechanism land in later issues (BT-3270+).

## Test plan
- [x] `rebar3 eunit --module=beamtalk_workspace_changelog_tests` → 164/164 pass
- [x] `rebar3 eunit --app=beamtalk_workspace` → 2846/2846 pass (no regressions in existing kinds)
- [x] `rebar3 fmt --check` clean

Part of Epic BT-3267 (ADR 0114). Second of 12 sequential issues landing on this epic branch (follows #3519 / BT-3268).

---
_Generated by [Claude Code](https://claude.ai/code/session_016Reae4miRyBSZTm4Mbxiry)_