### PR TITLE
BT-3271: Class-rename multi-file flush (Tier 2 staging)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_changelog.erl
@@ -140,6 +140,11 @@ release nodes do not start a workspace, so this code is a no-op there.
     entry_prev_source_ref/1,
     read_source_body/1,
     read_prev_source_body/1,
+    %% ADR 0114 (BT-3271): reads a `site()`'s own ref directly, for
+    %% `beamtalk_workspace_flush`'s multi-site rename-class splice — see this
+    %% function's own doc for why it cannot reuse `read_source_body/1`/
+    %% `read_prev_source_body/1` verbatim.
+    read_site_body/1,
     %% ADR 0114 (BT-3269).
     entry_old_class/1,
     entry_old_selector/1,
@@ -1360,6 +1365,32 @@ read_source_file(Ref) ->
         undefined ->
             {error, no_workspace}
     end.
+
+-doc """
+Read one rewrite site's own recorded body (its `source_ref` or
+`prev_source_ref`) from `<workspace>/changes/sources/<ref>.bt` (ADR 0114,
+BT-3271).
+
+Generalizes `read_source_body/1`/`read_prev_source_body/1` to a `site()`'s
+own per-site ref, rather than the OWNING ENTRY's top-level `source_ref`/
+`prev_source_ref` — which are always `undefined` for a `'rename-class'`/
+`'rename-method'` entry (the per-site bodies live under `sites` instead, see
+the ChangeEntry schema doc's `source_ref`/`sites` rows). `beamtalk_workspace_
+flush`'s multi-site rename-class splice needs to read a specific site's ref
+directly, so this takes the raw `binary() | undefined` ref rather than an
+`entry()` — reuses `read_source_file/1` verbatim (CLAUDE.md's no-duplicate-
+implementations rule) rather than re-deriving the `sources/` path lookup.
+
+Returns `{error, no_source}` for `undefined` — mirroring `read_source_body/1`'s
+handling of an absent top-level `source_ref` — rather than crashing on a
+missing filename: a site legitimately has an `undefined` `source_ref` or
+`prev_source_ref` (e.g. a site discovered but never itself given a body ref).
+""".
+-spec read_site_body(binary() | undefined) -> {ok, binary()} | {error, term()}.
+read_site_body(undefined) ->
+    {error, no_source};
+read_site_body(Ref) when is_binary(Ref) ->
+    read_source_file(Ref).
 
 -doc """
 Persist one rewrite site's body to the ChangeLog's `sources/` directory and

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
@@ -1502,30 +1502,27 @@ this is ours.
 -spec check_rename_target_safe(binary(), binary(), term()) -> ok | {conflict, map()}.
 check_rename_target_safe(NewPath, NewFileBody, Entry) ->
     AbsNewPath = binary_to_list(NewPath),
-    case file:read_file_info(AbsNewPath) of
+    case file:read_file(AbsNewPath) of
+        {ok, NewFileBody} ->
+            ok;
         {error, enoent} ->
             ok;
-        _Exists ->
-            case file:read_file(AbsNewPath) of
-                {ok, NewFileBody} ->
-                    ok;
-                _NotAlreadyOurs ->
-                    {conflict,
-                        conflict_map(
-                            NewPath,
-                            <<"rename_target_exists">>,
-                            [Entry],
-                            iolist_to_binary([
-                                <<"Cannot rename to ">>,
-                                NewPath,
-                                <<
-                                    "; a file already exists at that path with "
-                                    "different content; move or remove it first, "
-                                    "then re-flush the rename"
-                                >>
-                            ])
-                        )}
-            end
+        _NotAlreadyOurs ->
+            {conflict,
+                conflict_map(
+                    NewPath,
+                    <<"rename_target_exists">>,
+                    [Entry],
+                    iolist_to_binary([
+                        <<"Cannot rename to ">>,
+                        NewPath,
+                        <<
+                            "; a file already exists at that path with "
+                            "different content; move or remove it first, "
+                            "then re-flush the rename"
+                        >>
+                    ])
+                )}
     end.
 
 %% See moduledoc's "Atomicity (class rename)" — `old_path` gone disambiguates
@@ -1749,26 +1746,93 @@ resolve_site_unit_2(Body, File, Start, End, PrevText, NewText, OwnerEntry) ->
             end
     end.
 
--spec already_applied_at(binary(), non_neg_integer(), binary()) -> boolean().
+%% `Start` is `integer()`, not `non_neg_integer()`, because `all_units_
+%% already_applied_loop/3` calls this with an original recorded offset PLUS
+%% an accumulated shift that is mathematically always non-negative for a
+%% real site list, but not something Dialyzer can prove structurally.
+-spec already_applied_at(binary(), integer(), binary()) -> boolean().
 already_applied_at(Body, Start, NewText) ->
     NewLen = byte_size(NewText),
-    Start + NewLen =< byte_size(Body) andalso
+    Start >= 0 andalso
+        Start + NewLen =< byte_size(Body) andalso
         binary:part(Body, Start, NewLen) =:= NewText.
 
+-doc """
+Verify every unit's expected new text already sits at its correct position
+in `Body` — the "old_path already gone" recovery check `resolve_missing_
+rename_source/4` uses to tell a genuinely completed move apart from an
+unresolvable conflict.
+
+**Cannot just check each unit's own RECORDED `span.start` against `Body`**
+(review round 5 on PR #3526): that offset is relative to the ORIGINAL,
+pre-splice source — valid input to `apply_site_units/2`'s own progressive,
+rightmost-first application (each not-yet-applied lower-offset unit's
+recorded start is still correct at the moment ITS splice runs, since only
+content strictly after it has shifted so far), but NOT valid as a direct
+lookup into the FINAL, fully-spliced `Body` this function is handed instead
+— there is no original body to progressively splice against here (`old_path`
+is gone, which is the whole reason this recovery path exists). Once `move_
+sites/1` has more than one unit in the same file (a declaration plus a
+same-file self-reference, `rename_class_self_reference_folds_into_move/1`'s
+own fixture shape) and the rename changes the class name's byte length (the
+overwhelmingly common case), every unit at a HIGHER original offset than an
+earlier one has shifted in the final body by that earlier unit's own
+length delta — checking its stale, unshifted offset misses genuinely
+correct content and reports a live, working rename as an unresolvable
+`rename_target_mismatch`, contradicting this PR's whole idempotent-retry
+guarantee (fails safe, not silently, but still wrong).
+
+Fixed by walking units in ascending original-offset order and threading a
+running `Shift` — the sum of `byte_size(NewText) - byte_size(PrevText)`
+for every unit already processed (all of which sit at LOWER original
+offsets, hence entirely before this one in the file) — added to each
+unit's own recorded `start` before checking. This mirrors, in reverse
+order, exactly how `apply_site_units/2`'s rightmost-first application
+would have shifted this unit's true position, without needing the
+original pre-splice body at all — every input it needs (`prev_source_ref`
+alongside the already-used `source_ref`) is already recorded on the
+site.
+""".
 -spec all_units_already_applied(binary(), [{beamtalk_workspace_changelog:site(), term()}]) ->
     boolean().
 all_units_already_applied(Body, Units) ->
-    lists:all(
-        fun({Site, _Entry}) ->
-            #{span := #{start := Start}} = Site,
-            NewRef = maps:get(source_ref, Site, undefined),
-            case beamtalk_workspace_changelog:read_site_body(NewRef) of
-                {ok, NewText} -> already_applied_at(Body, Start, NewText);
-                {error, _} -> false
-            end
+    Sorted = lists:sort(
+        fun(
+            {#{span := #{start := A, 'end' := AEnd}}, _},
+            {#{span := #{start := B, 'end' := BEnd}}, _}
+        ) ->
+            {A, AEnd} =< {B, BEnd}
         end,
         Units
-    ).
+    ),
+    all_units_already_applied_loop(Body, Sorted, 0).
+
+-spec all_units_already_applied_loop(
+    binary(), [{beamtalk_workspace_changelog:site(), term()}], integer()
+) -> boolean().
+all_units_already_applied_loop(_Body, [], _Shift) ->
+    true;
+all_units_already_applied_loop(Body, [{Site, _Entry} | Rest], Shift) ->
+    #{span := #{start := Start}} = Site,
+    NewRef = maps:get(source_ref, Site, undefined),
+    PrevRef = maps:get(prev_source_ref, Site, undefined),
+    case
+        {
+            beamtalk_workspace_changelog:read_site_body(NewRef),
+            beamtalk_workspace_changelog:read_site_body(PrevRef)
+        }
+    of
+        {{ok, NewText}, {ok, PrevText}} ->
+            case already_applied_at(Body, Start + Shift, NewText) of
+                true ->
+                    NextShift = Shift + (byte_size(NewText) - byte_size(PrevText)),
+                    all_units_already_applied_loop(Body, Rest, NextShift);
+                false ->
+                    false
+            end;
+        _ ->
+            false
+    end.
 
 %% A rename-class entry is only considered fully flushed once EVERY file it
 %% touches (`rename_entry_all_files_to_write/1`) has committed in the SAME

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
@@ -1172,6 +1172,20 @@ same way `rename_entry_ordinary_collision/3` already uses the full set for
 the rename side of its own (asymmetric, since an ordinary patch has no
 separate "old"/"new" path) guard.
 
+Known, accepted limitation (BT-3283): since `old_path` is only ever refreshed
+by a recompile (`maybe_reload_renamed_class_source/1`, itself only triggered
+by a flush COMMIT), renaming the SAME class twice before ever flushing
+(`Foo renameTo: #Bar` then, with no flush in between, `Bar renameTo: #Baz`)
+produces two entries that both compute `old_path = foo.bt` — genuinely
+sharing a file, so this guard correctly (if confusingly) refuses the whole
+batch as a "collision" rather than the two-hop rename it actually is. Safe
+(clean abort, no data loss, both entries stay pending) but not the most
+permissive possible behaviour; supporting it would need chain detection
+(`entry2`'s `old_class` equal to `entry1`'s `class`) merged into an
+effective single-hop rename before staging — real design work, not a
+one-line fix, tracked separately rather than expanding this Blocker fix's
+own scope.
+
 Checked pairwise, each unordered pair exactly once (`Rest` only ever holds
 entries *after* `Entry` in list order) — mirrors `rename_entry_ordinary_
 collision/3`'s one-conflict-per-entry granularity, just against a peer

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
@@ -1147,16 +1147,30 @@ rename_entry_ordinary_collision(Entry, OrdinaryFiles, OrdinaryGroups) ->
 
 -doc """
 Suggestion from BT-3526 review: `rename_entry_ordinary_collision/3` only
-guards a rename-class entry's write-target files against *ordinary* pending
-entries — two rename-class entries whose own `rename_entry_all_files_to_write/1`
-sets happen to intersect (e.g. a future `new_path`-supplying producer, or two
-unrelated classes whose `derive_new_path/3` styles coincide — see the
-moduledoc's "Atomicity (class rename)" section) went unguarded, risking one
-rename's `.tmp` silently clobbering the other's. Unreachable today
-(`classRenameTo/2`'s own `ensure_rename_collision_free/2` refuses a second
-rename targeting a class name already live, which is what would be needed to
-co-pend two renames colliding on the SAME `new_path`) but defended
-proactively rather than left as a latent gap for the next producer.
+guards a rename-class entry's touched files against *ordinary* pending
+entries — two rename-class entries whose own files intersect (e.g. a future
+`new_path`-supplying producer, or two unrelated classes whose
+`derive_new_path/3` styles coincide — see the moduledoc's "Atomicity (class
+rename)" section) went unguarded, risking one rename's `.tmp` silently
+clobbering the other's. Unreachable today (`classRenameTo/2`'s own
+`ensure_rename_collision_free/2` refuses a second rename targeting a class
+name already live, which is what would be needed to co-pend two renames
+colliding on the SAME `new_path`) but defended proactively rather than left
+as a latent gap for the next producer.
+
+Compares each entry's FULL touched-file set (`rename_entry_all_files/1` —
+`old_path` included, not just write-targets) against the other's, on BOTH
+sides — a first fix here compared write-targets to write-targets only and
+missed the more dangerous shape review round 2 found: entry A's `new_path`
+equal to entry B's `old_path`. Since Phase B's `move` commit unlinks
+`old_path` only AFTER its own `new_path.tmp` rename succeeds, whichever of
+A/B commits second would delete the file the OTHER just wrote there —
+silently destroying a renamed class's content while both entries report as
+cleanly flushed. Using the full set on both sides catches this (and the
+symmetric case, B's `new_path` equal to A's `old_path`) in one check, the
+same way `rename_entry_ordinary_collision/3` already uses the full set for
+the rename side of its own (asymmetric, since an ordinary patch has no
+separate "old"/"new" path) guard.
 
 Checked pairwise, each unordered pair exactly once (`Rest` only ever holds
 entries *after* `Entry` in list order) — mirrors `rename_entry_ordinary_
@@ -1167,7 +1181,7 @@ rename instead of an ordinary group.
 rename_entry_rename_collisions([]) ->
     [];
 rename_entry_rename_collisions([Entry | Rest]) ->
-    Files = sets:from_list(rename_entry_all_files_to_write(Entry), [{version, 2}]),
+    Files = sets:from_list(rename_entry_all_files(Entry), [{version, 2}]),
     case rename_entry_rename_collision_with(Entry, Files, Rest) of
         {true, Conflict} -> [Conflict | rename_entry_rename_collisions(Rest)];
         false -> rename_entry_rename_collisions(Rest)
@@ -1178,7 +1192,7 @@ rename_entry_rename_collisions([Entry | Rest]) ->
 rename_entry_rename_collision_with(_Entry, _Files, []) ->
     false;
 rename_entry_rename_collision_with(Entry, Files, [Other | Rest]) ->
-    OtherFiles = sets:from_list(rename_entry_all_files_to_write(Other), [{version, 2}]),
+    OtherFiles = sets:from_list(rename_entry_all_files(Other), [{version, 2}]),
     case sets:to_list(sets:intersection(Files, OtherFiles)) of
         [] ->
             rename_entry_rename_collision_with(Entry, Files, Rest);
@@ -2061,8 +2075,11 @@ which is precisely what embeds the correct (new) `beamtalk_source` module
 attribute, closing the staleness gap at its root. It deliberately does NOT
 emit a `'class-def'` ChangeLog entry (see its own doc) so this never creates
 a fresh pending entry for a subsequent flush to trip over, and it does not
-touch the ChangeLog at all — this call sits entirely after `complete_flush/5`
-would run, so nothing here can race `mark_flushed/1`.
+touch the ChangeLog at all — this call runs inside `phase_b_loop/6`'s
+per-item recursion, right after each successful `commit/1` (so BEFORE
+`complete_flush/5`, which only runs once every `#prepared{}` has been
+processed), but since it never touches the ChangeLog either way, nothing
+here can race `mark_flushed/1` regardless of that ordering.
 """.
 -spec maybe_reload_renamed_class_source(#prepared{}) -> ok.
 maybe_reload_renamed_class_source(#prepared{op = Op, file = NewPath, entries = [Entry | _]}) when

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
@@ -146,14 +146,25 @@ separate marker file.
 **Crash-recovery design decision.** Three states `old_path`/`new_path` can be
 in when Phase A runs, and what each means:
 
-  - **Both exist** (the ordinary case, including a retry after ANY earlier
-    partial attempt that got no further than writing `.tmp` files): read
-    `old_path`, resolve every site's splice against it (see the idempotent
-    check below), write `<new_path>.tmp`. Retrying this state is always safe
-    and idempotent — `old_path` is never mutated by Phase A, only read, so
-    re-deriving `<new_path>.tmp` from it and overwriting whatever is already
-    at `new_path` (correct or not) is exactly the recovery this ADR's flush
-    table describes.
+  - **`old_path` exists** (the ordinary case, including a retry after ANY
+    earlier partial attempt that got no further than writing `.tmp` files):
+    read `old_path`, resolve every site's splice against it (see the
+    idempotent check below). If `new_path` does not exist yet, write
+    `<new_path>.tmp` — the ordinary case. If `new_path` ALSO already exists
+    (review round 4 on PR #3526 — `old_path` still being present here means
+    THIS attempt's own Phase B has not yet renamed `<new_path>.tmp` into
+    place, so a pre-existing `new_path` can only be an unrelated file that
+    happens to occupy the derived target, or — the one legitimate case — an
+    EARLIER attempt's Phase B rename that already succeeded but whose
+    subsequent unlink of `old_path` then failed, per `commit/1`'s `op =
+    move` doc), `check_rename_target_safe/3` compares `new_path`'s current
+    bytes against the FULL post-splice body Phase A just computed — an exact
+    match means this is that legitimate resume (harmless to overwrite with
+    the same bytes, or skip), anything else is a hard, unresolvable conflict
+    (`reason => <<"rename_target_exists">>`), mirroring `prepare_new_class/3`'s
+    `target_exists` guard for the identical reason. `old_path` is never
+    mutated by Phase A, only read, so a legitimate retry is always safe and
+    idempotent either way.
   - **`old_path` gone, `new_path` present**: since Phase A never touches
     `old_path` and Phase B's own ordering renames `<new_path>.tmp` into place
     *before* unlinking `old_path`, the ONLY way `old_path` can be gone is a
@@ -1440,18 +1451,23 @@ prepare_rename_move(Entry, MoveUnits) ->
         {ok, OldBody} ->
             case apply_site_units(OldBody, Units) of
                 {ok, NewFileBody} ->
-                    case write_tmp(binary_to_list(NewPath), NewFileBody) of
-                        {ok, Tmp} ->
-                            {ok, #prepared{
-                                file = NewPath,
-                                old_file = OldPath,
-                                tmp = Tmp,
-                                entries = [Entry],
-                                pre_existing = true,
-                                op = move
-                            }};
-                        {error, _} = Err ->
-                            wrap_io_error(Err, NewPath)
+                    case check_rename_target_safe(NewPath, NewFileBody, Entry) of
+                        ok ->
+                            case write_tmp(binary_to_list(NewPath), NewFileBody) of
+                                {ok, Tmp} ->
+                                    {ok, #prepared{
+                                        file = NewPath,
+                                        old_file = OldPath,
+                                        tmp = Tmp,
+                                        entries = [Entry],
+                                        pre_existing = true,
+                                        op = move
+                                    }};
+                                {error, _} = Err ->
+                                    wrap_io_error(Err, NewPath)
+                            end;
+                        {conflict, _} = C ->
+                            C
                     end;
                 {conflict, _} = C ->
                     C;
@@ -1462,6 +1478,54 @@ prepare_rename_move(Entry, MoveUnits) ->
             resolve_missing_rename_source(Entry, OldPath, NewPath, Units);
         {error, Reason} ->
             wrap_io_error({error, Reason}, OldPath)
+    end.
+
+-doc """
+Refuse to stage a move over an unrelated pre-existing file at `NewPath`
+(review round 4 on PR #3526): `old_path` still existing here means Phase B
+has not yet renamed `<new_path>.tmp` into place for THIS attempt, so
+`NewPath` already existing can only mean one of two things — an earlier
+attempt's own Phase B rename already succeeded but its subsequent unlink of
+`old_path` failed (the documented "unlink itself fails" recovery case,
+`commit/1`'s `op = move` doc), in which case `NewPath` already holds
+EXACTLY `NewFileBody`; or an unrelated file that happens to already occupy
+the derived target path, which this rename must never silently overwrite —
+mirrors `prepare_new_class/3`'s `target_exists` guard for the identical
+reason (`'new-class'` already refuses this; a rename creating a file at a
+brand-new path is not fundamentally different).
+
+Byte-for-byte equality against the ALREADY-COMPUTED `NewFileBody` (not just
+"a file exists") is what tells the two cases apart without a false
+positive on the legitimate resume — content merely existing doesn't mean
+this is ours.
+""".
+-spec check_rename_target_safe(binary(), binary(), term()) -> ok | {conflict, map()}.
+check_rename_target_safe(NewPath, NewFileBody, Entry) ->
+    AbsNewPath = binary_to_list(NewPath),
+    case file:read_file_info(AbsNewPath) of
+        {error, enoent} ->
+            ok;
+        _Exists ->
+            case file:read_file(AbsNewPath) of
+                {ok, NewFileBody} ->
+                    ok;
+                _NotAlreadyOurs ->
+                    {conflict,
+                        conflict_map(
+                            NewPath,
+                            <<"rename_target_exists">>,
+                            [Entry],
+                            iolist_to_binary([
+                                <<"Cannot rename to ">>,
+                                NewPath,
+                                <<
+                                    "; a file already exists at that path with "
+                                    "different content; move or remove it first, "
+                                    "then re-flush the rename"
+                                >>
+                            ])
+                        )}
+            end
     end.
 
 %% See moduledoc's "Atomicity (class rename)" — `old_path` gone disambiguates

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
@@ -195,11 +195,43 @@ reports exactly which files committed, and the idempotent check above means
 re-flushing the same entry only re-writes the files that did not.
 
 **A `'rename-class'` entry sharing a target file with an ordinary pending
-patch (or another rename)** in the same flush batch surfaces as a
-`mixed_rename_and_ordinary_edit` conflict, aborting the whole batch — the
+patch, or with another rename-class entry's own target files** in the same
+flush batch surfaces as a `mixed_rename_and_ordinary_edit` (respectively
+`mixed_rename_and_rename_edit`) conflict, aborting the whole batch — the
 same defensive posture `remove-class`'s `mixed_remove_class_and_splice`
 guard already takes for the identical reason (reordering "write" and "move
-away" within one Phase A/B pass is undesigned).
+away" within one Phase A/B pass is undesigned). Today only the ordinary-vs-
+rename shape is reachable (`classRenameTo/2`'s own collision refusal
+prevents two co-pending entries from targeting the same class name), but
+`resolve_new_path/1` documents a future `new_path`-supplying producer that
+would not have that same guard, and `derive_new_path/3`'s two derivation
+styles could coincide for two unrelated class names — so
+`check_no_rename_file_collisions/2` guards the rename-vs-rename shape too
+(`rename_entry_rename_collisions/1`), rather than leaving it to the day a
+`.tmp` write silently clobbers another rename's in-flight one.
+
+**Post-commit source-attribute refresh (BT-3526 review fix).** A class's
+compiled BEAM module embeds its own source path as a `beamtalk_source`
+module attribute at compile time (`beamtalk_reflection:
+source_file_from_module/1`; `Behaviour>>sourceFile`) — this is exactly what
+`beamtalk_behaviour_intrinsics:classRenameTo/2`'s *next* invocation on this
+same class reads to compute its own `old_path`. Flush moves the file on
+disk but never recompiled the class, so that attribute went stale the
+moment the move committed: a second `renameTo:` on the same class, flushed
+afterwards, would compute `old_path` from the now-deleted pre-move path and
+could never resolve it (`reason => <<"source_missing">>`) even though the
+file's real, current content sits at `new_path` the entire time — an
+entirely ordinary "rename, flush, rename again" sequence, not a race. Once
+a `move`/`move_noop` commits successfully, `maybe_reload_renamed_class_
+source/1` best-effort reloads the class from `new_path`
+(`beamtalk_repl_loader:reload_class_file/2` — the same tested machinery
+`Counter reload`/`:reload` already uses) purely to refresh this bookkeeping
+attribute for a possible future rename; the class's in-memory identity and
+behaviour are already correct at this point (`classRenameTo/2`'s own job,
+BT-3278). A reload failure (no compiler available, a bare runtime, or any
+other error) is logged via `?LOG_WARNING` and never fails the
+already-successful flush — see that function's own doc for the full
+rationale.
 
 ## Conflict detection
 
@@ -1076,12 +1108,12 @@ check_no_rename_file_collisions([], _OrdinaryGroups) ->
     ok;
 check_no_rename_file_collisions(RenameEntries, OrdinaryGroups) ->
     OrdinaryFiles = sets:from_list([F || {F, _} <- OrdinaryGroups], [{version, 2}]),
-    case
-        lists:filtermap(
-            fun(Entry) -> rename_entry_ordinary_collision(Entry, OrdinaryFiles, OrdinaryGroups) end,
-            RenameEntries
-        )
-    of
+    OrdinaryConflicts = lists:filtermap(
+        fun(Entry) -> rename_entry_ordinary_collision(Entry, OrdinaryFiles, OrdinaryGroups) end,
+        RenameEntries
+    ),
+    RenameConflicts = rename_entry_rename_collisions(RenameEntries),
+    case OrdinaryConflicts ++ RenameConflicts of
         [] -> ok;
         Conflicts -> {conflict, Conflicts}
     end.
@@ -1108,6 +1140,67 @@ rename_entry_ordinary_collision(Entry, OrdinaryFiles, OrdinaryGroups) ->
                             ") alongside a pending ordinary patch against the same file "
                             "in the same operation; flush or discard the other pending "
                             "entry first, then re-flush the rename"
+                        >>
+                    ])
+                )}
+    end.
+
+-doc """
+Suggestion from BT-3526 review: `rename_entry_ordinary_collision/3` only
+guards a rename-class entry's write-target files against *ordinary* pending
+entries — two rename-class entries whose own `rename_entry_all_files_to_write/1`
+sets happen to intersect (e.g. a future `new_path`-supplying producer, or two
+unrelated classes whose `derive_new_path/3` styles coincide — see the
+moduledoc's "Atomicity (class rename)" section) went unguarded, risking one
+rename's `.tmp` silently clobbering the other's. Unreachable today
+(`classRenameTo/2`'s own `ensure_rename_collision_free/2` refuses a second
+rename targeting a class name already live, which is what would be needed to
+co-pend two renames colliding on the SAME `new_path`) but defended
+proactively rather than left as a latent gap for the next producer.
+
+Checked pairwise, each unordered pair exactly once (`Rest` only ever holds
+entries *after* `Entry` in list order) — mirrors `rename_entry_ordinary_
+collision/3`'s one-conflict-per-entry granularity, just against a peer
+rename instead of an ordinary group.
+""".
+-spec rename_entry_rename_collisions([term()]) -> [map()].
+rename_entry_rename_collisions([]) ->
+    [];
+rename_entry_rename_collisions([Entry | Rest]) ->
+    Files = sets:from_list(rename_entry_all_files_to_write(Entry), [{version, 2}]),
+    case rename_entry_rename_collision_with(Entry, Files, Rest) of
+        {true, Conflict} -> [Conflict | rename_entry_rename_collisions(Rest)];
+        false -> rename_entry_rename_collisions(Rest)
+    end.
+
+-spec rename_entry_rename_collision_with(term(), sets:set(binary()), [term()]) ->
+    {true, map()} | false.
+rename_entry_rename_collision_with(_Entry, _Files, []) ->
+    false;
+rename_entry_rename_collision_with(Entry, Files, [Other | Rest]) ->
+    OtherFiles = sets:from_list(rename_entry_all_files_to_write(Other), [{version, 2}]),
+    case sets:to_list(sets:intersection(Files, OtherFiles)) of
+        [] ->
+            rename_entry_rename_collision_with(Entry, Files, Rest);
+        [Collided | _] ->
+            {true,
+                conflict_map(
+                    Collided,
+                    <<"mixed_rename_and_rename_edit">>,
+                    [Entry, Other],
+                    iolist_to_binary([
+                        <<"Cannot flush two rename-class entries (">>,
+                        beamtalk_workspace_changelog:entry_old_class(Entry),
+                        <<" -> ">>,
+                        beamtalk_workspace_changelog:entry_class(Entry),
+                        <<" and ">>,
+                        beamtalk_workspace_changelog:entry_old_class(Other),
+                        <<" -> ">>,
+                        beamtalk_workspace_changelog:entry_class(Other),
+                        <<
+                            ") whose target files collide in the same operation; "
+                            "flush or discard one of the pending entries first, "
+                            "then re-flush the other"
                         >>
                     ])
                 )}
@@ -1870,6 +1963,7 @@ phase_b_loop([], Shadowed, Committed, Failed, Skipped, RenameExpectedFiles) ->
 phase_b_loop([P | Rest], Shadowed, Committed, Failed, Skipped, RenameExpectedFiles) ->
     case commit(P) of
         ok ->
+            maybe_reload_renamed_class_source(P),
             phase_b_loop(Rest, Shadowed, [P | Committed], Failed, Skipped, RenameExpectedFiles);
         {error, Reason} ->
             ?LOG_ERROR(
@@ -1928,6 +2022,105 @@ commit(#prepared{op = move, tmp = Tmp, file = NewPath, old_file = OldPath}) ->
     end;
 commit(#prepared{op = move_noop}) ->
     ok.
+
+-doc """
+Best-effort post-commit source-attribute refresh (BT-3526 review Blocker,
+ADR 0114 follow-up). See the moduledoc's "Post-commit source-attribute
+refresh" section for the full "why" — in short: `classRenameTo/2`'s NEXT
+invocation on this same class reads the class's compiled BEAM module's
+`beamtalk_source` attribute to compute ITS `old_path`, and that attribute is
+only ever refreshed by *recompiling* the class — which an ordinary flush
+commit (a plain `file:rename/2` + `file:delete/1`, no compile step) never
+does. Left unrefreshed, a second `renameTo:` + flush on the same class would
+compute a stale, now-deleted `old_path` and could never resolve it.
+
+Gated on `op =:= move orelse op =:= move_noop` (design point 3: only a
+committed rename-class move needs this — every other `op` either isn't a
+rename at all, or (a rename's OTHER-site splices, `prepare_rename_site_group/2`)
+targets a file that was never the renamed class's own declaration file) AND
+`entry_kind(Entry) =:= 'rename-class'` (defensive — today every `move`/
+`move_noop` `#prepared{}` is always produced by `prepare_rename_move/2` for
+exactly one `'rename-class'` entry, but this function's contract should not
+silently misfire if that ever changes).
+
+Deliberately best-effort (design point 1): the class's in-memory identity
+and behaviour are ALREADY correct at this point — `classRenameTo/2`
+(BT-3278) is what made the rename real; this reload only refreshes a
+bookkeeping attribute for a POSSIBLE FUTURE rename. A failure here (no
+compiler available, a bare runtime, a transient error) must never fail the
+already-successful flush that files are durably written under — surfaced
+via `?LOG_WARNING` instead (never silently swallowed, per design point 1's
+"clear signal in the logs" requirement) so it is diagnosable without
+threatening what already succeeded.
+
+`reload_class_file/2` (`beamtalk_repl_loader`, exported and already used by
+`Counter reload`/`:reload Counter`) is reused rather than any new machinery
+(the ADR 0114 review's own recommended direction): it reads `new_path` from
+disk, compiles it through the ordinary pipeline, and installs the result —
+which is precisely what embeds the correct (new) `beamtalk_source` module
+attribute, closing the staleness gap at its root. It deliberately does NOT
+emit a `'class-def'` ChangeLog entry (see its own doc) so this never creates
+a fresh pending entry for a subsequent flush to trip over, and it does not
+touch the ChangeLog at all — this call sits entirely after `complete_flush/5`
+would run, so nothing here can race `mark_flushed/1`.
+""".
+-spec maybe_reload_renamed_class_source(#prepared{}) -> ok.
+maybe_reload_renamed_class_source(#prepared{op = Op, file = NewPath, entries = [Entry | _]}) when
+    Op =:= move; Op =:= move_noop
+->
+    case beamtalk_workspace_changelog:entry_kind(Entry) of
+        'rename-class' ->
+            reload_renamed_class_source(NewPath, beamtalk_workspace_changelog:entry_class(Entry));
+        _ ->
+            ok
+    end;
+maybe_reload_renamed_class_source(_Prepared) ->
+    ok.
+
+-spec reload_renamed_class_source(binary(), binary()) -> ok.
+reload_renamed_class_source(NewPath, NewClassBin) ->
+    ExpectedClassName =
+        case beamtalk_repl_server:safe_to_existing_atom(NewClassBin) of
+            {ok, Atom} -> Atom;
+            {error, _} -> undefined
+        end,
+    try beamtalk_repl_loader:reload_class_file(binary_to_list(NewPath), ExpectedClassName) of
+        {ok, _ClassNames} ->
+            ok;
+        {error, Reason} ->
+            ?LOG_WARNING(
+                "Workspace flush: best-effort reload of a just-renamed class's source "
+                "attribute failed. The rename itself already succeeded (the class's "
+                "identity and file move are both correct); only the class's compiled "
+                "beamtalk_source bookkeeping attribute may still point at its pre-rename "
+                "path until the class is next reloaded/recompiled — a subsequent rename "
+                "of this same class may need its old_path corrected manually before it "
+                "can flush",
+                #{
+                    path => NewPath,
+                    class => NewClassBin,
+                    reason => Reason,
+                    domain => [beamtalk, runtime]
+                }
+            ),
+            ok
+    catch
+        Class:Reason:Stack ->
+            ?LOG_WARNING(
+                "Workspace flush: best-effort reload of a just-renamed class's source "
+                "attribute crashed. The rename itself already succeeded; see "
+                "reload_class_file/2's own failure mode above for what this leaves stale",
+                #{
+                    path => NewPath,
+                    class => NewClassBin,
+                    error_class => Class,
+                    reason => Reason,
+                    stack => Stack,
+                    domain => [beamtalk, runtime]
+                }
+            ),
+            ok
+    end.
 
 %% Build a set of {Class, Selector} target keys from the entries whose file
 %% was renamed in Phase B. Used to gate which shadowed entries can be marked

--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
@@ -22,12 +22,13 @@ Every flushable entry classifies into one of two tiers (`entry_tier/1`):
     `'new-class'`, and `'remove-method'` (excising a recorded span leaves the
     file in place, mechanically identical to a patch). Applied by ordinary
     `flush/0` / `flush/1` / `flush_kinds/1` with no gate.
-  - **Tier 2** — destroys a file: `'remove-class'`. Only applied when the
-    caller passes `ConfirmDestructive = true` (`flush/2`, `flush_kinds/2`) or
-    calls the unscoped `flush_including_destructive/0`. Never silently
-    reached — no workspace setting or environment variable can imply it. A
-    pending Tier 2 entry left out of the applied set is reported in the
-    summary's `skipped` field with `reason => <<"destructive">>`.
+  - **Tier 2** — destroys a file: `'remove-class'`; or moves one:
+    `'rename-class'` (ADR 0114, BT-3271). Only applied when the caller passes
+    `ConfirmDestructive = true` (`flush/2`, `flush_kinds/2`) or calls the
+    unscoped `flush_including_destructive/0`. Never silently reached — no
+    workspace setting or environment variable can imply it. A pending Tier 2
+    entry left out of the applied set is reported in the summary's `skipped`
+    field with `reason => <<"destructive">>`.
 
 ## Selection
 
@@ -117,6 +118,89 @@ back to `<file>` — never the unlink, and never a stage left behind by a
 different (earlier, crashed) attempt, which stays exactly as found for a
 future flush to resume.
 
+## Atomicity (class rename — ADR 0114, BT-3271)
+
+A `'rename-class'` entry is the first Tier-2 kind that genuinely spans more
+than one file: `sites[0]` is the class's own declaration line (in the file
+being moved, `old_path` -> `new_path`); `sites[1..]` are every other
+in-project file with a rewritten reference (`entry_old_path/1`,
+`entry_new_path/1`, `entry_sites/1`, `beamtalk_workspace_changelog:site()`).
+It is only ever flushable when `entry_flushable/1` is true, which the
+schema guarantees means `old_path`/`new_path` are real paths and every site
+resolves to a flushable file (a dynamic class's rename is `flushable: false`
+and never reaches this code, via `flushable_pending/0`) — so this module
+never has to special-case a `sites[0] = null` dynamic-class shape.
+
+| Phase A (stage) | Phase B (commit) |
+|---|---|
+| Read `old_path`, splice the declaration span (and any *other* site whose own file happens to equal `old_path` — a class that references its own name inside one of its own methods, folded into the SAME write since the file is moving as a unit), write `<new_path>.tmp`; write `<file>.tmp` per *other* site file, each an ordinary splice | Rename `<new_path>.tmp` → `<new_path>`, `unlink <old_path>`, then rename each remaining site `<file>.tmp` → `<file>` |
+
+Phase A never touches `old_path` itself — only reads it — so a crash
+anywhere during Phase A leaves the on-disk tree exactly as flush found it
+(mirrors ordinary patch/new-class Phase A, not `remove-class`'s stage-rename,
+which mutates `old_path` immediately). This is deliberately simpler than
+`remove-class`'s epoch/seq-keyed staged-file disambiguation: a rename's own
+"did a prior attempt already finish this" signal is `new_path` itself, not a
+separate marker file.
+
+**Crash-recovery design decision.** Three states `old_path`/`new_path` can be
+in when Phase A runs, and what each means:
+
+  - **Both exist** (the ordinary case, including a retry after ANY earlier
+    partial attempt that got no further than writing `.tmp` files): read
+    `old_path`, resolve every site's splice against it (see the idempotent
+    check below), write `<new_path>.tmp`. Retrying this state is always safe
+    and idempotent — `old_path` is never mutated by Phase A, only read, so
+    re-deriving `<new_path>.tmp` from it and overwriting whatever is already
+    at `new_path` (correct or not) is exactly the recovery this ADR's flush
+    table describes.
+  - **`old_path` gone, `new_path` present**: since Phase A never touches
+    `old_path` and Phase B's own ordering renames `<new_path>.tmp` into place
+    *before* unlinking `old_path`, the ONLY way `old_path` can be gone is a
+    Phase B commit that already completed the move (in this attempt or an
+    earlier, crashed one whose `mark_flushed` never landed — the same
+    `flush_marker_failed` shape ordinary patches already document). Phase A
+    checks whether `new_path`'s current bytes already carry every move-group
+    site's recorded new text at its expected offset
+    (`all_units_already_applied/2`); if so, the move is treated as already
+    done (`op = move_noop`, no I/O) rather than an error — this is what lets
+    "re-issuing the same destructive flush call retries only what's left"
+    hold for the multi-file case, since the class's OTHER sites may still be
+    unwritten. If the bytes do not match, this is a genuine, unresolvable
+    conflict (`reason => <<"rename_target_mismatch">>`) — something else put
+    unrelated content at `new_path`.
+  - **Both gone**: nothing to recover from — `reason =>
+    <<"source_missing">>`, a hard conflict rather than a soft success (unlike
+    `remove-class`'s "already gone" case, a rename's desired end state is
+    "the class exists at `new_path`", which does not hold here and cannot be
+    reconstructed).
+
+**Idempotent per-site splice check.** Every site's splice (the declaration
+line and every other reference) uses a three-way check, not the ordinary
+two-way external-edit check: the recorded span either still holds the prior
+text (apply normally), already holds the new text (a previously-committed
+site from a partially-failed attempt — treated as a no-op, not a conflict),
+or neither (a genuine external edit). Without the middle case, re-flushing
+after a partial Phase B failure would see an already-correctly-rewritten
+site's `prev_source` permanently mismatch and report it as `external_edit`
+forever, defeating the "retry only what's left" guarantee.
+
+**Per-entry, not per-file, flushed marking.** A `'rename-class'` entry is
+only marked flushed once *every* file it touches (the move's own target
+plus every other rewritten site file) has committed in the SAME Phase B
+pass — `rename_class_fully_committed/3`. A Phase B failure partway through
+leaves the entry pending in its entirety (even though some of its files are
+now correctly on disk); the per-file `files`/`conflicts` summary still
+reports exactly which files committed, and the idempotent check above means
+re-flushing the same entry only re-writes the files that did not.
+
+**A `'rename-class'` entry sharing a target file with an ordinary pending
+patch (or another rename)** in the same flush batch surfaces as a
+`mixed_rename_and_ordinary_edit` conflict, aborting the whole batch — the
+same defensive posture `remove-class`'s `mixed_remove_class_and_splice`
+guard already takes for the identical reason (reordering "write" and "move
+away" within one Phase A/B pass is undesigned).
+
 ## Conflict detection
 
 External-edit conflict: the recorded `prev_source` does not byte-match the
@@ -193,7 +277,11 @@ set. A pending `'remove-class'` entry left out of the applied set because
     %% ADR 0113 Phase 2: lets a crash-recovery test construct the exact
     %% staged path a real flush attempt would have produced, without
     %% duplicating the naming format in the test module.
-    delete_staging_path/3
+    delete_staging_path/3,
+    %% ADR 0114 Phase 2 (BT-3271): rename-class multi-file staging, exported
+    %% for direct unit coverage independent of a full flush round-trip.
+    resolve_new_path/1,
+    is_rename_class_entry/1
 ]).
 
 -type filter() ::
@@ -546,15 +634,32 @@ run_flush(Pending, ConfirmDestructive) ->
             false -> {Tier1, Tier2}
         end,
     Skipped = [skipped_entry(E) || E <- SkippedTier2],
-    Groups = group_by_file(ToApply),
-    case phase_a(Groups) of
-        {ok, Prepared} ->
-            phase_b(Prepared, Shadowed, Skipped);
-        {error, _} = Err ->
-            Err;
-        {conflict, Conflicts} ->
-            {ok, conflict_summary(Conflicts, Skipped)}
+    %% ADR 0114 (BT-3271): a `'rename-class'` entry's top-level `sourceFile`
+    %% is always null (schema: ambiguous for a multi-file entry) so it can
+    %% never land in `group_by_file/1`'s grouping — pulled out up front and
+    %% staged through its own multi-file pipeline instead, then merged back
+    %% into one Phase A / Phase B pass with the ordinary entries.
+    {RenameEntries, OrdinaryEntries} = lists:partition(fun is_rename_class_entry/1, ToApply),
+    OrdinaryGroups = group_by_file(OrdinaryEntries),
+    case check_no_rename_file_collisions(RenameEntries, OrdinaryGroups) of
+        {conflict, Conflicts0} ->
+            {ok, conflict_summary(Conflicts0, Skipped)};
+        ok ->
+            Combined = combine_phase_a(phase_a(OrdinaryGroups), phase_a_renames(RenameEntries)),
+            case Combined of
+                {ok, Prepared} ->
+                    RenameExpectedFiles = rename_expected_files_map(RenameEntries),
+                    phase_b(Prepared, Shadowed, Skipped, RenameExpectedFiles);
+                {error, _} = Err ->
+                    Err;
+                {conflict, Conflicts} ->
+                    {ok, conflict_summary(Conflicts, Skipped)}
+            end
     end.
+
+-spec is_rename_class_entry(term()) -> boolean().
+is_rename_class_entry(E) ->
+    beamtalk_workspace_changelog:entry_kind(E) =:= 'rename-class'.
 
 %%% ----------------------------------------------------------------------------
 %%% Tiering (ADR 0113 Phase 2)
@@ -565,13 +670,15 @@ Classify a ChangeEntry into flush's destructive-confirmation tier.
 
 Tier 1 — edits a still-existing file (`instance`, `class`, `'new-class'`,
 `'remove-method'`) — applies under ordinary `flush/0` / `flush/1` /
-`flush_kinds/1` with no gate. Tier 2 — destroys a file (`'remove-class'`) —
-only applies when the caller passes `ConfirmDestructive = true`.
+`flush_kinds/1` with no gate. Tier 2 — destroys a file (`'remove-class'`) or
+moves one (`'rename-class'`, ADR 0114 BT-3271) — only applies when the
+caller passes `ConfirmDestructive = true`.
 """.
 -spec entry_tier(term()) -> tier1 | tier2.
 entry_tier(E) ->
     case beamtalk_workspace_changelog:entry_kind(E) of
         'remove-class' -> tier2;
+        'rename-class' -> tier2;
         _ -> tier1
     end.
 
@@ -680,25 +787,36 @@ group_by_file(Entries) ->
 %%% ----------------------------------------------------------------------------
 
 -record(prepared, {
-    %% Absolute target path on disk.
+    %% Absolute target path on disk. For `op = move`/`move_noop` (ADR 0114,
+    %% BT-3271) this is `new_path` — the file this operation ultimately
+    %% leaves on disk — not the file Phase A read from.
     file :: binary(),
-    %% The staging path Phase A produced: `<file>.tmp` for `op = write`,
-    %% `<file>.tmp-delete-<epoch>-<seq>` for `op = delete` (ADR 0113), unused
-    %% for `op = noop`.
-    tmp :: string(),
+    %% The staging path Phase A produced: `<file>.tmp` for `op = write` (and
+    %% `move`, staged at `<new_path>.tmp`), `<file>.tmp-delete-<epoch>-<seq>`
+    %% for `op = delete` (ADR 0113), unused for `op = noop`/`move_noop`.
+    tmp :: string() | undefined,
     %% The entries whose patches were merged into this file's new body (or,
-    %% for `op = delete` / `op = noop`, the single `'remove-class'` entry).
+    %% for `op = delete` / `op = noop` / `move` / `move_noop`, the owning
+    %% `'remove-class'`/`'rename-class'` entry/entries).
     entries :: [term()],
     %% Whether the target file existed prior to flush (informational for
     %% `op = write`; for `op = delete` distinguishes "this attempt performed
     %% the stage-rename" (`true`) from "a prior attempt already staged it,
     %% this run only resumed" (`false`) — see `cleanup_one/1`).
     pre_existing :: boolean(),
-    %% Phase B commit action (ADR 0113): `write` renames `tmp` into `file`
-    %% (patches, `'new-class'`, `'remove-method'`); `delete` unlinks the
-    %% staged `tmp` (class removal); `noop` performs no I/O (the target file
-    %% was already gone — external-edit soft success).
-    op = write :: write | delete | noop
+    %% Phase B commit action: `write` renames `tmp` into `file` (patches,
+    %% `'new-class'`, `'remove-method'`); `delete` unlinks the staged `tmp`
+    %% (class removal, ADR 0113); `noop` performs no I/O (the target file was
+    %% already gone — external-edit soft success); `move` renames `tmp` into
+    %% `file` (= `new_path`) THEN unlinks `old_file` (class rename, ADR 0114
+    %% BT-3271); `move_noop` performs no I/O (the move already completed in
+    %% an earlier, crashed/marker-failed attempt — see the moduledoc's
+    %% "Atomicity (class rename)" section).
+    op = write :: write | delete | noop | move | move_noop,
+    %% ADR 0114 (BT-3271): `op = move`-only — the pre-rename path Phase B
+    %% unlinks after the `tmp` -> `file` (`new_path`) rename succeeds.
+    %% `undefined` for every other op.
+    old_file :: binary() | undefined
 }).
 
 -spec phase_a([{binary(), [term()]}]) ->
@@ -933,6 +1051,593 @@ delete_staging_path(AbsPath, Epoch, Seq) ->
     AbsPath ++ ".tmp-delete-" ++ integer_to_list(Epoch) ++ "-" ++ integer_to_list(Seq).
 
 %%% ----------------------------------------------------------------------------
+%%% Class rename (Tier 2) — multi-file staged move (ADR 0114, BT-3271)
+%%% ----------------------------------------------------------------------------
+
+-doc """
+Cross-pipeline collision guard (ADR 0114): abort the whole flush, before any
+Phase A I/O runs, if a `'rename-class'` entry's target files (`old_path`,
+`new_path`, and every site's `sourceFile`) overlap any file an *ordinary*
+entry in the same batch is about to splice. Mirrors `prepare_file/2`'s
+`mixed_remove_class_and_splice` defensive guard for the identical reason —
+reordering "write a patch into this file" and "this file is moving/being
+deleted" within one Phase A/B pass is undesigned, so it is refused rather
+than silently racing.
+
+Two independent `'rename-class'` entries touching the same file (e.g. two
+unrelated renames each rewriting a reference in the same third file) are NOT
+a collision here — `group_units_by_file/1` (inside `phase_a_renames/1`)
+already merges their sites into one combined splice, the same way
+`group_by_file/1` already merges multiple ordinary entries against one file.
+""".
+-spec check_no_rename_file_collisions([term()], [{binary(), [term()]}]) ->
+    ok | {conflict, [map()]}.
+check_no_rename_file_collisions([], _OrdinaryGroups) ->
+    ok;
+check_no_rename_file_collisions(RenameEntries, OrdinaryGroups) ->
+    OrdinaryFiles = sets:from_list([F || {F, _} <- OrdinaryGroups], [{version, 2}]),
+    case
+        lists:filtermap(
+            fun(Entry) -> rename_entry_ordinary_collision(Entry, OrdinaryFiles, OrdinaryGroups) end,
+            RenameEntries
+        )
+    of
+        [] -> ok;
+        Conflicts -> {conflict, Conflicts}
+    end.
+
+-spec rename_entry_ordinary_collision(term(), sets:set(binary()), [{binary(), [term()]}]) ->
+    {true, map()} | false.
+rename_entry_ordinary_collision(Entry, OrdinaryFiles, OrdinaryGroups) ->
+    case [F || F <- rename_entry_all_files(Entry), sets:is_element(F, OrdinaryFiles)] of
+        [] ->
+            false;
+        [Collided | _] ->
+            {Collided, OrdEntries} = lists:keyfind(Collided, 1, OrdinaryGroups),
+            {true,
+                conflict_map(
+                    Collided,
+                    <<"mixed_rename_and_ordinary_edit">>,
+                    [Entry | OrdEntries],
+                    iolist_to_binary([
+                        <<"Cannot flush a rename-class entry (">>,
+                        beamtalk_workspace_changelog:entry_old_class(Entry),
+                        <<" -> ">>,
+                        beamtalk_workspace_changelog:entry_class(Entry),
+                        <<
+                            ") alongside a pending ordinary patch against the same file "
+                            "in the same operation; flush or discard the other pending "
+                            "entry first, then re-flush the rename"
+                        >>
+                    ])
+                )}
+    end.
+
+%% Every file `Entry`'s rename touches in any way — read (`old_path`),
+%% written (`new_path` and every other site's file). Used only for the
+%% cross-pipeline collision check above; `rename_entry_all_files_to_write/1`
+%% (excludes `old_path`) is the one that matters for "which files must
+%% commit for this entry to count as flushed" (`rename_expected_files_map/1`).
+-spec rename_entry_all_files(term()) -> [binary()].
+rename_entry_all_files(Entry) ->
+    OldPath = beamtalk_workspace_changelog:entry_old_path(Entry),
+    lists:usort([F || F <- [OldPath | rename_entry_all_files_to_write(Entry)], F =/= undefined]).
+
+-spec rename_entry_all_files_to_write(term()) -> [binary()].
+rename_entry_all_files_to_write(Entry) ->
+    NewPath = resolve_new_path(Entry),
+    SiteFiles = [maps:get(source_file, S) || S <- other_sites(Entry)],
+    lists:usort([F || F <- [NewPath | SiteFiles], F =/= undefined]).
+
+%% The `sites` entries whose own file is NOT the file being moved — an
+%% ordinary reference site in a different file. See `move_sites/1` for the
+%% complementary set (sites whose file IS `old_path`, folded into the move's
+%% own splice instead — ADR 0114 § "Atomicity (class rename)").
+-spec other_sites(term()) -> [beamtalk_workspace_changelog:site()].
+other_sites(Entry) ->
+    OldPath = beamtalk_workspace_changelog:entry_old_path(Entry),
+    [
+        S
+     || S <- beamtalk_workspace_changelog:entry_sites(Entry),
+        S =/= undefined,
+        maps:get(source_file, S) =/= OldPath
+    ].
+
+%% The `sites` entries whose own file IS `old_path` — the declaration site
+%% itself (`sites[0]`, always this) plus any OTHER reference the class makes
+%% to its own name inside its own file (a self-send/self-reference).
+%% Multiple entries here must be merged into ONE splice against `old_path`,
+%% never independent ones, or the second would silently discard the first's
+%% edit (mirrors `beamtalk_repl_loader:group_sites_by_class/1`'s identical
+%% same-class merge rule for the in-memory half of this mechanism, BT-3270).
+-spec move_sites(term()) -> [beamtalk_workspace_changelog:site()].
+move_sites(Entry) ->
+    OldPath = beamtalk_workspace_changelog:entry_old_path(Entry),
+    [
+        S
+     || S <- beamtalk_workspace_changelog:entry_sites(Entry),
+        S =/= undefined,
+        maps:get(source_file, S) =:= OldPath
+    ].
+
+-doc """
+Resolve `Entry`'s post-rename path, deriving one when the entry itself did
+not record `new_path` (ADR 0114 § ChangeLog schema documents `new_path` as
+"basename derived from new_class, same directory as old_path" as a RULE, not
+necessarily something the writer must have already computed — today's only
+producer, `classRenameTo/2`, always logs `new_path => undefined`, per its own
+`old_path => ..., new_path => undefined` ChangeLog spec). Preserves whichever
+of the project's two established file-naming conventions `old_path` itself
+used (`beamtalk_repl_loader`'s own `newClass:at:` basename check accepts
+either an exact `Counter.bt` match or a `to_snake_case/1` `greeter.bt`
+match) rather than forcing one style on the renamed file.
+""".
+-spec resolve_new_path(term()) -> binary() | undefined.
+resolve_new_path(Entry) ->
+    case beamtalk_workspace_changelog:entry_new_path(Entry) of
+        undefined ->
+            derive_new_path(
+                beamtalk_workspace_changelog:entry_old_path(Entry),
+                beamtalk_workspace_changelog:entry_old_class(Entry),
+                beamtalk_workspace_changelog:entry_class(Entry)
+            );
+        Path ->
+            Path
+    end.
+
+-spec derive_new_path(binary() | undefined, binary() | undefined, binary()) ->
+    binary() | undefined.
+derive_new_path(undefined, _OldClassBin, _NewClassBin) ->
+    undefined;
+derive_new_path(OldPath, OldClassBin, NewClassBin) ->
+    Dir = filename:dirname(binary_to_list(OldPath)),
+    OldBase = filename:basename(binary_to_list(OldPath), ".bt"),
+    NewStem =
+        case OldClassBin =/= undefined andalso list_to_binary(OldBase) =:= OldClassBin of
+            true -> binary_to_list(NewClassBin);
+            false -> beamtalk_repl_loader:to_snake_case(binary_to_list(NewClassBin))
+        end,
+    list_to_binary(filename:join(Dir, NewStem ++ ".bt")).
+
+-doc """
+Per-entry expected file set: every file that must appear in a Phase B
+commit for `Entry`'s `'rename-class'` to be considered fully flushed
+(`rename_class_fully_committed/3`). Keyed by `seq` since `#prepared{}`
+records carry the raw `entry()`, not a convenient lookup key.
+""".
+-spec rename_expected_files_map([term()]) -> #{non_neg_integer() => sets:set(binary())}.
+rename_expected_files_map(RenameEntries) ->
+    lists:foldl(
+        fun(Entry, Acc) ->
+            Seq = beamtalk_workspace_changelog:entry_seq(Entry),
+            Files = sets:from_list(rename_entry_all_files_to_write(Entry), [{version, 2}]),
+            Acc#{Seq => Files}
+        end,
+        #{},
+        RenameEntries
+    ).
+
+-doc """
+Phase A for every pending `'rename-class'` entry in this flush, combined
+across entries the same way `phase_a/1` combines ordinary file groups:
+build every entry's move task plus every OTHER-site file group (merged
+across entries, ADR 0114 § "Atomicity (class rename)"), prepare each in
+turn, and abort-with-cleanup on the first conflict or hard error exactly
+like `phase_a_loop/3` does for ordinary groups.
+""".
+-spec phase_a_renames([term()]) ->
+    {ok, [#prepared{}]} | {error, #beamtalk_error{}} | {conflict, [map()]}.
+phase_a_renames([]) ->
+    {ok, []};
+phase_a_renames(RenameEntries) ->
+    {MoveTasks, SiteGroups} = build_rename_tasks(RenameEntries),
+    Tasks = [{move, T} || T <- MoveTasks] ++ [{site_group, G} || G <- SiteGroups],
+    phase_a_renames_loop(Tasks, [], []).
+
+phase_a_renames_loop([], Prepared, []) ->
+    {ok, lists:reverse(Prepared)};
+phase_a_renames_loop([], Prepared, Conflicts) ->
+    cleanup_tmps(Prepared),
+    {conflict, lists:reverse(Conflicts)};
+phase_a_renames_loop([{move, {Entry, MoveUnits}} | Rest], Prepared, Conflicts) ->
+    case prepare_rename_move(Entry, MoveUnits) of
+        {ok, Rec} ->
+            phase_a_renames_loop(Rest, [Rec | Prepared], Conflicts);
+        {conflict, C} ->
+            phase_a_renames_loop(Rest, Prepared, [C | Conflicts]);
+        {error, _} = Err ->
+            cleanup_tmps(Prepared),
+            Err
+    end;
+phase_a_renames_loop([{site_group, {File, Units}} | Rest], Prepared, Conflicts) ->
+    case prepare_rename_site_group(File, Units) of
+        {ok, Rec} ->
+            phase_a_renames_loop(Rest, [Rec | Prepared], Conflicts);
+        {conflict, C} ->
+            phase_a_renames_loop(Rest, Prepared, [C | Conflicts]);
+        {error, _} = Err ->
+            cleanup_tmps(Prepared),
+            Err
+    end.
+
+%% Fan `RenameEntries` out into `{MoveTasks, SiteGroups}`:
+%%   - `MoveTasks`: one `{Entry, MoveUnits}` per entry (`move_sites/1` — the
+%%     declaration plus any self-reference in the same file).
+%%   - `SiteGroups`: `{File, [{Site, OwnerEntry}]}` merged ACROSS every
+%%     entry's `other_sites/1`, keyed by file, mirroring `group_by_file/1`'s
+%%     merge for ordinary entries — two different renames touching the same
+%%     referencing file compose into one splice, not two racing writes.
+-spec build_rename_tasks([term()]) ->
+    {[{term(), [beamtalk_workspace_changelog:site()]}], [
+        {binary(), [{beamtalk_workspace_changelog:site(), term()}]}
+    ]}.
+build_rename_tasks(RenameEntries) ->
+    {MoveTasksRev, OtherUnitsRev} = lists:foldl(
+        fun(Entry, {MoveAcc, OtherAcc}) ->
+            MoveUnits = move_sites(Entry),
+            OtherUnits = [{S, Entry} || S <- other_sites(Entry)],
+            {[{Entry, MoveUnits} | MoveAcc], lists:reverse(OtherUnits) ++ OtherAcc}
+        end,
+        {[], []},
+        RenameEntries
+    ),
+    {lists:reverse(MoveTasksRev), group_units_by_file(lists:reverse(OtherUnitsRev))}.
+
+-spec group_units_by_file([{beamtalk_workspace_changelog:site(), term()}]) ->
+    [{binary(), [{beamtalk_workspace_changelog:site(), term()}]}].
+group_units_by_file(Units) ->
+    lists:foldr(
+        fun({Site, _Entry} = Unit, Acc) ->
+            File = maps:get(source_file, Site),
+            case lists:keyfind(File, 1, Acc) of
+                {File, Us} -> lists:keyreplace(File, 1, Acc, {File, [Unit | Us]});
+                false -> [{File, [Unit]} | Acc]
+            end
+        end,
+        [],
+        Units
+    ).
+
+-doc """
+Stage a `'rename-class'` entry's move: splice `MoveUnits` (the declaration
+line, plus any self-reference sites in the same file) against `old_path`'s
+current content and write the result to `<new_path>.tmp`.
+
+Three outcomes, matching the moduledoc's "Atomicity (class rename)" table:
+`old_path` exists (the ordinary case — read, splice, stage); `old_path` is
+gone but `new_path` already carries every unit's expected new text (a prior
+attempt's move already completed — `op = move_noop`, no I/O); or neither
+resolves (a hard, unrecoverable conflict).
+""".
+-spec prepare_rename_move(term(), [beamtalk_workspace_changelog:site()]) ->
+    {ok, #prepared{}} | {conflict, map()} | {error, #beamtalk_error{}}.
+prepare_rename_move(Entry, MoveUnits) ->
+    OldPath = beamtalk_workspace_changelog:entry_old_path(Entry),
+    NewPath = resolve_new_path(Entry),
+    Units = [{Site, Entry} || Site <- MoveUnits],
+    case file:read_file(binary_to_list(OldPath)) of
+        {ok, OldBody} ->
+            case apply_site_units(OldBody, Units) of
+                {ok, NewFileBody} ->
+                    case write_tmp(binary_to_list(NewPath), NewFileBody) of
+                        {ok, Tmp} ->
+                            {ok, #prepared{
+                                file = NewPath,
+                                old_file = OldPath,
+                                tmp = Tmp,
+                                entries = [Entry],
+                                pre_existing = true,
+                                op = move
+                            }};
+                        {error, _} = Err ->
+                            wrap_io_error(Err, NewPath)
+                    end;
+                {conflict, _} = C ->
+                    C;
+                {error, _} = Err ->
+                    Err
+            end;
+        {error, enoent} ->
+            resolve_missing_rename_source(Entry, OldPath, NewPath, Units);
+        {error, Reason} ->
+            wrap_io_error({error, Reason}, OldPath)
+    end.
+
+%% See moduledoc's "Atomicity (class rename)" — `old_path` gone disambiguates
+%% into "already fully moved" (op = move_noop) vs. an unresolvable conflict.
+-spec resolve_missing_rename_source(
+    term(), binary(), binary() | undefined, [{beamtalk_workspace_changelog:site(), term()}]
+) ->
+    {ok, #prepared{}} | {conflict, map()} | {error, #beamtalk_error{}}.
+resolve_missing_rename_source(Entry, OldPath, undefined, _Units) ->
+    {conflict,
+        conflict_map(
+            OldPath,
+            <<"rename_target_unresolvable">>,
+            [Entry],
+            <<
+                "Could not determine the renamed class's target path (new_path was not "
+                "recorded and could not be derived); the rename cannot be flushed"
+            >>
+        )};
+resolve_missing_rename_source(Entry, OldPath, NewPath, Units) ->
+    case file:read_file(binary_to_list(NewPath)) of
+        {ok, NewBody} ->
+            case all_units_already_applied(NewBody, Units) of
+                true ->
+                    {ok, #prepared{
+                        file = NewPath,
+                        old_file = undefined,
+                        tmp = binary_to_list(NewPath) ++ ".tmp",
+                        entries = [Entry],
+                        pre_existing = false,
+                        op = move_noop
+                    }};
+                false ->
+                    {conflict,
+                        conflict_map(
+                            OldPath,
+                            <<"rename_target_mismatch">>,
+                            [Entry],
+                            iolist_to_binary([
+                                <<"Neither ">>,
+                                OldPath,
+                                <<" (old path) exists, nor does ">>,
+                                NewPath,
+                                <<
+                                    " (new path) already carry the expected renamed text; "
+                                    "the rename cannot be resumed automatically. Re-issue "
+                                    "the rename or resolve the target manually."
+                                >>
+                            ])
+                        )}
+            end;
+        {error, enoent} ->
+            {conflict,
+                conflict_map(
+                    OldPath,
+                    <<"source_missing">>,
+                    [Entry],
+                    iolist_to_binary([
+                        <<"Neither the old path (">>,
+                        OldPath,
+                        <<") nor the new path (">>,
+                        NewPath,
+                        <<
+                            ") exists; the rename cannot be completed automatically. "
+                            "Something external deleted both."
+                        >>
+                    ])
+                )};
+        {error, Reason} ->
+            wrap_io_error({error, Reason}, NewPath)
+    end.
+
+-doc """
+Stage one OTHER-site file group's splice: read `File`, resolve every unit's
+splice against it (idempotent — see `resolve_site_unit/2`), write
+`<File>.tmp`. Ordinary Tier-1-shaped splice, just sourced from `site()`
+maps carrying their own `span`/`source_ref`/`prev_source_ref` instead of an
+entry's own top-level fields.
+""".
+-spec prepare_rename_site_group(binary(), [{beamtalk_workspace_changelog:site(), term()}]) ->
+    {ok, #prepared{}} | {conflict, map()} | {error, #beamtalk_error{}}.
+prepare_rename_site_group(File, Units) ->
+    AbsPath = binary_to_list(File),
+    case file:read_file(AbsPath) of
+        {ok, Disk} ->
+            case apply_site_units(Disk, Units) of
+                {ok, NewBody} ->
+                    case write_tmp(AbsPath, NewBody) of
+                        {ok, Tmp} ->
+                            OwnerEntries = lists:usort(
+                                fun(A, B) ->
+                                    beamtalk_workspace_changelog:entry_seq(A) =<
+                                        beamtalk_workspace_changelog:entry_seq(B)
+                                end,
+                                [E || {_S, E} <- Units]
+                            ),
+                            {ok, #prepared{
+                                file = File,
+                                tmp = Tmp,
+                                entries = OwnerEntries,
+                                pre_existing = true
+                            }};
+                        {error, _} = Err ->
+                            wrap_io_error(Err, File)
+                    end;
+                {conflict, _} = C ->
+                    C;
+                {error, _} = Err ->
+                    Err
+            end;
+        {error, Reason} ->
+            {conflict,
+                conflict_map(
+                    File,
+                    <<"source_file_unreadable">>,
+                    [E || {_S, E} <- Units],
+                    iolist_to_binary([
+                        <<"Could not read source file: ">>, atom_to_binary(Reason, utf8)
+                    ])
+                )}
+    end.
+
+%% Apply every `{Site, OwnerEntry}` unit's splice to `Body`, rightmost-span-
+%% first (mirrors `apply_splices/2`/`beamtalk_repl_loader:apply_site_splices/2`'s
+%% identical tie-break: a later, higher-offset splice must land before an
+%% earlier one so a length-changing replacement never invalidates a
+%% not-yet-applied earlier span's recorded byte offsets).
+-spec apply_site_units(binary(), [{beamtalk_workspace_changelog:site(), term()}]) ->
+    {ok, binary()} | {conflict, map()} | {error, #beamtalk_error{}}.
+apply_site_units(Body, Units) ->
+    Sorted = lists:sort(
+        fun(
+            {#{span := #{start := A, 'end' := AEnd}}, _},
+            {#{span := #{start := B, 'end' := BEnd}}, _}
+        ) ->
+            {A, AEnd} >= {B, BEnd}
+        end,
+        Units
+    ),
+    apply_site_units_loop(Body, Sorted).
+
+apply_site_units_loop(Body, []) ->
+    {ok, Body};
+apply_site_units_loop(Body, [Unit | Rest]) ->
+    case resolve_site_unit(Body, Unit) of
+        {ok, NewBody} -> apply_site_units_loop(NewBody, Rest);
+        Other -> Other
+    end.
+
+-doc """
+Idempotent three-way splice check for one rewrite site (ADR 0114 §
+"Atomicity (class rename)"): the recorded span either still holds the prior
+text (splice normally), already holds the new text (a previously-committed
+site from a partially-failed flush attempt — a no-op, not a conflict), or
+neither (a genuine external edit or invalid span). The middle case is what
+lets a re-issued destructive flush retry only the sites that never
+committed instead of permanently misreporting an already-correct site as an
+external edit.
+""".
+-spec resolve_site_unit(binary(), {beamtalk_workspace_changelog:site(), term()}) ->
+    {ok, binary()} | {conflict, map()} | {error, #beamtalk_error{}}.
+resolve_site_unit(Body, {Site, OwnerEntry}) ->
+    #{source_file := File, span := #{start := Start, 'end' := End}} = Site,
+    NewRef = maps:get(source_ref, Site, undefined),
+    PrevRef = maps:get(prev_source_ref, Site, undefined),
+    case beamtalk_workspace_changelog:read_site_body(NewRef) of
+        {ok, NewText} ->
+            case beamtalk_workspace_changelog:read_site_body(PrevRef) of
+                {ok, PrevText} ->
+                    resolve_site_unit_2(Body, File, Start, End, PrevText, NewText, OwnerEntry);
+                {error, Reason} ->
+                    {error, prev_source_error(File, Reason)}
+            end;
+        {error, Reason} ->
+            {error, source_body_error(File, Reason)}
+    end.
+
+resolve_site_unit_2(Body, File, Start, End, PrevText, NewText, OwnerEntry) ->
+    case in_range(Body, Start, End) of
+        false ->
+            {conflict,
+                conflict_map(
+                    File,
+                    <<"span_out_of_range">>,
+                    [OwnerEntry],
+                    iolist_to_binary([
+                        <<"Recorded byte span ">>,
+                        (integer_to_binary(Start)),
+                        <<"..">>,
+                        (integer_to_binary(End)),
+                        <<" is outside the current ">>,
+                        (integer_to_binary(byte_size(Body))),
+                        <<"-byte file; the file changed externally">>
+                    ])
+                )};
+        true ->
+            Actual = binary:part(Body, Start, End - Start),
+            case Actual =:= PrevText of
+                true ->
+                    {ok, splice(Body, {Start, End}, NewText)};
+                false ->
+                    case already_applied_at(Body, Start, NewText) of
+                        true ->
+                            {ok, Body};
+                        false ->
+                            {conflict,
+                                conflict_map(
+                                    File,
+                                    <<"external_edit">>,
+                                    [OwnerEntry],
+                                    <<
+                                        "External edit detected: the bytes at the recorded "
+                                        "span no longer match the rewrite's recorded "
+                                        "prev_source, and do not already carry the rewritten "
+                                        "text either. Re-flush after reconciling, or use "
+                                        "`Workspace changes clear` to discard the pending "
+                                        "entries"
+                                    >>
+                                )}
+                    end
+            end
+    end.
+
+-spec already_applied_at(binary(), non_neg_integer(), binary()) -> boolean().
+already_applied_at(Body, Start, NewText) ->
+    NewLen = byte_size(NewText),
+    Start + NewLen =< byte_size(Body) andalso
+        binary:part(Body, Start, NewLen) =:= NewText.
+
+-spec all_units_already_applied(binary(), [{beamtalk_workspace_changelog:site(), term()}]) ->
+    boolean().
+all_units_already_applied(Body, Units) ->
+    lists:all(
+        fun({Site, _Entry}) ->
+            #{span := #{start := Start}} = Site,
+            NewRef = maps:get(source_ref, Site, undefined),
+            case beamtalk_workspace_changelog:read_site_body(NewRef) of
+                {ok, NewText} -> already_applied_at(Body, Start, NewText);
+                {error, _} -> false
+            end
+        end,
+        Units
+    ).
+
+%% A rename-class entry is only considered fully flushed once EVERY file it
+%% touches (`rename_entry_all_files_to_write/1`) has committed in the SAME
+%% Phase B pass — a non-rename-class entry has no multi-file fan-out (every
+%% other kind targets exactly one file) so it trivially satisfies this the
+%% moment it appears in `Committed` at all.
+-spec rename_class_fully_committed(
+    term(), #{non_neg_integer() => sets:set(binary())}, sets:set(binary())
+) -> boolean().
+rename_class_fully_committed(Entry, RenameExpectedFiles, CommittedFilesSet) ->
+    case beamtalk_workspace_changelog:entry_kind(Entry) of
+        'rename-class' ->
+            Seq = beamtalk_workspace_changelog:entry_seq(Entry),
+            Expected = maps:get(Seq, RenameExpectedFiles, sets:new([{version, 2}])),
+            sets:is_subset(Expected, CommittedFilesSet);
+        _ ->
+            true
+    end.
+
+%% Combine the ordinary-groups and rename-classes Phase A results into one
+%% `{ok, [#prepared{}]} | {error, _} | {conflict, [map()]}`, matching
+%% `phase_a_loop/3`'s own "any conflict/error aborts the whole batch, cleaning
+%% up every tmp already written" rule across BOTH pipelines — a Phase A
+%% conflict discovered while preparing ordinary files must clean up
+%% successfully-staged rename `.tmp`s too, and vice versa. Each side already
+%% cleans up its OWN tmps internally on an internal conflict/error
+%% (`phase_a_loop/3`, `phase_a_renames_loop/3`), so only the OTHER side's
+%% tmps need cleaning up here.
+-spec combine_phase_a(
+    {ok, [#prepared{}]} | {error, term()} | {conflict, [map()]},
+    {ok, [#prepared{}]} | {error, term()} | {conflict, [map()]}
+) -> {ok, [#prepared{}]} | {error, term()} | {conflict, [map()]}.
+combine_phase_a({ok, P1}, {ok, P2}) ->
+    {ok, P1 ++ P2};
+combine_phase_a({error, _} = Err, Other) ->
+    cleanup_other_prepared(Other),
+    Err;
+combine_phase_a(Other, {error, _} = Err) ->
+    cleanup_other_prepared(Other),
+    Err;
+combine_phase_a({conflict, C1}, {conflict, C2}) ->
+    {conflict, C1 ++ C2};
+combine_phase_a({conflict, C1}, {ok, P2}) ->
+    cleanup_tmps(P2),
+    {conflict, C1};
+combine_phase_a({ok, P1}, {conflict, C2}) ->
+    cleanup_tmps(P1),
+    {conflict, C2}.
+
+-spec cleanup_other_prepared({ok, [#prepared{}]} | term()) -> ok.
+cleanup_other_prepared({ok, P}) -> cleanup_tmps(P);
+cleanup_other_prepared(_) -> ok.
+
+%%% ----------------------------------------------------------------------------
 %%% Method splice
 %%% ----------------------------------------------------------------------------
 
@@ -1133,27 +1838,39 @@ append_method(Body, NewSrc) ->
 %% on-disk state is the new authoritative source for those files. `Skipped`
 %% (ADR 0113: pending Tier 2 entries left out of this flush) passes straight
 %% through to the summary — Phase B does nothing with it but report it.
--spec phase_b([#prepared{}], [term()], [map()]) -> {ok, map()}.
-phase_b(Prepared, Shadowed, Skipped) ->
-    phase_b_loop(Prepared, Shadowed, [], [], Skipped).
+-spec phase_b([#prepared{}], [term()], [map()], #{non_neg_integer() => sets:set(binary())}) ->
+    {ok, map()}.
+phase_b(Prepared, Shadowed, Skipped, RenameExpectedFiles) ->
+    phase_b_loop(Prepared, Shadowed, [], [], Skipped, RenameExpectedFiles).
 
-phase_b_loop([], Shadowed, Committed, Failed, Skipped) ->
+phase_b_loop([], Shadowed, Committed, Failed, Skipped, RenameExpectedFiles) ->
     Files = lists:reverse([P#prepared.file || P <- Committed]),
+    CommittedFilesSet = sets:from_list(Files, [{version, 2}]),
     CommittedEntries = lists:flatten([P#prepared.entries || P <- Committed]),
+    %% ADR 0114 (BT-3271): a `'rename-class'` entry spans multiple files (the
+    %% move target plus every other rewritten site), so appearing in
+    %% `CommittedEntries` at all (from ONE of its files) is not enough —
+    %% every file it touches must have committed in THIS pass. A non-rename
+    %% entry trivially satisfies this (every other kind targets one file).
+    FullyCommitted = [
+        E
+     || E <- CommittedEntries,
+        rename_class_fully_committed(E, RenameExpectedFiles, CommittedFilesSet)
+    ],
     %% Only mark shadowed entries whose survivor (same class+selector) was
     %% actually committed in this Phase B. When Phase B aborts mid-loop, a
     %% shadowed entry whose survivor never made it to disk must stay pending
     %% — otherwise we silently lose the change from the active view while it
     %% is not on disk. See Copilot review on PR #2325.
-    SurvivorKeys = renamed_target_keys(CommittedEntries),
+    SurvivorKeys = renamed_target_keys(FullyCommitted),
     AppliedShadowed = filter_shadowed_by_survivor(Shadowed, SurvivorKeys),
-    EntriesToMark = CommittedEntries ++ AppliedShadowed,
-    Seqs = [beamtalk_workspace_changelog:entry_seq(E) || E <- EntriesToMark],
+    EntriesToMark = FullyCommitted ++ AppliedShadowed,
+    Seqs = lists:usort([beamtalk_workspace_changelog:entry_seq(E) || E <- EntriesToMark]),
     complete_flush(Files, lists:reverse(Committed), Failed, Seqs, Skipped);
-phase_b_loop([P | Rest], Shadowed, Committed, Failed, Skipped) ->
+phase_b_loop([P | Rest], Shadowed, Committed, Failed, Skipped, RenameExpectedFiles) ->
     case commit(P) of
         ok ->
-            phase_b_loop(Rest, Shadowed, [P | Committed], Failed, Skipped);
+            phase_b_loop(Rest, Shadowed, [P | Committed], Failed, Skipped, RenameExpectedFiles);
         {error, Reason} ->
             ?LOG_ERROR(
                 "Workspace flush: Phase B commit failed",
@@ -1174,7 +1891,9 @@ phase_b_loop([P | Rest], Shadowed, Committed, Failed, Skipped) ->
             %% Clean up any unattempted tmps so we do not leave stale files
             %% behind for the next flush to trip over.
             cleanup_tmps([P | Rest]),
-            phase_b_loop([], Shadowed, Committed, [FailedHere | Failed], Skipped)
+            phase_b_loop(
+                [], Shadowed, Committed, [FailedHere | Failed], Skipped, RenameExpectedFiles
+            )
     end.
 
 %% Phase B's commit action, dispatched by `P#prepared.op`:
@@ -1185,12 +1904,29 @@ phase_b_loop([P | Rest], Shadowed, Committed, Failed, Skipped) ->
 %%     earlier one's), so this is the operation that finally makes the
 %%     removal durable.
 %%   - `noop`   — the external-edit soft success (already gone); no I/O.
+%%   - `move`   — rename `tmp` into `file` (= `new_path`) THEN unlink
+%%     `old_file` (ADR 0114, BT-3271): in THAT order, so a crash or failure
+%%     between the two never loses the file's content — `old_file` is only
+%%     ever removed once its content is durably present at the new name. If
+%%     the unlink itself fails, `old_file` simply lingers (still untouched,
+%%     still matching its recorded `prev_source`) and the next flush attempt
+%%     harmlessly re-derives and overwrites `new_path.tmp` before retrying
+%%     the unlink — see the moduledoc's "Atomicity (class rename)" section.
+%%   - `move_noop` — the move already completed in an earlier, crashed or
+%%     marker-failed attempt; no I/O.
 -spec commit(#prepared{}) -> ok | {error, term()}.
 commit(#prepared{op = write, tmp = Tmp, file = File}) ->
     file:rename(Tmp, binary_to_list(File));
 commit(#prepared{op = delete, tmp = Tmp}) ->
     file:delete(Tmp);
 commit(#prepared{op = noop}) ->
+    ok;
+commit(#prepared{op = move, tmp = Tmp, file = NewPath, old_file = OldPath}) ->
+    case file:rename(Tmp, binary_to_list(NewPath)) of
+        ok -> file:delete(binary_to_list(OldPath));
+        {error, _} = Err -> Err
+    end;
+commit(#prepared{op = move_noop}) ->
     ok.
 
 %% Build a set of {Class, Selector} target keys from the entries whose file
@@ -1249,7 +1985,7 @@ complete_flush(Files, Renamed, Failed, Seqs, Skipped) ->
         end,
     case MarkResult of
         ok ->
-            {ok, success_summary(Files, Renamed, Failed, Skipped)};
+            {ok, success_summary(Files, Renamed, Failed, Skipped, Seqs)};
         {error, Reason} ->
             ?LOG_ERROR(
                 "Workspace flush: mark_flushed failed after successful rename",
@@ -1274,7 +2010,7 @@ complete_flush(Files, Renamed, Failed, Seqs, Skipped) ->
                     io_lib:format("~p", [Reason])
                 ])
             },
-            {ok, success_summary(Files, Renamed, [MarkerFailure | Failed], Skipped)}
+            {ok, success_summary(Files, Renamed, [MarkerFailure | Failed], Skipped, Seqs)}
     end.
 
 %% Announce `FlushCompleted` on the `SystemAnnouncer` bus after a flush has
@@ -1370,6 +2106,16 @@ cleanup_one(#prepared{op = delete, pre_existing = false}) ->
     ok;
 %% `noop` (already-gone soft success): no I/O happened, nothing to undo.
 cleanup_one(#prepared{op = noop}) ->
+    ok;
+%% `move` (class rename, ADR 0114 BT-3271): delete the freshly-written
+%% `<new_path>.tmp` — Phase A never touches `old_path` for a move (only
+%% reads it), so, exactly like `write`, there is nothing else to undo.
+cleanup_one(#prepared{op = move, tmp = Tmp}) ->
+    _ = file:delete(Tmp),
+    ok;
+%% `move_noop` (the move already completed in an earlier attempt): no I/O
+%% happened this round, nothing to undo.
+cleanup_one(#prepared{op = move_noop}) ->
     ok.
 
 -spec span_start(term()) -> integer().
@@ -1391,9 +2137,31 @@ seq(E) ->
 empty_summary() ->
     base_summary(0, [], 0, 0, [], []).
 
--spec success_summary([binary()], [#prepared{}], [map()], [map()]) -> map().
-success_summary(Files, Committed, Failed, Skipped) ->
-    AllEntries = lists:flatten([P#prepared.entries || P <- Committed]),
+-doc """
+`Flushed`/`newClasses`/`removedClasses` are counted over `Seqs` — the seqs
+`complete_flush/5` actually asked `mark_flushed/1` to mark, i.e. exactly
+the entries `phase_b_loop/6` decided are fully committed — rather than
+naively flattening `Committed`'s `.entries` fields. For every existing
+single-file kind these two sets always coincide (each entry belongs to
+exactly one `#prepared{}` record) so this is a no-op change in behaviour;
+for a `'rename-class'` entry (ADR 0114, BT-3271) the SAME entry legitimately
+appears in `Committed` once per file it touches (the move plus every other
+rewritten site), and must count once, not once per file — and not at all if
+`phase_b_loop/6` excluded it for not having ALL of its files committed yet.
+""".
+-spec success_summary([binary()], [#prepared{}], [map()], [map()], [non_neg_integer()]) -> map().
+success_summary(Files, Committed, Failed, Skipped, Seqs) ->
+    SeqSet = sets:from_list(Seqs, [{version, 2}]),
+    AllEntries = lists:usort(
+        fun(A, B) ->
+            beamtalk_workspace_changelog:entry_seq(A) =< beamtalk_workspace_changelog:entry_seq(B)
+        end,
+        [
+            E
+         || E <- lists:flatten([P#prepared.entries || P <- Committed]),
+            sets:is_element(beamtalk_workspace_changelog:entry_seq(E), SeqSet)
+        ]
+    ),
     Flushed = length(AllEntries),
     NewClassCount = length([E || E <- AllEntries, is_new_class_entry(E)]),
     RemovedClassCount = length([E || E <- AllEntries, is_remove_class_entry(E)]),

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
@@ -99,6 +99,7 @@ flush_test_() ->
         fun rename_class_moves_file_rewrites_declaration_and_reference/1,
         fun rename_class_new_path_exists_as_unrelated_file_is_conflict/1,
         fun rename_class_self_reference_folds_into_move/1,
+        fun rename_class_self_reference_move_noop_after_old_path_gone/1,
         fun rename_class_external_edit_on_declaration_aborts_with_no_partial_writes/1,
         fun rename_class_external_edit_on_reference_site_aborts_with_no_partial_writes/1,
         fun rename_class_mixed_with_ordinary_patch_is_conflict/1,
@@ -2124,6 +2125,60 @@ rename_class_self_reference_folds_into_move(#{proj_dir := ProjDir}) ->
         %% write.
         ?_assertEqual([list_to_binary(NewPath)], maps:get(files, Summary)),
         ?_assert(entry_flushed(Seq))
+    ].
+
+%% BT-3526 review round 5 Blocker: `all_units_already_applied/2` (the
+%% "old_path already gone" recovery check) must account for the cumulative
+%% byte-length shift a same-file self-reference site picks up from an
+%% EARLIER (lower-offset) site's own splice — checking each unit's raw
+%% recorded offset independently against the fully-spliced final body
+%% misreads a genuinely-completed rename as unresolvable once the class
+%% name changes length (the common case: "Counter" (7) -> "Accumulator"
+%% (11)). Mirrors `rename_class_resumes_after_simulated_partial_phase_b`'s
+%% own technique — construct the "already fully moved, crashed before
+%% mark_flushed" on-disk state directly, without going through
+%% `beamtalk_workspace_flush` at all — but for the self-reference-folded
+%% single-file move shape `rename_class_self_reference_folds_into_move/1`
+%% covers on the happy path, not the multi-file shape `rename_class_
+%% resumes_after_simulated_partial_phase_b/1` already covers.
+rename_class_self_reference_move_noop_after_old_path_gone(#{proj_dir := ProjDir}) ->
+    OldPath = filename:join([ProjDir, "src", "counter.bt"]),
+    NewPath = filename:join([ProjDir, "src", "accumulator.bt"]),
+    OldSource = <<"Object subclass: Counter\n  self2 => Counter new\nend\n">>,
+    {DeclStart, DeclEnd, _} = locate(OldSource, <<"Counter">>),
+    DeclSite = rename_site(
+        list_to_binary(OldPath), DeclStart, DeclEnd, <<"Accumulator">>, <<"Counter">>
+    ),
+    {SelfStart, SelfEnd, _} = locate(OldSource, <<"Counter new">>),
+    SelfSite = rename_site(
+        list_to_binary(OldPath), SelfStart, SelfEnd, <<"Accumulator new">>, <<"Counter new">>
+    ),
+    {ok, Seq} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Accumulator">>,
+            <<"Counter">>,
+            list_to_binary(OldPath),
+            list_to_binary(NewPath),
+            [DeclSite, SelfSite]
+        )
+    ),
+    %% `old_path` is never created — this simulates a Phase B `move` commit
+    %% that already succeeded (renamed `<new_path>.tmp` into place, unlinked
+    %% `old_path`) and crashed before `mark_flushed` landed, exactly the
+    %% recovery state `resolve_missing_rename_source/4` must recognise as
+    %% `move_noop`, not a conflict.
+    ExpectedBody = <<"Object subclass: Accumulator\n  self2 => Accumulator new\nend\n">>,
+    ok = file:write_file(NewPath, ExpectedBody),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    {ok, NewBodyAfter} = file:read_file(NewPath),
+    [
+        ?_assertEqual(1, maps:get(flushed, Summary)),
+        ?_assertEqual([], maps:get(conflicts, Summary)),
+        %% Already-correct content is left byte-identical, not corrupted by
+        %% a redundant re-splice against the wrong (unshifted) offset.
+        ?_assertEqual(ExpectedBody, NewBodyAfter),
+        ?_assert(entry_flushed(Seq)),
+        ?_assertEqual(false, filelib:is_regular(NewPath ++ ".tmp"))
     ].
 
 %% Forced Phase A staleness on the declaration span: a Phase A failure

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
@@ -94,6 +94,14 @@ flush_test_() ->
         fun remove_class_mixed_with_patch_is_conflict/1,
         fun remove_class_abort_restores_staged_file_on_other_file_conflict/1,
         fun remove_class_staged_delete_crash_recovery/1,
+        %% ADR 0114 Phase 2 (BT-3271): rename-class multi-file destructive flush
+        fun rename_class_flush_without_confirm_is_skipped_destructive/1,
+        fun rename_class_moves_file_rewrites_declaration_and_reference/1,
+        fun rename_class_self_reference_folds_into_move/1,
+        fun rename_class_external_edit_on_declaration_aborts_with_no_partial_writes/1,
+        fun rename_class_external_edit_on_reference_site_aborts_with_no_partial_writes/1,
+        fun rename_class_mixed_with_ordinary_patch_is_conflict/1,
+        fun rename_class_resumes_after_simulated_partial_phase_b/1,
         fun flush_two_rejects_non_boolean_confirm/1,
         fun flush_kinds_two_rejects_non_boolean_confirm/1,
         %% BT-3212 (ADR 0113 LSP follow-up): per-file operation kind on the
@@ -110,7 +118,12 @@ unit_test_() ->
         fun filter_shadowed_keeps_only_renamed_survivors/0,
         fun filter_shadowed_drops_unrenamed_survivors/0,
         fun entry_tier_classifies_remove_class_as_tier2/0,
-        fun entry_tier_classifies_other_kinds_as_tier1/0
+        fun entry_tier_classifies_other_kinds_as_tier1/0,
+        %% ADR 0114 Phase 2 (BT-3271)
+        fun entry_tier_classifies_rename_class_as_tier2/0,
+        fun resolve_new_path_prefers_recorded_value/0,
+        fun resolve_new_path_derives_exact_style_from_old_path/0,
+        fun resolve_new_path_derives_snake_case_style_from_old_path/0
     ].
 
 new_class_directory_target_test_() ->
@@ -1722,6 +1735,363 @@ remove_class_staged_delete_crash_recovery(#{proj_dir := ProjDir}) ->
         ?_assert(entry_flushed(Seq))
     ].
 
+%%====================================================================
+%% Tests — rename-class multi-file destructive flush (ADR 0114, BT-3271)
+%%====================================================================
+
+%% Tier 2 gating, mirroring `remove_class_flush_without_confirm_is_skipped_
+%% destructive/1`: an ordinary `flush/0` never applies a pending
+%% `rename-class` entry — neither `old_path` nor `new_path` is touched.
+rename_class_flush_without_confirm_is_skipped_destructive(#{proj_dir := ProjDir}) ->
+    OldPath = filename:join([ProjDir, "src", "counter.bt"]),
+    NewPath = filename:join([ProjDir, "src", "accumulator.bt"]),
+    OldSource = <<"Object subclass: Counter\nend\n">>,
+    ok = file:write_file(OldPath, OldSource),
+    {DeclStart, DeclEnd, _} = locate(OldSource, <<"Counter">>),
+    DeclSite = rename_site(
+        list_to_binary(OldPath), DeclStart, DeclEnd, <<"Accumulator">>, <<"Counter">>
+    ),
+    {ok, Seq} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Accumulator">>,
+            <<"Counter">>,
+            list_to_binary(OldPath),
+            list_to_binary(NewPath),
+            [DeclSite]
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush(),
+    Skipped = maps:get(skipped, Summary),
+    [
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assertEqual(1, length(Skipped)),
+        ?_assertEqual(<<"destructive">>, maps:get(reason, hd(Skipped))),
+        ?_assertEqual(true, filelib:is_regular(OldPath)),
+        ?_assertEqual(false, filelib:is_regular(NewPath)),
+        ?_assertNot(entry_flushed(Seq))
+    ].
+
+%% BUnit acceptance-criteria coverage (this module's own EUnit-level slice —
+%% the real `Counter renameTo: #Accumulator` + `Workspace
+%% flushIncludingDestructive` round trip needs a real, in-project-classified
+%% compiled class and lives in `tests/repl-protocol/cases/`, since BUnit's
+%% `beamtalk test` runner has no project configured — see
+%% `stdlib/test/rename_to_test.bt`'s own doc comment). Exercises this
+%% module's actual flush mechanics directly: the moved file exists with its
+%% declaration rewritten (rest byte-identical), the old file is gone, and a
+%% cross-file reference is rewritten too.
+rename_class_moves_file_rewrites_declaration_and_reference(#{proj_dir := ProjDir}) ->
+    OldPath = filename:join([ProjDir, "src", "counter.bt"]),
+    NewPath = filename:join([ProjDir, "src", "accumulator.bt"]),
+    RefPath = filename:join([ProjDir, "src", "widget.bt"]),
+    OldSource = <<"Object subclass: Counter\n  value => 0\nend\n">>,
+    RefSource = <<"Object subclass: Widget\n  makeCounter => Counter new\nend\n">>,
+    ok = file:write_file(OldPath, OldSource),
+    ok = file:write_file(RefPath, RefSource),
+    {DeclStart, DeclEnd, _} = locate(OldSource, <<"Counter">>),
+    DeclSite = rename_site(
+        list_to_binary(OldPath), DeclStart, DeclEnd, <<"Accumulator">>, <<"Counter">>
+    ),
+    {RefStart, RefEnd, _} = locate(RefSource, <<"Counter new">>),
+    RefSite = rename_site(
+        list_to_binary(RefPath), RefStart, RefEnd, <<"Accumulator new">>, <<"Counter new">>
+    ),
+    {ok, Seq} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Accumulator">>,
+            <<"Counter">>,
+            list_to_binary(OldPath),
+            list_to_binary(NewPath),
+            [DeclSite, RefSite]
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    {ok, NewBody} = file:read_file(NewPath),
+    {ok, RefBody} = file:read_file(RefPath),
+    Files = maps:get(files, Summary),
+    [
+        ?_assertEqual(1, maps:get(flushed, Summary)),
+        ?_assertEqual([], maps:get(conflicts, Summary)),
+        ?_assertEqual([], maps:get(skipped, Summary)),
+        ?_assertEqual(false, filelib:is_regular(OldPath)),
+        ?_assertEqual(<<"Object subclass: Accumulator\n  value => 0\nend\n">>, NewBody),
+        ?_assertEqual(
+            <<"Object subclass: Widget\n  makeCounter => Accumulator new\nend\n">>, RefBody
+        ),
+        ?_assert(lists:member(list_to_binary(NewPath), Files)),
+        ?_assert(lists:member(list_to_binary(RefPath), Files)),
+        ?_assert(entry_flushed(Seq)),
+        ?_assertEqual(false, filelib:is_regular(NewPath ++ ".tmp")),
+        ?_assertEqual(false, filelib:is_regular(RefPath ++ ".tmp"))
+    ].
+
+%% A site whose OWN file equals `old_path` (a class referencing its own name
+%% inside one of its own methods) must fold into the SAME `new_path.tmp`
+%% write, never an independent `old_path.tmp` — `old_path` is being unlinked
+%% as part of this same operation, so a separate write-then-rename targeting
+%% it would race the move's own unlink (ADR 0114 § "Atomicity (class
+%% rename)").
+rename_class_self_reference_folds_into_move(#{proj_dir := ProjDir}) ->
+    OldPath = filename:join([ProjDir, "src", "counter.bt"]),
+    NewPath = filename:join([ProjDir, "src", "accumulator.bt"]),
+    OldSource = <<"Object subclass: Counter\n  self2 => Counter new\nend\n">>,
+    ok = file:write_file(OldPath, OldSource),
+    {DeclStart, DeclEnd, _} = locate(OldSource, <<"Counter">>),
+    DeclSite = rename_site(
+        list_to_binary(OldPath), DeclStart, DeclEnd, <<"Accumulator">>, <<"Counter">>
+    ),
+    {SelfStart, SelfEnd, _} = locate(OldSource, <<"Counter new">>),
+    SelfSite = rename_site(
+        list_to_binary(OldPath), SelfStart, SelfEnd, <<"Accumulator new">>, <<"Counter new">>
+    ),
+    {ok, Seq} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Accumulator">>,
+            <<"Counter">>,
+            list_to_binary(OldPath),
+            list_to_binary(NewPath),
+            [DeclSite, SelfSite]
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    {ok, NewBody} = file:read_file(NewPath),
+    [
+        ?_assertEqual(1, maps:get(flushed, Summary)),
+        ?_assertEqual([], maps:get(conflicts, Summary)),
+        ?_assertEqual(false, filelib:is_regular(OldPath)),
+        ?_assertEqual(
+            <<"Object subclass: Accumulator\n  self2 => Accumulator new\nend\n">>, NewBody
+        ),
+        %% Exactly one file was written for this whole entry (the two sites
+        %% merged into one splice) — never a spurious second `old_path`
+        %% write.
+        ?_assertEqual([list_to_binary(NewPath)], maps:get(files, Summary)),
+        ?_assert(entry_flushed(Seq))
+    ].
+
+%% Forced Phase A staleness on the declaration span: a Phase A failure
+%% aborts the whole batch before any Phase B write happens — neither file is
+%% touched, no `.tmp` is left behind, and the entry stays pending.
+rename_class_external_edit_on_declaration_aborts_with_no_partial_writes(#{proj_dir := ProjDir}) ->
+    OldPath = filename:join([ProjDir, "src", "counter.bt"]),
+    NewPath = filename:join([ProjDir, "src", "accumulator.bt"]),
+    RefPath = filename:join([ProjDir, "src", "widget.bt"]),
+    OldSource = <<"Object subclass: Counter\nend\n">>,
+    RefSource = <<"Object subclass: Widget\n  makeCounter => Counter new\nend\n">>,
+    ok = file:write_file(OldPath, OldSource),
+    ok = file:write_file(RefPath, RefSource),
+    {DeclStart, DeclEnd, _} = locate(OldSource, <<"Counter">>),
+    DeclSite = rename_site(
+        list_to_binary(OldPath), DeclStart, DeclEnd, <<"Accumulator">>, <<"Counter">>
+    ),
+    {RefStart, RefEnd, _} = locate(RefSource, <<"Counter new">>),
+    RefSite = rename_site(
+        list_to_binary(RefPath), RefStart, RefEnd, <<"Accumulator new">>, <<"Counter new">>
+    ),
+    {ok, Seq} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Accumulator">>,
+            <<"Counter">>,
+            list_to_binary(OldPath),
+            list_to_binary(NewPath),
+            [DeclSite, RefSite]
+        )
+    ),
+    %% Forced Phase A staleness: edit the declaration span externally between
+    %% the rename and the flush. A run of `X`s is long enough to cover the
+    %% recorded span regardless of its exact offset and cannot coincidentally
+    %% match either the recorded prior text or the rewritten new text.
+    ExternalEdit = binary:copy(<<"X">>, 80),
+    ok = file:write_file(OldPath, ExternalEdit),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    Conflicts = maps:get(conflicts, Summary),
+    [
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assert(length(Conflicts) >= 1),
+        ?_assertEqual(<<"external_edit">>, maps:get(reason, hd(Conflicts))),
+        ?_assertEqual(false, filelib:is_regular(NewPath)),
+        ?_assertEqual(false, filelib:is_regular(NewPath ++ ".tmp")),
+        ?_assertEqual(false, filelib:is_regular(RefPath ++ ".tmp")),
+        ?_assertEqual({ok, ExternalEdit}, file:read_file(OldPath)),
+        ?_assertEqual({ok, RefSource}, file:read_file(RefPath)),
+        ?_assertNot(entry_flushed(Seq))
+    ].
+
+%% Same shape, staleness on the OTHER (non-declaration) site instead —
+%% exercises `prepare_rename_site_group/2`'s own conflict path, and confirms
+%% the move's own (already-valid) declaration splice is still rolled back
+%% (no `.tmp` left over) when a SIBLING site conflicts.
+rename_class_external_edit_on_reference_site_aborts_with_no_partial_writes(#{
+    proj_dir := ProjDir
+}) ->
+    OldPath = filename:join([ProjDir, "src", "counter.bt"]),
+    NewPath = filename:join([ProjDir, "src", "accumulator.bt"]),
+    RefPath = filename:join([ProjDir, "src", "widget.bt"]),
+    OldSource = <<"Object subclass: Counter\nend\n">>,
+    RefSource = <<"Object subclass: Widget\n  makeCounter => Counter new\nend\n">>,
+    ok = file:write_file(OldPath, OldSource),
+    ok = file:write_file(RefPath, RefSource),
+    {DeclStart, DeclEnd, _} = locate(OldSource, <<"Counter">>),
+    DeclSite = rename_site(
+        list_to_binary(OldPath), DeclStart, DeclEnd, <<"Accumulator">>, <<"Counter">>
+    ),
+    {RefStart, RefEnd, _} = locate(RefSource, <<"Counter new">>),
+    RefSite = rename_site(
+        list_to_binary(RefPath), RefStart, RefEnd, <<"Accumulator new">>, <<"Counter new">>
+    ),
+    {ok, Seq} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Accumulator">>,
+            <<"Counter">>,
+            list_to_binary(OldPath),
+            list_to_binary(NewPath),
+            [DeclSite, RefSite]
+        )
+    ),
+    ExternalEdit = binary:copy(<<"Y">>, 80),
+    ok = file:write_file(RefPath, ExternalEdit),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    Conflicts = maps:get(conflicts, Summary),
+    [
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assert(length(Conflicts) >= 1),
+        ?_assertEqual(<<"external_edit">>, maps:get(reason, hd(Conflicts))),
+        %% The move's OWN splice was valid — it must still be rolled back
+        %% (no `.tmp`, `old_path` untouched) once the sibling site conflicts.
+        ?_assertEqual(false, filelib:is_regular(NewPath)),
+        ?_assertEqual(false, filelib:is_regular(NewPath ++ ".tmp")),
+        ?_assertEqual({ok, OldSource}, file:read_file(OldPath)),
+        ?_assertEqual({ok, ExternalEdit}, file:read_file(RefPath)),
+        ?_assertNot(entry_flushed(Seq))
+    ].
+
+%% Cross-pipeline collision guard: a rename-class entry sharing a target
+%% file with a pending ORDINARY patch aborts the whole flush rather than
+%% racing "rewrite this file" against "this file is moving away".
+rename_class_mixed_with_ordinary_patch_is_conflict(#{proj_dir := ProjDir}) ->
+    OldPath = filename:join([ProjDir, "src", "counter.bt"]),
+    NewPath = filename:join([ProjDir, "src", "accumulator.bt"]),
+    RefPath = filename:join([ProjDir, "src", "widget.bt"]),
+    OldSource = <<"Object subclass: Counter\nend\n">>,
+    RefSource = <<"Object subclass: Widget\n  foo => 1\nend\n">>,
+    ok = file:write_file(OldPath, OldSource),
+    ok = file:write_file(RefPath, RefSource),
+    {DeclStart, DeclEnd, _} = locate(OldSource, <<"Counter">>),
+    DeclSite = rename_site(
+        list_to_binary(OldPath), DeclStart, DeclEnd, <<"Accumulator">>, <<"Counter">>
+    ),
+    %% The rename ALSO touches RefPath (a reference site) — the same file an
+    %% independent, unrelated patch below is targeting. This is the actual
+    %% collision: without the guard, both pipelines would stage a `.tmp` for
+    %% RefPath and Phase B would apply only whichever happened to commit
+    %% last, silently discarding the other.
+    RefSite = rename_site(
+        list_to_binary(RefPath), 0, byte_size(<<"Object subclass: Widget">>), <<"ref">>, <<"ref">>
+    ),
+    {ok, RenameSeq} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Accumulator">>,
+            <<"Counter">>,
+            list_to_binary(OldPath),
+            list_to_binary(NewPath),
+            [DeclSite, RefSite]
+        )
+    ),
+    {PatchStart, PatchEnd, PatchOld} = locate(RefSource, <<"foo => 1\n">>),
+    {ok, PatchSeq} = beamtalk_workspace_changelog:append(
+        method_input(
+            <<"Widget">>,
+            <<"foo">>,
+            <<"foo => 2\n">>,
+            PatchOld,
+            list_to_binary(RefPath),
+            PatchStart,
+            PatchEnd
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    Conflicts = maps:get(conflicts, Summary),
+    [
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assert(length(Conflicts) >= 1),
+        ?_assertEqual(true, filelib:is_regular(OldPath)),
+        ?_assertEqual(false, filelib:is_regular(NewPath)),
+        ?_assertEqual({ok, RefSource}, file:read_file(RefPath)),
+        ?_assertNot(entry_flushed(RenameSeq)),
+        ?_assertNot(entry_flushed(PatchSeq))
+    ].
+
+%% Crash-recovery / partial-Phase-B-then-retry (ADR 0114 § "Atomicity (class
+%% rename)"): simulate a flush attempt that committed the move and ONE of two
+%% reference sites, then crashed before committing the second site or
+%% marking the entry flushed (the entry is still pending — exactly what a
+%% `flush_marker_failed`/mid-loop Phase B stop leaves behind). Re-issuing
+%% `flushIncludingDestructive` must recognise the already-done work as a
+%% no-op (not `external_edit`), finish the remaining site, and mark the
+%% entry flushed — "retries only what's left", not "fails forever".
+rename_class_resumes_after_simulated_partial_phase_b(#{proj_dir := ProjDir}) ->
+    OldPath = filename:join([ProjDir, "src", "counter.bt"]),
+    NewPath = filename:join([ProjDir, "src", "accumulator.bt"]),
+    RefPath1 = filename:join([ProjDir, "src", "widget.bt"]),
+    RefPath2 = filename:join([ProjDir, "src", "gadget.bt"]),
+    OldSource = <<"Object subclass: Counter\n  value => 0\nend\n">>,
+    RefSource1 = <<"Object subclass: Widget\n  makeCounter => Counter new\nend\n">>,
+    RefSource2 = <<"Object subclass: Gadget\n  makeCounter => Counter new\nend\n">>,
+    ok = file:write_file(OldPath, OldSource),
+    ok = file:write_file(RefPath1, RefSource1),
+    ok = file:write_file(RefPath2, RefSource2),
+    {DeclStart, DeclEnd, _} = locate(OldSource, <<"Counter">>),
+    DeclSite = rename_site(
+        list_to_binary(OldPath), DeclStart, DeclEnd, <<"Accumulator">>, <<"Counter">>
+    ),
+    {Ref1Start, Ref1End, _} = locate(RefSource1, <<"Counter new">>),
+    RefSite1 = rename_site(
+        list_to_binary(RefPath1), Ref1Start, Ref1End, <<"Accumulator new">>, <<"Counter new">>
+    ),
+    {Ref2Start, Ref2End, _} = locate(RefSource2, <<"Counter new">>),
+    RefSite2 = rename_site(
+        list_to_binary(RefPath2), Ref2Start, Ref2End, <<"Accumulator new">>, <<"Counter new">>
+    ),
+    {ok, Seq} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Accumulator">>,
+            <<"Counter">>,
+            list_to_binary(OldPath),
+            list_to_binary(NewPath),
+            [DeclSite, RefSite1, RefSite2]
+        )
+    ),
+    %% Simulate a flush attempt that committed the move and RefPath1, then
+    %% crashed before RefPath2 and before `mark_flushed` — WITHOUT going
+    %% through `beamtalk_workspace_flush` at all, so this is a pure on-disk
+    %% state fixture, not a call into the code under test.
+    NewBodyExpected = <<"Object subclass: Accumulator\n  value => 0\nend\n">>,
+    ok = file:write_file(NewPath, NewBodyExpected),
+    ok = file:delete(OldPath),
+    RefBody1Expected = <<"Object subclass: Widget\n  makeCounter => Accumulator new\nend\n">>,
+    ok = file:write_file(RefPath1, RefBody1Expected),
+    %% RefPath2 is left exactly as it was — this is the "what's left" half.
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    {ok, NewBodyAfter} = file:read_file(NewPath),
+    {ok, RefBody1After} = file:read_file(RefPath1),
+    {ok, RefBody2After} = file:read_file(RefPath2),
+    [
+        ?_assertEqual(1, maps:get(flushed, Summary)),
+        ?_assertEqual([], maps:get(conflicts, Summary)),
+        %% Already-correct files are left byte-identical, not corrupted by a
+        %% redundant re-splice.
+        ?_assertEqual(NewBodyExpected, NewBodyAfter),
+        ?_assertEqual(RefBody1Expected, RefBody1After),
+        %% The one file that was genuinely left behind is now correct too.
+        ?_assertEqual(
+            <<"Object subclass: Gadget\n  makeCounter => Accumulator new\nend\n">>, RefBody2After
+        ),
+        ?_assert(entry_flushed(Seq)),
+        ?_assertEqual(false, filelib:is_regular(NewPath ++ ".tmp")),
+        ?_assertEqual(false, filelib:is_regular(RefPath1 ++ ".tmp")),
+        ?_assertEqual(false, filelib:is_regular(RefPath2 ++ ".tmp"))
+    ].
+
 %% `confirmDestructive` must be a literal Boolean at both `flush/2` and
 %% `flush_kinds/2` — anything else is a structured type error, never coerced.
 flush_two_rejects_non_boolean_confirm(_Ctx) ->
@@ -1781,6 +2151,105 @@ entry_tier_classifies_other_kinds_as_tier1() ->
         Entries = beamtalk_workspace_changelog:flushable_pending(),
         Tiers = [beamtalk_workspace_flush:entry_tier(E) || E <- Entries],
         ?assertEqual([tier1, tier1, tier1], Tiers)
+    after
+        stop(Pid),
+        restore_home(OldHome),
+        del_tree(TmpHome)
+    end.
+
+%% ADR 0114 Phase 2 (BT-3271): `'rename-class'` joins `'remove-class'` in
+%% Tier 2 — a destructive flush gate, since it moves (and unlinks) a file.
+entry_tier_classifies_rename_class_as_tier2() ->
+    {WorkspaceId, TmpHome, OldHome} = fresh_workspace(),
+    {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => WorkspaceId}),
+    try
+        {ok, _} = beamtalk_workspace_changelog:append(
+            rename_class_input(
+                <<"Accumulator">>,
+                <<"Counter">>,
+                <<"/proj/src/counter.bt">>,
+                <<"/proj/src/accumulator.bt">>,
+                [rename_site(<<"/proj/src/counter.bt">>, 0, 7, <<"Accumulator">>, <<"Counter">>)]
+            )
+        ),
+        [Entry] = beamtalk_workspace_changelog:flushable_pending(),
+        ?assertEqual(tier2, beamtalk_workspace_flush:entry_tier(Entry))
+    after
+        stop(Pid),
+        restore_home(OldHome),
+        del_tree(TmpHome)
+    end.
+
+%% `resolve_new_path/1` prefers a recorded `new_path` verbatim over deriving
+%% one — forward-compatible with a future producer (e.g. `moveClass:to:`)
+%% that records an explicit target path.
+resolve_new_path_prefers_recorded_value() ->
+    {WorkspaceId, TmpHome, OldHome} = fresh_workspace(),
+    {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => WorkspaceId}),
+    try
+        {ok, _} = beamtalk_workspace_changelog:append(
+            rename_class_input(
+                <<"Accumulator">>,
+                <<"Counter">>,
+                <<"/proj/src/counter.bt">>,
+                <<"/proj/src/somewhere_else.bt">>,
+                [rename_site(<<"/proj/src/counter.bt">>, 0, 7, <<"Accumulator">>, <<"Counter">>)]
+            )
+        ),
+        [Entry] = beamtalk_workspace_changelog:flushable_pending(),
+        ?assertEqual(
+            <<"/proj/src/somewhere_else.bt">>, beamtalk_workspace_flush:resolve_new_path(Entry)
+        )
+    after
+        stop(Pid),
+        restore_home(OldHome),
+        del_tree(TmpHome)
+    end.
+
+%% `resolve_new_path/1` derives a target path when the entry itself did not
+%% record one (today's only producer, `classRenameTo/2`, always logs
+%% `new_path => undefined`) — preserving an EXACT-match old basename style
+%% (`Counter.bt`) for the new one (`Accumulator.bt`), not forcing snake_case.
+resolve_new_path_derives_exact_style_from_old_path() ->
+    {WorkspaceId, TmpHome, OldHome} = fresh_workspace(),
+    {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => WorkspaceId}),
+    try
+        Input = rename_class_input(
+            <<"Accumulator">>,
+            <<"Counter">>,
+            <<"/proj/src/Counter.bt">>,
+            undefined,
+            [rename_site(<<"/proj/src/Counter.bt">>, 0, 7, <<"Accumulator">>, <<"Counter">>)]
+        ),
+        {ok, _} = beamtalk_workspace_changelog:append(Input),
+        [Entry] = beamtalk_workspace_changelog:flushable_pending(),
+        ?assertEqual(
+            <<"/proj/src/Accumulator.bt">>, beamtalk_workspace_flush:resolve_new_path(Entry)
+        )
+    after
+        stop(Pid),
+        restore_home(OldHome),
+        del_tree(TmpHome)
+    end.
+
+%% Same, but the old file used the snake_case convention (`counter.bt`) — the
+%% derived new path follows suit (`accumulator.bt`), not `Accumulator.bt`.
+resolve_new_path_derives_snake_case_style_from_old_path() ->
+    {WorkspaceId, TmpHome, OldHome} = fresh_workspace(),
+    {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => WorkspaceId}),
+    try
+        Input = rename_class_input(
+            <<"Accumulator">>,
+            <<"Counter">>,
+            <<"/proj/src/counter.bt">>,
+            undefined,
+            [rename_site(<<"/proj/src/counter.bt">>, 0, 7, <<"Accumulator">>, <<"Counter">>)]
+        ),
+        {ok, _} = beamtalk_workspace_changelog:append(Input),
+        [Entry] = beamtalk_workspace_changelog:flushable_pending(),
+        ?assertEqual(
+            <<"/proj/src/accumulator.bt">>, beamtalk_workspace_flush:resolve_new_path(Entry)
+        )
     after
         stop(Pid),
         restore_home(OldHome),
@@ -1944,6 +2413,45 @@ remove_class_input(ClassName, PrevSource, File) ->
         prev_source => PrevSource
     }.
 
+%% A flushable `'rename-class'` append_input (ADR 0114, BT-3269/BT-3271):
+%% `sites[0]` is always the class's own declaration site, whose `sourceFile`
+%% is `OldPath` — matching what `beamtalk_behaviour_intrinsics:classRenameTo/2`
+%% actually records (`capture_class_removal_snapshot/1` captures the OLD
+%% class's source file BEFORE any rename happens), NOT `NewPath` — see
+%% `beamtalk_workspace_flush`'s own "Atomicity (class rename)" moduledoc
+%% section for why this matters (the declaration's own splice reads from
+%% `OldPath`, not `NewPath`, since the file hasn't moved yet at flush time).
+rename_class_input(NewClass, OldClass, OldPath, NewPath, Sites) ->
+    #{
+        class => NewClass,
+        kind => 'rename-class',
+        old_class => OldClass,
+        old_path => OldPath,
+        new_path => NewPath,
+        sites => Sites,
+        intent => durable,
+        flushable => true,
+        author => <<"sess-test">>,
+        author_kind => human
+    }.
+
+%% One `site()` map for a `'rename-class'`/`'rename-method'` entry, with its
+%% `source_ref`/`prev_source_ref` bodies actually persisted to the ChangeLog's
+%% `sources/` directory (via `store_site_body/1`) so `beamtalk_workspace_flush`
+%% can read them back through `read_site_body/1` — unlike
+%% `beamtalk_workspace_changelog_tests.erl`'s own `site_map/2` fixture, which
+%% is schema-only and leaves both refs `undefined` (it never round-trips
+%% through flush).
+rename_site(SourceFile, Start, End, NewText, PrevText) ->
+    {ok, NewRef} = beamtalk_workspace_changelog:store_site_body(NewText),
+    {ok, PrevRef} = beamtalk_workspace_changelog:store_site_body(PrevText),
+    #{
+        source_file => SourceFile,
+        span => #{start => Start, 'end' => End},
+        source_ref => NewRef,
+        prev_source_ref => PrevRef
+    }.
+
 %% Build the sources/ filename for a seq (mirrors the changelog's zero-padded
 %% naming): "000042-source.bt" / "000042-prev.bt".
 source_ref_name(Seq, Suffix) ->
@@ -1965,7 +2473,17 @@ entry_flushed(Seq) ->
     beamtalk_workspace_changelog:entry_flushed(Entry).
 
 fresh_workspace() ->
-    Unique = integer_to_list(erlang:unique_integer([positive])),
+    %% `os:getpid()` mixed in alongside `erlang:unique_integer/1` (not that
+    %% counter alone): the counter resets on every fresh `rebar3 eunit` VM
+    %% invocation, so two separate test runs reaching this call site after
+    %% the same fixed number of prior `unique_integer` calls can compute an
+    %% IDENTICAL workspace id — and `beamtalk_workspace_changelog`'s own
+    %% `load_from_disk` would then restore a prior run's leftover ChangeLog
+    %% entries into this run's ETS table. Same bug, same fix as BT-3278's
+    %% `beamtalk_behaviour_intrinsics_rename_to_tests.erl:setup_with_
+    %% changelog/0`. `os:getpid()` (the OS process id) is genuinely distinct
+    %% per separate VM invocation, unlike the in-VM counter.
+    Unique = os:getpid() ++ "-" ++ integer_to_list(erlang:unique_integer([positive])),
     WorkspaceId = list_to_binary("test-ws-flush-" ++ Unique),
     Tmp = filename:join(temp_dir(), "bt-flush-" ++ Unique),
     ok = filelib:ensure_path(Tmp),

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
@@ -97,6 +97,7 @@ flush_test_() ->
         %% ADR 0114 Phase 2 (BT-3271): rename-class multi-file destructive flush
         fun rename_class_flush_without_confirm_is_skipped_destructive/1,
         fun rename_class_moves_file_rewrites_declaration_and_reference/1,
+        fun rename_class_new_path_exists_as_unrelated_file_is_conflict/1,
         fun rename_class_self_reference_folds_into_move/1,
         fun rename_class_external_edit_on_declaration_aborts_with_no_partial_writes/1,
         fun rename_class_external_edit_on_reference_site_aborts_with_no_partial_writes/1,
@@ -2041,6 +2042,44 @@ rename_class_moves_file_rewrites_declaration_and_reference(#{proj_dir := ProjDir
         ?_assert(entry_flushed(Seq)),
         ?_assertEqual(false, filelib:is_regular(NewPath ++ ".tmp")),
         ?_assertEqual(false, filelib:is_regular(RefPath ++ ".tmp"))
+    ].
+
+%% BT-3526 review round 4 Blocker: `new_path` already existing as an
+%% UNRELATED file (never touched by any pending rename entry — a plain
+%% pre-existing scratch file, not a resumed prior attempt) must refuse the
+%% flush rather than silently overwriting it once Phase B's bare
+%% `file:rename/2` replaces whatever is already there. Mirrors
+%% `prepare_new_class/3`'s `target_exists` guard.
+rename_class_new_path_exists_as_unrelated_file_is_conflict(#{proj_dir := ProjDir}) ->
+    OldPath = filename:join([ProjDir, "src", "counter.bt"]),
+    NewPath = filename:join([ProjDir, "src", "accumulator.bt"]),
+    OldSource = <<"Object subclass: Counter\n  value => 0\nend\n">>,
+    UnrelatedContent = <<"this file has nothing to do with the rename\n">>,
+    ok = file:write_file(OldPath, OldSource),
+    ok = file:write_file(NewPath, UnrelatedContent),
+    {DeclStart, DeclEnd, _} = locate(OldSource, <<"Counter">>),
+    DeclSite = rename_site(
+        list_to_binary(OldPath), DeclStart, DeclEnd, <<"Accumulator">>, <<"Counter">>
+    ),
+    {ok, Seq} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Accumulator">>, <<"Counter">>, list_to_binary(OldPath), list_to_binary(NewPath), [
+                DeclSite
+            ]
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    Conflicts = maps:get(conflicts, Summary),
+    [
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assert(length(Conflicts) >= 1),
+        ?_assertEqual(<<"rename_target_exists">>, maps:get(reason, hd(Conflicts))),
+        %% The unrelated file at new_path is completely untouched, old_path
+        %% is untouched too (whole batch aborted), and no .tmp is left behind.
+        ?_assertEqual({ok, UnrelatedContent}, file:read_file(NewPath)),
+        ?_assertEqual({ok, OldSource}, file:read_file(OldPath)),
+        ?_assertEqual(false, filelib:is_regular(NewPath ++ ".tmp")),
+        ?_assertNot(entry_flushed(Seq))
     ].
 
 %% A site whose OWN file equals `old_path` (a class referencing its own name

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
@@ -102,6 +102,7 @@ flush_test_() ->
         fun rename_class_external_edit_on_reference_site_aborts_with_no_partial_writes/1,
         fun rename_class_mixed_with_ordinary_patch_is_conflict/1,
         fun rename_class_two_renames_colliding_on_new_path_is_conflict/1,
+        fun rename_class_new_path_collides_with_other_rename_old_path_is_conflict/1,
         fun rename_class_resumes_after_simulated_partial_phase_b/1,
         fun flush_two_rejects_non_boolean_confirm/1,
         fun flush_kinds_two_rejects_non_boolean_confirm/1,
@@ -2290,6 +2291,54 @@ rename_class_two_renames_colliding_on_new_path_is_conflict(#{proj_dir := ProjDir
         ?_assertEqual(true, filelib:is_regular(OldPath2)),
         ?_assertEqual(false, filelib:is_regular(SharedNewPath)),
         ?_assertEqual(false, filelib:is_regular(SharedNewPath ++ ".tmp")),
+        ?_assertNot(entry_flushed(Seq1)),
+        ?_assertNot(entry_flushed(Seq2))
+    ].
+
+%% BT-3526 review round 2 Blocker: the write-vs-write guard above does not
+%% catch the more dangerous shape — entry A's `new_path` equal to entry B's
+%% `old_path`. Phase B's `move` commit unlinks `old_path` only AFTER its own
+%% `new_path.tmp` rename succeeds, so committing A (writes `bar.bt`) then B
+%% (unlinks its own `old_path`, `bar.bt`) would silently destroy the content
+%% A just wrote there — both entries would still report as cleanly flushed.
+%% This must be refused up front, exactly like the write-vs-write case.
+rename_class_new_path_collides_with_other_rename_old_path_is_conflict(#{proj_dir := ProjDir}) ->
+    OldPath1 = filename:join([ProjDir, "src", "foo.bt"]),
+    SharedPath = filename:join([ProjDir, "src", "bar.bt"]),
+    NewPath2 = filename:join([ProjDir, "src", "baz.bt"]),
+    OldSource1 = <<"Object subclass: Foo\nend\n">>,
+    OldSource2 = <<"Object subclass: Bar\nend\n">>,
+    ok = file:write_file(OldPath1, OldSource1),
+    ok = file:write_file(SharedPath, OldSource2),
+    {DeclStart1, DeclEnd1, _} = locate(OldSource1, <<"Foo">>),
+    %% Entry A: Foo (foo.bt) -> X, writing its new content to SharedPath.
+    DeclSite1 = rename_site(list_to_binary(OldPath1), DeclStart1, DeclEnd1, <<"X">>, <<"Foo">>),
+    {DeclStart2, DeclEnd2, _} = locate(OldSource2, <<"Bar">>),
+    %% Entry B: Bar (SharedPath) -> Y, moving AWAY from the exact file A is
+    %% about to write into.
+    DeclSite2 = rename_site(list_to_binary(SharedPath), DeclStart2, DeclEnd2, <<"Y">>, <<"Bar">>),
+    {ok, Seq1} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"X">>, <<"Foo">>, list_to_binary(OldPath1), list_to_binary(SharedPath), [DeclSite1]
+        )
+    ),
+    {ok, Seq2} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Y">>, <<"Bar">>, list_to_binary(SharedPath), list_to_binary(NewPath2), [DeclSite2]
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    Conflicts = maps:get(conflicts, Summary),
+    [
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assert(length(Conflicts) >= 1),
+        ?_assertEqual(<<"mixed_rename_and_rename_edit">>, maps:get(reason, hd(Conflicts))),
+        %% Whole batch aborted — neither original file touched, and Bar's
+        %% real content (at SharedPath) was never clobbered or moved.
+        ?_assertEqual(true, filelib:is_regular(OldPath1)),
+        ?_assertEqual({ok, OldSource2}, file:read_file(SharedPath)),
+        ?_assertEqual(false, filelib:is_regular(NewPath2)),
+        ?_assertEqual(false, filelib:is_regular(SharedPath ++ ".tmp")),
         ?_assertNot(entry_flushed(Seq1)),
         ?_assertNot(entry_flushed(Seq2))
     ].

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
@@ -101,6 +101,7 @@ flush_test_() ->
         fun rename_class_external_edit_on_declaration_aborts_with_no_partial_writes/1,
         fun rename_class_external_edit_on_reference_site_aborts_with_no_partial_writes/1,
         fun rename_class_mixed_with_ordinary_patch_is_conflict/1,
+        fun rename_class_two_renames_colliding_on_new_path_is_conflict/1,
         fun rename_class_resumes_after_simulated_partial_phase_b/1,
         fun flush_two_rejects_non_boolean_confirm/1,
         fun flush_kinds_two_rejects_non_boolean_confirm/1,
@@ -131,6 +132,222 @@ new_class_directory_target_test_() ->
 
 mark_flushed_failure_test_() ->
     {setup, fun setup/0, fun cleanup/1, fun mark_flushed_failure_is_reported/1}.
+
+%% BT-3526 review Blocker regression coverage: a REAL compiled class (not a
+%% ChangeLog-entry fixture) is required here, unlike every other test in this
+%% module — the bug is specifically that a rename-class flush commit never
+%% recompiled the renamed class, leaving its compiled module's `beamtalk_source`
+%% attribute pointing at the pre-move path. Heavier suite-level setup mirrors
+%% `beamtalk_workspace_revert_tests.erl`'s own `suite_setup/0` /
+%% `case_setup/0` split (start the compiler + runtime once; an isolated
+%% workspace + temp HOME per case).
+rename_class_reload_test_() ->
+    {setup, fun reload_suite_setup/0, fun reload_suite_teardown/1,
+        {foreach, fun reload_case_setup/0, fun reload_case_teardown/1, [
+            fun rename_class_move_commit_refreshes_stale_source_attribute/1,
+            fun rename_class_sequential_rename_after_flush_succeeds/1
+        ]}}.
+
+reload_suite_setup() ->
+    {ok, _} = application:ensure_all_started(compiler),
+    ok = ensure_beamtalk_runtime_started(),
+    case application:ensure_all_started(beamtalk_compiler) of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
+    %% Let the runtime register bootstrap classes before compiling user code
+    %% (mirrors beamtalk_workspace_revert_tests:suite_setup/0).
+    timer:sleep(300),
+    ok.
+
+%% Never tear down or restart a shared, already-live runtime here — this
+%% module runs alongside every other `beamtalk_workspace` EUnit module in one
+%% shared-VM `rebar3 eunit --app=beamtalk_workspace` invocation, and other
+%% test modules' own bootstrap (e.g. `beamtalk_test_boot:boot_real_stdlib/1`)
+%% may already have booted the runtime and be relying on that SAME instance
+%% staying up for the rest of the run; killing it here to force our own clean
+%% start would orphan that state for everything that runs after us (an
+%% earlier version of this fix did exactly that and cost 36 unrelated test
+%% failures elsewhere in the app suite — `Integer`/`Subprocess` no longer
+%% registered — found by running `rebar3 eunit --app=beamtalk_workspace`,
+%% not just this module in isolation).
+%%
+%% `'Object'` already resolving is the signal that some prior boot (this
+%% run's own, or another test module's) already did the work — reuse it
+%% as-is. Only when NOTHING is up yet do we attempt our own start, in which
+%% case this module's own lightweight `announce_flush_completed_emits_typed_
+%% event_test/0` may have already brought up `beamtalk_announcements`
+%% standalone/unsupervised (its own `ensure_started/0` contract, meant for a
+%% bare BUnit/REPL context with no full runtime) — blocking `beamtalk_
+%% runtime`'s supervisor from starting its OWN, properly-supervised child
+%% under the same registered name. Stopping it is safe ONLY in this branch:
+%% since `'Object'` is not yet registered, nothing else in this run can be
+%% relying on that standalone instance either.
+ensure_beamtalk_runtime_started() ->
+    case beamtalk_class_registry:whereis_class('Object') of
+        Pid when is_pid(Pid) ->
+            ok;
+        _NotYetBooted ->
+            case application:ensure_all_started(beamtalk_runtime) of
+                {ok, _} ->
+                    ok;
+                {error, _Reason} ->
+                    case whereis(beamtalk_announcements) of
+                        undefined ->
+                            error(beamtalk_runtime_start_failed);
+                        AnnouncementsPid ->
+                            stop(AnnouncementsPid),
+                            {ok, _} = application:ensure_all_started(beamtalk_runtime),
+                            ok
+                    end
+            end
+    end.
+
+reload_suite_teardown(_) ->
+    _ = application:stop(beamtalk_compiler),
+    ok.
+
+reload_case_setup() ->
+    Unique = os:getpid() ++ "-" ++ integer_to_list(erlang:unique_integer([positive])),
+    WorkspaceId = list_to_binary("test-ws-flush-reload-" ++ Unique),
+    Tmp = filename:join(temp_dir(), "bt-flush-reload-" ++ Unique),
+    ProjDir = filename:join(Tmp, "proj"),
+    ok = filelib:ensure_path(filename:join(ProjDir, "src")),
+    OldHome = os:getenv("HOME"),
+    true = os:putenv("HOME", Tmp),
+    {ok, ClogPid} = beamtalk_workspace_changelog:start_link(#{workspace_id => WorkspaceId}),
+    {ok, MetaPid} = beamtalk_workspace_meta:start_link(#{
+        workspace_id => WorkspaceId,
+        project_path => list_to_binary(ProjDir),
+        created_at => erlang:system_time(second),
+        last_activity => erlang:system_time(second)
+    }),
+    #{
+        clog_pid => ClogPid,
+        meta_pid => MetaPid,
+        workspace_id => WorkspaceId,
+        tmp_home => Tmp,
+        old_home => OldHome,
+        proj_dir => ProjDir
+    }.
+
+reload_case_teardown(#{
+    clog_pid := ClogPid, meta_pid := MetaPid, tmp_home := Tmp, old_home := OldHome
+}) ->
+    stop(MetaPid),
+    stop(ClogPid),
+    restore_home(OldHome),
+    del_tree(Tmp),
+    ok.
+
+%% Compile+load a real, in-project-backed class from `Path` (reusing the
+%% tested `beamtalk_repl_loader:reload_class_file/1` path directly, the same
+%% mechanism `Counter reload`/`:reload` and `beamtalk_workspace_revert_tests:
+%% define_project_class/3` use) so its compiled module carries a real
+%% `beamtalk_source` attribute pointing at `Path`.
+compile_project_class(Path, Source) ->
+    ok = file:write_file(Path, Source),
+    {ok, _ClassNames} = beamtalk_repl_loader:reload_class_file(Path),
+    ok.
+
+%% THE root-cause regression test. Before the fix, `beamtalk_repl_loader:
+%% class_source_file/1` for the renamed class (`Bar`) still returns
+%% `OldPath` after a successful `flush_including_destructive/0` — the
+%% compiled module was never recompiled, so its embedded `beamtalk_source`
+%% attribute is stale even though the file has genuinely moved to `NewPath`
+%% on disk. After the fix (`maybe_reload_renamed_class_source/1`), it
+%% correctly reads `NewPath`.
+rename_class_move_commit_refreshes_stale_source_attribute(#{proj_dir := ProjDir}) ->
+    OldPath = filename:join([ProjDir, "src", "foo.bt"]),
+    NewPath = filename:join([ProjDir, "src", "bar.bt"]),
+    OldSource = <<"Object subclass: Foo\n  greet => 1\n">>,
+    ok = compile_project_class(OldPath, OldSource),
+    %% Precondition: the freshly-compiled class's attribute matches reality —
+    %% the bug only manifests once the file has moved out from under it.
+    PreSourceFile = beamtalk_repl_loader:class_source_file(<<"Foo">>),
+    {DeclStart, DeclEnd, _} = locate(OldSource, <<"Foo">>),
+    DeclSite = rename_site(list_to_binary(OldPath), DeclStart, DeclEnd, <<"Bar">>, <<"Foo">>),
+    {ok, _Seq} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Bar">>, <<"Foo">>, list_to_binary(OldPath), list_to_binary(NewPath), [DeclSite]
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    PostSourceFile = beamtalk_repl_loader:class_source_file(<<"Bar">>),
+    [
+        ?_assertEqual(list_to_binary(OldPath), PreSourceFile),
+        ?_assertEqual(1, maps:get(flushed, Summary)),
+        ?_assertEqual([], maps:get(conflicts, Summary)),
+        ?_assertEqual(false, filelib:is_regular(OldPath)),
+        ?_assertEqual(true, filelib:is_regular(NewPath)),
+        %% THE fix: the renamed class's own sourceFile attribute now reflects
+        %% where the file actually lives, not the pre-move path.
+        ?_assertEqual(list_to_binary(NewPath), PostSourceFile)
+    ].
+
+%% The full sequential-rename scenario (BT-3526 Blocker) at the flush level:
+%% `OldPath2` is read from the class's REAL, current `class_source_file/1`
+%% attribute — exactly what `beamtalk_behaviour_intrinsics:classRenameTo/2`'s
+%% `capture_class_removal_snapshot/1` reads in production — rather than a
+%% value hardcoded by the test. Before the fix that attribute is stale
+%% (`OldPath1`, already deleted by the first flush's move-commit) and this
+%% second flush would hit the unresolvable `source_missing` conflict the
+%% Blocker describes; after the fix it correctly reads `NewPath1` (still
+%% present) and the second flush completes cleanly. This is what makes the
+%% test a genuine regression test for the ROOT CAUSE rather than one that
+%% tests around it (see BT-3526's own note on this distinction) — it
+%% exercises the same read path the bug is about, even though it does not
+%% go through `classRenameTo/2` itself.
+rename_class_sequential_rename_after_flush_succeeds(#{proj_dir := ProjDir}) ->
+    OldPath1 = filename:join([ProjDir, "src", "foo.bt"]),
+    NewPath1 = filename:join([ProjDir, "src", "bar.bt"]),
+    NewPath2 = filename:join([ProjDir, "src", "baz.bt"]),
+    OldSource = <<"Object subclass: Foo\n  greet => 1\n">>,
+    ok = compile_project_class(OldPath1, OldSource),
+    {Decl1Start, Decl1End, _} = locate(OldSource, <<"Foo">>),
+    DeclSite1 = rename_site(list_to_binary(OldPath1), Decl1Start, Decl1End, <<"Bar">>, <<"Foo">>),
+    {ok, _Seq1} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Bar">>, <<"Foo">>, list_to_binary(OldPath1), list_to_binary(NewPath1), [DeclSite1]
+        )
+    ),
+    {ok, Summary1} = beamtalk_workspace_flush:flush_including_destructive(),
+    %% The class's REAL current sourceFile — correct (NewPath1) after the
+    %% fix, stale (OldPath1, already deleted) without it. Coerced to `<<>>`
+    %% on a non-binary result (the class was never even reloaded, i.e. the
+    %% fix never ran) so this constructs a well-formed, if wrong, ChangeLog
+    %% entry rather than crashing on `binary_to_list(nil)` below — the
+    %% second flush then reports a clean `source_missing` conflict instead
+    %% of an opaque test-body exception, and either way `Summary2` fails the
+    %% "flushed with no conflicts" assertions below.
+    OldPath2 =
+        case beamtalk_repl_loader:class_source_file(<<"Bar">>) of
+            Bin when is_binary(Bin) -> Bin;
+            _NotReloaded -> <<>>
+        end,
+    {ok, BarBodyOnDisk} = file:read_file(NewPath1),
+    {Decl2Start, Decl2End, _} = locate(BarBodyOnDisk, <<"Bar">>),
+    DeclSite2 = rename_site(OldPath2, Decl2Start, Decl2End, <<"Baz">>, <<"Bar">>),
+    {ok, _Seq2} = beamtalk_workspace_changelog:append(
+        rename_class_input(<<"Baz">>, <<"Bar">>, OldPath2, list_to_binary(NewPath2), [DeclSite2])
+    ),
+    {ok, Summary2} = beamtalk_workspace_flush:flush_including_destructive(),
+    [
+        ?_assertEqual(1, maps:get(flushed, Summary1)),
+        ?_assertEqual([], maps:get(conflicts, Summary1)),
+        %% The precise assertion this whole scenario is about: the second
+        %% rename's old_path (read from the live class, as production code
+        %% does) must be the CURRENT file (NewPath1), not the already-deleted
+        %% OldPath1.
+        ?_assertEqual(list_to_binary(NewPath1), OldPath2),
+        ?_assertEqual(1, maps:get(flushed, Summary2)),
+        ?_assertEqual([], maps:get(conflicts, Summary2)),
+        ?_assertEqual(false, filelib:is_regular(NewPath1)),
+        ?_assertEqual(true, filelib:is_regular(NewPath2)),
+        ?_assertEqual(
+            {ok, <<"Object subclass: Baz\n  greet => 1\n">>}, file:read_file(NewPath2)
+        )
+    ].
 
 setup() ->
     {WorkspaceId, TmpHome, OldHome} = fresh_workspace(),
@@ -2019,6 +2236,62 @@ rename_class_mixed_with_ordinary_patch_is_conflict(#{proj_dir := ProjDir}) ->
         ?_assertEqual({ok, RefSource}, file:read_file(RefPath)),
         ?_assertNot(entry_flushed(RenameSeq)),
         ?_assertNot(entry_flushed(PatchSeq))
+    ].
+
+%% BT-3526 review Suggestion: two INDEPENDENT rename-class entries (different
+%% classes, different `old_path`s) whose `new_path`s happen to coincide must
+%% conflict the same way a rename-vs-ordinary-patch collision does — a `.tmp`
+%% write from one would otherwise silently clobber the other's. Unreachable
+%% via the real `classRenameTo/2` primitive today (its own collision refusal
+%% prevents two co-pending renames targeting the same class name), but
+%% `resolve_new_path/1` explicitly records `new_path` when the entry itself
+%% supplies one, so a future producer that does could construct exactly this
+%% shape — constructed directly here the same way `resolve_new_path_prefers_
+%% recorded_value/0` does.
+rename_class_two_renames_colliding_on_new_path_is_conflict(#{proj_dir := ProjDir}) ->
+    OldPath1 = filename:join([ProjDir, "src", "foo.bt"]),
+    OldPath2 = filename:join([ProjDir, "src", "bar.bt"]),
+    SharedNewPath = filename:join([ProjDir, "src", "shared.bt"]),
+    OldSource1 = <<"Object subclass: Foo\nend\n">>,
+    OldSource2 = <<"Object subclass: Bar\nend\n">>,
+    ok = file:write_file(OldPath1, OldSource1),
+    ok = file:write_file(OldPath2, OldSource2),
+    {DeclStart1, DeclEnd1, _} = locate(OldSource1, <<"Foo">>),
+    DeclSite1 = rename_site(list_to_binary(OldPath1), DeclStart1, DeclEnd1, <<"X">>, <<"Foo">>),
+    {DeclStart2, DeclEnd2, _} = locate(OldSource2, <<"Bar">>),
+    DeclSite2 = rename_site(list_to_binary(OldPath2), DeclStart2, DeclEnd2, <<"Y">>, <<"Bar">>),
+    {ok, Seq1} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"X">>,
+            <<"Foo">>,
+            list_to_binary(OldPath1),
+            list_to_binary(SharedNewPath),
+            [DeclSite1]
+        )
+    ),
+    {ok, Seq2} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Y">>,
+            <<"Bar">>,
+            list_to_binary(OldPath2),
+            list_to_binary(SharedNewPath),
+            [DeclSite2]
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    Conflicts = maps:get(conflicts, Summary),
+    [
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assert(length(Conflicts) >= 1),
+        ?_assertEqual(<<"mixed_rename_and_rename_edit">>, maps:get(reason, hd(Conflicts))),
+        %% Whole batch aborted — neither original file moved, and the shared
+        %% target was never written.
+        ?_assertEqual(true, filelib:is_regular(OldPath1)),
+        ?_assertEqual(true, filelib:is_regular(OldPath2)),
+        ?_assertEqual(false, filelib:is_regular(SharedNewPath)),
+        ?_assertEqual(false, filelib:is_regular(SharedNewPath ++ ".tmp")),
+        ?_assertNot(entry_flushed(Seq1)),
+        ?_assertNot(entry_flushed(Seq2))
     ].
 
 %% Crash-recovery / partial-Phase-B-then-retry (ADR 0114 § "Atomicity (class

--- a/tests/repl-protocol/cases/rename_class_flush_roundtrip.btscript
+++ b/tests/repl-protocol/cases/rename_class_flush_roundtrip.btscript
@@ -1,0 +1,261 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-3271 (ADR 0114 Phase 2, class-rename multi-file flush): required e2e
+// validation for the full `renameTo:` + `Workspace flushIncludingDestructive`
+// chain against a real, file-backed class with a cross-file reference.
+//
+// `Behaviour>>renameTo:` (BT-3278) only ever produces a `flushable: true`
+// `'rename-class'` ChangeLog entry for a class the xref index actually
+// covers — an ordinary in-project class, not a BUnit fixture (BUnit's
+// `beamtalk test` runner has no project configured at all, so every
+// compiled `.bt` fixture there classifies as "dependency" and `renameTo:`
+// correctly refuses it before any mutation — see
+// `stdlib/test/rename_to_test.bt`'s own doc comment). This harness DOES run
+// with a real project path (`beamtalk_workspace_meta`'s `project_path`,
+// already relied on by `remove_class_flush_roundtrip.btscript`), so it is
+// the one place the full disk-flush half of BT-3271's acceptance criteria
+// can actually be exercised end to end, mirroring that companion test's own
+// "write a real .bt file inside the project tree, `Workspace load:` it"
+// pattern.
+//
+// Two files, one reference relationship (mirrors
+// `beamtalk_behaviour_intrinsics_rename_to_tests.erl`'s own fixture graph,
+// EUnit-side coverage of the identical mechanism):
+//
+//   Bt3271RenameFlushDemo.bt:
+//     Value subclass: Bt3271RenameFlushDemo
+//       greet -> String => "hi from the rename-flush e2e"
+//
+//   Bt3271RenameFlushDemoUser.bt (references the class being renamed):
+//     Value subclass: Bt3271RenameFlushDemoUser
+//       makeDemo -> Bt3271RenameFlushDemo => Bt3271RenameFlushDemo new
+//
+// After `Bt3271RenameFlushDemo renameTo: #Bt3271RenameFlushDemoRenamed` and
+// `Workspace flushIncludingDestructive`:
+//   - `Bt3271RenameFlushDemo.bt` is gone; `Bt3271RenameFlushDemoRenamed.bt`
+//     exists with its declaration line rewritten (rest byte-identical).
+//   - `Bt3271RenameFlushDemoUser.bt`'s cross-file reference is rewritten too.
+//   - Reloading the renamed class and its referrer from their new paths
+//     resolves cleanly — no dangling `class_not_found`.
+
+// ===========================================================================
+// CLEAN START
+// ===========================================================================
+
+Workspace changes clear
+// => _
+
+Workspace changes isEmpty
+// => true
+
+// ===========================================================================
+// STEP 1 — WRITE TWO REAL .bt FILES INSIDE THE PROJECT TREE AND LOAD THEM
+// ===========================================================================
+
+_meta := ((Erlang beamtalk_workspace_meta) get_metadata) unwrap
+// => _
+
+_projectPath := Erlang maps get: #project_path with: _meta
+// => _
+
+_projDir := _projectPath ++ "/bt_e2e_rename_class_flush_" ++ (Erlang erlang) unique_integer asString
+// => _
+
+(Erlang filelib) ensure_dir: (_projDir ++ "/.keep")
+// => Result ok: nil
+
+_demoPath := _projDir ++ "/Bt3271RenameFlushDemo.bt"
+// => _
+
+_userPath := _projDir ++ "/Bt3271RenameFlushDemoUser.bt"
+// => _
+
+// A genuine LF byte built via the Erlang FFI (BT-3214: `(Character value:
+// 10) asString` empirically returns the two-character string "10" here, not
+// a newline — see `remove_class_flush_roundtrip.btscript`'s identical note).
+_nl := (Erlang unicode) characters_to_binary: #(10)
+// => _
+
+_demoSource := "Value subclass: Bt3271RenameFlushDemo" ++ _nl ++ "  greet -> String => ""hi from the rename-flush e2e"""
+// => _
+
+_userSource := "Value subclass: Bt3271RenameFlushDemoUser" ++ _nl ++ "  makeDemo -> Bt3271RenameFlushDemo => Bt3271RenameFlushDemo new"
+// => _
+
+File writeAll: _demoPath contents: _demoSource
+// => Result ok: nil
+
+File writeAll: _userPath contents: _userSource
+// => Result ok: nil
+
+Workspace load: _demoPath
+// => _
+
+Workspace load: _userPath
+// => _
+
+Object allSubclasses includes: Bt3271RenameFlushDemo
+// => true
+
+Bt3271RenameFlushDemoUser new makeDemo greet
+// => hi from the rename-flush e2e
+
+// ===========================================================================
+// STEP 2 — renameTo: RE-REGISTERS IN MEMORY AND LOGS A rename-class ENTRY
+// (ADR 0114 Phase 2, BT-3278)
+// ===========================================================================
+
+Bt3271RenameFlushDemo renameTo: #Bt3271RenameFlushDemoRenamed
+// => _
+
+Object allSubclasses includes: Bt3271RenameFlushDemoRenamed
+// => true
+
+Bt3271RenameFlushDemoUser new makeDemo greet
+// => hi from the rename-flush e2e
+
+_renameEntry := (Workspace changes select: [:e | e className =:= #Bt3271RenameFlushDemoRenamed]) first
+// => _
+
+_renameEntry kind
+// => rename-class
+
+_renameEntry isFlushable
+// => true
+
+// The in-memory rename does not touch disk — only flush does.
+File exists: _demoPath
+// => true
+
+File exists: _userPath
+// => true
+
+// ===========================================================================
+// STEP 3 — Workspace flush REPORTS IT skipped: destructive, FILES SURVIVE
+// (ADR 0113 Phase 2 tier reused verbatim by ADR 0114 Phase 2)
+// ===========================================================================
+
+_tier1Flush := Workspace flush
+// => _
+
+Erlang maps get: #flushed with: _tier1Flush
+// => 0
+
+_skipped := Erlang maps get: #skipped with: _tier1Flush
+// => _
+
+_skipped size
+// => 1
+
+_skippedFirst := _skipped first
+// => _
+
+Erlang maps get: #reason with: _skippedFirst
+// => destructive
+
+File exists: _demoPath
+// => true
+
+// ===========================================================================
+// STEP 4 — Workspace flushIncludingDestructive MOVES THE FILE AND REWRITES
+// THE CROSS-FILE REFERENCE (ADR 0114 Phase 2, BT-3271)
+// ===========================================================================
+
+_destructiveFlush := Workspace flushIncludingDestructive
+// => _
+
+Erlang maps get: #flushed with: _destructiveFlush
+// => 1
+
+(Erlang maps get: #skipped with: _destructiveFlush) isEmpty
+// => true
+
+(Erlang maps get: #conflicts with: _destructiveFlush) isEmpty
+// => true
+
+Workspace changes isEmpty
+// => true
+
+// The old file is gone; the moved file exists with the declaration rewritten
+// and the rest of the body byte-identical.
+File exists: _demoPath
+// => false
+
+_renamedPath := _projDir ++ "/Bt3271RenameFlushDemoRenamed.bt"
+// => _
+
+File exists: _renamedPath
+// => true
+
+_renamedBody := (File readAll: _renamedPath) unwrap
+// => _
+
+_expectedRenamedSource := "Value subclass: Bt3271RenameFlushDemoRenamed" ++ _nl ++ "  greet -> String => ""hi from the rename-flush e2e"""
+// => _
+
+_renamedBody =:= _expectedRenamedSource
+// => true
+
+// The referencing file's cross-file reference was rewritten too.
+_userBody := (File readAll: _userPath) unwrap
+// => _
+
+_expectedUserSource := "Value subclass: Bt3271RenameFlushDemoUser" ++ _nl ++ "  makeDemo -> Bt3271RenameFlushDemoRenamed => Bt3271RenameFlushDemoRenamed new"
+// => _
+
+_userBody =:= _expectedUserSource
+// => true
+
+// ===========================================================================
+// STEP 5 — NO DANGLING class_not_found: A FRESH RE-LOAD OF BOTH (NOW-MOVED)
+// FILES RESOLVES CLEANLY — the end-to-end point of this test.
+// ===========================================================================
+
+Bt3271RenameFlushDemoRenamed removeFromSystem
+// => nil
+
+Bt3271RenameFlushDemoUser removeFromSystem
+// => nil
+
+Workspace changes clear
+// => _
+
+Workspace load: _renamedPath
+// => _
+
+Workspace load: _userPath
+// => _
+
+Bt3271RenameFlushDemoUser new makeDemo greet
+// => hi from the rename-flush e2e
+
+Bt3271RenameFlushDemoUser new makeDemo class name
+// => Bt3271RenameFlushDemoRenamed
+
+// The old name no longer resolves to anything — renamed away, and its file
+// no longer exists on disk for a fresh compiler/REPL run to find either.
+Bt3271RenameFlushDemo
+// => ERROR: Class 'Bt3271RenameFlushDemo' not found
+
+// ===========================================================================
+// CLEANUP
+// ===========================================================================
+
+Bt3271RenameFlushDemoRenamed removeFromSystem
+// => nil
+
+Bt3271RenameFlushDemoUser removeFromSystem
+// => nil
+
+(Erlang file) delete: _renamedPath
+// => _
+
+(Erlang file) delete: _userPath
+// => _
+
+(Erlang file) del_dir: _projDir
+// => Result ok: nil
+
+Workspace changes clear
+// => _

--- a/tests/repl-protocol/cases/rename_class_flush_sequential_rename.btscript
+++ b/tests/repl-protocol/cases/rename_class_flush_sequential_rename.btscript
@@ -1,0 +1,186 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-3526 (review Blocker on PR #3526, class-rename multi-file flush, ADR
+// 0114 Phase 2): rename a class, flush, then rename the SAME class again and
+// flush again — entirely ordinary usage, not a race or external-tooling
+// scenario.
+//
+// The bug: `Behaviour>>renameTo:` (BT-3278) computes `old_path` for its
+// ChangeLog entry by reading the class's compiled BEAM module's embedded
+// `beamtalk_source` attribute (`sourceFile`) — a value baked in at the point
+// the class was last recompiled, NOT refreshed by a physical file move.
+// `Workspace flushIncludingDestructive` moves the file on disk (renaming
+// `<new_path>.tmp` into place and unlinking `old_path`) but, before this
+// fix, never recompiled the renamed class — so its `sourceFile` attribute
+// kept pointing at the now-deleted pre-move path. A SECOND `renameTo:` on
+// that same class would then compute a stale, already-gone `old_path`, and
+// the second flush could never resolve it (`reason => "source_missing"`)
+// even though the file's real, current content sat at the FIRST rename's
+// `new_path` the entire time.
+//
+// This is the real, reachable path a user would hit — unlike
+// `beamtalk_workspace_flush_tests.erl`'s EUnit-level coverage of the same
+// fix (which constructs ChangeLog entries directly and therefore cannot, by
+// itself, prove the real `beamtalk_source` attribute staleness this bug is
+// actually about), this script goes through the REAL `renameTo:` primitive
+// twice, with a real flush in between, against a real project file.
+
+// ===========================================================================
+// CLEAN START
+// ===========================================================================
+
+Workspace changes clear
+// => _
+
+Workspace changes isEmpty
+// => true
+
+// ===========================================================================
+// STEP 1 — WRITE A REAL .bt FILE INSIDE THE PROJECT TREE AND LOAD IT
+// ===========================================================================
+
+_meta := ((Erlang beamtalk_workspace_meta) get_metadata) unwrap
+// => _
+
+_projectPath := Erlang maps get: #project_path with: _meta
+// => _
+
+_projDir := _projectPath ++ "/bt_e2e_rename_class_sequential_" ++ (Erlang erlang) unique_integer asString
+// => _
+
+(Erlang filelib) ensure_dir: (_projDir ++ "/.keep")
+// => Result ok: nil
+
+_fooPath := _projDir ++ "/Bt3526SeqRenameFoo.bt"
+// => _
+
+_nl := (Erlang unicode) characters_to_binary: #(10)
+// => _
+
+_fooSource := "Value subclass: Bt3526SeqRenameFoo" ++ _nl ++ "  greet -> String => ""hi from the sequential rename e2e"""
+// => _
+
+File writeAll: _fooPath contents: _fooSource
+// => Result ok: nil
+
+Workspace load: _fooPath
+// => _
+
+Bt3526SeqRenameFoo new greet
+// => hi from the sequential rename e2e
+
+// ===========================================================================
+// STEP 2 — FIRST renameTo:: Foo -> Bar. Before the file has moved, the
+// class's own sourceFile attribute still (correctly) points at _fooPath —
+// this is the moment described in the bug report as "correctly reflecting
+// reality AT THAT MOMENT".
+// ===========================================================================
+
+Bt3526SeqRenameFoo renameTo: #Bt3526SeqRenameBar
+// => _
+
+(Bt3526SeqRenameBar sourceFile) =:= _fooPath
+// => true
+
+// ===========================================================================
+// STEP 3 — FIRST FLUSH: commits the move (_fooPath -> _barPath on disk).
+// THE FIX under test: this must also refresh Bar's own compiled sourceFile
+// attribute to the NEW path, not leave it stale.
+// ===========================================================================
+
+_flush1 := Workspace flushIncludingDestructive
+// => _
+
+Erlang maps get: #flushed with: _flush1
+// => 1
+
+(Erlang maps get: #conflicts with: _flush1) isEmpty
+// => true
+
+_barPath := _projDir ++ "/Bt3526SeqRenameBar.bt"
+// => _
+
+File exists: _fooPath
+// => false
+
+File exists: _barPath
+// => true
+
+// THE FIX (BT-3526): Bar's own sourceFile attribute now correctly reflects
+// the moved file, not the stale pre-move path.
+(Bt3526SeqRenameBar sourceFile) =:= _barPath
+// => true
+
+// ===========================================================================
+// STEP 4 — SECOND renameTo:: Bar -> Baz. Without the fix, classRenameTo:
+// would compute old_path from Bar's (stale) sourceFile attribute (_fooPath,
+// already deleted in step 3) instead of the real current file (_barPath).
+// ===========================================================================
+
+Bt3526SeqRenameBar renameTo: #Bt3526SeqRenameBaz
+// => _
+
+Workspace changes notEmpty
+// => true
+
+// ===========================================================================
+// STEP 5 — SECOND FLUSH must complete cleanly — no stuck, unresolvable
+// entry, and no "Something external deleted both" conflict over a file
+// (_barPath) that plainly still existed the whole time.
+// ===========================================================================
+
+_flush2 := Workspace flushIncludingDestructive
+// => _
+
+Erlang maps get: #flushed with: _flush2
+// => 1
+
+_conflicts2 := Erlang maps get: #conflicts with: _flush2
+// => _
+
+_conflicts2 isEmpty
+// => true
+
+_bazPath := _projDir ++ "/Bt3526SeqRenameBaz.bt"
+// => _
+
+File exists: _barPath
+// => false
+
+File exists: _bazPath
+// => true
+
+_bazBody := (File readAll: _bazPath) unwrap
+// => _
+
+_expectedBazSource := "Value subclass: Bt3526SeqRenameBaz" ++ _nl ++ "  greet -> String => ""hi from the sequential rename e2e"""
+// => _
+
+_bazBody =:= _expectedBazSource
+// => true
+
+Workspace changes isEmpty
+// => true
+
+Object allSubclasses includes: Bt3526SeqRenameBaz
+// => true
+
+Bt3526SeqRenameBaz new greet
+// => hi from the sequential rename e2e
+
+// ===========================================================================
+// CLEANUP
+// ===========================================================================
+
+Bt3526SeqRenameBaz removeFromSystem
+// => nil
+
+(Erlang file) delete: _bazPath
+// => _
+
+(Erlang file) del_dir: _projDir
+// => Result ok: nil
+
+Workspace changes clear
+// => _

--- a/tests/repl-protocol/cases/rename_class_flush_staleness_aborts.btscript
+++ b/tests/repl-protocol/cases/rename_class_flush_staleness_aborts.btscript
@@ -1,0 +1,173 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-3271 (ADR 0114 Phase 2, class-rename multi-file flush): required e2e
+// validation for the OTHER half of the acceptance criteria —
+// `rename_class_flush_roundtrip.btscript` covers the happy path; this
+// covers "a forced Phase A staleness (edit a target span externally between
+// rename and flush) aborts cleanly with no partial writes."
+//
+// Same two-file fixture shape as the companion roundtrip test (a class and
+// one in-project referrer), but the class's own declaration line is edited
+// externally — by a tool other than this workspace, e.g. another editor or
+// `git checkout` — after `renameTo:` has already computed and recorded the
+// rewrite, and before `Workspace flushIncludingDestructive` runs. Phase A's
+// external-edit check must catch this BEFORE any file is touched: neither
+// the (would-be) moved file nor the referencing file's rewrite reaches
+// disk, the original file survives with the externally-edited content
+// intact (flush never overwrites what it didn't validate), and the pending
+// entry stays in `Workspace changes` for the caller to resolve.
+
+// ===========================================================================
+// CLEAN START
+// ===========================================================================
+
+Workspace changes clear
+// => _
+
+Workspace changes isEmpty
+// => true
+
+// ===========================================================================
+// STEP 1 — WRITE TWO REAL .bt FILES INSIDE THE PROJECT TREE AND LOAD THEM
+// ===========================================================================
+
+_meta := ((Erlang beamtalk_workspace_meta) get_metadata) unwrap
+// => _
+
+_projectPath := Erlang maps get: #project_path with: _meta
+// => _
+
+_projDir := _projectPath ++ "/bt_e2e_rename_class_staleness_" ++ (Erlang erlang) unique_integer asString
+// => _
+
+(Erlang filelib) ensure_dir: (_projDir ++ "/.keep")
+// => Result ok: nil
+
+_demoPath := _projDir ++ "/Bt3271StaleRenameDemo.bt"
+// => _
+
+_userPath := _projDir ++ "/Bt3271StaleRenameDemoUser.bt"
+// => _
+
+_nl := (Erlang unicode) characters_to_binary: #(10)
+// => _
+
+_demoSource := "Value subclass: Bt3271StaleRenameDemo" ++ _nl ++ "  greet -> String => ""hi from the staleness e2e"""
+// => _
+
+_userSource := "Value subclass: Bt3271StaleRenameDemoUser" ++ _nl ++ "  makeDemo -> Bt3271StaleRenameDemo => Bt3271StaleRenameDemo new"
+// => _
+
+File writeAll: _demoPath contents: _demoSource
+// => Result ok: nil
+
+File writeAll: _userPath contents: _userSource
+// => Result ok: nil
+
+Workspace load: _demoPath
+// => _
+
+Workspace load: _userPath
+// => _
+
+// ===========================================================================
+// STEP 2 — renameTo: RECORDS THE REWRITE (IN MEMORY ONLY — NO DISK WRITE YET)
+// ===========================================================================
+
+Bt3271StaleRenameDemo renameTo: #Bt3271StaleRenameDemoRenamed
+// => _
+
+Workspace changes notEmpty
+// => true
+
+// ===========================================================================
+// STEP 3 — FORCED PHASE A STALENESS: SOMETHING ELSE EDITS THE DECLARATION
+// SPAN EXTERNALLY BEFORE THE FLUSH RUNS
+// ===========================================================================
+
+_externalEdit := "Value subclass: SomeoneElseChangedThisFile" ++ _nl ++ "  totallyDifferent => 999"
+// => _
+
+File writeAll: _demoPath contents: _externalEdit
+// => Result ok: nil
+
+// ===========================================================================
+// STEP 4 — Workspace flushIncludingDestructive ABORTS CLEANLY, NO PARTIAL
+// WRITES
+// ===========================================================================
+
+_flushResult := Workspace flushIncludingDestructive
+// => _
+
+Erlang maps get: #flushed with: _flushResult
+// => 0
+
+_conflicts := Erlang maps get: #conflicts with: _flushResult
+// => _
+
+_conflicts isEmpty
+// => false
+
+_conflictFirst := _conflicts first
+// => _
+
+Erlang maps get: #reason with: _conflictFirst
+// => external_edit
+
+// Neither file was touched: the original (now externally-edited) file keeps
+// exactly the bytes the external edit wrote, and the referencing file is
+// completely untouched — no partial rewrite, no `.tmp` left behind at
+// either path.
+(File readAll: _demoPath) unwrap =:= _externalEdit
+// => true
+
+(File readAll: _userPath) unwrap =:= _userSource
+// => true
+
+_renamedPath := _projDir ++ "/Bt3271StaleRenameDemoRenamed.bt"
+// => _
+
+File exists: _renamedPath
+// => false
+
+File exists: (_demoPath ++ ".tmp")
+// => false
+
+File exists: (_renamedPath ++ ".tmp")
+// => false
+
+File exists: (_userPath ++ ".tmp")
+// => false
+
+// The pending entry stays exactly that — pending, for the caller to resolve.
+Workspace changes isEmpty
+// => false
+
+_renameEntry := (Workspace changes select: [:e | e className =:= #Bt3271StaleRenameDemoRenamed]) first
+// => _
+
+_renameEntry isActive
+// => true
+
+// ===========================================================================
+// CLEANUP
+// ===========================================================================
+
+Bt3271StaleRenameDemoRenamed removeFromSystem
+// => nil
+
+Bt3271StaleRenameDemoUser removeFromSystem
+// => nil
+
+(Erlang file) delete: _demoPath
+// => _
+
+(Erlang file) delete: _userPath
+// => _
+
+(Erlang file) del_dir: _projDir
+// => Result ok: nil
+
+Workspace changes clear
+// => _


### PR DESCRIPTION
## Summary
- Teaches `Workspace flush` / `flushIncludingDestructive` how to write a `'rename-class'` ChangeLog entry to disk (ADR 0114 Phase 2), extending ADR 0113's Tier 2 `confirmDestructive` gate to the first genuinely multi-file destructive operation.
- Phase A stages `<new_path>.tmp` (declaration line rewritten against `old_path`'s current content, folding in any self-reference the class makes to its own name in the same file) plus `<file>.tmp` per other reference site, using an **idempotent three-way splice check** (prior text / already-new text / genuine conflict) so a re-issued flush after a partial failure only rewrites what didn't already commit.
- Phase B renames `<new_path>.tmp` into place, unlinks `old_path`, then commits each remaining site in sequence — in that order, so a mid-commit failure never loses the file's content. A `'rename-class'` entry is marked flushed only once *every* file it touches has committed in the same pass.
- `new_path` is derived (preserving `old_path`'s exact-class-name-vs-`snake_case` naming convention) since `classRenameTo/2` (BT-3278, already merged) always logs it as `undefined`.
- A rename sharing a target file with a pending ordinary patch (or another rename) aborts the whole flush rather than racing the two operations — mirrors `remove-class`'s existing `mixed_remove_class_and_splice` guard.
- Adds `beamtalk_workspace_changelog:read_site_body/1` to read a rename site's own recorded ref — a `'rename-class'` entry's per-site bodies aren't reachable via the existing entry-keyed `read_source_body/1`/`read_prev_source_body/1`.

## Test plan
- [x] New EUnit coverage in `beamtalk_workspace_flush_tests.erl`: move + declaration + reference rewrite, self-reference folded into the move, external-edit staleness on the declaration site (aborts, no partial writes), external-edit staleness on a reference site (aborts, rolls back the move's own valid splice too), mixed rename + ordinary patch (conflict), and a simulated partial-Phase-B-then-resume scenario (proves idempotent retry: already-correct files are left byte-identical, the one file left behind gets fixed, no stray `.tmp` files) → 254/254, run 4× across two checkouts, consistent
- [x] Two new REPL-protocol e2e tests (`tests/repl-protocol/cases/rename_class_flush_*.btscript`) exercising the full `renameTo:` + `flushIncludingDestructive` chain against real project files — BUnit's no-project sandbox can't reach a flushable rename (per `rename_to_test.bt`'s own documented limitation), so this is where the acceptance criteria's "real .bt files on disk" scenarios actually run end to end. Covers: file moved + declaration rewritten + cross-file reference rewritten + fresh reload of both new paths resolves cleanly with no dangling `class_not_found`; and a forced Phase A staleness aborting cleanly with zero partial writes.
- [x] Full `beamtalk_workspace` app EUnit suite → 2910/2910, 0 failures
- [x] `just test-repl-protocol` (includes both new e2e files) → 3/3 passed
- [x] `just test-bunit` → 3310/3312 passed (2 pre-existing, unrelated to this change — same baseline as BT-3278's PR)
- [x] `rebar3 fmt -c` / `just lint-binary-literal-encoding` / `just lint-beamtalk` all clean
- [x] `rebar3 dialyzer` / spec validation clean (via pre-push hook)

Out of scope per issue text: method-rename flush (separate issue), the in-memory atomicity protocol (already covered by BT-3278/BT-3270) — this issue is disk-side only.

Part of Epic BT-3267 (ADR 0114). Fifth of 12 sequential issues landing on this epic branch (follows #3519 / BT-3268, #3521 / BT-3269, #3522 / BT-3270, #3523 / BT-3278).

---
_Generated by [Claude Code](https://claude.ai/code/session_016Reae4miRyBSZTm4Mbxiry)_