### PR TITLE
Dedupe coverage-badge publish retry logic (BT-3288 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -785,43 +785,13 @@ jobs:
             ERLANG_COLOR=$(badge_color "$ERLANG_COV")
           fi
 
-          # Update only rust-coverage.json/erlang-coverage.json on the shared
-          # `badges` branch, via a worktree so the main checkout is untouched.
-          # The `liveview.yml` `coverage` job publishes elixir-coverage.json to
-          # the same branch independently — this must NOT recreate the branch
-          # as an orphan (that previously deleted elixir-coverage.json on every
-          # run of this job, since it only ever re-added the two files below).
-          #
-          # Retry loop: this job and liveview.yml's `coverage` job can both push
-          # to `badges` around the same time (e.g. a PR touching both paths), and
-          # a non-fast-forward push must not fail the run outright — refetch and
-          # reapply instead (PR #3549 review).
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          attempt=0
-          until [ "$attempt" -ge 5 ]; do
-            attempt=$((attempt + 1))
-            git worktree remove --force /tmp/badges-branch 2>/dev/null || true
-            rm -rf /tmp/badges-branch
-            git fetch origin badges
-            git worktree add /tmp/badges-branch origin/badges
-            echo "{\"schemaVersion\":1,\"label\":\"Rust coverage\",\"message\":\"${RUST_MSG}\",\"color\":\"${RUST_COLOR}\"}" > /tmp/badges-branch/rust-coverage.json
-            echo "{\"schemaVersion\":1,\"label\":\"Erlang coverage\",\"message\":\"${ERLANG_MSG}\",\"color\":\"${ERLANG_COLOR}\"}" > /tmp/badges-branch/erlang-coverage.json
-            git -C /tmp/badges-branch add rust-coverage.json erlang-coverage.json
-            if git -C /tmp/badges-branch diff --staged --quiet; then
-              echo "No badge changes to publish"
-              exit 0
-            fi
-            git -C /tmp/badges-branch commit -m "Update coverage badges [skip ci]"
-            if git -C /tmp/badges-branch push origin HEAD:badges; then
-              echo "Badge published"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}), retrying..."
-            sleep $((RANDOM % 5 + attempt))
-          done
-          echo "::error::Failed to push coverage badges after ${attempt} attempts (concurrent badge publisher?)"
-          exit 1
+          # Shared with liveview.yml's `coverage` job (elixir-coverage.json) —
+          # see scripts/ci/publish-coverage-badge.sh for the retry/worktree
+          # rationale (PR #3549 review: dedupe the two near-identical copies).
+          scripts/ci/publish-coverage-badge.sh \
+            "Update coverage badges [skip ci]" \
+            rust-coverage.json "{\"schemaVersion\":1,\"label\":\"Rust coverage\",\"message\":\"${RUST_MSG}\",\"color\":\"${RUST_COLOR}\"}" \
+            erlang-coverage.json "{\"schemaVersion\":1,\"label\":\"Erlang coverage\",\"message\":\"${ERLANG_MSG}\",\"color\":\"${ERLANG_COLOR}\"}"
 
       - name: Fail if coverage thresholds not met
         if: steps.rust_thresholds.outcome == 'failure' || steps.erlang_thresholds.outcome == 'failure'

--- a/.github/workflows/liveview.yml
+++ b/.github/workflows/liveview.yml
@@ -140,16 +140,9 @@ jobs:
           fi
           echo "total=${total}" >> "$GITHUB_OUTPUT"
 
-      # Updates only elixir-coverage.json on the shared `badges` branch, via a
-      # worktree so the main checkout (and its editors/liveview cwd) is never
-      # disturbed. The `ci.yml` `coverage` job publishes rust/erlang-coverage.json
-      # to the same branch independently — must NOT recreate it as an orphan
-      # (that would delete those files), so this fetches + amends in place.
-      #
-      # Retry loop: this job and ci.yml's `coverage` job can both push to
-      # `badges` around the same time (e.g. a PR touching both paths), and a
-      # non-fast-forward push must not fail the run outright — refetch and
-      # reapply instead (PR #3549 review).
+      # Shared with ci.yml's `coverage` job (rust/erlang-coverage.json) — see
+      # scripts/ci/publish-coverage-badge.sh for the retry/worktree rationale
+      # (PR #3549 review: dedupe the two near-identical copies).
       - name: Publish coverage badge
         working-directory: .
         run: |
@@ -173,28 +166,6 @@ jobs:
             COLOR=$(badge_color "$COV")
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          attempt=0
-          until [ "$attempt" -ge 5 ]; do
-            attempt=$((attempt + 1))
-            git worktree remove --force /tmp/badges-branch 2>/dev/null || true
-            rm -rf /tmp/badges-branch
-            git fetch origin badges
-            git worktree add /tmp/badges-branch origin/badges
-            echo "{\"schemaVersion\":1,\"label\":\"Elixir coverage\",\"message\":\"${MSG}\",\"color\":\"${COLOR}\"}" > /tmp/badges-branch/elixir-coverage.json
-            git -C /tmp/badges-branch add elixir-coverage.json
-            if git -C /tmp/badges-branch diff --staged --quiet; then
-              echo "No badge changes to publish"
-              exit 0
-            fi
-            git -C /tmp/badges-branch commit -m "Update Elixir coverage badge [skip ci]"
-            if git -C /tmp/badges-branch push origin HEAD:badges; then
-              echo "Badge published"
-              exit 0
-            fi
-            echo "Push rejected (attempt ${attempt}), retrying..."
-            sleep $((RANDOM % 5 + attempt))
-          done
-          echo "::error::Failed to push Elixir coverage badge after ${attempt} attempts (concurrent badge publisher?)"
-          exit 1
+          scripts/ci/publish-coverage-badge.sh \
+            "Update Elixir coverage badge [skip ci]" \
+            elixir-coverage.json "{\"schemaVersion\":1,\"label\":\"Elixir coverage\",\"message\":\"${MSG}\",\"color\":\"${COLOR}\"}"

--- a/scripts/ci/publish-coverage-badge.sh
+++ b/scripts/ci/publish-coverage-badge.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+#
+# Publishes one or more shields.io endpoint-format coverage-badge JSON files
+# to the shared `badges` orphan branch, via a git worktree so the caller's
+# own checkout is never disturbed. ci.yml's `coverage` job (rust/erlang) and
+# liveview.yml's `coverage` job (elixir) both call this — they can publish
+# around the same time, so a plain fetch+commit+push can hit a non-fast-
+# forward rejection; this retries (refetch + reapply + push) instead of
+# failing the run outright (PR #3549 review).
+#
+# Usage: publish-coverage-badge.sh <commit-message> <file1> <content1> [<file2> <content2> ...]
+set -euo pipefail
+
+if [ "$#" -lt 3 ] || [ $(( ($# - 1) % 2 )) -ne 0 ]; then
+  echo "Usage: $0 <commit-message> <file1> <content1> [<file2> <content2> ...]" >&2
+  exit 2
+fi
+
+commit_message="$1"
+shift
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+worktree=$(mktemp -d)
+trap 'git worktree remove --force "$worktree" >/dev/null 2>&1 || true; rm -rf "$worktree"' EXIT
+
+attempt=0
+until [ "$attempt" -ge 5 ]; do
+  attempt=$((attempt + 1))
+  git worktree remove --force "$worktree" >/dev/null 2>&1 || true
+  rm -rf "$worktree"
+  git fetch origin badges
+  git worktree add "$worktree" origin/badges >/dev/null
+
+  files=()
+  i=1
+  while [ "$i" -le "$#" ]; do
+    file="${!i}"
+    content_idx=$((i + 1))
+    content="${!content_idx}"
+    echo "$content" > "$worktree/$file"
+    files+=("$file")
+    i=$((i + 2))
+  done
+
+  git -C "$worktree" add "${files[@]}"
+  if git -C "$worktree" diff --staged --quiet; then
+    echo "No badge changes to publish"
+    exit 0
+  fi
+  git -C "$worktree" commit -m "$commit_message" >/dev/null
+  if git -C "$worktree" push origin HEAD:badges; then
+    echo "Badge published"
+    exit 0
+  fi
+  echo "Push rejected (attempt ${attempt}), retrying..."
+  sleep $((RANDOM % 5 + attempt))
+done
+
+echo "::error::Failed to push badge(s) after ${attempt} attempts (concurrent badge publisher?)"
+exit 1


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-3288/measure-elixir-test-coverage-for-the-liveview-ide-editorsliveview

## Summary

Follow-up to #3549, which had already merged by the time this fix landed. The Claude review bot's last (non-blocking) suggestion on that PR was that the fetch/worktree/commit/push retry loop for publishing coverage badges was duplicated near-verbatim between `.github/workflows/ci.yml` and `.github/workflows/liveview.yml` — exactly why the badges-branch clobbering bug needed two separate fixes across two files earlier in that PR's history.

This extracts the shared logic into `scripts/ci/publish-coverage-badge.sh` (per CLAUDE.md's "No duplicate implementations"); both workflows now call it with their own commit message and file/content pairs.

## Changes

- New `scripts/ci/publish-coverage-badge.sh`: publishes one or more shields.io endpoint-format badge JSON files to the shared `badges` branch via a worktree, with retry-on-non-fast-forward.
- `.github/workflows/ci.yml` and `.github/workflows/liveview.yml`: both `coverage` jobs' "Publish coverage badge(s)" steps now call the shared script instead of duplicating it.

## Test plan

- [x] Re-verified locally against a scratch bare repo: normal publish, no-op (unchanged content), and a simulated concurrent competing push all behave correctly through the shared script.
- [x] `bash -n` syntax check on the script; both workflow YAMLs validated.
- [x] Pre-push hook (full `just ci`) passed clean.