### PR TITLE
Codegen: classBuilder addClassMethod:body:/classMethods: block clobbers enclosing method's State-version counter (BT-3289)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -1411,6 +1411,16 @@ pub(super) struct SavedClassMethodCtx {
     class_var_mutated: bool,
     class_slot_constructor_selector: Option<String>,
     builder_class_method_class: Option<String>,
+    // BT-3289: unlike `class_var_version` above, the instance-`State` version
+    // counter lives outside `ClassContext` (it's shared by every class, not
+    // per-class-context), so nothing captured it here even though
+    // `generate_class_method_fun_from_block` unconditionally resets it. A
+    // builder cascade nested inside an enclosing method's own field-assignment
+    // value (e.g. `self.x := Object classBuilder … addClassMethod:body: […]; register`)
+    // would silently clobber the enclosing method's in-progress `State`
+    // version, producing two bindings for the same version — caught by the
+    // ADR-0111 verifier as `NonLinearVersion`.
+    state_version: usize,
 }
 
 impl ClassContext {
@@ -2159,6 +2169,7 @@ impl CoreErlangGenerator {
             class_var_mutated: self.class_var_mutated(),
             class_slot_constructor_selector: self.class_slot_constructor_selector().cloned(),
             builder_class_method_class: self.builder_class_method_class(),
+            state_version: self.state_version(),
         };
         self.set_in_class_method(true);
         *self.class_var_names_mut() = class_var_names.iter().cloned().collect();
@@ -2203,6 +2214,12 @@ impl CoreErlangGenerator {
             // (REPL) builder cascades don't leak a class context.
             self.class_context = None;
         }
+        // BT-3289: `state_version` lives outside `ClassContext`, so it must be
+        // restored unconditionally here — independent of `had_context` — or a
+        // builder cascade nested inside an enclosing method's field-assignment
+        // value leaves that method's `State` version counter reset to 0
+        // instead of wherever it legitimately was.
+        self.set_state_version(saved.state_version);
     }
 
     /// BT-2709: Clears per-method parameter-type tracking. Call alongside

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -7619,3 +7619,47 @@ fn test_mixed_foldl_nested_in_letrec_is_compile_error() {
         ),
     }
 }
+
+#[test]
+fn test_class_builder_cascade_in_second_field_assignment_does_not_corrupt_state_version() {
+    // BT-3289: a `classBuilder … addClassMethod:body:`/`classMethods:` cascade
+    // lowers its block via `generate_class_method_fun_from_block`, which resets
+    // the instance-`State` version counter (`reset_state_version`) to give the
+    // class-method fun its own fresh count — but nothing saved/restored the
+    // ENCLOSING method's counter around that reset. When such a cascade sits in
+    // the value of a field-assignment that is not the method's first (i.e. an
+    // earlier statement already minted a `State` version), the reset rewinds
+    // the enclosing counter, and the enclosing assignment's own next-minted
+    // version collides with the earlier one — an ADR-0111 `NonLinearVersion`
+    // ThreadedIr-verify violation (`producers: 2, consumers: 1`), which used to
+    // hard-panic via `report_threaded_ir_verify_errors`'s `debug_assert!` (this
+    // crate's dev/test profile builds with debug_assertions on).
+    //
+    // This requires an Actor with real `state:` elsewhere in the SAME compiled
+    // module: instance field-assignment only threads through this
+    // version-counted `State`/`maps:put` convention when the module needs
+    // gen_server/actor semantics — otherwise fields thread through a separate
+    // `Self`-counted convention `generate_class_method_fun_from_block` never
+    // touches. Beamtalk's CLI enforces one class per `.bt` file and the REPL
+    // compiles one expression per turn, so this exact shape is unreachable
+    // through either surface — only a caller building a multi-class `Module`
+    // directly (as `generate_module` allows, and as fuzzing does) can hit it.
+    // That's exactly how the nightly `compile_pipeline` fuzz target found it: a
+    // `CrossOver` mutation spliced fragments of an Actor fixture and
+    // `class_builder_incremental_test.bt` into one fuzz input.
+    let src = "Actor subclass: SlwActor\n  state: value = 41\n\nTestCase subclass: FooTest\n  field: cls = nil\n  field: parentCls = nil\n\n  testX =>\n    self.parentCls := 1\n    self.cls := Object classBuilder name: #Child;\n      superclass: Object;\n      addClassMethod: #greeting body: [:self | \"child\"];\n      register\n";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, diags) = crate::source_analysis::parse(tokens);
+    assert!(
+        diags.is_empty(),
+        "Reproducer must parse cleanly. Got diagnostics: {diags:?}"
+    );
+
+    let result = generate_module(&module, CodegenOptions::new("bt3289_state_version_repro"));
+
+    assert!(
+        result.is_ok(),
+        "generate_module must not fail/panic on a second field-assignment \
+         whose value contains a classBuilder addClassMethod:body: cascade. Got: {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes a nightly-fuzz-found panic: a `classBuilder … addClassMethod:body:`/`classMethods:` cascade nested inside a field-assignment's value clobbered the enclosing method's instance-`State` version counter, tripping the ADR-0111 ThreadedIr verifier's `NonLinearVersion` check.

Linear: https://linear.app/beamtalk/issue/BT-3289

## Root cause

`generate_class_method_fun_from_block` (`gen_server/methods.rs:3814`) calls `self.reset_state_version()` to give a lowered class-method fun its own fresh `State` counter — correct in isolation, but nothing saved/restored the *enclosing* method's counter around that reset. When such a cascade sits in the value of a field-assignment that isn't the method's first (i.e. an earlier statement already minted a `State` version), the reset rewinds the enclosing counter, and the next-minted version collides with the earlier one.

Unlike `class_var_version`, which is already properly captured in `SavedClassMethodCtx` and restored by `enter_builder_class_method_context`/`exit_builder_class_method_context`, `state_version` had no equivalent save/restore anywhere in that pair.

## Changes

- `crates/beamtalk-core/src/codegen/core_erlang/mod.rs`: add `state_version` to `SavedClassMethodCtx`, save it on enter and restore it unconditionally on exit (it lives outside `ClassContext`, so restoration can't be gated on `had_context` the way the other fields are).
- `crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs`: regression test reproducing the exact minimal trigger shape, verified to fail without the fix and pass with it.

## Investigation notes

The original crash artifact's `ActorNlrMutate`/NLR framing turned out to be a red herring — parser error recovery discarded that fragment entirely; the real trigger was an unrelated `ClassBuilderIncrementalTest`-shaped fragment elsewhere in the same fuzzed file. Full bisection and root-cause writeup is in the BT-3289 comment thread. Also found (and filed separately, not fixed here): `generate_class_method_fun_from_block` has the same unguarded-reset shape for `current_method_params`/`current_method_param_types` — tracked in BT-3300, pending a concrete reproduction to confirm real-world impact.

## Test plan

- [x] `just test` — full suite green (Rust, stdlib, BUnit, runtime, metamorphic)
- [x] `just ci-changed` — build/lint/test/check-corpus/check-surface-drift all pass
- [x] New regression test confirmed to fail pre-fix (reverted the fix locally) and pass post-fix
- [x] Original 7057-byte fuzz crash artifact and 6298-byte minimized reproducer both compile without panicking post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016WurXg8HGcA43tp5Hg1YfD