### PR TITLE
Fix two pre-existing LiveView test flakes (BT-3287)

### DIFF
--- a/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_browser_test.exs
@@ -241,8 +241,18 @@ defmodule BtAttachWeb.WorkspaceBrowserTest do
     |> set_source("10 + 5")
     # ⌘P / Ctrl+P is bound (data-shortcuts "mod+p" → "submit:print_it"): the hook
     # sets the hidden action field and request-submits the eval form — no button
-    # click. Linux/CI uses Ctrl as the mod key.
-    |> press("#workspace-editor-overlay .cm-content", "Control+p")
+    # click. `ControlOrMeta` is Ctrl on Linux/CI and Cmd on macOS (mirrors
+    # `press_save/1`'s ⌘S chord) — BT-3287: a hardcoded "Control+p" collides on
+    # macOS with CodeMirror 6's built-in mac-only Emacs-style keymap
+    # (`@codemirror/commands`), which binds bare Ctrl-P to "cursor up" and calls
+    # `preventDefault()` on the keydown before it ever reaches the
+    # `KeyboardShortcuts` hook's chord handling (which correctly backs off on an
+    # already-`defaultPrevented` event — see `keyboard_shortcuts.js`). Real
+    # macOS users hit this shortcut via ⌘P (metaKey), which that keymap does
+    # NOT bind, so they're unaffected; only the test's hardcoded bare Ctrl chord
+    # was macOS-local-flaky. `ControlOrMeta+p` exercises the actual per-platform
+    # user gesture instead of a CI-only stand-in, sidestepping the collision.
+    |> press("#workspace-editor-overlay .cm-content", "ControlOrMeta+p")
     |> assert_has(".eval-status .val", text: "15")
   end
 

--- a/editors/liveview/test/bt_attach_web/workspace_live_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_test.exs
@@ -1173,10 +1173,25 @@ defmodule BtAttachWeb.WorkspaceLiveTest do
     # selector. `phx-value-entry-side="instance"` proves BT-3187's per-row side
     # (ADR 0112) rides along on a `remove-method` row exactly like the
     # instance/class/new-class rows already covered above.
-    assert has_element?(
-             view,
-             ~s(button[phx-click="revert"][phx-value-class="#{class}"][phx-value-selector="greeting"][phx-value-entry-side="instance"])
-           )
+    #
+    # BT-3287: the raw eval form (`#eval-form`, used above) drives `removeSelector:`
+    # through the generic `handle_event("eval", ...)` -> `eval_success/5` path,
+    # which — unlike the "Remove Method" button's own `remove_method_eval/6`
+    # (which calls `assign_changes/1` synchronously right after its own
+    # `Facade.dispatch(:eval, ...)`) — never refreshes the Changes pane itself.
+    # The new ChangeLog entry only becomes visible once the class-lifecycle
+    # broadcast this same removal triggers arrives back as the coalesced
+    # `:do_source_refresh` push (BT-2600, ~60ms debounce + round-trip) and its
+    # `refresh_after_source_change/1` calls `assign_changes/1`. A bare
+    # `has_element?` right after `render_submit` races that async refresh —
+    # intermittently missing it under load — so poll for it exactly like every
+    # other async-dependent assertion in this file does.
+    assert eventually(fn ->
+             has_element?(
+               view,
+               ~s(button[phx-click="revert"][phx-value-class="#{class}"][phx-value-selector="greeting"][phx-value-entry-side="instance"])
+             )
+           end)
 
     # Click it: the button dispatches the owner-gated `:revert` op, which
     # reaches `revert_method/3` — reusing its existing side-aware selection


### PR DESCRIPTION
Fixes https://linear.app/beamtalk/issue/BT-3287

## Summary

Two test-only fixes for flakes discovered incidentally while verifying BT-2588 (both confirmed pre-existing on unmodified `main` via `git stash` A/B testing at the time).

1. **⌘/Ctrl+P Playwright test, macOS-local-only.** The test hardcoded `"Control+p"`. On macOS, bare Ctrl-P collides with CodeMirror 6's built-in mac-only Emacs-style keymap (`@codemirror/commands`), which binds it to "cursor up" and calls `preventDefault()` before the keydown reaches our `KeyboardShortcuts` hook — confirmed via debug instrumentation showing the event arrives at the hook already `defaultPrevented`. Real macOS users hit this shortcut via ⌘P (metaKey), which that keymap doesn't bind, so they were never affected. Switched to `ControlOrMeta+p`, mirroring how `press_save/1` already handles ⌘S.
2. **ChangeLog revert-button test, intermittent.** The test asserted `has_element?` immediately after a raw eval-driven `removeSelector:` submit. Unlike the "Remove Method" button's handler (which calls `assign_changes/1` synchronously), a raw eval only refreshes the Changes pane via the async, ~60ms-debounced class-reload push (BT-2600) — an inherent LiveViewTest-vs-async-push race. Wrapped the assertion in the file's existing `eventually/2` helper, matching the pattern already used elsewhere in the same file.

Both root causes are precisely identified and the fixes are minimal, test-only changes — no production code touched.

## Verification

- Full Playwright suite (36/36) passes repeatedly against a fresh local workspace.
- Full workspace-gated `Phoenix.LiveViewTest` suite (96/96) passes repeatedly against a fresh local workspace.
- (Noted, not fixed here: this local machine shows unrelated general flakiness under very heavy repeated parallel `mix test` runs against a single long-lived shared workspace node — traced to workspace-state/resource degradation from my own repeated stress-testing in-session, not a code bug; a fresh workspace resolves it every time. Out of scope for this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)