### PR TITLE
test: cover format_error in repl display module

### DIFF
--- a/crates/beamtalk-cli/src/commands/repl/display.rs
+++ b/crates/beamtalk-cli/src/commands/repl/display.rs
@@ -295,4 +295,24 @@ mod tests {
         let rendered = strip_ansi(&format_value(&val));
         assert_eq!(rendered, "hello");
     }
+
+    // --- format_error ---
+
+    #[test]
+    fn format_error_prefixes_message_with_error_label() {
+        let rendered = strip_ansi(&format_error("connection refused"));
+        assert_eq!(rendered, "Error: connection refused");
+    }
+
+    #[test]
+    fn format_error_empty_message_keeps_prefix() {
+        let rendered = strip_ansi(&format_error(""));
+        assert_eq!(rendered, "Error: ");
+    }
+
+    #[test]
+    fn format_error_message_containing_colon() {
+        let rendered = strip_ansi(&format_error("undefined variable: x"));
+        assert_eq!(rendered, "Error: undefined variable: x");
+    }
 }


### PR DESCRIPTION
## Summary

- Adds three Rust unit tests for `format_error` in `crates/beamtalk-cli/src/commands/repl/display.rs`, a function previously at 0% coverage
- Tests exercise the plain-text rendering path: normal message, empty message, and a message containing colons
- Uses the `strip_ansi` helper already present in the test module to make assertions color-mode-agnostic (works regardless of whether ANSI is enabled in the test environment)

**Coverage target:** `crates.beamtalk-cli.src.commands.repl` (was 43% per CI artifact run 32890114716). Lines 49–51 of `display.rs` are now covered.

## Test plan

- [x] `cargo test -p beamtalk-cli display` — all 9 tests pass (3 new + 5 pre-existing `format_value` tests)
- [x] Pre-push lint hooks pass (clippy, fmt, Beamtalk formatter, Erlang checks)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTvjcG5JbEZJ8rT4KRBe1N)_