### PR TITLE
BT-3273: Method-rename multi-file flush (Tier 2 staging)

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
@@ -22,13 +22,15 @@ Every flushable entry classifies into one of two tiers (`entry_tier/1`):
     `'new-class'`, and `'remove-method'` (excising a recorded span leaves the
     file in place, mechanically identical to a patch). Applied by ordinary
     `flush/0` / `flush/1` / `flush_kinds/1` with no gate.
-  - **Tier 2** — destroys a file: `'remove-class'`; or moves one:
-    `'rename-class'` (ADR 0114, BT-3271). Only applied when the caller passes
-    `ConfirmDestructive = true` (`flush/2`, `flush_kinds/2`) or calls the
-    unscoped `flush_including_destructive/0`. Never silently reached — no
-    workspace setting or environment variable can imply it. A pending Tier 2
-    entry left out of the applied set is reported in the summary's `skipped`
-    field with `reason => <<"destructive">>`.
+  - **Tier 2** — destroys a file: `'remove-class'`; moves one: `'rename-class'`
+    (ADR 0114, BT-3271); or rewrites a method's confirmed call sites across
+    files in place, no file moved: `'rename-method'` (ADR 0114, BT-3273).
+    Only applied when the caller passes `ConfirmDestructive = true`
+    (`flush/2`, `flush_kinds/2`) or calls the unscoped
+    `flush_including_destructive/0`. Never silently reached — no workspace
+    setting or environment variable can imply it. A pending Tier 2 entry left
+    out of the applied set is reported in the summary's `skipped` field with
+    `reason => <<"destructive">>`.
 
 ## Selection
 
@@ -199,7 +201,8 @@ forever, defeating the "retry only what's left" guarantee.
 **Per-entry, not per-file, flushed marking.** A `'rename-class'` entry is
 only marked flushed once *every* file it touches (the move's own target
 plus every other rewritten site file) has committed in the SAME Phase B
-pass — `rename_class_fully_committed/3`. A Phase B failure partway through
+pass — `multi_site_entry_fully_committed/3` (BT-3273: shared with
+`'rename-method'`). A Phase B failure partway through
 leaves the entry pending in its entirety (even though some of its files are
 now correctly on disk); the per-file `files`/`conflicts` summary still
 reports exactly which files committed, and the idempotent check above means
@@ -243,6 +246,48 @@ BT-3278). A reload failure (no compiler available, a bare runtime, or any
 other error) is logged via `?LOG_WARNING` and never fails the
 already-successful flush — see that function's own doc for the full
 rationale.
+
+## Atomicity (method rename — ADR 0114, BT-3273)
+
+A `'rename-method'` entry is also genuinely multi-file (`sites[0]` is the
+definition, `sites[1..]` are every *confirmed* self/super sender site —
+`candidate_sites` are reported for human/agent review only and are never
+staged, written, or otherwise touched by flush) but, unlike class rename, it
+has no file-move component: renaming a selector never changes which file a
+method's class lives in, so every one of its sites — including the
+definition — is an ordinary in-place splice against the file it already sits
+in. This means method rename needs none of class rename's move-specific
+machinery (`old_path`/`new_path`, staged-rename crash recovery, the
+`already gone` disambiguation) — it reuses the exact same generic
+`{site(), OwnerEntry}` splice/grouping machinery class rename's own
+*other*-site references already go through (`group_units_by_file/1`,
+`prepare_rename_site_group/2`, `apply_site_units/2`), just seeded from
+*every* site instead of only the non-declaration ones.
+
+| Phase A (stage) | Phase B (commit) |
+|---|---|
+| For every confirmed site across every pending `'rename-method'` entry, group by `sourceFile` (sites from different entries landing in the same file merge into one splice, exactly like `group_by_file/1` already does for ordinary Tier-1 entries), read each file, splice every site's `span` against its recorded `source_ref`/`prev_source_ref`, write `<file>.tmp` | Rename each `<file>.tmp` → `<file>`, in sequence — same sequential-commit, partial-failure-is-recoverable-via-re-flush shape ordinary multi-file flush already documents above |
+
+A Phase A failure on any one file (a confirmed site's recorded span no
+longer resolves against current disk content) aborts the whole batch before
+any file is renamed, cleaning up every `.tmp` already written — mirrors the
+"any conflict aborts the whole flush" rule for ordinary multi-file flush and
+class rename alike. Like `'rename-class'`, a `'rename-method'` entry is only
+counted as fully flushed (and only then marked flushed in the ChangeLog)
+once *every* file among its confirmed sites has committed in the *same*
+Phase B pass (`multi_site_entry_fully_committed/3`) — a Phase B failure
+partway through leaves the whole entry pending even though some of its files
+already landed correctly; re-flushing retries only what didn't.
+
+A `'rename-method'` entry sharing a target file with a pending ordinary
+patch, or with a pending `'rename-class'` entry's own touched files, aborts
+the whole flush (`mixed_rename_method_and_pending_edit`) — the same
+defensive posture `'rename-class'`'s own collision guards take, for the
+identical reason (reordering two different splice mechanisms against one
+file within a single Phase A/B pass is undesigned). Two `'rename-method'`
+entries sharing a file are *not* a collision: their sites simply merge into
+one splice via `group_units_by_file/1`, the same way multiple ordinary
+patches against one file already merge via `group_by_file/1`.
 
 ## Conflict detection
 
@@ -324,7 +369,10 @@ set. A pending `'remove-class'` entry left out of the applied set because
     %% ADR 0114 Phase 2 (BT-3271): rename-class multi-file staging, exported
     %% for direct unit coverage independent of a full flush round-trip.
     resolve_new_path/1,
-    is_rename_class_entry/1
+    is_rename_class_entry/1,
+    %% ADR 0114 Phase 3 (BT-3273): rename-method multi-file staging, exported
+    %% for direct unit coverage independent of a full flush round-trip.
+    is_rename_method_entry/1
 ]).
 
 -type filter() ::
@@ -677,32 +725,65 @@ run_flush(Pending, ConfirmDestructive) ->
             false -> {Tier1, Tier2}
         end,
     Skipped = [skipped_entry(E) || E <- SkippedTier2],
-    %% ADR 0114 (BT-3271): a `'rename-class'` entry's top-level `sourceFile`
-    %% is always null (schema: ambiguous for a multi-file entry) so it can
-    %% never land in `group_by_file/1`'s grouping — pulled out up front and
-    %% staged through its own multi-file pipeline instead, then merged back
-    %% into one Phase A / Phase B pass with the ordinary entries.
-    {RenameEntries, OrdinaryEntries} = lists:partition(fun is_rename_class_entry/1, ToApply),
+    %% ADR 0114 (BT-3271/BT-3273): a `'rename-class'`/`'rename-method'`
+    %% entry's top-level `sourceFile` is always null (schema: ambiguous for a
+    %% multi-file entry) so neither can ever land in `group_by_file/1`'s
+    %% grouping — both are pulled out up front and staged through their own
+    %% multi-file pipelines instead, then merged back into one Phase A /
+    %% Phase B pass with the ordinary entries.
+    {RenameClassEntries, Rest1} = lists:partition(fun is_rename_class_entry/1, ToApply),
+    {RenameMethodEntries, OrdinaryEntries} = lists:partition(fun is_rename_method_entry/1, Rest1),
     OrdinaryGroups = group_by_file(OrdinaryEntries),
-    case check_no_rename_file_collisions(RenameEntries, OrdinaryGroups) of
+    case check_no_rename_file_collisions(RenameClassEntries, OrdinaryGroups) of
         {conflict, Conflicts0} ->
             {ok, conflict_summary(Conflicts0, Skipped)};
         ok ->
-            Combined = combine_phase_a(phase_a(OrdinaryGroups), phase_a_renames(RenameEntries)),
-            case Combined of
-                {ok, Prepared} ->
-                    RenameExpectedFiles = rename_expected_files_map(RenameEntries),
-                    phase_b(Prepared, Shadowed, Skipped, RenameExpectedFiles);
-                {error, _} = Err ->
-                    Err;
-                {conflict, Conflicts} ->
-                    {ok, conflict_summary(Conflicts, Skipped)}
+            %% BT-3273: a `'rename-method'` entry must not race a pending
+            %% ordinary patch OR a pending `'rename-class'` entry over the
+            %% same file — see the moduledoc's "Atomicity (method rename)"
+            %% section.
+            OtherFiles = sets:union(
+                sets:from_list([F || {F, _} <- OrdinaryGroups], [{version, 2}]),
+                sets:from_list(
+                    lists:flatmap(fun rename_entry_all_files/1, RenameClassEntries), [{version, 2}]
+                )
+            ),
+            case
+                check_no_rename_method_file_collisions(
+                    RenameMethodEntries, OtherFiles, OrdinaryGroups
+                )
+            of
+                {conflict, Conflicts1} ->
+                    {ok, conflict_summary(Conflicts1, Skipped)};
+                ok ->
+                    Combined = combine_phase_a(
+                        combine_phase_a(
+                            phase_a(OrdinaryGroups), phase_a_renames(RenameClassEntries)
+                        ),
+                        phase_a_rename_methods(RenameMethodEntries)
+                    ),
+                    case Combined of
+                        {ok, Prepared} ->
+                            RenameExpectedFiles = maps:merge(
+                                rename_expected_files_map(RenameClassEntries),
+                                rename_method_expected_files_map(RenameMethodEntries)
+                            ),
+                            phase_b(Prepared, Shadowed, Skipped, RenameExpectedFiles);
+                        {error, _} = Err ->
+                            Err;
+                        {conflict, Conflicts} ->
+                            {ok, conflict_summary(Conflicts, Skipped)}
+                    end
             end
     end.
 
 -spec is_rename_class_entry(term()) -> boolean().
 is_rename_class_entry(E) ->
     beamtalk_workspace_changelog:entry_kind(E) =:= 'rename-class'.
+
+-spec is_rename_method_entry(term()) -> boolean().
+is_rename_method_entry(E) ->
+    beamtalk_workspace_changelog:entry_kind(E) =:= 'rename-method'.
 
 %%% ----------------------------------------------------------------------------
 %%% Tiering (ADR 0113 Phase 2)
@@ -713,15 +794,17 @@ Classify a ChangeEntry into flush's destructive-confirmation tier.
 
 Tier 1 — edits a still-existing file (`instance`, `class`, `'new-class'`,
 `'remove-method'`) — applies under ordinary `flush/0` / `flush/1` /
-`flush_kinds/1` with no gate. Tier 2 — destroys a file (`'remove-class'`) or
-moves one (`'rename-class'`, ADR 0114 BT-3271) — only applies when the
-caller passes `ConfirmDestructive = true`.
+`flush_kinds/1` with no gate. Tier 2 — destroys a file (`'remove-class'`),
+moves one (`'rename-class'`, ADR 0114 BT-3271), or rewrites a method's
+confirmed call sites across files (`'rename-method'`, ADR 0114 BT-3273) —
+only applies when the caller passes `ConfirmDestructive = true`.
 """.
 -spec entry_tier(term()) -> tier1 | tier2.
 entry_tier(E) ->
     case beamtalk_workspace_changelog:entry_kind(E) of
         'remove-class' -> tier2;
         'rename-class' -> tier2;
+        'rename-method' -> tier2;
         _ -> tier1
     end.
 
@@ -1334,7 +1417,7 @@ derive_new_path(OldPath, OldClassBin, NewClassBin) ->
 -doc """
 Per-entry expected file set: every file that must appear in a Phase B
 commit for `Entry`'s `'rename-class'` to be considered fully flushed
-(`rename_class_fully_committed/3`). Keyed by `seq` since `#prepared{}`
+(`multi_site_entry_fully_committed/3`). Keyed by `seq` since `#prepared{}`
 records carry the raw `entry()`, not a convenient lookup key.
 """.
 -spec rename_expected_files_map([term()]) -> #{non_neg_integer() => sets:set(binary())}.
@@ -1834,17 +1917,20 @@ all_units_already_applied_loop(Body, [{Site, _Entry} | Rest], Shift) ->
             false
     end.
 
-%% A rename-class entry is only considered fully flushed once EVERY file it
-%% touches (`rename_entry_all_files_to_write/1`) has committed in the SAME
-%% Phase B pass — a non-rename-class entry has no multi-file fan-out (every
-%% other kind targets exactly one file) so it trivially satisfies this the
+%% A `'rename-class'`/`'rename-method'` entry is only considered fully
+%% flushed once EVERY file it touches (`rename_entry_all_files_to_write/1` /
+%% `rename_method_entry_all_files/1`, folded together into the single
+%% `RenameExpectedFiles` map `run_flush/2` builds, keyed by seq — globally
+%% unique across every entry regardless of kind, so the two kinds' entries
+%% never collide in one map) has committed in the SAME Phase B pass — every
+%% other kind targets exactly one file, so it trivially satisfies this the
 %% moment it appears in `Committed` at all.
--spec rename_class_fully_committed(
+-spec multi_site_entry_fully_committed(
     term(), #{non_neg_integer() => sets:set(binary())}, sets:set(binary())
 ) -> boolean().
-rename_class_fully_committed(Entry, RenameExpectedFiles, CommittedFilesSet) ->
+multi_site_entry_fully_committed(Entry, RenameExpectedFiles, CommittedFilesSet) ->
     case beamtalk_workspace_changelog:entry_kind(Entry) of
-        'rename-class' ->
+        Kind when Kind =:= 'rename-class'; Kind =:= 'rename-method' ->
             Seq = beamtalk_workspace_changelog:entry_seq(Entry),
             Expected = maps:get(Seq, RenameExpectedFiles, sets:new([{version, 2}])),
             sets:is_subset(Expected, CommittedFilesSet);
@@ -1885,6 +1971,166 @@ combine_phase_a({ok, P1}, {conflict, C2}) ->
 -spec cleanup_other_prepared({ok, [#prepared{}]} | term()) -> ok.
 cleanup_other_prepared({ok, P}) -> cleanup_tmps(P);
 cleanup_other_prepared(_) -> ok.
+
+%%% ----------------------------------------------------------------------------
+%%% Method rename (Tier 2) — multi-file staged splice (ADR 0114, BT-3273)
+%%% ----------------------------------------------------------------------------
+
+-doc """
+Cross-pipeline collision guard for `'rename-method'` (ADR 0114, BT-3273):
+abort the whole flush, before any Phase A I/O runs, if a `'rename-method'`
+entry's confirmed-site files overlap any file an ordinary pending patch or a
+pending `'rename-class'` entry is about to touch in the same batch (`OtherFiles`,
+built by the caller as the union of both). Mirrors `check_no_rename_file_
+collisions/2`'s identical defensive posture for the identical reason —
+reordering two different splice mechanisms against one file within a single
+Phase A/B pass is undesigned, so it is refused rather than silently raced.
+
+Two `'rename-method'` entries sharing a file are deliberately NOT a collision
+here (unlike class rename, which guards rename-vs-rename because a move can
+race another move's own unlink) — their confirmed sites simply merge into one
+splice via `group_units_by_file/1`, the same way multiple ordinary patches
+against one file already merge via `group_by_file/1`. There is no move/unlink
+step for a method rename to race.
+""".
+-spec check_no_rename_method_file_collisions([term()], sets:set(binary()), [{binary(), [term()]}]) ->
+    ok | {conflict, [map()]}.
+check_no_rename_method_file_collisions([], _OtherFiles, _OrdinaryGroups) ->
+    ok;
+check_no_rename_method_file_collisions(RenameMethodEntries, OtherFiles, OrdinaryGroups) ->
+    Conflicts = lists:filtermap(
+        fun(Entry) -> rename_method_entry_collision(Entry, OtherFiles, OrdinaryGroups) end,
+        RenameMethodEntries
+    ),
+    case Conflicts of
+        [] -> ok;
+        _ -> {conflict, Conflicts}
+    end.
+
+-spec rename_method_entry_collision(term(), sets:set(binary()), [{binary(), [term()]}]) ->
+    {true, map()} | false.
+rename_method_entry_collision(Entry, OtherFiles, OrdinaryGroups) ->
+    case [F || F <- rename_method_entry_all_files(Entry), sets:is_element(F, OtherFiles)] of
+        [] ->
+            false;
+        [Collided | _] ->
+            %% The colliding file may belong to a pending ordinary group (in
+            %% which case its entries are worth reporting alongside this
+            %% one) or to a `'rename-class'` entry's own touched files (no
+            %% convenient group to look up here — reporting just this
+            %% entry's own seq is still an accurate, actionable conflict).
+            OrdEntries =
+                case lists:keyfind(Collided, 1, OrdinaryGroups) of
+                    {Collided, Es} -> Es;
+                    false -> []
+                end,
+            {true,
+                conflict_map(
+                    Collided,
+                    <<"mixed_rename_method_and_pending_edit">>,
+                    [Entry | OrdEntries],
+                    iolist_to_binary([
+                        <<"Cannot flush a rename-method entry (">>,
+                        beamtalk_workspace_changelog:entry_class(Entry),
+                        <<" ">>,
+                        display_selector(beamtalk_workspace_changelog:entry_old_selector(Entry)),
+                        <<" -> ">>,
+                        display_selector(beamtalk_workspace_changelog:entry_selector(Entry)),
+                        <<
+                            ") alongside a pending ordinary patch or another pending "
+                            "rename against the same file in the same operation; flush "
+                            "or discard the other pending entry first, then re-flush "
+                            "this rename"
+                        >>
+                    ])
+                )}
+    end.
+
+-spec display_selector(binary() | undefined) -> binary().
+display_selector(undefined) -> <<"?">>;
+display_selector(Sel) when is_binary(Sel) -> Sel.
+
+%% Every file a `'rename-method'` entry's CONFIRMED sites touch — the
+%% definition (`sites[0]`) plus every confirmed self/super sender
+%% (`sites[1..]`). `candidate_sites` are never consulted here (ADR 0114: they
+%% are never staged, written, or otherwise touched by flush under any
+%% circumstance).
+-spec rename_method_entry_all_files(term()) -> [binary()].
+rename_method_entry_all_files(Entry) ->
+    lists:usort([
+        maps:get(source_file, S)
+     || S <- entry_confirmed_sites(Entry), S =/= undefined
+    ]).
+
+-spec entry_confirmed_sites(term()) -> [beamtalk_workspace_changelog:site()].
+entry_confirmed_sites(Entry) ->
+    case beamtalk_workspace_changelog:entry_sites(Entry) of
+        undefined -> [];
+        Sites -> Sites
+    end.
+
+-doc """
+Per-entry expected file set for a `'rename-method'` entry: every file that
+must appear in a Phase B commit for it to be considered fully flushed
+(`multi_site_entry_fully_committed/3`). Mirrors `rename_expected_files_map/1`
+for class rename; keyed by `seq` for the same reason (`#prepared{}` records
+carry the raw `entry()`, not a convenient lookup key).
+""".
+-spec rename_method_expected_files_map([term()]) -> #{non_neg_integer() => sets:set(binary())}.
+rename_method_expected_files_map(RenameMethodEntries) ->
+    lists:foldl(
+        fun(Entry, Acc) ->
+            Seq = beamtalk_workspace_changelog:entry_seq(Entry),
+            Files = sets:from_list(rename_method_entry_all_files(Entry), [{version, 2}]),
+            Acc#{Seq => Files}
+        end,
+        #{},
+        RenameMethodEntries
+    ).
+
+-doc """
+Phase A for every pending `'rename-method'` entry in this flush (ADR 0114,
+BT-3273): build the union of every entry's CONFIRMED `sites` (never
+`candidate_sites`) as `{Site, OwnerEntry}` units — sites from different
+entries that land in the same file merge, via `group_units_by_file/1`,
+exactly the way class rename's own OTHER-site references already merge
+across entries — then stage each file group with the same generic
+`prepare_rename_site_group/2` class rename's reference-site splices use.
+A `'rename-method'` entry has no file-move component (renaming a selector
+never changes which file a method's class lives in), so every one of its
+sites, including the definition site, is an ordinary in-place splice; abort-
+with-cleanup on the first conflict or hard error exactly like
+`phase_a_loop/3`/`phase_a_renames_loop/3` do for their own groups.
+""".
+-spec phase_a_rename_methods([term()]) ->
+    {ok, [#prepared{}]} | {error, #beamtalk_error{}} | {conflict, [map()]}.
+phase_a_rename_methods([]) ->
+    {ok, []};
+phase_a_rename_methods(RenameMethodEntries) ->
+    Units = lists:flatmap(
+        fun(Entry) ->
+            [{Site, Entry} || Site <- entry_confirmed_sites(Entry), Site =/= undefined]
+        end,
+        RenameMethodEntries
+    ),
+    Groups = group_units_by_file(Units),
+    phase_a_rename_methods_loop(Groups, [], []).
+
+phase_a_rename_methods_loop([], Prepared, []) ->
+    {ok, lists:reverse(Prepared)};
+phase_a_rename_methods_loop([], Prepared, Conflicts) ->
+    cleanup_tmps(Prepared),
+    {conflict, lists:reverse(Conflicts)};
+phase_a_rename_methods_loop([{File, Units} | Rest], Prepared, Conflicts) ->
+    case prepare_rename_site_group(File, Units) of
+        {ok, Rec} ->
+            phase_a_rename_methods_loop(Rest, [Rec | Prepared], Conflicts);
+        {conflict, C} ->
+            phase_a_rename_methods_loop(Rest, Prepared, [C | Conflicts]);
+        {error, _} = Err ->
+            cleanup_tmps(Prepared),
+            Err
+    end.
 
 %%% ----------------------------------------------------------------------------
 %%% Method splice
@@ -2096,15 +2342,17 @@ phase_b_loop([], Shadowed, Committed, Failed, Skipped, RenameExpectedFiles) ->
     Files = lists:reverse([P#prepared.file || P <- Committed]),
     CommittedFilesSet = sets:from_list(Files, [{version, 2}]),
     CommittedEntries = lists:flatten([P#prepared.entries || P <- Committed]),
-    %% ADR 0114 (BT-3271): a `'rename-class'` entry spans multiple files (the
-    %% move target plus every other rewritten site), so appearing in
-    %% `CommittedEntries` at all (from ONE of its files) is not enough —
-    %% every file it touches must have committed in THIS pass. A non-rename
-    %% entry trivially satisfies this (every other kind targets one file).
+    %% ADR 0114 (BT-3271/BT-3273): a `'rename-class'` entry spans multiple
+    %% files (the move target plus every other rewritten site) and a
+    %% `'rename-method'` entry does too (the definition plus every confirmed
+    %% sender site), so appearing in `CommittedEntries` at all (from ONE of
+    %% its files) is not enough — every file either kind touches must have
+    %% committed in THIS pass. A non-multi-site entry trivially satisfies
+    %% this (every other kind targets one file).
     FullyCommitted = [
         E
      || E <- CommittedEntries,
-        rename_class_fully_committed(E, RenameExpectedFiles, CommittedFilesSet)
+        multi_site_entry_fully_committed(E, RenameExpectedFiles, CommittedFilesSet)
     ],
     %% Only mark shadowed entries whose survivor (same class+selector) was
     %% actually committed in this Phase B. When Phase B aborts mid-loop, a

--- a/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
+++ b/runtime/apps/beamtalk_workspace/test/beamtalk_workspace_flush_tests.erl
@@ -106,6 +106,14 @@ flush_test_() ->
         fun rename_class_two_renames_colliding_on_new_path_is_conflict/1,
         fun rename_class_new_path_collides_with_other_rename_old_path_is_conflict/1,
         fun rename_class_resumes_after_simulated_partial_phase_b/1,
+        %% ADR 0114 Phase 3 (BT-3273): rename-method multi-file destructive flush
+        fun rename_method_flush_without_confirm_is_skipped_destructive/1,
+        fun rename_method_rewrites_definition_and_confirmed_senders/1,
+        fun rename_method_candidate_sites_are_never_written/1,
+        fun rename_method_external_edit_on_confirmed_site_aborts_whole_batch/1,
+        fun rename_method_mixed_with_ordinary_patch_is_conflict/1,
+        fun rename_method_mixed_with_rename_class_is_conflict/1,
+        fun rename_method_two_entries_merge_in_same_file/1,
         fun flush_two_rejects_non_boolean_confirm/1,
         fun flush_kinds_two_rejects_non_boolean_confirm/1,
         %% BT-3212 (ADR 0113 LSP follow-up): per-file operation kind on the
@@ -125,6 +133,8 @@ unit_test_() ->
         fun entry_tier_classifies_other_kinds_as_tier1/0,
         %% ADR 0114 Phase 2 (BT-3271)
         fun entry_tier_classifies_rename_class_as_tier2/0,
+        %% ADR 0114 Phase 3 (BT-3273)
+        fun entry_tier_classifies_rename_method_as_tier2/0,
         fun resolve_new_path_prefers_recorded_value/0,
         fun resolve_new_path_derives_exact_style_from_old_path/0,
         fun resolve_new_path_derives_snake_case_style_from_old_path/0
@@ -2508,6 +2518,365 @@ rename_class_resumes_after_simulated_partial_phase_b(#{proj_dir := ProjDir}) ->
         ?_assertEqual(false, filelib:is_regular(RefPath2 ++ ".tmp"))
     ].
 
+%%====================================================================
+%% Tests — rename-method multi-file destructive flush (ADR 0114, BT-3273)
+%%====================================================================
+
+%% Tier 2 gating, mirroring `rename_class_flush_without_confirm_is_skipped_
+%% destructive/1`: an ordinary `flush/0` never applies a pending
+%% `rename-method` entry — neither the definition nor any confirmed sender
+%% site is touched.
+rename_method_flush_without_confirm_is_skipped_destructive(#{proj_dir := ProjDir}) ->
+    File = filename:join([ProjDir, "src", "counter.bt"]),
+    Source = <<"Object subclass: Counter\n  increment => self.value := self.value + 1\nend\n">>,
+    ok = file:write_file(File, Source),
+    {DefStart, DefEnd, _} = locate(Source, <<"increment">>),
+    DefSite = rename_site(
+        list_to_binary(File), DefStart, DefEnd, <<"incrementBy">>, <<"increment">>
+    ),
+    {ok, Seq} = beamtalk_workspace_changelog:append(
+        rename_method_input(
+            <<"Counter">>, <<"incrementBy">>, <<"increment">>, instance, [DefSite], []
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush(),
+    Skipped = maps:get(skipped, Summary),
+    [
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assertEqual(1, length(Skipped)),
+        ?_assertEqual(<<"destructive">>, maps:get(reason, hd(Skipped))),
+        ?_assertEqual({ok, Source}, file:read_file(File)),
+        ?_assertNot(entry_flushed(Seq))
+    ].
+
+%% BUnit/BT-3273 acceptance-criteria coverage (this module's own EUnit-level
+%% slice — the real `Counter renameSelector: #increment to: #incrementBy` +
+%% `flush: Counter confirmDestructive: true` round trip against a real,
+%% in-project-classified compiled class lives in `tests/repl-protocol/cases/`,
+%% mirroring `rename_class_moves_file_rewrites_declaration_and_reference/1`'s
+%% own documented reason for the same split — BUnit's `beamtalk test` runner
+%% has no project configured). Exercises this module's actual flush mechanics
+%% directly: the fixture graph named in the ADR's own Phase 3 acceptance
+%% criteria — a definition plus a same-file confirmed self-send plus a
+%% cross-file confirmed super-send — all rewritten in one flush, with
+%% `candidate_sites` left completely untouched on disk.
+rename_method_rewrites_definition_and_confirmed_senders(#{proj_dir := ProjDir}) ->
+    DefFile = filename:join([ProjDir, "src", "counter.bt"]),
+    SubFile = filename:join([ProjDir, "src", "sub_counter.bt"]),
+    DefSource = <<
+        "Object subclass: Counter\n"
+        "  increment => self.value := self.value + 1\n"
+        "  bump => self increment\n"
+        "end\n"
+    >>,
+    SubSource = <<
+        "Counter subclass: SubCounter\n"
+        "  bumpTwice => super increment\n"
+        "end\n"
+    >>,
+    ok = file:write_file(DefFile, DefSource),
+    ok = file:write_file(SubFile, SubSource),
+    {DefStart, DefEnd, _} = locate(DefSource, <<"increment">>),
+    DefSite = rename_site(
+        list_to_binary(DefFile), DefStart, DefEnd, <<"incrementBy">>, <<"increment">>
+    ),
+    {SelfStart, SelfEnd, _} = locate(DefSource, <<"self increment">>),
+    SelfSite = rename_site(
+        list_to_binary(DefFile), SelfStart, SelfEnd, <<"self incrementBy">>, <<"self increment">>
+    ),
+    {SuperStart, SuperEnd, _} = locate(SubSource, <<"super increment">>),
+    SuperSite = rename_site(
+        list_to_binary(SubFile),
+        SuperStart,
+        SuperEnd,
+        <<"super incrementBy">>,
+        <<"super increment">>
+    ),
+    %% An unrelated candidate site — an arbitrary-receiver send of the same
+    %% selector name that must never be auto-rewritten. No source_ref/
+    %% prev_source_ref: candidate sites are reported, never spliced.
+    CandidatePath = filename:join([ProjDir, "src", "widget.bt"]),
+    CandidateSource = <<"Object subclass: Widget\n  bump => aCounter increment\nend\n">>,
+    ok = file:write_file(CandidatePath, CandidateSource),
+    {CandStart, CandEnd, _} = locate(CandidateSource, <<"increment">>),
+    CandidateSite = candidate_site(list_to_binary(CandidatePath), CandStart, CandEnd),
+    {ok, Seq} = beamtalk_workspace_changelog:append(
+        rename_method_input(
+            <<"Counter">>,
+            <<"incrementBy">>,
+            <<"increment">>,
+            instance,
+            [DefSite, SelfSite, SuperSite],
+            [CandidateSite]
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    {ok, DefBody} = file:read_file(DefFile),
+    {ok, SubBody} = file:read_file(SubFile),
+    {ok, CandidateBody} = file:read_file(CandidatePath),
+    Files = maps:get(files, Summary),
+    [
+        ?_assertEqual(1, maps:get(flushed, Summary)),
+        ?_assertEqual([], maps:get(conflicts, Summary)),
+        ?_assertEqual([], maps:get(skipped, Summary)),
+        ?_assertEqual(
+            <<
+                "Object subclass: Counter\n"
+                "  incrementBy => self.value := self.value + 1\n"
+                "  bump => self incrementBy\n"
+                "end\n"
+            >>,
+            DefBody
+        ),
+        ?_assertEqual(
+            <<
+                "Counter subclass: SubCounter\n"
+                "  bumpTwice => super incrementBy\n"
+                "end\n"
+            >>,
+            SubBody
+        ),
+        %% The candidate site's file is completely untouched — `#increment`
+        %% verbatim, never rewritten to `#incrementBy`.
+        ?_assertEqual(CandidateSource, CandidateBody),
+        ?_assert(lists:member(list_to_binary(DefFile), Files)),
+        ?_assert(lists:member(list_to_binary(SubFile), Files)),
+        ?_assertNot(lists:member(list_to_binary(CandidatePath), Files)),
+        ?_assert(entry_flushed(Seq)),
+        ?_assertEqual(false, filelib:is_regular(DefFile ++ ".tmp")),
+        ?_assertEqual(false, filelib:is_regular(SubFile ++ ".tmp"))
+    ].
+
+%% Explicit acceptance-criteria coverage: `candidate_sites` must never be
+%% staged, written, or otherwise touched by flush "under any circumstance" —
+%% verified directly against a `.tmp` check, not just the final body, so a
+%% regression that stages-then-cleans-up a candidate site would still be
+%% caught mid-flush by an equivalent test with a forced abort (see the next
+%% test) even though the happy-path test above cannot observe an intermediate
+%% `.tmp`.
+rename_method_candidate_sites_are_never_written(#{proj_dir := ProjDir}) ->
+    DefFile = filename:join([ProjDir, "src", "counter.bt"]),
+    DefSource = <<"Object subclass: Counter\n  increment => self.value := self.value + 1\nend\n">>,
+    ok = file:write_file(DefFile, DefSource),
+    {DefStart, DefEnd, _} = locate(DefSource, <<"increment">>),
+    DefSite = rename_site(
+        list_to_binary(DefFile), DefStart, DefEnd, <<"incrementBy">>, <<"increment">>
+    ),
+    CandidatePath = filename:join([ProjDir, "src", "widget.bt"]),
+    CandidateSource = <<"Object subclass: Widget\n  bump => aCounter increment\nend\n">>,
+    ok = file:write_file(CandidatePath, CandidateSource),
+    {CandStart, CandEnd, _} = locate(CandidateSource, <<"increment">>),
+    CandidateSite = candidate_site(list_to_binary(CandidatePath), CandStart, CandEnd),
+    {ok, _Seq} = beamtalk_workspace_changelog:append(
+        rename_method_input(
+            <<"Counter">>, <<"incrementBy">>, <<"increment">>, instance, [DefSite], [CandidateSite]
+        )
+    ),
+    {ok, _Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    [
+        ?_assertEqual({ok, CandidateSource}, file:read_file(CandidatePath)),
+        ?_assertEqual(false, filelib:is_regular(CandidatePath ++ ".tmp"))
+    ].
+
+%% Acceptance criterion: "A Phase A failure (a confirmed site's span no
+%% longer resolves) aborts the whole batch". Externally edit the cross-file
+%% confirmed sender site so its recorded span no longer matches, then verify
+%% neither file was written — not even the definition site's file, which
+%% would have staged cleanly on its own.
+rename_method_external_edit_on_confirmed_site_aborts_whole_batch(#{proj_dir := ProjDir}) ->
+    DefFile = filename:join([ProjDir, "src", "counter.bt"]),
+    SubFile = filename:join([ProjDir, "src", "sub_counter.bt"]),
+    DefSource = <<"Object subclass: Counter\n  increment => self.value := self.value + 1\nend\n">>,
+    SubSource = <<"Counter subclass: SubCounter\n  bumpTwice => super increment\nend\n">>,
+    ok = file:write_file(DefFile, DefSource),
+    ok = file:write_file(SubFile, SubSource),
+    {DefStart, DefEnd, _} = locate(DefSource, <<"increment">>),
+    DefSite = rename_site(
+        list_to_binary(DefFile), DefStart, DefEnd, <<"incrementBy">>, <<"increment">>
+    ),
+    {SuperStart, SuperEnd, _} = locate(SubSource, <<"super increment">>),
+    SuperSite = rename_site(
+        list_to_binary(SubFile),
+        SuperStart,
+        SuperEnd,
+        <<"super incrementBy">>,
+        <<"super increment">>
+    ),
+    {ok, Seq} = beamtalk_workspace_changelog:append(
+        rename_method_input(
+            <<"Counter">>, <<"incrementBy">>, <<"increment">>, instance, [DefSite, SuperSite], []
+        )
+    ),
+    %% Externally edit SubFile so the recorded span no longer matches.
+    ok = file:write_file(
+        SubFile, <<"Counter subclass: SubCounter\n  bumpTwice => super somethingElse\nend\n">>
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    Conflicts = maps:get(conflicts, Summary),
+    [
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assert(length(Conflicts) >= 1),
+        %% The whole batch aborted: DefFile is untouched even though its own
+        %% splice would have staged cleanly in isolation.
+        ?_assertEqual({ok, DefSource}, file:read_file(DefFile)),
+        ?_assertEqual(false, filelib:is_regular(DefFile ++ ".tmp")),
+        ?_assertEqual(false, filelib:is_regular(SubFile ++ ".tmp")),
+        ?_assertNot(entry_flushed(Seq))
+    ].
+
+%% Collision guard: a `'rename-method'` entry sharing a target file with a
+%% pending ordinary patch aborts the whole flush rather than racing the two
+%% splice mechanisms — mirrors `rename_class_mixed_with_ordinary_patch_is_
+%% conflict/1`.
+rename_method_mixed_with_ordinary_patch_is_conflict(#{proj_dir := ProjDir}) ->
+    DefFile = filename:join([ProjDir, "src", "counter.bt"]),
+    DefSource = <<
+        "Object subclass: Counter\n"
+        "  increment => self.value := self.value + 1\n"
+        "  other => 1\n"
+        "end\n"
+    >>,
+    ok = file:write_file(DefFile, DefSource),
+    {DefStart, DefEnd, _} = locate(DefSource, <<"increment">>),
+    DefSite = rename_site(
+        list_to_binary(DefFile), DefStart, DefEnd, <<"incrementBy">>, <<"increment">>
+    ),
+    {ok, RenameSeq} = beamtalk_workspace_changelog:append(
+        rename_method_input(
+            <<"Counter">>, <<"incrementBy">>, <<"increment">>, instance, [DefSite], []
+        )
+    ),
+    {PatchStart, PatchEnd, PatchOld} = locate(DefSource, <<"other => 1\n">>),
+    {ok, PatchSeq} = beamtalk_workspace_changelog:append(
+        method_input(
+            <<"Counter">>,
+            <<"other">>,
+            <<"other => 2\n">>,
+            PatchOld,
+            list_to_binary(DefFile),
+            PatchStart,
+            PatchEnd
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    Conflicts = maps:get(conflicts, Summary),
+    [
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assert(length(Conflicts) >= 1),
+        ?_assertEqual(<<"mixed_rename_method_and_pending_edit">>, maps:get(reason, hd(Conflicts))),
+        ?_assertEqual({ok, DefSource}, file:read_file(DefFile)),
+        ?_assertNot(entry_flushed(RenameSeq)),
+        ?_assertNot(entry_flushed(PatchSeq))
+    ].
+
+%% Collision guard, the OTHER branch: a `'rename-method'` entry's own
+%% confirmed-site file collides with a pending `'rename-class'` entry's
+%% touched file (not merely an ordinary patch) — verifies the `OtherFiles`
+%% union in `run_flush/2` actually reaches the rename-class side, not just
+%% the ordinary-patch side `rename_method_mixed_with_ordinary_patch_is_
+%% conflict/1` already covers. Mirrors a real scenario: `Widget.bt`
+%% references `Counter` (a pending class rename's reference site) AND
+%% separately has its own method being renamed.
+rename_method_mixed_with_rename_class_is_conflict(#{proj_dir := ProjDir}) ->
+    OldPath = filename:join([ProjDir, "src", "counter.bt"]),
+    NewPath = filename:join([ProjDir, "src", "accumulator.bt"]),
+    RefPath = filename:join([ProjDir, "src", "widget.bt"]),
+    OldSource = <<"Object subclass: Counter\nend\n">>,
+    RefSource = <<
+        "Object subclass: Widget\n"
+        "  bump => Counter new\n"
+        "  poke => 1\n"
+        "end\n"
+    >>,
+    ok = file:write_file(OldPath, OldSource),
+    ok = file:write_file(RefPath, RefSource),
+    {DeclStart, DeclEnd, _} = locate(OldSource, <<"Counter">>),
+    DeclSite = rename_site(
+        list_to_binary(OldPath), DeclStart, DeclEnd, <<"Accumulator">>, <<"Counter">>
+    ),
+    {RefStart, RefEnd, _} = locate(RefSource, <<"Counter new">>),
+    RefSite = rename_site(
+        list_to_binary(RefPath), RefStart, RefEnd, <<"Accumulator new">>, <<"Counter new">>
+    ),
+    {ok, ClassRenameSeq} = beamtalk_workspace_changelog:append(
+        rename_class_input(
+            <<"Accumulator">>,
+            <<"Counter">>,
+            list_to_binary(OldPath),
+            list_to_binary(NewPath),
+            [DeclSite, RefSite]
+        )
+    ),
+    {PokeStart, PokeEnd, _} = locate(RefSource, <<"poke">>),
+    PokeSite = rename_site(list_to_binary(RefPath), PokeStart, PokeEnd, <<"poked">>, <<"poke">>),
+    {ok, MethodRenameSeq} = beamtalk_workspace_changelog:append(
+        rename_method_input(<<"Widget">>, <<"poked">>, <<"poke">>, instance, [PokeSite], [])
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    Conflicts = maps:get(conflicts, Summary),
+    [
+        ?_assertEqual(0, maps:get(flushed, Summary)),
+        ?_assert(length(Conflicts) >= 1),
+        ?_assertEqual(<<"mixed_rename_method_and_pending_edit">>, maps:get(reason, hd(Conflicts))),
+        ?_assertEqual({ok, OldSource}, file:read_file(OldPath)),
+        ?_assertEqual({ok, RefSource}, file:read_file(RefPath)),
+        ?_assertEqual(false, filelib:is_regular(NewPath)),
+        ?_assertNot(entry_flushed(ClassRenameSeq)),
+        ?_assertNot(entry_flushed(MethodRenameSeq))
+    ].
+
+%% Two DIFFERENT `'rename-method'` entries whose confirmed sites both land in
+%% the same file are NOT a collision (unlike `'rename-class'`, which guards
+%% rename-vs-rename because a move can race another move's own unlink) — they
+%% simply merge into one splice via `group_units_by_file/1`, exactly like
+%% multiple ordinary patches against one file already merge via
+%% `group_by_file/1`. Verifies the moduledoc's own claim to this effect.
+rename_method_two_entries_merge_in_same_file(#{proj_dir := ProjDir}) ->
+    File = filename:join([ProjDir, "src", "counter.bt"]),
+    Source = <<
+        "Object subclass: Counter\n"
+        "  increment => 1\n"
+        "  decrement => 2\n"
+        "end\n"
+    >>,
+    ok = file:write_file(File, Source),
+    {IncStart, IncEnd, _} = locate(Source, <<"increment">>),
+    IncSite = rename_site(
+        list_to_binary(File), IncStart, IncEnd, <<"incrementBy">>, <<"increment">>
+    ),
+    {DecStart, DecEnd, _} = locate(Source, <<"decrement">>),
+    DecSite = rename_site(
+        list_to_binary(File), DecStart, DecEnd, <<"decrementBy">>, <<"decrement">>
+    ),
+    {ok, Seq1} = beamtalk_workspace_changelog:append(
+        rename_method_input(
+            <<"Counter">>, <<"incrementBy">>, <<"increment">>, instance, [IncSite], []
+        )
+    ),
+    {ok, Seq2} = beamtalk_workspace_changelog:append(
+        rename_method_input(
+            <<"Counter">>, <<"decrementBy">>, <<"decrement">>, instance, [DecSite], []
+        )
+    ),
+    {ok, Summary} = beamtalk_workspace_flush:flush_including_destructive(),
+    {ok, FinalBody} = file:read_file(File),
+    [
+        ?_assertEqual(2, maps:get(flushed, Summary)),
+        ?_assertEqual([], maps:get(conflicts, Summary)),
+        ?_assertEqual([list_to_binary(File)], maps:get(files, Summary)),
+        ?_assertEqual(
+            <<
+                "Object subclass: Counter\n"
+                "  incrementBy => 1\n"
+                "  decrementBy => 2\n"
+                "end\n"
+            >>,
+            FinalBody
+        ),
+        ?_assert(entry_flushed(Seq1)),
+        ?_assert(entry_flushed(Seq2))
+    ].
+
 %% `confirmDestructive` must be a literal Boolean at both `flush/2` and
 %% `flush_kinds/2` — anything else is a structured type error, never coerced.
 flush_two_rejects_non_boolean_confirm(_Ctx) ->
@@ -2590,6 +2959,31 @@ entry_tier_classifies_rename_class_as_tier2() ->
         ),
         [Entry] = beamtalk_workspace_changelog:flushable_pending(),
         ?assertEqual(tier2, beamtalk_workspace_flush:entry_tier(Entry))
+    after
+        stop(Pid),
+        restore_home(OldHome),
+        del_tree(TmpHome)
+    end.
+
+%% ADR 0114 Phase 3 (BT-3273): `'rename-method'` joins `'remove-class'`/
+%% `'rename-class'` in Tier 2 — a destructive flush gate, since it rewrites
+%% every confirmed sender site across the project, not just the definition.
+entry_tier_classifies_rename_method_as_tier2() ->
+    {WorkspaceId, TmpHome, OldHome} = fresh_workspace(),
+    {ok, Pid} = beamtalk_workspace_changelog:start_link(#{workspace_id => WorkspaceId}),
+    try
+        {ok, _} = beamtalk_workspace_changelog:append(
+            rename_method_input(
+                <<"Counter">>,
+                <<"incrementBy">>,
+                <<"increment">>,
+                instance,
+                [rename_site(<<"/proj/src/counter.bt">>, 0, 9, <<"incrementBy">>, <<"increment">>)],
+                []
+            )
+        ),
+        [MethodEntry] = beamtalk_workspace_changelog:flushable_pending(),
+        ?assertEqual(tier2, beamtalk_workspace_flush:entry_tier(MethodEntry))
     after
         stop(Pid),
         restore_home(OldHome),
@@ -2866,6 +3260,33 @@ rename_site(SourceFile, Start, End, NewText, PrevText) ->
         span => #{start => Start, 'end' => End},
         source_ref => NewRef,
         prev_source_ref => PrevRef
+    }.
+
+%% A flushable `'rename-method'` append_input (ADR 0114, BT-3269/BT-3273):
+%% `sites[0]` is always the definition site, `sites[1..]` are every
+%% *confirmed* self/super sender site; `CandidateSites` are reported-only —
+%% flush must never stage, write, or otherwise touch them.
+rename_method_input(Class, NewSelector, OldSelector, Side, Sites, CandidateSites) ->
+    #{
+        class => Class,
+        selector => NewSelector,
+        old_selector => OldSelector,
+        kind => 'rename-method',
+        side => Side,
+        sites => Sites,
+        candidate_sites => CandidateSites,
+        intent => durable,
+        flushable => true,
+        author => <<"sess-test">>,
+        author_kind => human
+    }.
+
+%% One `candidate_site()` map (ADR 0114, BT-3269): reported for human/agent
+%% review, never spliced — no `source_ref`/`prev_source_ref`.
+candidate_site(SourceFile, Start, End) ->
+    #{
+        source_file => SourceFile,
+        span => #{start => Start, 'end' => End}
     }.
 
 %% Build the sources/ filename for a seq (mirrors the changelog's zero-padded

--- a/tests/repl-protocol/cases/rename_method_flush_roundtrip.btscript
+++ b/tests/repl-protocol/cases/rename_method_flush_roundtrip.btscript
@@ -1,0 +1,312 @@
+// Copyright 2026 James Casey
+// SPDX-License-Identifier: Apache-2.0
+
+// BT-3273 (ADR 0114 Phase 3, method-rename multi-file flush): required e2e
+// validation for the full `renameSelector:to:` + `Workspace flush:
+// confirmDestructive:` chain against a real, file-backed class hierarchy —
+// matching this issue's own acceptance criteria wording verbatim: `Counter
+// renameSelector: #increment to: #incrementBy` followed by `flush: Counter
+// confirmDestructive: true` rewrites the definition and every confirmed
+// self/super sender, verifies no dangling `does_not_understand` for any
+// confirmed site, and leaves `candidate_sites` untouched on disk.
+//
+// `Behaviour>>renameSelector:to:` (BT-3279) only ever produces a
+// `flushable: true` `'rename-method'` ChangeLog entry for a class the xref
+// index actually covers — an ordinary in-project class, not a BUnit fixture
+// (BUnit's `beamtalk test` runner has no project configured at all — see
+// `stdlib/test/rename_selector_test.bt`'s own doc comment). This harness
+// DOES run with a real project path (`beamtalk_workspace_meta`'s
+// `project_path`), so it is the one place the full disk-flush half of
+// BT-3273's acceptance criteria can actually be exercised end to end,
+// mirroring `rename_class_flush_roundtrip.btscript`'s identical split for
+// the sibling `renameTo:`/`'rename-class'` mechanism.
+//
+// Three files (mirrors `beamtalk_behaviour_intrinsics_rename_selector_tests.erl`'s
+// own fixture-graph shape, EUnit-side coverage of site *discovery*):
+//
+//   Bt3273Counter.bt (the definition):
+//     Value subclass: Bt3273Counter
+//       increment -> String => "incremented"
+//       bump -> String => self increment
+//
+//   Bt3273SubCounter.bt (a confirmed same-hierarchy `super` sender):
+//     Bt3273Counter subclass: Bt3273SubCounter
+//       bumpTwice -> String => super increment
+//
+//   Bt3273Widget.bt (an unrelated class sending the same selector name via
+//   an arbitrary-expression receiver — `other_recv`, always a
+//   `candidate_sites` entry, never auto-rewritten):
+//     Value subclass: Bt3273Widget
+//       poke: aCounter -> String => aCounter increment
+//
+// After `Bt3273Counter renameSelector: #increment to: #incrementBy` and
+// `Workspace flush: Bt3273Counter confirmDestructive: true`:
+//   - `Bt3273Counter.bt`'s definition AND its own `self increment` send are
+//     both rewritten to `incrementBy` (same-file confirmed sites).
+//   - `Bt3273SubCounter.bt`'s cross-file `super increment` send is
+//     rewritten too (cross-file confirmed site).
+//   - `Bt3273Widget.bt` is byte-identical — its `other_recv` send is a
+//     `candidate_sites` entry, reported but never staged or written.
+//   - Reloading all three files from disk resolves cleanly: the new
+//     selector works everywhere it was rewritten, and the old selector is a
+//     genuine `does_not_understand` — no dangling sender anywhere a
+//     confirmed rewrite promised coverage.
+
+// ===========================================================================
+// CLEAN START
+// ===========================================================================
+
+Workspace changes clear
+// => _
+
+Workspace changes isEmpty
+// => true
+
+// ===========================================================================
+// STEP 1 — WRITE THREE REAL .bt FILES INSIDE THE PROJECT TREE AND LOAD THEM
+// ===========================================================================
+
+_meta := ((Erlang beamtalk_workspace_meta) get_metadata) unwrap
+// => _
+
+_projectPath := Erlang maps get: #project_path with: _meta
+// => _
+
+_projDir := _projectPath ++ "/bt_e2e_rename_method_flush_" ++ (Erlang erlang) unique_integer asString
+// => _
+
+(Erlang filelib) ensure_dir: (_projDir ++ "/.keep")
+// => Result ok: nil
+
+_counterPath := _projDir ++ "/Bt3273Counter.bt"
+// => _
+
+_subPath := _projDir ++ "/Bt3273SubCounter.bt"
+// => _
+
+_widgetPath := _projDir ++ "/Bt3273Widget.bt"
+// => _
+
+// A genuine LF byte built via the Erlang FFI (BT-3214: see
+// `rename_class_flush_roundtrip.btscript`'s identical note).
+_nl := (Erlang unicode) characters_to_binary: #(10)
+// => _
+
+_counterSource := "Value subclass: Bt3273Counter" ++ _nl ++ "  increment -> String => ""incremented""" ++ _nl ++ "  bump -> String => self increment"
+// => _
+
+_subSource := "Bt3273Counter subclass: Bt3273SubCounter" ++ _nl ++ "  bumpTwice -> String => super increment"
+// => _
+
+_widgetSource := "Value subclass: Bt3273Widget" ++ _nl ++ "  poke: aCounter -> String => aCounter increment"
+// => _
+
+File writeAll: _counterPath contents: _counterSource
+// => Result ok: nil
+
+File writeAll: _subPath contents: _subSource
+// => Result ok: nil
+
+File writeAll: _widgetPath contents: _widgetSource
+// => Result ok: nil
+
+Workspace load: _counterPath
+// => _
+
+Workspace load: _subPath
+// => _
+
+Workspace load: _widgetPath
+// => _
+
+Bt3273Counter new increment
+// => incremented
+
+Bt3273Counter new bump
+// => incremented
+
+Bt3273SubCounter new bumpTwice
+// => incremented
+
+Bt3273Widget new poke: Bt3273Counter new
+// => incremented
+
+// ===========================================================================
+// STEP 2 — renameSelector:to: RE-REGISTERS THE CONFIRMED SITES IN MEMORY AND
+// LOGS A rename-method ENTRY (ADR 0114 Phase 3, BT-3279)
+// ===========================================================================
+
+Bt3273Counter renameSelector: #increment to: #incrementBy
+// => Bt3273Counter
+
+Bt3273Counter new incrementBy
+// => incremented
+
+Bt3273Counter new bump
+// => incremented
+
+Bt3273SubCounter new bumpTwice
+// => incremented
+
+_renameEntry := (Workspace changes select: [:e | e className =:= #Bt3273Counter]) first
+// => _
+
+_renameEntry kind
+// => rename-method
+
+_renameEntry isFlushable
+// => true
+
+// The in-memory rename does not touch disk — only flush does.
+_counterBodyBeforeFlush := (File readAll: _counterPath) unwrap
+// => _
+
+_counterBodyBeforeFlush =:= _counterSource
+// => true
+
+// ===========================================================================
+// STEP 3 — Workspace flush REPORTS IT skipped: destructive, FILES SURVIVE
+// (ADR 0113 Phase 2 tier reused verbatim by ADR 0114 Phase 3)
+// ===========================================================================
+
+_tier1Flush := Workspace flush
+// => _
+
+Erlang maps get: #flushed with: _tier1Flush
+// => 0
+
+_skipped := Erlang maps get: #skipped with: _tier1Flush
+// => _
+
+_skipped size
+// => 1
+
+(Erlang maps get: #reason with: _skipped first)
+// => destructive
+
+// ===========================================================================
+// STEP 4 — Workspace flush: aClass confirmDestructive: true REWRITES EVERY
+// CONFIRMED SITE ACROSS FILES; candidate_sites STAY UNTOUCHED (ADR 0114
+// Phase 3, BT-3273)
+// ===========================================================================
+
+_destructiveFlush := Workspace flush: Bt3273Counter confirmDestructive: true
+// => _
+
+Erlang maps get: #flushed with: _destructiveFlush
+// => 1
+
+(Erlang maps get: #skipped with: _destructiveFlush) isEmpty
+// => true
+
+(Erlang maps get: #conflicts with: _destructiveFlush) isEmpty
+// => true
+
+Workspace changes isEmpty
+// => true
+
+// The definition AND the same-file self-send are both rewritten.
+_counterBodyAfterFlush := (File readAll: _counterPath) unwrap
+// => _
+
+_expectedCounterSource := "Value subclass: Bt3273Counter" ++ _nl ++ "  incrementBy -> String => ""incremented""" ++ _nl ++ "  bump -> String => self incrementBy"
+// => _
+
+_counterBodyAfterFlush =:= _expectedCounterSource
+// => true
+
+// The cross-file confirmed `super` sender is rewritten too.
+_subBodyAfterFlush := (File readAll: _subPath) unwrap
+// => _
+
+_expectedSubSource := "Bt3273Counter subclass: Bt3273SubCounter" ++ _nl ++ "  bumpTwice -> String => super incrementBy"
+// => _
+
+_subBodyAfterFlush =:= _expectedSubSource
+// => true
+
+// The candidate site (an arbitrary-receiver send of the same selector name)
+// is completely untouched — `#increment` verbatim, never rewritten, never
+// staged, never even given a `.tmp`.
+_widgetBodyAfterFlush := (File readAll: _widgetPath) unwrap
+// => _
+
+_widgetBodyAfterFlush =:= _widgetSource
+// => true
+
+// ===========================================================================
+// STEP 5 — NO DANGLING does_not_understand: A FRESH RE-LOAD OF ALL THREE
+// (NOW-REWRITTEN) FILES RESOLVES CLEANLY FOR EVERY CONFIRMED SITE — the
+// end-to-end point of this test.
+// ===========================================================================
+
+Bt3273Widget removeFromSystem
+// => nil
+
+Bt3273SubCounter removeFromSystem
+// => nil
+
+Bt3273Counter removeFromSystem
+// => nil
+
+Workspace changes clear
+// => _
+
+Workspace load: _counterPath
+// => _
+
+Workspace load: _subPath
+// => _
+
+Workspace load: _widgetPath
+// => _
+
+Bt3273Counter new incrementBy
+// => incremented
+
+Bt3273Counter new bump
+// => incremented
+
+Bt3273SubCounter new bumpTwice
+// => incremented
+
+// The old selector no longer resolves on the renamed class — a genuine
+// does_not_understand, not a silently-dangling sender.
+[Bt3273Counter new increment] on: Error do: [:e | e kind]
+// => does_not_understand
+
+// The candidate site's own (never-rewritten) send still resolves — it was
+// never broken because it was never touched: `aCounter increment` still
+// means the OLD selector, and the renamed class no longer answers it, so
+// this now-stale candidate call site itself would raise DNU too — exactly
+// the reviewed-follow-up burden ADR 0114 documents `candidate_sites` for.
+[Bt3273Widget new poke: Bt3273Counter new] on: Error do: [:e | e kind]
+// => does_not_understand
+
+// ===========================================================================
+// CLEANUP
+// ===========================================================================
+
+Bt3273Widget removeFromSystem
+// => nil
+
+Bt3273SubCounter removeFromSystem
+// => nil
+
+Bt3273Counter removeFromSystem
+// => nil
+
+(Erlang file) delete: _counterPath
+// => _
+
+(Erlang file) delete: _subPath
+// => _
+
+(Erlang file) delete: _widgetPath
+// => _
+
+(Erlang file) del_dir: _projDir
+// => Result ok: nil
+
+Workspace changes clear
+// => _


### PR DESCRIPTION
## Summary
- Extends ADR 0113's `confirmDestructive` Tier 2 to `rename-method` ChangeLog entries (ADR 0114 Phase 3), joining `remove-class`/`rename-class` in the destructive-confirmation gate.
- Unlike `rename-class`, a method rename has no file-move component — renaming a selector never changes which file a method's class lives in — so every confirmed site (the definition plus every confirmed self/super sender) is an ordinary in-place splice. Reuses the exact generic `{site(), OwnerEntry}` splice/grouping machinery `rename-class`'s own reference-site rewrites already built (`group_units_by_file/1`, `prepare_rename_site_group/2`, `apply_site_units/2`) rather than duplicating it — new code is limited to the Phase A file-grouping/Phase B completion-tracking glue and a collision guard.
- Phase A stages a `.tmp` per file touched by any confirmed site across every pending `rename-method` entry (sites from different entries landing in the same file merge into one splice, exactly like ordinary multi-file flush already merges multiple patches against one file). `candidate_sites` are never read, staged, or written under any circumstance.
- Phase B commits sequentially; an entry counts as fully flushed (and is only then marked flushed in the ChangeLog) once *every* file among its confirmed sites has committed in the same pass — mirrors `rename-class`'s per-entry, not per-file, flushed-marking rule (`multi_site_entry_fully_committed/3`, generalized from `rename_class_fully_committed/3`).
- A confirmed site's recorded span no longer resolving against current disk content aborts the whole batch before any file is renamed, with full `.tmp` cleanup.
- A `rename-method` entry sharing a target file with a pending ordinary patch or a pending `rename-class` entry's own touched files aborts the whole flush (`mixed_rename_method_and_pending_edit`) — same defensive posture `rename-class`'s own collision guards take. Two `rename-method` entries sharing a file are *not* a collision — they merge.

## Test plan
- [x] New EUnit coverage in `beamtalk_workspace_flush_tests.erl`: Tier 2 gating, happy path (definition + same-file self-send + cross-file super-send, all rewritten in one flush), `candidate_sites` never written (verified via both final body and absence of `.tmp`), Phase A abort on an external edit to a confirmed site (whole batch aborts, not even the definition's own file is touched), collision vs. an ordinary patch, collision vs. a `rename-class` entry's own touched file, and two `rename-method` entries merging cleanly in one file → 346/346 pass
- [x] New REPL-protocol e2e test (`tests/repl-protocol/cases/rename_method_flush_roundtrip.btscript`) exercising the full `renameSelector:to:` + `Workspace flush: aClass confirmDestructive: true` chain against real project files, matching this issue's acceptance criteria wording verbatim — covers definition + same-file self-send + cross-file super-send rewritten, the candidate site left byte-identical on disk, and a fresh reload confirming no dangling `does_not_understand` for any confirmed site (the old selector genuinely DNUs post-rename) → `just test-repl-protocol` 2374/2374 pass
- [x] Full `beamtalk_workspace` app EUnit suite → 3000/3000, 0 failures (includes the full pre-existing `rename-class` (BT-3271) suite passing unchanged through the shared code path — this issue's explicit regression-test acceptance criterion)
- [x] `just test-stdlib` / `just test-bunit` (3314/3316, 2 pre-existing unrelated skips, same baseline as prior ADR 0114 PRs) / `just test-metamorphic` all clean
- [x] `just build` / `just clippy` / `just fmt-check` (Rust/Erlang/JS/Beamtalk) / `rebar3 dialyzer` all clean
- [ ] `just test` (`test-rust`) — one pre-existing, environment-only failure: `commands::workspace::epmd::tests::bt2424_default_deployment_keeps_epmd_off_public_interfaces`. Unrelated to this change (never touches `epmd.rs` or deployment code); the test's own failure message identifies the cause as another Erlang/OTP process on this shared, multi-agent sandbox host binding `epmd` first. Reproduces identically running the test in isolation before any of this branch's edits were applied.

Part of Epic BT-3267 (ADR 0114). Blocked by (already merged, this branch is based on top of): BT-3268, BT-3269, BT-3270, BT-3278, BT-3271, BT-3272, BT-3279.

Filed BT-3284 as a follow-up for two small pre-existing surface gaps found during review (unrelated to this issue's scope, present since `rename-class`/`rename-method` were introduced): `flushKinds:` doesn't recognize either rename kind symbol, and `ChangeEntry>>printString` mislabels a `rename-class` entry as `(new-class)`.

Linear: https://linear.app/beamtalk/issue/BT-3273

---
_Generated by [Claude Code](https://claude.ai/code/session_013rAzBVQtZgxDhG9tdCKGcV)_