### PR TITLE
refactor: delete duplicate format_type_annotation in CLI native codegen

### DIFF
--- a/crates/beamtalk-cli/src/commands/generate/native.rs
+++ b/crates/beamtalk-cli/src/commands/generate/native.rs
@@ -7,7 +7,7 @@
 //! `self delegate` methods, and writes a skeleton `.erl` file with matching
 //! `handle_call/3` clauses.
 
-use beamtalk_core::ast::{ClassDefinition, MessageSelector, MethodDefinition, TypeAnnotation};
+use beamtalk_core::ast::{ClassDefinition, MessageSelector, MethodDefinition};
 use camino::Utf8PathBuf;
 use miette::{Context, Result};
 use std::fmt::Write as _;
@@ -260,7 +260,7 @@ fn write_handle_call_clause(out: &mut String, method: &MethodDefinition) {
 
     // Add return type comment for this clause
     if let Some(ref ret_type) = method.return_type {
-        let type_str = format_type_annotation(ret_type);
+        let type_str = beamtalk_core::unparse::unparse_type_annotation_display(ret_type);
         writeln!(out, "%% {selector_name} -> {type_str}").unwrap();
     }
 
@@ -329,40 +329,6 @@ fn capitalize_erlang_var(name: &str) -> String {
             let upper: String = first.to_uppercase().collect();
             format!("{upper}{}", chars.as_str())
         }
-    }
-}
-
-/// Format a type annotation as a human-readable string (for comments).
-fn format_type_annotation(ty: &TypeAnnotation) -> String {
-    match ty {
-        TypeAnnotation::Simple(id) => id.name.to_string(),
-        TypeAnnotation::Singleton { name, .. } => format!("#{name}"),
-        TypeAnnotation::Union { types, .. } => {
-            let parts: Vec<String> = types.iter().map(format_type_annotation).collect();
-            parts.join(" | ")
-        }
-        TypeAnnotation::Generic {
-            base, parameters, ..
-        } => {
-            let params: Vec<String> = parameters.iter().map(format_type_annotation).collect();
-            format!("{}({})", base.name, params.join(", "))
-        }
-        TypeAnnotation::Difference { base, excluded, .. } => {
-            format!(
-                "{} \\ {}",
-                format_type_annotation(base),
-                format_type_annotation(excluded)
-            )
-        }
-        TypeAnnotation::Intersection { left, right, .. } => {
-            format!(
-                "{} & {}",
-                format_type_annotation(left),
-                format_type_annotation(right)
-            )
-        }
-        // For other variants, just produce a placeholder
-        _ => "Object".to_string(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Delete the private `format_type_annotation` function in `crates/beamtalk-cli/src/commands/generate/native.rs` — it was a 32-line duplicate of the public `beamtalk_core::unparse::unparse_type_annotation_display`, which `beamtalk-cli` already depends on.
- Replace the single call site (line 263) with the canonical core function.
- Remove the now-unused `TypeAnnotation` import.

## Finding

`crates/beamtalk-cli/src/commands/generate/native.rs:336–367` contained a private `fn format_type_annotation(ty: &TypeAnnotation) -> String` that re-implemented the same match as `beamtalk_core::unparse::unparse_type_annotation_display` (`crates/beamtalk-core/src/unparse/mod.rs:282`).

The CLI copy was also strictly worse — it fell back to `"Object"` for `FalseOr`, `SelfType`, `SelfClass`, and `ClassOf` variants, while the core correctly renders `"inner | False"`, `"Self"`, `"Self class"`, and `"className class"` respectively.

This is the anti-pattern described in `docs/development/architecture-principles.md` §6: "Module X sits below Y in the dependency graph" is not a reason to duplicate — extract to a shared leaf module or (here) simply import the already-public function from the lower layer.

## Diff size

1 file, +2 / -36 lines.

## Testing

- `cargo clippy -p beamtalk-cli --all-targets` — clean.
- `cargo test -p beamtalk-cli commands::generate::native` — 13/13 passing, including the `includes_return_type_comments` test that exercises the type-rendering path.
- Full pre-push hook suite (clippy, Dialyzer, erlfmt, Biome, generated-spec validation) — all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_015J1DHFrYvoa1CXrZioNchD)_