### PR TITLE
Measure Elixir test coverage for the LiveView IDE (BT-3288)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -791,17 +791,37 @@ jobs:
           # the same branch independently — this must NOT recreate the branch
           # as an orphan (that previously deleted elixir-coverage.json on every
           # run of this job, since it only ever re-added the two files below).
+          #
+          # Retry loop: this job and liveview.yml's `coverage` job can both push
+          # to `badges` around the same time (e.g. a PR touching both paths), and
+          # a non-fast-forward push must not fail the run outright — refetch and
+          # reapply instead (PR #3549 review).
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin badges
-          git worktree add /tmp/badges-branch origin/badges
-          echo "{\"schemaVersion\":1,\"label\":\"Rust coverage\",\"message\":\"${RUST_MSG}\",\"color\":\"${RUST_COLOR}\"}" > /tmp/badges-branch/rust-coverage.json
-          echo "{\"schemaVersion\":1,\"label\":\"Erlang coverage\",\"message\":\"${ERLANG_MSG}\",\"color\":\"${ERLANG_COLOR}\"}" > /tmp/badges-branch/erlang-coverage.json
-          cd /tmp/badges-branch
-          git add rust-coverage.json erlang-coverage.json
-          git diff --staged --quiet && exit 0
-          git commit -m "Update coverage badges [skip ci]"
-          git push origin HEAD:badges
+          attempt=0
+          until [ "$attempt" -ge 5 ]; do
+            attempt=$((attempt + 1))
+            git worktree remove --force /tmp/badges-branch 2>/dev/null || true
+            rm -rf /tmp/badges-branch
+            git fetch origin badges
+            git worktree add /tmp/badges-branch origin/badges
+            echo "{\"schemaVersion\":1,\"label\":\"Rust coverage\",\"message\":\"${RUST_MSG}\",\"color\":\"${RUST_COLOR}\"}" > /tmp/badges-branch/rust-coverage.json
+            echo "{\"schemaVersion\":1,\"label\":\"Erlang coverage\",\"message\":\"${ERLANG_MSG}\",\"color\":\"${ERLANG_COLOR}\"}" > /tmp/badges-branch/erlang-coverage.json
+            git -C /tmp/badges-branch add rust-coverage.json erlang-coverage.json
+            if git -C /tmp/badges-branch diff --staged --quiet; then
+              echo "No badge changes to publish"
+              exit 0
+            fi
+            git -C /tmp/badges-branch commit -m "Update coverage badges [skip ci]"
+            if git -C /tmp/badges-branch push origin HEAD:badges; then
+              echo "Badge published"
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}), retrying..."
+            sleep $((RANDOM % 5 + attempt))
+          done
+          echo "::error::Failed to push coverage badges after ${attempt} attempts (concurrent badge publisher?)"
+          exit 1
 
       - name: Fail if coverage thresholds not met
         if: steps.rust_thresholds.outcome == 'failure' || steps.erlang_thresholds.outcome == 'failure'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -785,21 +785,23 @@ jobs:
             ERLANG_COLOR=$(badge_color "$ERLANG_COV")
           fi
 
-          # Create badge JSON files (shields.io endpoint format)
-          mkdir -p badges
-          echo "{\"schemaVersion\":1,\"label\":\"Rust coverage\",\"message\":\"${RUST_MSG}\",\"color\":\"${RUST_COLOR}\"}" > badges/rust-coverage.json
-          echo "{\"schemaVersion\":1,\"label\":\"Erlang coverage\",\"message\":\"${ERLANG_MSG}\",\"color\":\"${ERLANG_COLOR}\"}" > badges/erlang-coverage.json
-
-          # Commit to badges branch
+          # Update only rust-coverage.json/erlang-coverage.json on the shared
+          # `badges` branch, via a worktree so the main checkout is untouched.
+          # The `liveview.yml` `coverage` job publishes elixir-coverage.json to
+          # the same branch independently — this must NOT recreate the branch
+          # as an orphan (that previously deleted elixir-coverage.json on every
+          # run of this job, since it only ever re-added the two files below).
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout --orphan badges-tmp
-          git rm -rf . > /dev/null 2>&1 || true
-          cp -r badges/* .
-          rm -rf badges
+          git fetch origin badges
+          git worktree add /tmp/badges-branch origin/badges
+          echo "{\"schemaVersion\":1,\"label\":\"Rust coverage\",\"message\":\"${RUST_MSG}\",\"color\":\"${RUST_COLOR}\"}" > /tmp/badges-branch/rust-coverage.json
+          echo "{\"schemaVersion\":1,\"label\":\"Erlang coverage\",\"message\":\"${ERLANG_MSG}\",\"color\":\"${ERLANG_COLOR}\"}" > /tmp/badges-branch/erlang-coverage.json
+          cd /tmp/badges-branch
           git add rust-coverage.json erlang-coverage.json
+          git diff --staged --quiet && exit 0
           git commit -m "Update coverage badges [skip ci]"
-          git push origin HEAD:badges --force
+          git push origin HEAD:badges
 
       - name: Fail if coverage thresholds not met
         if: steps.rust_thresholds.outcome == 'failure' || steps.erlang_thresholds.outcome == 'failure'

--- a/.github/workflows/liveview.yml
+++ b/.github/workflows/liveview.yml
@@ -145,6 +145,11 @@ jobs:
       # disturbed. The `ci.yml` `coverage` job publishes rust/erlang-coverage.json
       # to the same branch independently — must NOT recreate it as an orphan
       # (that would delete those files), so this fetches + amends in place.
+      #
+      # Retry loop: this job and ci.yml's `coverage` job can both push to
+      # `badges` around the same time (e.g. a PR touching both paths), and a
+      # non-fast-forward push must not fail the run outright — refetch and
+      # reapply instead (PR #3549 review).
       - name: Publish coverage badge
         working-directory: .
         run: |
@@ -170,11 +175,26 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin badges
-          git worktree add /tmp/badges-branch origin/badges
-          echo "{\"schemaVersion\":1,\"label\":\"Elixir coverage\",\"message\":\"${MSG}\",\"color\":\"${COLOR}\"}" > /tmp/badges-branch/elixir-coverage.json
-          cd /tmp/badges-branch
-          git add elixir-coverage.json
-          git diff --staged --quiet && exit 0
-          git commit -m "Update Elixir coverage badge [skip ci]"
-          git push origin HEAD:badges
+          attempt=0
+          until [ "$attempt" -ge 5 ]; do
+            attempt=$((attempt + 1))
+            git worktree remove --force /tmp/badges-branch 2>/dev/null || true
+            rm -rf /tmp/badges-branch
+            git fetch origin badges
+            git worktree add /tmp/badges-branch origin/badges
+            echo "{\"schemaVersion\":1,\"label\":\"Elixir coverage\",\"message\":\"${MSG}\",\"color\":\"${COLOR}\"}" > /tmp/badges-branch/elixir-coverage.json
+            git -C /tmp/badges-branch add elixir-coverage.json
+            if git -C /tmp/badges-branch diff --staged --quiet; then
+              echo "No badge changes to publish"
+              exit 0
+            fi
+            git -C /tmp/badges-branch commit -m "Update Elixir coverage badge [skip ci]"
+            if git -C /tmp/badges-branch push origin HEAD:badges; then
+              echo "Badge published"
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}), retrying..."
+            sleep $((RANDOM % 5 + attempt))
+          done
+          echo "::error::Failed to push Elixir coverage badge after ${attempt} attempts (concurrent badge publisher?)"
+          exit 1

--- a/.github/workflows/liveview.yml
+++ b/.github/workflows/liveview.yml
@@ -85,5 +85,92 @@ jobs:
         run: mix assets.build
 
       # Workspace-attach tests are skipped automatically (no BT_WORKSPACE_COOKIE).
-      - name: Run tests
-        run: mix test
+      # --cover instruments via OTP's built-in :cover (same tool family as the
+      # Erlang runtime's rebar3 cover) and enforces the threshold set in
+      # mix.exs test_coverage (BT-3288) — a real CI gate, not just a report.
+      - name: Run tests with coverage
+        run: mix test --cover
+
+  coverage:
+    needs: liveview
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: editors/liveview
+    permissions:
+      contents: write
+    steps:
+      # persist-credentials kept: the step below pushes the coverage badge to the `badges` branch.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
+
+      - name: Install Erlang/OTP + Elixir
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Mix deps and build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: |
+            editors/liveview/deps
+            editors/liveview/_build
+          key: ${{ runner.os }}-liveview-mix-${{ hashFiles('editors/liveview/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-liveview-mix-
+
+      - name: Fetch deps
+        run: mix deps.get
+
+      # No asset build needed here: :playwright/:workspace tests (the only
+      # ones needing built JS/CSS) are excluded from a bare `mix test`.
+      - name: Run tests with coverage
+        id: coverage
+        run: |
+          mix test --cover | tee coverage-output.txt
+          total=$(grep -E '\|\s*Total\s*\|' coverage-output.txt | grep -oE '[0-9]+\.[0-9]+' | head -1)
+          echo "total=${total:-0}" >> "$GITHUB_OUTPUT"
+
+      # Updates only elixir-coverage.json on the shared `badges` branch, via a
+      # worktree so the main checkout (and its editors/liveview cwd) is never
+      # disturbed. The `ci.yml` `coverage` job publishes rust/erlang-coverage.json
+      # to the same branch independently — must NOT recreate it as an orphan
+      # (that would delete those files), so this fetches + amends in place.
+      - name: Publish coverage badge
+        working-directory: .
+        run: |
+          badge_color() {
+            local cov=$1
+            awk -v c="$cov" 'BEGIN {
+              if (c >= 80) print "brightgreen"
+              else if (c >= 70) print "green"
+              else if (c >= 60) print "yellowgreen"
+              else if (c >= 50) print "yellow"
+              else print "red"
+            }'
+          }
+
+          COV="${{ steps.coverage.outputs.total }}"
+          MSG="unknown"
+          COLOR="lightgrey"
+
+          if echo "$COV" | grep -Eq '^[0-9]+([.][0-9]+)?$'; then
+            MSG="${COV}%"
+            COLOR=$(badge_color "$COV")
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin badges
+          git worktree add /tmp/badges-branch origin/badges
+          echo "{\"schemaVersion\":1,\"label\":\"Elixir coverage\",\"message\":\"${MSG}\",\"color\":\"${COLOR}\"}" > /tmp/badges-branch/elixir-coverage.json
+          cd /tmp/badges-branch
+          git add elixir-coverage.json
+          git diff --staged --quiet && exit 0
+          git commit -m "Update Elixir coverage badge [skip ci]"
+          git push origin HEAD:badges

--- a/.github/workflows/liveview.yml
+++ b/.github/workflows/liveview.yml
@@ -134,7 +134,11 @@ jobs:
         run: |
           mix test --cover | tee coverage-output.txt
           total=$(grep -E '\|\s*Total\s*\|' coverage-output.txt | grep -oE '[0-9]+\.[0-9]+' | head -1)
-          echo "total=${total:-0}" >> "$GITHUB_OUTPUT"
+          if [ -z "$total" ]; then
+            echo "::error::Could not parse coverage total from 'mix test --cover' output — table format may have changed"
+            exit 1
+          fi
+          echo "total=${total}" >> "$GITHUB_OUTPUT"
 
       # Updates only elixir-coverage.json on the shared `badges` branch, via a
       # worktree so the main checkout (and its editors/liveview cwd) is never

--- a/Justfile
+++ b/Justfile
@@ -1435,6 +1435,17 @@ coverage-runtime-open:
         echo "   Report: runtime/_build/test/cover/index.html"
     fi
 
+# Generate LiveView IDE (editors/liveview) coverage via Elixir's built-in
+# `mix test --cover` (OTP :cover — same tool family as coverage-runtime's
+# rebar3 cover). Threshold/ignore_modules are configured in mix.exs (BT-3288).
+# `mix deps.get` first mirrors fmt-check-elixir/fmt-elixir's fresh-checkout-safe pattern.
+[working-directory: 'editors/liveview']
+coverage-liveview:
+    @echo "📊 Generating LiveView IDE (Elixir) coverage..."
+    mix deps.get --quiet
+    mix test --cover
+    @echo "  📁 HTML report: editors/liveview/cover/index.html"
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Clean Tasks
 # ═══════════════════════════════════════════════════════════════════════════

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![API Docs](https://img.shields.io/badge/docs-API%20Reference-blue)](https://www.beamtalk.dev/apidocs/)
 [![Rust coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jamesc/beamtalk/badges/rust-coverage.json)](https://github.com/jamesc/beamtalk/actions/workflows/ci.yml)
 [![Erlang coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jamesc/beamtalk/badges/erlang-coverage.json)](https://github.com/jamesc/beamtalk/actions/workflows/ci.yml)
+[![Elixir coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jamesc/beamtalk/badges/elixir-coverage.json)](https://github.com/jamesc/beamtalk/actions/workflows/liveview.yml)
 
 <picture>
   <source srcset="docs/images/beamtalk-logo-dark.svg" media="(prefers-color-scheme: dark)" style="max-width: 480px; width: 100%; height: auto;" />

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -73,6 +73,22 @@ cargo llvm-cov --all-targets --workspace --cobertura --output-path coverage.cobe
 just coverage-all
 ```
 
+**Elixir coverage (LiveView IDE, `editors/liveview`):**
+```bash
+just coverage-liveview
+```
+Uses Elixir's built-in `mix test --cover` (OTP's `:cover` — the same tool
+family as `coverage-runtime`'s `rebar3 cover`, so no extra Hex dependency like
+`excoveralls` is needed). `test_coverage` in `editors/liveview/mix.exs`
+configures `ignore_modules` (currently just `BtAttachWeb.Layouts`, a pure
+`embed_templates` boilerplate module with no logic) and the pass/fail
+`summary: [threshold: ...]` floor — nested under `:summary`, since
+`Mix.Tasks.Test.Coverage` only reads `:threshold` from there, not from the
+top-level `test_coverage` options. The `liveview` CI job runs `mix test
+--cover` directly, so PRs get the threshold enforced as a real gate; a
+separate `coverage` job (push-to-`main` only) publishes the
+`elixir-coverage.json` badge.
+
 The Erlang coverage badge blends all four runtime apps —
 `beamtalk_runtime`, `beamtalk_workspace`, `beamtalk_stdlib`, and
 `beamtalk_compiler`. The `beamtalk_stdlib` figure reflects only the
@@ -124,6 +140,7 @@ beam-write-error arm, and root-only `permission_denied` / TOCTOU
 Coverage reports are saved to:
 - Rust HTML: `target/llvm-cov/html/index.html`
 - Erlang HTML: `runtime/_build/test/cover/index.html`
+- Elixir HTML: `editors/liveview/cover/index.html`
 - Rust Cobertura XML: `coverage.cobertura.xml`
 - Erlang Cobertura XML: one per app under `runtime/_build/test/covertool/` (`beamtalk_runtime`, `beamtalk_workspace`, `beamtalk_stdlib`, `beamtalk_compiler`)
 

--- a/editors/liveview/mix.exs
+++ b/editors/liveview/mix.exs
@@ -20,6 +20,18 @@ defmodule BtAttach.MixProject do
       version: @version,
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
+      test_coverage: [
+        ignore_modules: [
+          # Pure Phoenix boilerplate: `embed_templates` only, no logic to exercise.
+          BtAttachWeb.Layouts
+        ],
+        # :threshold only takes effect nested under :summary — Mix.Tasks.Test.Coverage
+        # reads it from the :summary opts, not the top-level test_coverage opts.
+        # Floor below the current ~60% baseline (BT-3288) so CI has headroom to
+        # fluctuate without going red; raise as coverage improves. Mirrors the
+        # Rust/Erlang coverage-job thresholds in .github/workflows/ci.yml.
+        summary: [threshold: 55]
+      ],
       # Warnings-as-errors for our own code only — deps compile with their
       # upstream settings and routinely warn under newer Elixir releases.
       elixirc_options: [warnings_as_errors: true],


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-3288/measure-elixir-test-coverage-for-the-liveview-ide-editorsliveview

## Summary

The repo measures Rust (`cargo-llvm-cov`) and Erlang (`rebar3 cover`) coverage with badges in the README, but `editors/liveview` (the Phoenix/Elixir LiveView IDE) had no coverage measurement at all. This wires it up using Elixir's built-in `mix test --cover` (OTP's `:cover` — same tool family as the Erlang side, no new Hex dependency).

## Changes

- `editors/liveview/mix.exs`: `test_coverage` config — `ignore_modules: [BtAttachWeb.Layouts]` (pure `embed_templates` boilerplate, no logic) and `summary: [threshold: 55]` (floor below the current ~60% baseline; note `:threshold` only takes effect nested under `:summary` in `Mix.Tasks.Test.Coverage`).
- `.github/workflows/liveview.yml`: the PR-facing `liveview` job now runs `mix test --cover` as a real gate. A new `coverage` job (push-to-`main` only) parses the total and publishes `elixir-coverage.json` to the shared `badges` branch via a git worktree, without disturbing the `rust-coverage.json`/`erlang-coverage.json` files `ci.yml` publishes there.
- `README.md`: added the Elixir coverage badge next to Rust/Erlang.
- `Justfile`: `coverage-liveview` recipe for a local HTML report.
- `docs/development/testing-strategy.md`: documented the new lane.

## Test plan

- [x] `mix format --check-formatted` / `mix compile --warnings-as-errors` / `mix test --cover` (passes at 59.92%, threshold 55) — verified locally
- [x] `just coverage-liveview` — verified locally
- [x] YAML validity of the updated workflow — verified locally
- [x] Pre-push hook (full `just ci`, including `lint-elixir`) passed clean