### PR TITLE
Extract Inspector + object-window pane out of WorkspaceLive (BT-3291)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/components/core_components.ex
+++ b/editors/liveview/lib/bt_attach_web/components/core_components.ex
@@ -668,4 +668,46 @@ defmodule BtAttachWeb.CoreComponents do
   def translate_errors(errors, field) when is_list(errors) do
     for {^field, {msg, opts}} <- errors, do: translate_error({msg, opts})
   end
+
+  # ── dismissable status notices (BT-2612) ────────────────────────────────────
+  #
+  # A single reusable notice component for every `io-block` status banner
+  # (err/ok/warn/plain), shared by `BtAttachWeb.WorkspaceLive` and its
+  # extracted panes (e.g. `BtAttachWeb.Live.Inspector`, BT-3291) — moved here
+  # (rather than kept as a private component on the LiveView) so an extracted
+  # pane module can render it too without a back-reference to the god module
+  # (CLAUDE.md's shared-leaf-module rule). Each notice carries a
+  # keyboard-accessible `×` dismiss control, wired by the *caller* via
+  # `dismiss_attrs` — a map of `phx-*` attributes (e.g. `%{"phx-click" =>
+  # "dismiss_notice", "phx-value-key" => "git_error"}`) so top-level scalar
+  # assigns route through the generic `dismiss_notice` event while
+  # nested/per-window notices route through their own targeted events.
+  # Variant maps to the `io-block` modifier class.
+  attr :variant, :atom, default: :plain, values: [:err, :ok, :warn, :plain]
+  attr :message, :string, required: true
+  # Map of phx-* attributes rendered onto the dismiss button. The caller
+  # decides which event/values clear the right backing assign.
+  attr :dismiss_attrs, :map, required: true
+
+  def notice(assigns) do
+    ~H"""
+    <div class={["io-block", notice_variant_class(@variant)]}>
+      <span class="io-block-msg">{@message}</span>
+      <button
+        type="button"
+        class="io-block-dismiss"
+        aria-label="Dismiss notification"
+        title="Dismiss"
+        {@dismiss_attrs}
+      >
+        ×
+      </button>
+    </div>
+    """
+  end
+
+  defp notice_variant_class(:err), do: "err"
+  defp notice_variant_class(:ok), do: "ok"
+  defp notice_variant_class(:warn), do: "warn"
+  defp notice_variant_class(:plain), do: nil
 end

--- a/editors/liveview/lib/bt_attach_web/live/facade_error.ex
+++ b/editors/liveview/lib/bt_attach_web/live/facade_error.ex
@@ -1,0 +1,25 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.Live.FacadeError do
+  @moduledoc """
+  Renders a `BtAttach.Facade` short-circuit (RBAC denial / off-vocabulary op)
+  as a clear, user-facing message. These are Phoenix-side decisions, so they
+  don't go through `BtAttach.Workspace`'s own error formatter except as a
+  fallback for reasons the facade didn't short-circuit itself.
+
+  Extracted as a shared leaf module (BT-3291) so `BtAttachWeb.WorkspaceLive`
+  and its extracted panes (e.g. `BtAttachWeb.Live.Inspector`) render the same
+  facade-error copy rather than each keeping its own (CLAUDE.md's
+  no-duplicate-implementations rule).
+  """
+
+  alias BtAttach.Workspace
+
+  @spec render(term()) :: String.t()
+  def render(:unauthorized),
+    do: "Not authorized: your role may not perform this operation."
+
+  def render(:forbidden_op), do: "Operation not permitted."
+  def render(reason), do: Workspace.render_error(reason)
+end

--- a/editors/liveview/lib/bt_attach_web/live/inspector.ex
+++ b/editors/liveview/lib/bt_attach_web/live/inspector.ex
@@ -1,0 +1,1784 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.Live.Inspector do
+  @moduledoc """
+  The docked Inspector + floating object-window pane, extracted out of
+  `BtAttachWeb.WorkspaceLive` (BT-3291, epic BT-3290) so its
+  `handle_event`/`handle_info` branches and their supporting helpers are
+  directly unit-testable instead of only reachable through a full-LiveView
+  integration test.
+
+  Originally built as the "Bindings + Inspector restyle" (BT-2486, epic
+  BT-2482 Phase 1) and its live-tracking follow-up "Inspector live tracking —
+  field flash, freeze, pid stats chips, poke quick-actions" (BT-2492), plus
+  the floating-window mode (BT-2493).
+
+  This module owns:
+
+    * The docked Inspector's inspect/drill/crumb navigation, live tracking
+      (per-object change subscription, field-flash coalescing, freeze/
+      unfreeze), pid-stats chips, and owner-only poke quick-action.
+    * The floating-window overlay (BT-2493): open/drill/crumb/close/focus/
+      move/freeze/poke per window, each a self-contained inspector keyed by
+      id, plus the `inspector_windows/1` function component that renders the
+      overlay.
+    * Reconnect persistence for the open window desk (BT-2527 #3).
+
+  State (`:inspect_target`, `:inspect_rows`, `:inspect_crumbs`,
+  `:inspect_watch`, `:inspect_stats`, `:inspect_frozen`, `:flash_gen`,
+  `:refresh_pending`, `:poke_result`, `:poke_error`, `:windows`, `:window_z`,
+  `:next_window_id`, `:inspector_mode`) stays on the LiveView's own socket —
+  it is threaded today as plain `WorkspaceLive` assigns (not a
+  `Phoenix.LiveComponent`'s isolated assigns), initialised in
+  `WorkspaceLive.bind_session/3` and read live by object-change pushes
+  delivered straight to the LiveView pid. `WorkspaceLive` still owns
+  `handle_event/3`/`handle_info/2` (a `Phoenix.LiveView` callback contract),
+  but delegates every inspector/window event and push to the functions here
+  by name — see the `@inspector_events` guard clause in `WorkspaceLive`.
+
+  Every workspace read/write goes through `BtAttach.Facade.dispatch/3` (ADR
+  0091 Decision 3) with the RBAC-relevant `BtAttachWeb.Live.RequestContext` —
+  never a raw `BtAttach.Workspace`/`:rpc` call — so this module never
+  reimplements the read-surface `inspect`/`subscribe_object`/`pid_stats` ops
+  or the RBAC gate `eval` already rides for poke (CLAUDE.md
+  no-duplicate-implementations).
+  """
+
+  use BtAttachWeb, :html
+
+  alias BtAttach.Facade
+  alias BtAttach.SessionRegistry
+  alias BtAttach.Workspace
+  alias BtAttachWeb.Live.FacadeError
+  alias BtAttachWeb.Live.RequestContext
+
+  defp ctx(socket), do: RequestContext.build(socket)
+
+  # ── handle_event dispatch ────────────────────────────────────────────────
+  #
+  # `WorkspaceLive.handle_event/3` forwards every event whose name is in
+  # `@inspector_events` here unchanged (same event name, params, socket), so
+  # each clause below is exactly the body the LiveView used to run directly.
+
+  # Inspect a binding by name: look up its live term and drill into it via the
+  # read-surface `inspect` op. Reference-following starts here. In `"float"`
+  # mode (BT-2493) the click opens a *new floating window* on the binding
+  # instead of driving the docked pane; in `"docked"` mode it drives the
+  # docked Inspector as before. Docked is the default, so the existing
+  # single-pane flow is untouched unless the user flipped the top-bar
+  # Dock/Float toggle.
+  def handle_event("inspect", %{"name" => name}, %{assigns: %{session_pid: pid}} = socket)
+      when is_pid(pid) do
+    if socket.assigns.inspector_mode == "float" do
+      {:noreply, open_window(socket, pid, name)}
+    else
+      {:noreply, inspect_binding(socket, pid, name)}
+    end
+  end
+
+  # Drill into an object-valued field of the currently-inspected object: the
+  # field term is itself a live `{:beamtalk_object, …}` handle, so following
+  # it is the same read-surface inspect call one level deeper. The clicked
+  # field's term is carried back to the server by index against the current
+  # rows, so we never round-trip a flattened string.
+  def handle_event("drill", %{"index" => index}, %{assigns: %{inspect_rows: rows}} = socket) do
+    # `index` is client-supplied; parse defensively so a malformed value can't
+    # crash the LiveView (`String.to_integer/1` would raise on non-digits).
+    with {i, ""} when i >= 0 <- Integer.parse(index),
+         %{term: term, name: name} <- Enum.at(rows, i) do
+      # Following a reference extends the drill breadcrumb one level deeper.
+      crumbs = socket.assigns.inspect_crumbs ++ [%{label: to_string(name), term: term}]
+      {:noreply, inspect_term(socket, name, term, crumbs)}
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("drill", _params, socket), do: {:noreply, socket}
+
+  # Jump back to an earlier level of the drill breadcrumb (BT-2486): truncate
+  # the trail at the clicked crumb and re-inspect that level's live term.
+  # Defensive against a client-supplied index that no longer maps to a crumb.
+  def handle_event("crumb", %{"index" => index}, %{assigns: %{inspect_crumbs: crumbs}} = socket) do
+    with {i, ""} when i >= 0 <- Integer.parse(index),
+         %{term: term, label: label} <- Enum.at(crumbs, i) do
+      {:noreply, inspect_term(socket, label, term, Enum.take(crumbs, i + 1))}
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("crumb", _params, socket), do: {:noreply, socket}
+
+  # ── live Inspector tracking events (BT-2492, epic BT-2482 Phase 3) ───────────
+
+  # Freeze / unfreeze the Inspector's live tracking (the spike's `iw-freeze`
+  # toggle, inspector.jsx). Freezing drops the per-object change subscription
+  # so the pane holds the snapshot it has — no more field-flash, no re-reads.
+  # Unfreezing re-subscribes the *current* head object and refreshes its
+  # fields + stats immediately so the pane catches up to the live state. A
+  # toggle with no object inspected (or a scalar head) just flips the flag.
+  def handle_event("freeze_toggle", _params, socket) do
+    {:noreply, toggle_freeze(socket)}
+  end
+
+  # Owner-only "send a message" quick action (the spike's PokeBar / quick-
+  # pokes, inspector.jsx). Sends the typed Beamtalk message to the inspected
+  # actor by eval'ing `<binding> <message>` against the workspace session —
+  # the same `eval` facade op the Workspace dock uses, so poke invents no new
+  # server op and rides the existing RBAC gate (an Observer's `eval` is
+  # refused; the bar is also owner-gated in the markup). The object is
+  # addressed by its *binding name* (the head crumb / target label), which is
+  # the live handle's source-level name; a drilled field with no binding name
+  # can't be poked, so we say so.
+  def handle_event("poke", %{"message" => message}, socket) when is_binary(message) do
+    {:noreply, poke_object(socket, message)}
+  end
+
+  def handle_event("poke", _params, socket), do: {:noreply, socket}
+
+  # ── floating inspector windows (BT-2493, epic BT-2482 Phase 3) ───────────────
+
+  # Flip the Inspector between docked and floating ("overlay") modes (the
+  # spike's Dock/Float toggle). Switching to docked leaves the open windows
+  # alone — they stay in state and reappear if the user flips back — so a
+  # misclick doesn't tear down a desk full of inspectors and their
+  # subscriptions. Only an explicit window close releases a window's watch.
+  def handle_event("set_inspector_mode", %{"mode" => mode}, socket)
+      when mode in ~w(docked float) do
+    {:noreply, assign(socket, inspector_mode: mode)}
+  end
+
+  def handle_event("set_inspector_mode", _params, socket), do: {:noreply, socket}
+
+  # Close *only* the Inspector pane (BT-2611), not the whole right column. The
+  # `×` lives in the Inspector sub-pane header, so it must dismiss just the
+  # Inspector and leave the Bindings pane (and the column) visible — the
+  # whole-column show/hide stays on `toggle_inspector`/`.panel-toggle`. We
+  # reset the inspector target/rows/crumbs/error back to the empty state and
+  # tear down the live subscription via `track_object(nil)` so re-inspecting
+  # an object later rebinds cleanly. Unfreeze too, so a frozen pane doesn't
+  # reopen stale on the next inspect. `show_inspector` is intentionally left
+  # untouched.
+  def handle_event("close_inspector", _params, socket) do
+    socket =
+      socket
+      |> assign(
+        inspect_target: nil,
+        inspect_rows: [],
+        inspect_crumbs: [],
+        inspect_error: nil,
+        inspect_frozen: false
+      )
+      |> track_object(nil)
+
+    {:noreply, socket}
+  end
+
+  # Drill into an object-valued field of a *floating window* (BT-2493): the
+  # field term is carried by index against that window's current rows,
+  # exactly like the docked `"drill"` event but scoped to one window.
+  # Defensive against a malformed id/index so a crafted event can't crash the
+  # LiveView.
+  def handle_event("window_drill", %{"id" => id, "index" => index}, socket) do
+    with %{} = win <- find_window(socket, id),
+         {i, ""} when i >= 0 <- Integer.parse(index),
+         %{term: term, name: name} <- Enum.at(win.rows, i) do
+      crumbs = win.crumbs ++ [%{label: to_string(name), term: term}]
+
+      {:noreply,
+       update_window(socket, id, fn w -> inspect_window(socket, w, name, term, crumbs) end)}
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("window_drill", _params, socket), do: {:noreply, socket}
+
+  # Walk a floating window's drill breadcrumb back to an earlier level:
+  # truncate its crumb trail at the clicked index and re-inspect that level's
+  # live term.
+  def handle_event("window_crumb", %{"id" => id, "index" => index}, socket) do
+    with %{} = win <- find_window(socket, id),
+         {i, ""} when i >= 0 <- Integer.parse(index),
+         %{term: term, label: label} <- Enum.at(win.crumbs, i) do
+      crumbs = Enum.take(win.crumbs, i + 1)
+
+      {:noreply,
+       update_window(socket, id, fn w -> inspect_window(socket, w, label, term, crumbs) end)}
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("window_crumb", _params, socket), do: {:noreply, socket}
+
+  # Close a floating window: drop it from the list and release its per-object
+  # change subscription (BT-2493 acceptance: "Close removes the window and
+  # releases any subscriptions"). Idempotent — closing an unknown id is a
+  # no-op.
+  def handle_event("window_close", %{"id" => id}, socket) do
+    {:noreply, close_window(socket, id)}
+  end
+
+  def handle_event("window_close", _params, socket), do: {:noreply, socket}
+
+  # Bring a floating window to the front (z-order follows focus, the spike's
+  # stacking). The WindowDrag JS hook fires this on a mousedown anywhere in
+  # the window; we bump the clicked window's z above the current max so it
+  # overlays the others. Pure view state — no workspace round-trip.
+  def handle_event("window_focus", %{"id" => id}, socket) do
+    {:noreply, focus_window(socket, id)}
+  end
+
+  def handle_event("window_focus", _params, socket), do: {:noreply, socket}
+
+  # Persist a floating window's final position after a drag (BT-2493): the
+  # WindowDrag hook reports x/y ONCE on drop (no per-mousemove round-trip), so
+  # the position lives in LV state and survives an unrelated re-render.
+  # Coordinates are clamped to non-negative integers so a crafted payload
+  # can't place a window off into NaN-land.
+  def handle_event("window_moved", %{"id" => id, "x" => x, "y" => y}, socket) do
+    {:noreply, update_window(socket, id, fn w -> %{w | x: clamp_coord(x), y: clamp_coord(y)} end)}
+  end
+
+  def handle_event("window_moved", _params, socket), do: {:noreply, socket}
+
+  # Bring every floating window back onto the default on-screen ladder
+  # (BT-2527 #4): recovery for a window dragged/restored outside the visible
+  # viewport. Pure view state — positions only.
+  def handle_event("window_reset_positions", _params, socket) do
+    {:noreply, reset_window_positions(socket)}
+  end
+
+  # Freeze / unfreeze a single floating window's live tracking (per-window
+  # freeze, mirroring the docked `"freeze_toggle"`). Each window watches
+  # independently, so one frozen window holds its snapshot while others keep
+  # tracking.
+  def handle_event("window_freeze", %{"id" => id}, socket) do
+    {:noreply, update_window(socket, id, fn w -> toggle_window_freeze(socket, w) end)}
+  end
+
+  def handle_event("window_freeze", _params, socket), do: {:noreply, socket}
+
+  # Owner-only per-window poke (the docked `"poke"`, scoped to one window):
+  # send the typed message to that window's inspected actor by eval'ing
+  # `<binding> <message>`. Rides the same RBAC-gated eval op +
+  # well-formedness gate as the docked poke; a window not at a named-binding
+  # root reports it can't send.
+  def handle_event("window_poke", %{"id" => id, "message" => message}, socket)
+      when is_binary(message) do
+    {:noreply, update_window(socket, id, fn w -> poke_window(socket, w, message) end)}
+  end
+
+  def handle_event("window_poke", _params, socket), do: {:noreply, socket}
+
+  # Dismiss a per-window inspector error. `@windows` is a list of window
+  # maps; the client sends the window `id` so we clear `:error` on the
+  # matching window only.
+  def handle_event("dismiss_window_error", %{"id" => id}, socket) do
+    {:noreply, update_window(socket, id, fn w -> Map.put(w, :error, nil) end)}
+  end
+
+  def handle_event("dismiss_window_error", _params, socket), do: {:noreply, socket}
+
+  # ── handle_info dispatch ─────────────────────────────────────────────────
+  #
+  # `WorkspaceLive.handle_info/2` forwards the object-change / coalesced-
+  # refresh messages below unchanged, mirroring the `handle_event` dispatch
+  # above.
+
+  # Per-object change push (BT-2492, backend BT-2489): the watched actor
+  # committed a state write. Like the bindings stream this is a *refresh
+  # trigger*, not the data — re-read the object's fields + pid stats through
+  # the read-surface so the Inspector shows the live snapshot, and bump
+  # `:flash_gen` so the FieldFlash JS hook flashes the cells that changed.
+  #
+  # **Coalescing (no flash storm):** a hot actor can emit a burst of writes.
+  # Rather than re-read on every push (which would re-render — and re-flash —
+  # the whole table repeatedly), the first push schedules a single deferred
+  # refresh via a self-send and sets `:refresh_pending`; intervening pushes
+  # are dropped while the flag is set. The deferred `:do_object_refresh` then
+  # performs ONE re-read for the whole burst. We ignore the push entirely
+  # once frozen, once we've navigated off this object, or for a `pid` that
+  # isn't the currently-watched one — the watch server warns it may deliver
+  # one final push after we unsubscribe (a navigate-away/freeze race), so we
+  # drop a push whose pid doesn't match the head.
+  def handle_info({:object_changed, pid, _slots}, %{assigns: assigns} = socket) do
+    # The push fans out to TWO independent watchers: the docked Inspector
+    # (its `:inspect_watch`) and any floating windows watching this same pid
+    # (BT-2493). Each coalesces its own burst, so we schedule the docked
+    # refresh here and let `notify_windows_changed/2` schedule a per-pid
+    # window refresh — a single push can pulse both the docked pane and a
+    # float window on the same actor.
+    docked =
+      cond do
+        assigns.inspect_frozen or not watched_pid?(assigns.inspect_watch, pid) ->
+          socket
+
+        assigns.refresh_pending ->
+          # A refresh is already queued for this burst — collapse this push
+          # into it.
+          socket
+
+        true ->
+          Process.send_after(self(), :do_object_refresh, refresh_debounce_ms())
+          assign(socket, refresh_pending: true)
+      end
+
+    {:noreply, notify_windows_changed(docked, pid)}
+  end
+
+  # The coalesced refresh fired by `{:object_changed, …}`: re-read the
+  # watched object's fields + stats once for the whole burst, then clear the
+  # pending flag so the next burst schedules afresh. Guarded against a stale
+  # timer firing after the pane froze or navigated away (the watched term
+  # went nil / changed).
+  def handle_info(:do_object_refresh, %{assigns: %{inspect_watch: term}} = socket)
+      when not is_nil(term) do
+    {:noreply, refresh_inspector(assign(socket, refresh_pending: false), term)}
+  end
+
+  def handle_info(:do_object_refresh, socket) do
+    {:noreply, assign(socket, refresh_pending: false)}
+  end
+
+  # The coalesced per-window refresh fired by `notify_windows_changed/2` for
+  # one `pid`: re-read every floating window whose watched head is that pid,
+  # clearing ONLY those windows' pending flags so the burst collapses into
+  # one re-read + flash per window. A window watching a *different* pid keeps
+  # its own `:refresh_pending` untouched — its own `{:do_window_refresh,
+  # otherpid}` timer is still in flight and must not be pre-empted (else that
+  # window's refresh would be silently dropped). A window that froze or
+  # navigated off this pid since the timer armed no longer matches
+  # `watched_pid?/2`, so it is left as-is.
+  def handle_info({:do_window_refresh, pid}, socket) do
+    windows =
+      Enum.map(socket.assigns.windows, fn w ->
+        cond do
+          # Pending refresh for this pid: re-read + flash, clearing the flag.
+          w.refresh_pending and watched_pid?(w.watch, pid) ->
+            refresh_window(%{w | refresh_pending: false}, socket, w.watch)
+
+          # Still watching this pid but not pending (already serviced / never
+          # scheduled): clear any stale flag so it can't wedge future
+          # refreshes.
+          watched_pid?(w.watch, pid) ->
+            %{w | refresh_pending: false}
+
+          # A different pid (or no watch): leave it untouched — its own timer
+          # (if any) is still in flight and must not be pre-empted.
+          true ->
+            w
+        end
+      end)
+
+    {:noreply, assign(socket, :windows, windows)}
+  end
+
+  # ── shared with WorkspaceLive (repl_inspect, mount, terminate) ──────────────
+  #
+  # Public because they're called directly from `WorkspaceLive` at sites
+  # outside `@inspector_events` (the "Events to move" list in BT-3291 is
+  # `handle_event`-only): the REPL's Inspect-it action, and session
+  # mount/terminate's window-desk resume/stash.
+
+  # Inspect a single live term via the read-surface `inspect` op and assign
+  # the resulting structured-field rows plus the drill breadcrumb (`crumbs`).
+  # Object-valued fields are flagged drillable, carrying their live term so
+  # the next drill follows the reference one level deeper. Non-object terms
+  # are not inspectable, so we say so rather than guess.
+  def inspect_term(socket, label, term, crumbs) do
+    if Workspace.inspectable?(term) do
+      case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
+        # BT-2634: a supervisor's content is its CHILDREN / supervision tree,
+        # not actor instance vars. Each child row carries a live
+        # `{:beamtalk_supervisor, …}` / `{:beamtalk_object, …}` handle, so the
+        # existing "drill" event follows it as its own reference (ADR 0095),
+        # and the crumb walk-back re-inspects the supervisor handle
+        # (re-listing its children). Live-tracking is deliberately NOT armed
+        # for a supervisor (`track_object/2`'s catch-all): no field-flash, no
+        # per-object watch, no pid-stats poll against a supervisor.
+        {:ok, {:supervisor_children, child_rows}} ->
+          socket
+          |> assign(
+            inspect_target: target_info(label, term),
+            inspect_rows: supervisor_child_rows(child_rows),
+            inspect_crumbs: crumbs,
+            inspect_error: nil
+          )
+          |> track_object(term)
+
+        {:ok, fields} when is_map(fields) ->
+          socket
+          |> assign(
+            inspect_target: target_info(label, term),
+            inspect_rows: field_rows(fields),
+            inspect_crumbs: crumbs,
+            inspect_error: nil
+          )
+          |> track_object(term)
+
+        {:ok, scalar} ->
+          socket
+          |> assign(
+            inspect_target: target_info(label, term),
+            inspect_rows: [
+              %{
+                name: "value",
+                value: Workspace.format_value(scalar),
+                term: scalar,
+                drillable: false,
+                kind: term_kind(scalar)
+              }
+            ],
+            inspect_crumbs: crumbs,
+            inspect_error: nil
+          )
+          |> track_object(term)
+
+        {:error, reason} ->
+          # A failed inspect leaves no coherent head: reset the crumbs + rows
+          # so a later freeze/poke doesn't act on a stale level, and drop any
+          # watch.
+          socket
+          |> assign(
+            inspect_target: nil,
+            inspect_rows: [],
+            inspect_crumbs: [],
+            inspect_error: Workspace.render_error(reason)
+          )
+          |> track_object(nil)
+      end
+    else
+      socket
+      |> assign(
+        inspect_target: target_info(label, term),
+        inspect_rows: [],
+        inspect_crumbs: crumbs,
+        inspect_error: "#{label} is a #{scalar_kind(term)} — no fields to inspect"
+      )
+      |> track_object(term)
+    end
+  end
+
+  # Inspect a binding selected by name: resolve its live term from the
+  # current binding list, then inspect that term. The term — not a string —
+  # drives the op.
+  defp inspect_binding(socket, pid, name) do
+    case Facade.dispatch(:bindings, %{session_pid: pid}, ctx(socket)) do
+      pairs when is_list(pairs) ->
+        case List.keyfind(pairs, name, 0) do
+          # Inspecting a binding starts a fresh drill breadcrumb at this
+          # object.
+          {^name, term} ->
+            inspect_term(socket, name, term, [%{label: to_string(name), term: term}])
+
+          nil ->
+            assign(socket, inspect_error: "binding not found: #{name}")
+        end
+
+      {:error, reason} ->
+        assign(socket, inspect_error: Workspace.render_error(reason))
+    end
+  end
+
+  # ── live Inspector tracking (BT-2492, backend BT-2489 / ADR 0095 §5) ─────────
+
+  # Arm (or tear down) the per-object change subscription + pid-stats read
+  # for the newly-inspected `term`, called on every `inspect_term/4` so
+  # re-inspecting a different object (a drill, a crumb walk-back, a fresh
+  # binding) rebinds the watch onto the *current* object and drops the
+  # previous one. The flow keeps the contract honest:
+  #
+  #   * A pid-backed object → subscribe THIS LiveView pid (over distribution)
+  #     to its `{:object_changed, …}` stream, read its pid stats now, and
+  #     clear any stale poke result. A frozen pane does NOT subscribe (it
+  #     holds a snapshot) but still reads stats once so the chips reflect the
+  #     snapshot.
+  #   * A non-pid term (a scalar field, a drilled value) has nothing to
+  #     watch: drop any prior subscription and clear the stats/watch.
+  #
+  # The previously-watched term (`:inspect_watch`) is always unsubscribed
+  # first so the workspace never keeps pushing changes for an object we
+  # navigated away from.
+  defp track_object(socket, {:beamtalk_object, _class, _module, pid} = term) when is_pid(pid) do
+    # Reset any in-flight coalesced-refresh flag: a pending `:do_object_refresh`
+    # timer was scheduled for the *previous* object, so clearing the flag lets
+    # the NEW object's first change push schedule its own refresh immediately
+    # (the stale timer, if it still fires, is a harmless no-op on the fresh
+    # watch).
+    socket = unwatch(assign(socket, refresh_pending: false))
+
+    socket =
+      if socket.assigns.inspect_frozen do
+        # Frozen: hold the snapshot — no live subscription, but read stats
+        # once so the chips populate. `:inspect_watch` stays nil (nothing to
+        # unsubscribe).
+        assign(socket, inspect_watch: nil)
+      else
+        case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
+          :ok -> assign(socket, inspect_watch: term)
+          # A non-:ok (term not watchable, dist hiccup) leaves the pane
+          # un-watched rather than claiming a live subscription that isn't
+          # there.
+          _ -> assign(socket, inspect_watch: nil)
+        end
+      end
+
+    socket
+    |> refresh_stats(term)
+    |> assign(poke_result: nil, poke_error: nil)
+  end
+
+  # Non-object target: nothing to track. Drop any prior watch and clear
+  # stats.
+  defp track_object(socket, _term) do
+    socket
+    |> unwatch()
+    |> assign(inspect_stats: nil, poke_result: nil, poke_error: nil)
+  end
+
+  # Drop the docked Inspector's per-object subscription (if any) and forget
+  # the watched term. Idempotent: a nil watch unsubscribes nothing.
+  #
+  # Reference-aware (BT-2493): the workspace keys subscriptions by `(pid,
+  # subscriber)` and our subscriber is always this LiveView, so one
+  # unsubscribe would silence EVERY this-pid watcher in this process. If a
+  # floating window still watches the same actor, we must NOT unsubscribe
+  # here — the window still needs the push. (Before floating windows existed
+  # the docked pane was the sole watcher, so this collapses to the original
+  # unconditional unsubscribe.)
+  defp unwatch(%{assigns: %{inspect_watch: term}} = socket)
+       when not is_nil(term) do
+    unless docked_pid_watched_by_window?(socket, term) do
+      Facade.dispatch(:unsubscribe_object, %{term: term, pid: self()}, ctx(socket))
+    end
+
+    assign(socket, inspect_watch: nil)
+  end
+
+  defp unwatch(socket), do: assign(socket, inspect_watch: nil)
+
+  # True when the pid backing the docked pane's `term` is also watched by an
+  # open floating window — so the docked pane releasing it must keep the
+  # subscription alive for the window.
+  defp docked_pid_watched_by_window?(socket, {:beamtalk_object, _c, _m, pid})
+       when is_pid(pid) do
+    Enum.any?(socket.assigns[:windows] || [], fn w -> watched_pid?(w.watch, pid) end)
+  end
+
+  defp docked_pid_watched_by_window?(_socket, _term), do: false
+
+  # Read the inspected actor's live process metrics (mailbox/reductions/
+  # status/…) and assign the snapshot for the head chips. A read failure
+  # clears the chips rather than rendering stale numbers — the change stream
+  # still drives the field flash, so the pane stays useful even when stats
+  # are momentarily unavailable.
+  defp refresh_stats(socket, term) do
+    case Facade.dispatch(:pid_stats, %{term: term}, ctx(socket)) do
+      {:ok, stats} when is_map(stats) -> assign(socket, inspect_stats: stats)
+      _ -> assign(socket, inspect_stats: nil)
+    end
+  end
+
+  # Re-read the *already-watched* object's fields + stats after a change push
+  # (BT-2492) WITHOUT re-arming the subscription — the watch is still live,
+  # so `track_object/2` would needlessly unsubscribe + resubscribe. The drill
+  # breadcrumb is preserved (same level); only the field values + stats
+  # refresh. `:flash_gen` bumps so the FieldFlash hook flashes the changed
+  # cells. The target label/crumbs come from the current head (the last
+  # crumb's label).
+  defp refresh_inspector(socket, {:beamtalk_object, _class, _module, pid} = term)
+       when is_pid(pid) do
+    label = current_inspect_label(socket)
+
+    case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
+      {:ok, fields} when is_map(fields) ->
+        socket
+        |> assign(
+          inspect_target: target_info(label, term),
+          inspect_rows: field_rows(fields),
+          inspect_error: nil
+        )
+        |> refresh_stats(term)
+        |> bump_flash()
+
+      {:ok, _scalar} ->
+        # The object resolved to a scalar (no fields) — refresh stats +
+        # flash; the row already reflects the value the next render reads.
+        socket |> refresh_stats(term) |> bump_flash()
+
+      {:error, _reason} ->
+        # A transient read failure on a live refresh: keep the existing rows
+        # rather than blanking the pane mid-track; the next push retries.
+        socket
+    end
+  end
+
+  defp refresh_inspector(socket, _term), do: socket
+
+  # The label of the inspector head right now — the last drill crumb,
+  # falling back to the target label. Used so a live refresh re-renders the
+  # head with the same label the user navigated to.
+  defp current_inspect_label(socket) do
+    case List.last(socket.assigns.inspect_crumbs) do
+      %{label: label} -> label
+      _ -> (socket.assigns.inspect_target || %{})[:label] || "value"
+    end
+  end
+
+  defp bump_flash(socket), do: assign(socket, :flash_gen, socket.assigns.flash_gen + 1)
+
+  # The coalescing window for a burst of `{:object_changed, …}` pushes. A
+  # small delay collapses a flurry of rapid writes into a single re-read +
+  # flash. Kept as a function so a test can drive it deterministically if
+  # needed.
+  defp refresh_debounce_ms, do: 60
+
+  # ── floating inspector windows (BT-2493, epic BT-2482 Phase 3) ───────────────
+  #
+  # Each floating window is a self-contained inspector: its own drill
+  # `crumbs`, `rows`, `target`, live `watch`/`stats`/`frozen` and a
+  # `flash_gen`, plus its `x`/`y`/`z` placement (client-reported by the
+  # WindowDrag hook on drop / focus). The window-list lives in `:windows`;
+  # helpers below open / drill / close / focus / freeze a window by id and
+  # route change pushes to the right window. They reuse the same
+  # read-surface ops (`:inspect`, `:subscribe_object`, `:pid_stats`) and the
+  # same `target_info` / `field_rows` builders as the docked pane (BT-2486),
+  # so a window's content is the docked Inspector parameterised by window id.
+
+  # The window placement step (px): each new window is offset down-right from
+  # the last so a burst of opens cascades rather than stacking dead-on (the
+  # spike's `+24` cascade). The first window opens near the top-left of the
+  # overlay.
+  defp window_origin_x, do: 120
+  defp window_origin_y, do: 96
+  defp window_cascade, do: 28
+
+  # Open a floating window on a session binding selected by name: resolve its
+  # live term (same path as the docked `inspect_binding/3`), then build a
+  # window on it. A binding that no longer resolves opens a window showing
+  # the error rather than silently doing nothing.
+  defp open_window(socket, pid, name) do
+    case Facade.dispatch(:bindings, %{session_pid: pid}, ctx(socket)) do
+      pairs when is_list(pairs) ->
+        case List.keyfind(pairs, name, 0) do
+          {^name, term} -> open_window_for_term(socket, to_string(name), term)
+          nil -> open_window_error(socket, to_string(name), "binding not found: #{name}")
+        end
+
+      {:error, reason} ->
+        open_window_error(socket, to_string(name), Workspace.render_error(reason))
+    end
+  end
+
+  # Open a floating window on an already-resolved live `term` (used by
+  # Inspect-it, whose head is the `→ result`, and by `open_window/3`). Mints
+  # a fresh id + cascade position, fills its first inspector level, and arms
+  # its watch. Public: called directly by `WorkspaceLive`'s `repl_inspect`
+  # event (not in the `@inspector_events` delegation list).
+  def open_window_for_term(socket, label, term) do
+    {id, socket} = mint_window_id(socket)
+    {x, y, socket} = next_window_pos(socket)
+    z = socket.assigns.window_z + 1
+
+    win = %{
+      id: id,
+      label: to_string(label),
+      crumbs: [%{label: to_string(label), term: term}],
+      target: nil,
+      rows: [],
+      error: nil,
+      watch: nil,
+      stats: nil,
+      frozen: false,
+      refresh_pending: false,
+      flash_gen: 0,
+      poke_result: nil,
+      poke_error: nil,
+      x: x,
+      y: y,
+      z: z
+    }
+
+    win = inspect_window(socket, win, label, term, win.crumbs)
+
+    socket
+    |> assign(:windows, socket.assigns.windows ++ [win])
+    |> assign(:window_z, z)
+  end
+
+  # Open a window that carries only an error head (a binding that vanished):
+  # still gives the user a closable window explaining what happened rather
+  # than a no-op.
+  defp open_window_error(socket, label, message) do
+    {id, socket} = mint_window_id(socket)
+    {x, y, socket} = next_window_pos(socket)
+    z = socket.assigns.window_z + 1
+
+    win = %{
+      id: id,
+      label: to_string(label),
+      crumbs: [],
+      target: nil,
+      rows: [],
+      error: message,
+      watch: nil,
+      stats: nil,
+      frozen: false,
+      refresh_pending: false,
+      flash_gen: 0,
+      poke_result: nil,
+      poke_error: nil,
+      x: x,
+      y: y,
+      z: z
+    }
+
+    socket
+    |> assign(:windows, socket.assigns.windows ++ [win])
+    |> assign(:window_z, z)
+  end
+
+  # ── reconnect persistence (BT-2527 #3) ──────────────────────────────────────
+  #
+  # A LiveView reconnect (transient socket drop / page reload) mounts a
+  # brand-new process whose assigns — including the open floating-window
+  # list — start empty, even though the underlying workspace session resumes
+  # with its bindings intact. Without help, a desk full of inspector windows
+  # silently vanishes on a blip. So `WorkspaceLive.terminate/2` stashes the
+  # open windows' ROOTS in the registry (Phoenix-node memory that outlives
+  # the reconnect) via `build_window_stash/1`, and the resuming mount
+  # rebuilds them via `restore_windows/3`.
+
+  # Snapshot the open floating windows into a resume stash: each window's
+  # root (its first crumb — label + live term) plus placement and freeze,
+  # alongside the inspector mode. Drilled levels are intentionally dropped —
+  # a resume restores each window to its root (the issue's "or at least the
+  # roots"). Error-only windows carry no root term, so there's nothing live
+  # to reopen — they're skipped by the crumb pattern. Public: called
+  # directly by `WorkspaceLive.terminate/2`.
+  def build_window_stash(socket) do
+    roots =
+      for %{crumbs: [%{label: label, term: term} | _]} = w <- socket.assigns[:windows] || [] do
+        %{label: to_string(label), term: term, x: w.x, y: w.y, z: w.z, frozen: w.frozen}
+      end
+
+    %{windows: roots, mode: socket.assigns[:inspector_mode] || "docked"}
+  end
+
+  # Rebuild the stashed desk on a genuine session resume. A fresh session or
+  # a failed bind (not connected) leaves the empty desk untouched. Each
+  # stashed root is reopened from its still-live term — the inspected actor
+  # lives on the workspace node and survives the LiveView reconnect — which
+  # re-reads its fields and re-arms its per-object watch for the NEW
+  # LiveView pid, then it is placed at its saved position and re-frozen. The
+  # mode is restored too so a resumed Float desk comes back in Float.
+  # Public: called directly by `WorkspaceLive.attach/1` (mount).
+  def restore_windows(socket, _token, :fresh), do: socket
+
+  def restore_windows(socket, token, :resumed) do
+    with true <- socket.assigns[:connected],
+         %{windows: [_ | _] = roots, mode: mode} <- SessionRegistry.window_stash(token) do
+      socket = assign(socket, :inspector_mode, mode)
+      Enum.reduce(roots, socket, &restore_window/2)
+    else
+      _ -> socket
+    end
+  end
+
+  # Reopen one stashed root, then override the cascade position
+  # `open_window_for_term` assigned with the stashed placement and re-apply
+  # its freeze.
+  defp restore_window(root, socket) do
+    socket = open_window_for_term(socket, root.label, root.term)
+
+    case List.last(socket.assigns.windows) do
+      %{id: id} ->
+        socket
+        |> update_window(id, fn w -> %{w | x: root.x, y: root.y, z: root.z} end)
+        |> assign(:window_z, max(socket.assigns.window_z, root.z))
+        |> restore_window_freeze(id, root.frozen)
+
+      _ ->
+        socket
+    end
+  end
+
+  defp restore_window_freeze(socket, _id, false), do: socket
+
+  defp restore_window_freeze(socket, id, true) do
+    update_window(socket, id, fn w -> toggle_window_freeze(socket, w) end)
+  end
+
+  # Re-cascade every open window back onto the default on-screen ladder
+  # (BT-2527 #4): a recovery affordance for a window dragged to (or restored
+  # at) a spot outside the visible viewport. Positions only — drill state,
+  # watches, stats and freeze are untouched.
+  defp reset_window_positions(socket) do
+    {windows, _} =
+      Enum.map_reduce(socket.assigns.windows, 0, fn w, i ->
+        step = rem(i, 8)
+        x = window_origin_x() + step * window_cascade()
+        y = window_origin_y() + step * window_cascade()
+        {%{w | x: x, y: y}, i + 1}
+      end)
+
+    assign(socket, :windows, windows)
+  end
+
+  # Inspect a live `term` into a window `w` (parameterised twin of the docked
+  # `inspect_term/4`): read the object's fields via the read-surface, set the
+  # window's target/rows/crumbs/error, then (re)arm its per-object watch +
+  # stats. A re-inspect (drill / crumb walk-back) rebinds the watch onto the
+  # new head and releases the previous one — but only if no OTHER watcher
+  # (window or docked pane) still needs that pid (so closing one of two
+  # windows on the same actor doesn't silence the other).
+  defp inspect_window(socket, w, label, term, crumbs) do
+    if Workspace.inspectable?(term) do
+      case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
+        # BT-2634: a supervisor renders its children / supervision tree
+        # (drillable child handles), not actor instance vars — the
+        # float-window twin of the docked supervisor case. `track_window/3`
+        # does not arm a watch for a supervisor term (its no-track
+        # catch-all), so no field-flash / pid-stats.
+        {:ok, {:supervisor_children, child_rows}} ->
+          %{
+            w
+            | target: target_info(label, term),
+              rows: supervisor_child_rows(child_rows),
+              crumbs: crumbs,
+              error: nil
+          }
+          |> track_window(socket, term)
+
+        {:ok, fields} when is_map(fields) ->
+          %{
+            w
+            | target: target_info(label, term),
+              rows: field_rows(fields),
+              crumbs: crumbs,
+              error: nil
+          }
+          |> track_window(socket, term)
+
+        {:ok, scalar} ->
+          %{
+            w
+            | target: target_info(label, term),
+              rows: [
+                %{
+                  name: "value",
+                  value: Workspace.format_value(scalar),
+                  term: scalar,
+                  drillable: false,
+                  kind: term_kind(scalar)
+                }
+              ],
+              crumbs: crumbs,
+              error: nil
+          }
+          |> track_window(socket, scalar)
+
+        {:error, reason} ->
+          %{
+            w
+            | target: nil,
+              rows: [],
+              crumbs: [],
+              error: Workspace.render_error(reason)
+          }
+          |> track_window(socket, nil)
+      end
+    else
+      %{
+        w
+        | target: target_info(label, term),
+          rows: [],
+          crumbs: crumbs,
+          error: "#{label} is a #{scalar_kind(term)} — no fields to inspect"
+      }
+      |> track_window(socket, term)
+    end
+  end
+
+  # Arm (or tear down) a window's per-object change subscription + pid-stats
+  # read for `term`, called on every `inspect_window/5`. Mirrors the docked
+  # `track_object/2` but scoped to one window's `watch`. The
+  # previously-watched term is released first (guarded so a pid another
+  # watcher still needs is kept subscribed), then a non-frozen pid-backed
+  # head re-subscribes + reads stats.
+  defp track_window(w, socket, {:beamtalk_object, _c, _m, pid} = term) when is_pid(pid) do
+    w = unwatch_window(w, socket)
+
+    w =
+      if w.frozen do
+        %{w | watch: nil}
+      else
+        case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
+          :ok -> %{w | watch: term}
+          _ -> %{w | watch: nil}
+        end
+      end
+
+    %{w | refresh_pending: false}
+    |> refresh_window_stats(socket, term)
+    |> Map.merge(%{poke_result: nil, poke_error: nil})
+  end
+
+  defp track_window(w, socket, _term) do
+    w
+    |> unwatch_window(socket)
+    |> Map.merge(%{stats: nil, poke_result: nil, poke_error: nil})
+  end
+
+  # Drop a window's per-object subscription, unless the same pid is still
+  # watched by another window or the docked pane (reference-aware
+  # unsubscribe). Idempotent.
+  defp unwatch_window(%{watch: nil} = w, _socket), do: w
+
+  defp unwatch_window(%{watch: term} = w, socket) do
+    unless pid_watched_elsewhere?(socket, term, w.id) do
+      Facade.dispatch(:unsubscribe_object, %{term: term, pid: self()}, ctx(socket))
+    end
+
+    %{w | watch: nil}
+  end
+
+  # True when the pid backing `term` is still watched by some watcher OTHER
+  # than window `except_id` — another floating window, or the docked
+  # Inspector. Used to avoid unsubscribing a pid a sibling watcher still
+  # depends on (the workspace keys subscriptions by `(pid, subscriber)`, so
+  # one unsubscribe would silence all this-pid watchers in this LiveView).
+  defp pid_watched_elsewhere?(socket, {:beamtalk_object, _c, _m, pid}, except_id)
+       when is_pid(pid) do
+    docked = watched_pid?(socket.assigns[:inspect_watch], pid)
+
+    windowed =
+      Enum.any?(socket.assigns.windows, fn w ->
+        w.id != except_id and watched_pid?(w.watch, pid)
+      end)
+
+    docked or windowed
+  end
+
+  defp pid_watched_elsewhere?(_socket, _term, _except_id), do: false
+
+  # Read a window's inspected actor's live pid stats for its head chips. A
+  # failure clears the chips rather than rendering stale numbers (same
+  # contract as the docked `refresh_stats/2`).
+  defp refresh_window_stats(w, socket, term) do
+    case Facade.dispatch(:pid_stats, %{term: term}, ctx(socket)) do
+      {:ok, stats} when is_map(stats) -> %{w | stats: stats}
+      _ -> %{w | stats: nil}
+    end
+  end
+
+  # Re-read a window's *already-watched* object after a change push WITHOUT
+  # re-arming the subscription (the watch is still live). Bumps the window's
+  # `flash_gen` so its FieldFlash hook flashes the changed cells. Mirrors the
+  # docked `refresh_inspector/2`.
+  defp refresh_window(w, socket, {:beamtalk_object, _c, _m, pid} = term) when is_pid(pid) do
+    label = window_label(w)
+
+    case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
+      {:ok, fields} when is_map(fields) ->
+        %{
+          w
+          | target: target_info(label, term),
+            rows: field_rows(fields),
+            error: nil
+        }
+        |> refresh_window_stats(socket, term)
+        |> bump_window_flash()
+
+      {:ok, _scalar} ->
+        w |> refresh_window_stats(socket, term) |> bump_window_flash()
+
+      {:error, _reason} ->
+        w
+    end
+  end
+
+  # The label at a window's current head: its last drill crumb, falling back
+  # to its target label.
+  defp window_label(w) do
+    case List.last(w.crumbs) do
+      %{label: label} -> label
+      _ -> (w.target || %{})[:label] || "value"
+    end
+  end
+
+  defp bump_window_flash(w), do: %{w | flash_gen: w.flash_gen + 1}
+
+  # Per-window freeze toggle (the docked `toggle_freeze/1`, scoped to one
+  # window). Unfreeze re-arms the window's watch on its current head and
+  # catches up; freeze drops its subscription (reference-aware) and holds
+  # the snapshot.
+  defp toggle_window_freeze(socket, %{frozen: true} = w) do
+    w = %{w | frozen: false, refresh_pending: false}
+
+    case window_head_term(w) do
+      {:beamtalk_object, _c, _m, pid} = term when is_pid(pid) ->
+        w
+        |> rearm_window_watch(socket, term)
+        |> refresh_window(socket, term)
+
+      _ ->
+        w
+    end
+  end
+
+  defp toggle_window_freeze(socket, w) do
+    w
+    |> unwatch_window(socket)
+    |> Map.put(:frozen, true)
+  end
+
+  defp rearm_window_watch(w, socket, term) do
+    case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
+      :ok -> %{w | watch: term}
+      _ -> %{w | watch: nil}
+    end
+  end
+
+  # The live term at a window's current head (its last crumb), or nil.
+  defp window_head_term(w) do
+    case List.last(w.crumbs) do
+      %{term: term} -> term
+      _ -> nil
+    end
+  end
+
+  # Send `message` to a window's inspected actor by eval'ing `<binding>
+  # <message>` against the session (the docked `poke_object/2`, scoped to one
+  # window). The actor is addressed by its window's single-crumb binding
+  # label; a window not at a named-binding root can't be poked. On success
+  # the window re-reads so its fields reflect the write synchronously (the
+  # docked `refresh_poked_inspector`).
+  defp poke_window(socket, w, message) do
+    message = String.trim(message)
+    pid = socket.assigns[:session_pid]
+    label = window_poke_label(w)
+
+    cond do
+      not is_pid(pid) ->
+        %{w | poke_result: nil, poke_error: "not attached to workspace"}
+
+      message == "" ->
+        %{w | poke_result: nil, poke_error: "Enter a message to send."}
+
+      is_nil(label) ->
+        %{
+          w
+          | poke_result: nil,
+            poke_error: "Can only send to a bound object — inspect a binding to poke it."
+        }
+
+      true ->
+        send_window_poke(socket, w, pid, label, message)
+    end
+  end
+
+  defp send_window_poke(socket, w, pid, label, message) do
+    code = "#{label} #{message}"
+
+    case Facade.dispatch(:eval, %{session_pid: pid, code: code}, ctx(socket)) do
+      {:ok, term, _output, _warnings} ->
+        w = %{w | poke_result: "→ #{Workspace.render_term(term)}", poke_error: nil}
+
+        # Re-read only when this window is live (`watch` is a pid). A FROZEN
+        # window shows the poke result but deliberately does NOT re-read its
+        # field rows (BT-2527 #6, reviewed): frozen means "snapshot", and
+        # overriding it here would diverge from the docked poke, which is
+        # governed by the same rule — surface parity over a one-off
+        # exception. Unfreeze to see the new state.
+        case w.watch do
+          {:beamtalk_object, _c, _m, p} = watched when is_pid(p) ->
+            refresh_window(w, socket, watched)
+
+          _ ->
+            w
+        end
+
+      {:error, reason, _output, _warnings} ->
+        %{w | poke_result: nil, poke_error: Workspace.render_error(reason)}
+
+      {:error, reason} ->
+        %{w | poke_result: nil, poke_error: facade_error(reason)}
+    end
+  end
+
+  # The binding name to address a window poke to (its single-crumb root
+  # label), or nil — the same well-formedness gate as the docked
+  # `poke_label/1`.
+  defp window_poke_label(%{crumbs: [%{label: label}]}) when is_binary(label) do
+    if valid_receiver?(label), do: label, else: nil
+  end
+
+  defp window_poke_label(_w), do: nil
+
+  # ── window-list manipulation (pure view state, no workspace round-trip) ──────
+
+  # Mint the next unique window id (a string so it rides DOM ids + phx-value
+  # cleanly) and advance the counter.
+  defp mint_window_id(socket) do
+    n = socket.assigns.next_window_id
+    {"win-#{n}", assign(socket, :next_window_id, n + 1)}
+  end
+
+  # The cascade position for the next window: offset down-right by one step
+  # per already-open window, wrapping after a few so a long-lived session
+  # doesn't march windows off-screen. Returns {x, y, socket} (socket
+  # unchanged — kept symmetric with `mint_window_id/1` for a tidy call site).
+  defp next_window_pos(socket) do
+    step = rem(length(socket.assigns.windows), 8)
+    x = window_origin_x() + step * window_cascade()
+    y = window_origin_y() + step * window_cascade()
+    {x, y, socket}
+  end
+
+  # Look up a window by id, or nil.
+  defp find_window(socket, id), do: Enum.find(socket.assigns.windows, &(&1.id == id))
+
+  # Replace the window `id` with `fun.(window)`, leaving the list order (and
+  # so the DOM order) stable — z-order is carried by each window's `:z`, not
+  # list position, so an update never reshuffles the windows and resets
+  # their drag positions.
+  defp update_window(socket, id, fun) do
+    windows =
+      Enum.map(socket.assigns.windows, fn w ->
+        if w.id == id, do: fun.(w), else: w
+      end)
+
+    assign(socket, :windows, windows)
+  end
+
+  # Close a window: release its watch (reference-aware) and drop it from the
+  # list.
+  defp close_window(socket, id) do
+    case find_window(socket, id) do
+      nil ->
+        socket
+
+      w ->
+        _ = unwatch_window(w, socket)
+        assign(socket, :windows, Enum.reject(socket.assigns.windows, &(&1.id == id)))
+    end
+  end
+
+  # Bring window `id` to the front: bump its z above the current max so it
+  # overlays the others. No-op for an unknown id.
+  defp focus_window(socket, id) do
+    case find_window(socket, id) do
+      nil ->
+        socket
+
+      _w ->
+        z = socket.assigns.window_z + 1
+
+        socket
+        |> assign(:window_z, z)
+        |> update_window(id, fn w -> %{w | z: z} end)
+    end
+  end
+
+  # Clamp a client-reported drag coordinate to a non-negative integer (a
+  # crafted payload could send a float/NaN/negative).
+  defp clamp_coord(n) when is_integer(n) and n >= 0, do: n
+  defp clamp_coord(n) when is_float(n) and n >= 0.0, do: trunc(n)
+
+  defp clamp_coord(n) when is_binary(n) do
+    case Integer.parse(n) do
+      {i, _} when i >= 0 -> i
+      _ -> 0
+    end
+  end
+
+  defp clamp_coord(_), do: 0
+
+  # Route an `{:object_changed, pid, …}` push to every open floating window
+  # whose watched head is that pid (a non-frozen, currently-watching
+  # window). Each such window coalesces its own burst via its
+  # `:refresh_pending` flag and schedules a per-window deferred refresh.
+  # Windows watching a different pid (or frozen) are untouched. Returns the
+  # updated socket.
+  defp notify_windows_changed(socket, pid) do
+    {windows, scheduled} =
+      Enum.map_reduce(socket.assigns.windows, false, fn w, sched ->
+        cond do
+          w.frozen or not watched_pid?(w.watch, pid) ->
+            {w, sched}
+
+          w.refresh_pending ->
+            {w, sched}
+
+          true ->
+            {%{w | refresh_pending: true}, true}
+        end
+      end)
+
+    if scheduled do
+      Process.send_after(self(), {:do_window_refresh, pid}, refresh_debounce_ms())
+    end
+
+    assign(socket, :windows, windows)
+  end
+
+  # Flip the freeze flag and (un)arm tracking accordingly. Freezing
+  # unsubscribes the live object change stream (the pane now holds a
+  # snapshot). Unfreezing re-subscribes the current head object and
+  # refreshes it so it catches up.
+  defp toggle_freeze(%{assigns: %{inspect_frozen: true}} = socket) do
+    # Unfreeze: re-arm tracking on the current head term (if any) and catch
+    # up. Clear any stale `refresh_pending` too: a timer scheduled before
+    # the freeze could otherwise fire a redundant second refresh (double
+    # flash) right after this catch-up re-read.
+    socket = assign(socket, inspect_frozen: false, refresh_pending: false)
+
+    case head_term(socket) do
+      {:beamtalk_object, _c, _m, pid} = term when is_pid(pid) ->
+        socket
+        |> rearm_watch(term)
+        |> refresh_inspector(term)
+
+      _ ->
+        socket
+    end
+  end
+
+  defp toggle_freeze(socket) do
+    # Freeze: drop the subscription, keep the current rows/stats as the
+    # snapshot.
+    socket
+    |> unwatch()
+    |> assign(inspect_frozen: true)
+  end
+
+  # Subscribe the current head object for change pushes without touching the
+  # rows (used by unfreeze, which re-reads separately). A non-:ok result
+  # leaves the watch nil rather than claiming a live subscription.
+  defp rearm_watch(socket, term) do
+    case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
+      :ok -> assign(socket, inspect_watch: term)
+      _ -> assign(socket, inspect_watch: nil)
+    end
+  end
+
+  # The live term at the current inspector head: the last drill crumb
+  # carries it. nil when nothing is inspected.
+  defp head_term(socket) do
+    case List.last(socket.assigns.inspect_crumbs) do
+      %{term: term} -> term
+      _ -> nil
+    end
+  end
+
+  # Send `message` to the inspected actor by eval'ing `<binding> <message>`
+  # against the session (the spike's poke). The actor is addressed by its
+  # binding name — the head crumb's label — so a poke only makes sense when
+  # the head IS a named binding (not a drilled field or the `→ result` of an
+  # inspectIt). A successful send renders a terse confirmation and lets the
+  # change stream flash the updated field; a failure renders the structured
+  # error.
+  defp poke_object(socket, message) do
+    message = String.trim(message)
+    pid = socket.assigns[:session_pid]
+    label = poke_target_label(socket)
+
+    cond do
+      not is_pid(pid) ->
+        assign(socket, poke_result: nil, poke_error: "not attached to workspace")
+
+      message == "" ->
+        assign(socket, poke_result: nil, poke_error: "Enter a message to send.")
+
+      is_nil(label) ->
+        assign(socket,
+          poke_result: nil,
+          poke_error: "Can only send to a bound object — inspect a binding to poke it."
+        )
+
+      true ->
+        send_poke(socket, pid, label, message)
+    end
+  end
+
+  defp send_poke(socket, pid, label, message) do
+    code = "#{label} #{message}"
+
+    case Facade.dispatch(:eval, %{session_pid: pid, code: code}, ctx(socket)) do
+      {:ok, term, _output, _warnings} ->
+        socket
+        |> assign(poke_result: "→ #{Workspace.render_term(term)}", poke_error: nil)
+        # A poke is a user-initiated mutation — re-read the inspected object
+        # now so its fields reflect the write immediately, rather than
+        # waiting on the async `{:object_changed, …}` change-stream push
+        # (which is coalesced/delayed, and is the live-tracking path tracked
+        # separately by BT-2524). No-op when the pane is frozen or nothing is
+        # watched.
+        |> refresh_poked_inspector()
+
+      {:error, reason, _output, _warnings} ->
+        assign(socket, poke_result: nil, poke_error: Workspace.render_error(reason))
+
+      {:error, reason} ->
+        assign(socket, poke_result: nil, poke_error: facade_error(reason))
+    end
+  end
+
+  # Re-read the inspected object after a successful poke so the pane
+  # reflects the mutation synchronously. Only when an object is actively
+  # watched (a live, non-frozen pid-backed head) — a frozen pane holds its
+  # snapshot, and a non-object head has nothing to re-read.
+  defp refresh_poked_inspector(%{assigns: %{inspect_watch: term}} = socket)
+       when not is_nil(term) do
+    refresh_inspector(socket, term)
+  end
+
+  defp refresh_poked_inspector(socket), do: socket
+
+  # The binding name to address a poke to. A poke eval's `<receiver>
+  # <message>` against the session, so the receiver must be a
+  # *source-addressable* name — a session binding. That holds only at the
+  # inspection root (a single crumb whose label IS the binding the
+  # inspection started from): once you drill into a field the head is a
+  # referenced object with no session binding to name, and an inspectIt `→
+  # result` has no name at all. So poke is offered only when there's a
+  # single crumb with a valid-identifier label; otherwise nil (the bar
+  # reports it can't send, and the markup can hide it). This keeps the eval
+  # well-formed and honest rather than sending to a name that isn't bound.
+  defp poke_target_label(socket), do: poke_label(socket.assigns)
+
+  # Whether the current Inspector head can be poked: a pid-backed object at
+  # the inspection root with a valid-identifier binding name. Takes the bare
+  # `assigns` so the render template can gate the poke bar with it directly.
+  # Public: called from `WorkspaceLive`'s docked-panel template.
+  def pokeable?(assigns), do: poke_label(assigns) != nil
+
+  # The session-binding name to address a poke to, or nil (see
+  # `poke_target_label`).
+  defp poke_label(assigns) do
+    case assigns[:inspect_crumbs] do
+      [%{label: label}] when is_binary(label) ->
+        if valid_receiver?(label), do: label, else: nil
+
+      _ ->
+        nil
+    end
+  end
+
+  # A poke receiver must be a plain lowercase Beamtalk identifier (a binding
+  # name) — not the `→ result` synthetic label or anything with
+  # spaces/punctuation that would make `<label> <message>` ill-formed
+  # source. This is a well-formedness gate, not an injection guard: the poke
+  # eval is RBAC-gated (owner-only) and the label comes from the crumb the
+  # *server* set from the inspected binding name, never raw browser input. A
+  # pseudo-keyword binding (`self`/`nil`/…) that slips through just produces
+  # a normal eval that DNUs or no-ops — no escalation.
+  defp valid_receiver?(label), do: Regex.match?(~r/\A[a-z_][A-Za-z0-9_]*\z/, label)
+
+  # Build the Inspector head's target descriptor: the binding/field label,
+  # the live printString header, and the class/pid type chips. For a live
+  # actor the term is `{:beamtalk_object, class, _module, pid}` (over
+  # distribution), so the class atom and pid render straight into the
+  # spike's `proc-chips`. Non-object values carry no pid and report their
+  # scalar kind as the class chip.
+  defp target_info(label, {:beamtalk_object, class, _module, pid} = term) when is_pid(pid) do
+    %{
+      label: to_string(label),
+      header: Workspace.render_term(term),
+      class_name: to_string(class),
+      pid: inspect(pid)
+    }
+  end
+
+  # Supervisor handles are pid-backed live refs too: chip the class + pid the
+  # same way as objects so the head renders as a drillable target
+  # (content/children is a follow-up — see `Workspace.inspect_value/1`).
+  defp target_info(label, {:beamtalk_supervisor, class, _module, pid} = term) when is_pid(pid) do
+    %{
+      label: to_string(label),
+      header: Workspace.render_term(term),
+      class_name: to_string(class),
+      pid: inspect(pid)
+    }
+  end
+
+  defp target_info(label, term) do
+    %{
+      label: to_string(label),
+      header: Workspace.render_term(term),
+      class_name: scalar_kind(term),
+      pid: nil
+    }
+  end
+
+  # Turn an inspect fields map (live terms) into ordered display rows. Each
+  # row keeps the live field `term` so a drill on an object-valued slot
+  # follows the real reference; `drillable` marks the object-valued ones.
+  defp field_rows(fields) do
+    fields
+    |> Enum.map(fn {key, term} ->
+      %{
+        name: to_string(key),
+        value: Workspace.render_term(term),
+        term: term,
+        drillable: Workspace.inspectable?(term),
+        kind: term_kind(term)
+      }
+    end)
+    |> Enum.sort_by(& &1.name)
+  end
+
+  # BT-2634: turn the runtime's supervisor-child maps (binary-keyed, from
+  # `beamtalk_process_navigation:child_handles/1`) into Inspector display
+  # rows. A child with a live `handle` (a Beamtalk actor / supervisor child)
+  # is drillable — its `term` is the live `{:beamtalk_supervisor, …}` /
+  # `{:beamtalk_object, …}` reference the "drill" event follows (ADR 0095). A
+  # foreign / restarting child has `handle => :null`: it renders (so the
+  # tree is complete) but is not drillable. The value column shows kind + pid
+  # + child count so the supervision structure is legible at a glance.
+  defp supervisor_child_rows(child_rows) when is_list(child_rows) do
+    Enum.map(child_rows, &supervisor_child_row/1)
+  end
+
+  defp supervisor_child_row(row) when is_map(row) do
+    handle = Map.get(row, "handle", :null)
+    drillable = handle != :null and handle != nil
+
+    %{
+      name: to_string(Map.get(row, "label", "child")),
+      value: supervisor_child_value(row),
+      term: if(drillable, do: handle, else: nil),
+      drillable: drillable,
+      kind: "ref"
+    }
+  end
+
+  # The value-column text for a supervisor child row: "kind · pid · N
+  # children" (child count only for supervisors), or "kind · restarting" for
+  # a child caught mid-restart (no pid).
+  defp supervisor_child_value(row) do
+    kind = to_string(Map.get(row, "kind", "process"))
+    pid = supervisor_child_pid_text(Map.get(row, "pid", :null))
+
+    if Map.get(row, "isSupervisor", false) do
+      count = Map.get(row, "childCount", 0)
+      "#{kind} · #{pid} · #{count} #{pluralize_children(count)}"
+    else
+      "#{kind} · #{pid}"
+    end
+  end
+
+  defp supervisor_child_pid_text(:null), do: "restarting"
+  defp supervisor_child_pid_text(nil), do: "restarting"
+  defp supervisor_child_pid_text(pid) when is_binary(pid), do: pid
+  defp supervisor_child_pid_text(pid), do: to_string(pid)
+
+  defp pluralize_children(1), do: "child"
+  defp pluralize_children(_), do: "children"
+
+  # Map a live term to the Inspector's "no fields to inspect" type word ("X
+  # is a <scalar_kind>"). Derives from the single classifier
+  # `Workspace.term_class/1` (BT-2635), so this is purely a presentation
+  # mapping of its `{:scalar, kind}` output — it does not re-enumerate term
+  # shapes. `{:ref, _}` terms never reach here from the non-inspectable
+  # else-branch; they can reach it from `target_info/2`'s fallback, where
+  # they fall through to "value". The `:value` / unmapped-scalar cases all
+  # render "value".
+  defp scalar_kind(term) do
+    case Workspace.term_class(term) do
+      {:scalar, :integer} -> "number"
+      {:scalar, :float} -> "number"
+      {:scalar, :string} -> "string"
+      {:scalar, :boolean} -> "boolean"
+      {:scalar, :list} -> "collection"
+      {:scalar, :map} -> "map"
+      _ -> "value"
+    end
+  end
+
+  # Map a live term to the spike Inspector's value-kind class (inspector.jsx
+  # `valueClass`), driving the type-chip / value colour. Derives from the
+  # single classifier `Workspace.term_class/1` (BT-2635): any live ref
+  # (object, supervisor, future, pid) chips as the drillable `ref`; scalars
+  # map to their CSS class. Booleans classify as `{:scalar, :boolean}`
+  # (matched before the atom guard inside `term_class/1`), so they chip as
+  # "bool", not "symbol". Lists/maps and any unrecognised term fall through
+  # to "value", exactly as before centralisation. Public: also used by
+  # `WorkspaceLive`'s Bindings-row kind chip (`apply_bindings/2`), which
+  # predates this extraction and reuses the same classifier.
+  def term_kind(term) do
+    case Workspace.term_class(term) do
+      {:ref, _kind} -> "ref"
+      {:scalar, :boolean} -> "bool"
+      {:scalar, :integer} -> "int"
+      {:scalar, :float} -> "int"
+      {:scalar, :string} -> "string"
+      {:scalar, :atom} -> "symbol"
+      _ -> "value"
+    end
+  end
+
+  # ── pid-stats chip accessors (BT-2492) ──────────────────────────────────────
+  #
+  # The `pid_stats` op returns a binary-keyed map (`beamtalk_repl_ops_watch`):
+  # `status`, `queue_depth`, `memory_bytes`, `reductions`, `current_function`,
+  # plus `alive`. These read the head chips off that snapshot, returning nil
+  # when the stat is absent (so the chip's `:if` hides it) — a dead pid
+  # reports only `status: "dead"`, so the mailbox/reductions chips vanish
+  # rather than show 0. Public: called from `WorkspaceLive`'s docked/window
+  # panel template.
+
+  # Process scheduling status (`running`/`waiting`/`runnable`/`dead`/…),
+  # always shown when stats are present — it's the live "is it ticking" tell.
+  def stat_status(stats) when is_map(stats), do: Map.get(stats, "status")
+  def stat_status(_), do: nil
+
+  # Mailbox (message queue) depth — only when the pid is alive (a dead pid
+  # has no queue, and the map omits it).
+  def stat_mailbox(stats) when is_map(stats), do: Map.get(stats, "queue_depth")
+  def stat_mailbox(_), do: nil
+
+  # Reduction count (a coarse "how much work has it done" gauge), thousands-
+  # separated for readability like the spike. Absent on a dead pid.
+  def stat_reductions(stats) when is_map(stats) do
+    case Map.get(stats, "reductions") do
+      n when is_integer(n) -> format_thousands(n)
+      _ -> nil
+    end
+  end
+
+  def stat_reductions(_), do: nil
+
+  # Group an integer with thousands separators (the spike's
+  # `toLocaleString()`), e.g. 1234567 → "1,234,567".
+  defp format_thousands(n) when is_integer(n) and n < 0, do: "-" <> format_thousands(-n)
+
+  defp format_thousands(n) when is_integer(n) do
+    n
+    |> Integer.to_string()
+    |> String.graphemes()
+    |> Enum.reverse()
+    |> Enum.chunk_every(3)
+    |> Enum.map_join(",", &Enum.join/1)
+    |> String.reverse()
+  end
+
+  # `BtAttachWeb.Live.FacadeError` (shared with `WorkspaceLive` and its other
+  # extracted panes) renders a facade short-circuit (RBAC denial /
+  # off-vocabulary op) as a clear, user-facing message.
+  defp facade_error(reason), do: FacadeError.render(reason)
+
+  # True when `watch` is a pid-backed term watching `pid` — the shared
+  # predicate every docked/window change-push router (`handle_info`) and
+  # watch-sharing check (`docked_pid_watched_by_window?/2`,
+  # `pid_watched_elsewhere?/3`) uses to decide whether a push/unsubscribe
+  # applies to a given watcher.
+  defp watched_pid?({:beamtalk_object, _c, _m, watched}, pid)
+       when is_pid(watched) and is_pid(pid),
+       do: watched == pid
+
+  defp watched_pid?(_watch, _pid), do: false
+
+  # Every distinct pid watched by an open floating window (BT-2493), deduped
+  # so `WorkspaceLive.terminate/2` unsubscribes each watched actor exactly
+  # once even when several windows share it. Public: called directly by
+  # `WorkspaceLive.terminate/2`.
+  def window_watched_terms(nil), do: []
+
+  def window_watched_terms(windows) when is_list(windows) do
+    windows
+    |> Enum.map(& &1.watch)
+    |> Enum.filter(&match?({:beamtalk_object, _c, _m, p} when is_pid(p), &1))
+    |> Enum.uniq_by(fn {:beamtalk_object, _c, _m, pid} -> pid end)
+  end
+
+  # ── floating inspector windows overlay (BT-2493, epic BT-2482 Phase 3) ───────
+  #
+  # The overlay layer: one draggable, stackable inspector window per
+  # `:windows` entry. The layer itself is pointer-inert so it never eats
+  # clicks on the cockpit beneath; each window re-enables pointer events on
+  # itself. Window position (`left`/`top`) and stacking (`z-index`) come
+  # straight from the per-window state the WindowDrag hook reports on drop /
+  # focus, so they survive an unrelated re-render. Each window's content
+  # reuses the docked Inspector's markup (head + breadcrumb + chips + ivar
+  # table + poke), parameterised by window id so its drill/crumb/close/
+  # freeze/poke events carry the id back to the right window.
+
+  attr :windows, :list, required: true
+  attr :role, :atom, required: true
+
+  def inspector_windows(assigns) do
+    ~H"""
+    <div class="insp-overlay" id="inspector-overlay">
+      <%!-- Off-screen recovery (BT-2527 #4): re-cascade every window back onto
+           the visible ladder. Shown only when a desk is open so it never
+           floats over an empty cockpit. --%>
+      <button
+        :if={@windows != []}
+        type="button"
+        class="insp-tidy"
+        phx-click="window_reset_positions"
+        title="Bring all inspector windows back on-screen"
+      >
+        Tidy windows
+      </button>
+      <.inspector_window :for={w <- @windows} win={w} role={@role} />
+    </div>
+    """
+  end
+
+  attr :win, :map, required: true
+  attr :role, :atom, required: true
+
+  defp inspector_window(assigns) do
+    ~H"""
+    <section
+      class="insp-window"
+      id={"inspector-window-#{@win.id}"}
+      style={"left:#{@win.x}px;top:#{@win.y}px;z-index:#{@win.z};"}
+      phx-hook="WindowDrag"
+      data-window-id={@win.id}
+    >
+      <%!-- Title bar: the drag handle (`.iw-title`, grabbed by the WindowDrag
+           hook) plus the live freeze toggle and the close button. Dragging
+           the bar moves the window client-side; the hook reports the final
+           x/y on drop. --%>
+      <header class="iw-bar" data-window-drag-handle>
+        <span class="iw-title mono">
+          {(@win.target && @win.target.label) || @win.label}
+        </span>
+        <span class="spacer"></span>
+        <button
+          :if={@win.target && @win.target.pid}
+          type="button"
+          class={["insp-freeze", (@win.frozen && "frozen") || "live"]}
+          phx-click="window_freeze"
+          phx-value-id={@win.id}
+          title={
+            if @win.frozen,
+              do: "Frozen snapshot — click to track live",
+              else: "Tracking live (subscribed to changes) — click to freeze a snapshot"
+          }
+        >
+          <span class="iwf-dot"></span>{(@win.frozen && "frozen") || "live"}
+        </button>
+        <button
+          type="button"
+          class="iw-close"
+          phx-click="window_close"
+          phx-value-id={@win.id}
+          title="Close window"
+          aria-label="Close window"
+        >
+          ×
+        </button>
+      </header>
+      <div class="iw-body">
+        <%= if @win.target do %>
+          <div class="insp-head">
+            <div :if={length(@win.crumbs) > 1} class="insp-crumbs">
+              <%= for {crumb, i} <- Enum.with_index(@win.crumbs) do %>
+                <span :if={i > 0} class="sep">›</span>
+                <span class="c" phx-click="window_crumb" phx-value-id={@win.id} phx-value-index={i}>
+                  {crumb.label}
+                </span>
+              <% end %>
+            </div>
+            <div class="ps mono">
+              Inspecting <strong>{@win.target.label}</strong>
+              <span class="ps-header">{@win.target.header}</span>
+            </div>
+            <div class="proc-chips">
+              <span class="chip">class <b>{@win.target.class_name}</b></span>
+              <span :if={@win.target.pid} class="chip">
+                pid <b>{@win.target.pid}</b>
+              </span>
+              <span :if={stat_status(@win.stats)} class="chip pid-stat">
+                <span class="dot"></span>{stat_status(@win.stats)}
+              </span>
+              <span :if={not is_nil(stat_mailbox(@win.stats))} class="chip pid-stat">
+                mailbox <b>{stat_mailbox(@win.stats)}</b>
+              </span>
+              <span :if={not is_nil(stat_reductions(@win.stats))} class="chip pid-stat">
+                reductions <b>{stat_reductions(@win.stats)}</b>
+              </span>
+            </div>
+          </div>
+        <% end %>
+        <div class="iw-content">
+          <.notice
+            :if={@win.error}
+            variant={:warn}
+            message={@win.error}
+            dismiss_attrs={%{"phx-click" => "dismiss_window_error", "phx-value-id" => @win.id}}
+          />
+          <%= if @win.target && @win.rows != [] do %>
+            <table
+              id={"inspector-window-fields-#{@win.id}"}
+              class="ivar-table"
+              phx-hook="FieldFlash"
+              data-flash-gen={@win.flash_gen}
+            >
+              <tbody>
+                <tr
+                  :for={{row, i} <- Enum.with_index(@win.rows)}
+                  class={row.drillable && "drillable"}
+                  phx-click={row.drillable && "window_drill"}
+                  phx-value-id={row.drillable && @win.id}
+                  phx-value-index={row.drillable && i}
+                >
+                  <td class="k">{row.name}</td>
+                  <td class={["v", row.kind]} data-flash-key={row.name} data-flash-val={row.value}>
+                    {row.value}
+                  </td>
+                  <td class="follow">
+                    <span :if={row.drillable} class="follow-link">follow →</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          <% else %>
+            <p :if={@win.target == nil && @win.error == nil} class="empty">
+              Nothing to inspect.
+            </p>
+          <% end %>
+          <%!-- Owner-only poke bar (BT-2492), per-window: pokeable only at a
+               single named-binding crumb root (the same well-formedness gate
+               the docked pane uses), and only for the owner role. --%>
+          <div
+            :if={@win.target && @win.target.pid && @role == :owner && window_pokeable?(@win)}
+            class="poke"
+          >
+            <div class="poke-label">Send a message to {@win.target.label}</div>
+            <form class="poke-row" phx-submit="window_poke" phx-value-id={@win.id}>
+              <span class="poke-recv mono">‹recv›</span>
+              <input
+                class="field mono"
+                name="message"
+                autocomplete="off"
+                placeholder="increment   ·   incrementBy: 10"
+              />
+              <button type="submit" class="btn">Send</button>
+            </form>
+            <div :if={@win.poke_result} class="poke-out ok mono">{@win.poke_result}</div>
+            <div :if={@win.poke_error} class="poke-out warn mono">{@win.poke_error}</div>
+          </div>
+        </div>
+      </div>
+    </section>
+    """
+  end
+
+  # Whether a floating window's head can be poked: a pid-backed object at the
+  # inspection root with a valid-identifier binding name (the same contract
+  # as the docked `pokeable?/1`, scoped to one window's crumbs).
+  defp window_pokeable?(%{crumbs: [%{label: label}]}) when is_binary(label),
+    do: valid_receiver?(label)
+
+  defp window_pokeable?(_w), do: false
+end

--- a/editors/liveview/lib/bt_attach_web/live/request_context.ex
+++ b/editors/liveview/lib/bt_attach_web/live/request_context.ex
@@ -1,0 +1,22 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.Live.RequestContext do
+  @moduledoc """
+  Builds the RBAC-relevant request identity (`user`, `role`) that
+  `BtAttach.Facade.dispatch/3` audits/gates on (ADR 0091 Decision 3,
+  BT-2421).
+
+  Extracted as a shared leaf module (BT-3291) so `BtAttachWeb.WorkspaceLive`
+  and its extracted panes (e.g. `BtAttachWeb.Live.Inspector`) build the same
+  context from a socket's assigns rather than each keeping its own copy
+  (CLAUDE.md's no-duplicate-implementations rule).
+  """
+
+  @type t :: %{user: term(), role: atom()}
+
+  @doc "The facade context for `socket`: its authenticated user + RBAC role."
+  @spec build(Phoenix.LiveView.Socket.t()) :: t()
+  def build(socket),
+    do: %{user: socket.assigns[:current_user], role: socket.assigns[:role] || :owner}
+end

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -243,6 +243,9 @@ defmodule BtAttachWeb.WorkspaceLive do
   alias BtAttach.Facade
   alias BtAttach.SessionRegistry
   alias BtAttach.Workspace
+  alias BtAttachWeb.Live.FacadeError
+  alias BtAttachWeb.Live.Inspector
+  alias BtAttachWeb.Live.RequestContext
 
   # All RBAC-relevant workspace ops go through the curated facade (ADR 0091
   # Decision 3) — never a raw Workspace/:rpc call from an event handler. Pure
@@ -250,8 +253,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   # go through the injectable workspace client so the mount and session-start
   # paths are testable without a live node (BT-2554). `ctx/1` carries the
   # request identity the facade audits / RBAC gates on (BT-2421).
-  defp ctx(socket),
-    do: %{user: socket.assigns[:current_user], role: socket.assigns[:role] || :owner}
+  defp ctx(socket), do: RequestContext.build(socket)
 
   defp ws_client, do: Application.get_env(:bt_attach, :workspace_client, Workspace)
 
@@ -298,7 +300,7 @@ defmodule BtAttachWeb.WorkspaceLive do
             {:ok, session_id, pid, origin} ->
               socket
               |> bind_session(session_id, pid)
-              |> restore_windows(token, origin)
+              |> Inspector.restore_windows(token, origin)
               |> restore_doc(token, origin)
 
             {:error, reason} ->
@@ -313,6 +315,25 @@ defmodule BtAttachWeb.WorkspaceLive do
       end
 
     {:ok, socket}
+  end
+
+  # Restore the method-editor doc-block expand state on a genuine session resume
+  # (BT-2570). The block's `:doc_expanded` is a socket assign that a fresh mount —
+  # which every reconnect is — re-inits to its collapsed default, so a user who
+  # expanded it would lose that on any transient socket drop, redeploy, or laptop
+  # wake. `terminate/2` stashes the flag in the registry (Phoenix-node memory that
+  # outlives the reconnect); here we read it back and re-apply it. A fresh session
+  # or a failed bind (not connected) leaves the collapsed default untouched; a
+  # missing stash (nothing was expanded) likewise leaves the default.
+  defp restore_doc(socket, _token, :fresh), do: socket
+
+  defp restore_doc(socket, token, :resumed) do
+    with true <- socket.assigns[:connected],
+         expanded when is_boolean(expanded) <- SessionRegistry.doc_stash(token) do
+      assign(socket, :doc_expanded, expanded)
+    else
+      _ -> socket
+    end
   end
 
   # Resume the tab's session if the registry has a *live* one for this token,
@@ -1243,9 +1264,9 @@ defmodule BtAttachWeb.WorkspaceLive do
 
         socket =
           if socket.assigns.inspector_mode == "float" do
-            open_window_for_term(socket, label, term)
+            Inspector.open_window_for_term(socket, label, term)
           else
-            inspect_term(socket, label, term, [%{label: label, term: term}])
+            Inspector.inspect_term(socket, label, term, [%{label: label, term: term}])
           end
 
         {:noreply, socket}
@@ -1257,95 +1278,22 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   def handle_event("repl_inspect", _params, socket), do: {:noreply, socket}
 
-  # Inspect a binding by name: look up its live term and drill into it via the
-  # read-surface `inspect` op. Reference-following starts here. In `"float"` mode
-  # (BT-2493) the click opens a *new floating window* on the binding instead of
-  # driving the docked pane; in `"docked"` mode it drives the docked Inspector as
-  # before. Docked is the default, so the existing single-pane flow is untouched
-  # unless the user flipped the top-bar Dock/Float toggle.
+  # Inspector + object-window events (BT-3291, epic BT-3290): the docked
+  # Inspector's inspect/drill/crumb/freeze/poke navigation and the floating
+  # window overlay's own copies of the same actions all delegate to
+  # `BtAttachWeb.Live.Inspector`, extracted out of this module so they're
+  # directly unit-testable. See that module's `handle_event/3` for the full
+  # per-event behaviour (each clause below is exactly what used to run here).
+  @inspector_events ~w(
+    inspect drill crumb freeze_toggle poke close_inspector set_inspector_mode
+    window_close window_crumb window_drill window_focus window_freeze
+    window_moved window_poke window_reset_positions dismiss_window_error
+  )
+
   @impl true
-  def handle_event("inspect", %{"name" => name}, %{assigns: %{session_pid: pid}} = socket)
-      when is_pid(pid) do
-    if socket.assigns.inspector_mode == "float" do
-      {:noreply, open_window(socket, pid, name)}
-    else
-      {:noreply, inspect_binding(socket, pid, name)}
-    end
+  def handle_event(event, params, socket) when event in @inspector_events do
+    Inspector.handle_event(event, params, socket)
   end
-
-  # Drill into an object-valued field of the currently-inspected object: the
-  # field term is itself a live `{:beamtalk_object, …}` handle, so following it
-  # is the same read-surface inspect call one level deeper. The clicked field's
-  # term is carried back to the server by index against the current rows, so we
-  # never round-trip a flattened string.
-  def handle_event("drill", %{"index" => index}, %{assigns: %{inspect_rows: rows}} = socket) do
-    # `index` is client-supplied; parse defensively so a malformed value can't
-    # crash the LiveView (`String.to_integer/1` would raise on non-digits).
-    with {i, ""} when i >= 0 <- Integer.parse(index),
-         %{term: term, name: name} <- Enum.at(rows, i) do
-      # Following a reference extends the drill breadcrumb one level deeper.
-      crumbs = socket.assigns.inspect_crumbs ++ [%{label: to_string(name), term: term}]
-      {:noreply, inspect_term(socket, name, term, crumbs)}
-    else
-      _ -> {:noreply, socket}
-    end
-  end
-
-  def handle_event("drill", _params, socket), do: {:noreply, socket}
-
-  # Jump back to an earlier level of the drill breadcrumb (BT-2486): truncate the
-  # trail at the clicked crumb and re-inspect that level's live term. Defensive
-  # against a client-supplied index that no longer maps to a crumb.
-  def handle_event("crumb", %{"index" => index}, %{assigns: %{inspect_crumbs: crumbs}} = socket) do
-    with {i, ""} when i >= 0 <- Integer.parse(index),
-         %{term: term, label: label} <- Enum.at(crumbs, i) do
-      {:noreply, inspect_term(socket, label, term, Enum.take(crumbs, i + 1))}
-    else
-      _ -> {:noreply, socket}
-    end
-  end
-
-  def handle_event("crumb", _params, socket), do: {:noreply, socket}
-
-  # ── live Inspector tracking events (BT-2492, epic BT-2482 Phase 3) ───────────
-
-  # Freeze / unfreeze the Inspector's live tracking (the spike's `iw-freeze`
-  # toggle, inspector.jsx). Freezing drops the per-object change subscription so
-  # the pane holds the snapshot it has — no more field-flash, no re-reads.
-  # Unfreezing re-subscribes the *current* head object and refreshes its fields +
-  # stats immediately so the pane catches up to the live state. A toggle with no
-  # object inspected (or a scalar head) just flips the flag.
-  def handle_event("freeze_toggle", _params, socket) do
-    {:noreply, toggle_freeze(socket)}
-  end
-
-  # Owner-only "send a message" quick action (the spike's PokeBar / quick-pokes,
-  # inspector.jsx). Sends the typed Beamtalk message to the inspected actor by
-  # eval'ing `<binding> <message>` against the workspace session — the same `eval`
-  # facade op the Workspace dock uses, so poke invents no new server op and rides
-  # the existing RBAC gate (an Observer's `eval` is refused; the bar is also
-  # owner-gated in the markup). The object is addressed by its *binding name* (the
-  # head crumb / target label), which is the live handle's source-level name; a
-  # drilled field with no binding name can't be poked, so we say so.
-  def handle_event("poke", %{"message" => message}, socket) when is_binary(message) do
-    {:noreply, poke_object(socket, message)}
-  end
-
-  def handle_event("poke", _params, socket), do: {:noreply, socket}
-
-  # ── floating inspector windows (BT-2493, epic BT-2482 Phase 3) ───────────────
-
-  # Flip the Inspector between docked and floating ("overlay") modes (the spike's
-  # Dock/Float toggle). Switching to docked leaves the open windows alone — they
-  # stay in state and reappear if the user flips back — so a misclick doesn't tear
-  # down a desk full of inspectors and their subscriptions. Only an explicit
-  # window close releases a window's watch.
-  def handle_event("set_inspector_mode", %{"mode" => mode}, socket)
-      when mode in ~w(docked float) do
-    {:noreply, assign(socket, inspector_mode: mode)}
-  end
-
-  def handle_event("set_inspector_mode", _params, socket), do: {:noreply, socket}
 
   # Open / close the top-bar appearance (Tweaks) dropdown. Pure view state — the
   # panel itself stays mounted (see `:show_settings` in `mount/3`); this only
@@ -1386,122 +1334,6 @@ defmodule BtAttachWeb.WorkspaceLive do
   def handle_event("close_browser", _params, socket) do
     {:noreply, assign(socket, show_browser: false)}
   end
-
-  # Close *only* the Inspector pane (BT-2611), not the whole right column. The `×`
-  # lives in the Inspector sub-pane header, so it must dismiss just the Inspector
-  # and leave the Bindings pane (and the column) visible — the whole-column
-  # show/hide stays on `toggle_inspector`/`.panel-toggle`. We reset the inspector
-  # target/rows/crumbs/error back to the empty state and tear down the live
-  # subscription via `track_object(nil)` so re-inspecting an object later rebinds
-  # cleanly. Unfreeze too, so a frozen pane doesn't reopen stale on the next
-  # inspect. `show_inspector` is intentionally left untouched.
-  def handle_event("close_inspector", _params, socket) do
-    socket =
-      socket
-      |> assign(
-        inspect_target: nil,
-        inspect_rows: [],
-        inspect_crumbs: [],
-        inspect_error: nil,
-        inspect_frozen: false
-      )
-      |> track_object(nil)
-
-    {:noreply, socket}
-  end
-
-  # Drill into an object-valued field of a *floating window* (BT-2493): the field
-  # term is carried by index against that window's current rows, exactly like the
-  # docked `"drill"` event but scoped to one window. Defensive against a malformed
-  # id/index so a crafted event can't crash the LiveView.
-  def handle_event("window_drill", %{"id" => id, "index" => index}, socket) do
-    with %{} = win <- find_window(socket, id),
-         {i, ""} when i >= 0 <- Integer.parse(index),
-         %{term: term, name: name} <- Enum.at(win.rows, i) do
-      crumbs = win.crumbs ++ [%{label: to_string(name), term: term}]
-
-      {:noreply,
-       update_window(socket, id, fn w -> inspect_window(socket, w, name, term, crumbs) end)}
-    else
-      _ -> {:noreply, socket}
-    end
-  end
-
-  def handle_event("window_drill", _params, socket), do: {:noreply, socket}
-
-  # Walk a floating window's drill breadcrumb back to an earlier level: truncate
-  # its crumb trail at the clicked index and re-inspect that level's live term.
-  def handle_event("window_crumb", %{"id" => id, "index" => index}, socket) do
-    with %{} = win <- find_window(socket, id),
-         {i, ""} when i >= 0 <- Integer.parse(index),
-         %{term: term, label: label} <- Enum.at(win.crumbs, i) do
-      crumbs = Enum.take(win.crumbs, i + 1)
-
-      {:noreply,
-       update_window(socket, id, fn w -> inspect_window(socket, w, label, term, crumbs) end)}
-    else
-      _ -> {:noreply, socket}
-    end
-  end
-
-  def handle_event("window_crumb", _params, socket), do: {:noreply, socket}
-
-  # Close a floating window: drop it from the list and release its per-object
-  # change subscription (BT-2493 acceptance: "Close removes the window and releases
-  # any subscriptions"). Idempotent — closing an unknown id is a no-op.
-  def handle_event("window_close", %{"id" => id}, socket) do
-    {:noreply, close_window(socket, id)}
-  end
-
-  def handle_event("window_close", _params, socket), do: {:noreply, socket}
-
-  # Bring a floating window to the front (z-order follows focus, the spike's
-  # stacking). The WindowDrag JS hook fires this on a mousedown anywhere in the
-  # window; we bump the clicked window's z above the current max so it overlays the
-  # others. Pure view state — no workspace round-trip.
-  def handle_event("window_focus", %{"id" => id}, socket) do
-    {:noreply, focus_window(socket, id)}
-  end
-
-  def handle_event("window_focus", _params, socket), do: {:noreply, socket}
-
-  # Persist a floating window's final position after a drag (BT-2493): the
-  # WindowDrag hook reports x/y ONCE on drop (no per-mousemove round-trip), so the
-  # position lives in LV state and survives an unrelated re-render. Coordinates are
-  # clamped to non-negative integers so a crafted payload can't place a window off
-  # into NaN-land.
-  def handle_event("window_moved", %{"id" => id, "x" => x, "y" => y}, socket) do
-    {:noreply, update_window(socket, id, fn w -> %{w | x: clamp_coord(x), y: clamp_coord(y)} end)}
-  end
-
-  def handle_event("window_moved", _params, socket), do: {:noreply, socket}
-
-  # Bring every floating window back onto the default on-screen ladder (BT-2527
-  # #4): recovery for a window dragged/restored outside the visible viewport. Pure
-  # view state — positions only.
-  def handle_event("window_reset_positions", _params, socket) do
-    {:noreply, reset_window_positions(socket)}
-  end
-
-  # Freeze / unfreeze a single floating window's live tracking (per-window freeze,
-  # mirroring the docked `"freeze_toggle"`). Each window watches independently, so
-  # one frozen window holds its snapshot while others keep tracking.
-  def handle_event("window_freeze", %{"id" => id}, socket) do
-    {:noreply, update_window(socket, id, fn w -> toggle_window_freeze(socket, w) end)}
-  end
-
-  def handle_event("window_freeze", _params, socket), do: {:noreply, socket}
-
-  # Owner-only per-window poke (the docked `"poke"`, scoped to one window): send
-  # the typed message to that window's inspected actor by eval'ing
-  # `<binding> <message>`. Rides the same RBAC-gated eval op + well-formedness gate
-  # as the docked poke; a window not at a named-binding root reports it can't send.
-  def handle_event("window_poke", %{"id" => id, "message" => message}, socket)
-      when is_binary(message) do
-    {:noreply, update_window(socket, id, fn w -> poke_window(socket, w, message) end)}
-  end
-
-  def handle_event("window_poke", _params, socket), do: {:noreply, socket}
 
   # ── method editor (Wave 3, write-surface ADR 0082) ──────────────────────────
 
@@ -2355,14 +2187,6 @@ defmodule BtAttachWeb.WorkspaceLive do
     end
   end
 
-  # Dismiss a per-window inspector error. `@windows` is a list of window maps; the
-  # client sends the window `id` so we clear `:error` on the matching window only.
-  def handle_event("dismiss_window_error", %{"id" => id}, socket) do
-    {:noreply, update_window(socket, id, fn w -> Map.put(w, :error, nil) end)}
-  end
-
-  def handle_event("dismiss_window_error", _params, socket), do: {:noreply, socket}
-
   # Selection tracking (BT-2485, BT-2539): the method-editor CmEditor hook
   # reports the editor's current selection (text + offsets). We hold it in
   # `edit_selection` so a later pane can evaluate the selected expression rather
@@ -2550,87 +2374,17 @@ defmodule BtAttachWeb.WorkspaceLive do
     {:noreply, socket}
   end
 
-  # Per-object change push (BT-2492, backend BT-2489): the watched actor committed
-  # a state write. Like the bindings stream this is a *refresh trigger*, not the
-  # data — re-read the object's fields + pid stats through the read-surface so the
-  # Inspector shows the live snapshot, and bump `:flash_gen` so the FieldFlash JS
-  # hook flashes the cells that changed.
-  #
-  # **Coalescing (no flash storm):** a hot actor can emit a burst of writes. Rather
-  # than re-read on every push (which would re-render — and re-flash — the whole
-  # table repeatedly), the first push schedules a single deferred refresh via a
-  # self-send and sets `:refresh_pending`; intervening pushes are dropped while the
-  # flag is set. The deferred `:do_object_refresh` then performs ONE re-read for
-  # the whole burst. We ignore the push entirely once frozen, once we've navigated
-  # off this object, or for a `pid` that isn't the currently-watched one — the
-  # watch server warns it may deliver one final push after we unsubscribe (a
-  # navigate-away/freeze race), so we drop a push whose pid doesn't match the head.
-  def handle_info({:object_changed, pid, _slots}, %{assigns: assigns} = socket) do
-    # The push fans out to TWO independent watchers: the docked Inspector (its
-    # `:inspect_watch`) and any floating windows watching this same pid (BT-2493).
-    # Each coalesces its own burst, so we schedule the docked refresh here and let
-    # `notify_windows_changed/2` schedule a per-pid window refresh — a single push
-    # can pulse both the docked pane and a float window on the same actor.
-    docked =
-      cond do
-        assigns.inspect_frozen or not watched_pid?(assigns.inspect_watch, pid) ->
-          socket
+  # Inspector/object-window live-tracking pushes (BT-3291, epic BT-3290):
+  # the per-object change push and its coalesced-refresh follow-ups delegate
+  # to `BtAttachWeb.Live.Inspector.handle_info/2` — see that module for the
+  # full behaviour (each clause below is exactly what used to run here).
+  def handle_info({:object_changed, _pid, _slots} = msg, socket),
+    do: Inspector.handle_info(msg, socket)
 
-        assigns.refresh_pending ->
-          # A refresh is already queued for this burst — collapse this push into it.
-          socket
+  def handle_info(:do_object_refresh = msg, socket), do: Inspector.handle_info(msg, socket)
 
-        true ->
-          Process.send_after(self(), :do_object_refresh, refresh_debounce_ms())
-          assign(socket, refresh_pending: true)
-      end
-
-    {:noreply, notify_windows_changed(docked, pid)}
-  end
-
-  # The coalesced refresh fired by `{:object_changed, …}`: re-read the watched
-  # object's fields + stats once for the whole burst, then clear the pending flag
-  # so the next burst schedules afresh. Guarded against a stale timer firing after
-  # the pane froze or navigated away (the watched term went nil / changed).
-  def handle_info(:do_object_refresh, %{assigns: %{inspect_watch: term}} = socket)
-      when not is_nil(term) do
-    {:noreply, refresh_inspector(assign(socket, refresh_pending: false), term)}
-  end
-
-  def handle_info(:do_object_refresh, socket) do
-    {:noreply, assign(socket, refresh_pending: false)}
-  end
-
-  # The coalesced per-window refresh fired by `notify_windows_changed/2` for one
-  # `pid`: re-read every floating window whose watched head is that pid, clearing
-  # ONLY those windows' pending flags so the burst collapses into one re-read +
-  # flash per window. A window watching a *different* pid keeps its own
-  # `:refresh_pending` untouched — its own `{:do_window_refresh, otherpid}` timer
-  # is still in flight and must not be pre-empted (else that window's refresh would
-  # be silently dropped). A window that froze or navigated off this pid since the
-  # timer armed no longer matches `watched_pid?/2`, so it is left as-is.
-  def handle_info({:do_window_refresh, pid}, socket) do
-    windows =
-      Enum.map(socket.assigns.windows, fn w ->
-        cond do
-          # Pending refresh for this pid: re-read + flash, clearing the flag.
-          w.refresh_pending and watched_pid?(w.watch, pid) ->
-            refresh_window(%{w | refresh_pending: false}, socket, w.watch)
-
-          # Still watching this pid but not pending (already serviced / never
-          # scheduled): clear any stale flag so it can't wedge future refreshes.
-          watched_pid?(w.watch, pid) ->
-            %{w | refresh_pending: false}
-
-          # A different pid (or no watch): leave it untouched — its own timer (if
-          # any) is still in flight and must not be pre-empted.
-          true ->
-            w
-        end
-      end)
-
-    {:noreply, assign(socket, :windows, windows)}
-  end
+  def handle_info({:do_window_refresh, _pid} = msg, socket),
+    do: Inspector.handle_info(msg, socket)
 
   def handle_info(_msg, socket), do: {:noreply, socket}
 
@@ -2795,28 +2549,6 @@ defmodule BtAttachWeb.WorkspaceLive do
      )}
   end
 
-  # True when `pid` is the pid backing the currently-watched object term — so a
-  # late push for an object we've since navigated away from (or never watched) is
-  # ignored rather than spuriously re-reading + flashing the current head. Kept
-  # below the `handle_info/2` clauses so they stay grouped (compiler warning).
-  defp watched_pid?({:beamtalk_object, _c, _m, watched}, pid)
-       when is_pid(watched) and is_pid(pid),
-       do: watched == pid
-
-  defp watched_pid?(_watch, _pid), do: false
-
-  # The distinct live terms watched by the open floating windows (BT-2493) — the
-  # set we must unsubscribe on terminate. Deduped on the watched pid so two windows
-  # on the same actor unsubscribe it once.
-  defp window_watched_terms(nil), do: []
-
-  defp window_watched_terms(windows) when is_list(windows) do
-    windows
-    |> Enum.map(& &1.watch)
-    |> Enum.filter(&match?({:beamtalk_object, _c, _m, p} when is_pid(p), &1))
-    |> Enum.uniq_by(fn {:beamtalk_object, _c, _m, pid} -> pid end)
-  end
-
   @impl true
   def terminate(_reason, socket) do
     # Best-effort: drop our Transcript + bindings subscriptions so the workspace
@@ -2853,7 +2585,7 @@ defmodule BtAttachWeb.WorkspaceLive do
       # watch server keys subscriptions by `(pid, subscriber)` so one unsubscribe
       # per distinct watched pid suffices even if several windows share an actor —
       # `Enum.uniq` over the watched terms avoids a redundant (harmless) RPC.
-      for term <- window_watched_terms(socket.assigns[:windows]) do
+      for term <- Inspector.window_watched_terms(socket.assigns[:windows]) do
         Workspace.unsubscribe_object_changes(term, self())
       end
 
@@ -2865,7 +2597,7 @@ defmodule BtAttachWeb.WorkspaceLive do
           # the reconnect rather than re-collapsing (BT-2570), then defer teardown
           # to the grace window. The stash dies with the entry if no reconnect
           # arrives, so a genuinely-closed tab leaves nothing behind.
-          SessionRegistry.stash_windows(token, build_window_stash(socket))
+          SessionRegistry.stash_windows(token, Inspector.build_window_stash(socket))
           SessionRegistry.stash_doc(token, socket.assigns[:doc_expanded])
           SessionRegistry.release(token)
 
@@ -2882,14 +2614,27 @@ defmodule BtAttachWeb.WorkspaceLive do
     :ok
   end
 
-  # Render a facade short-circuit (RBAC denial / off-vocabulary op) as a clear,
-  # user-facing message. These are Phoenix-side decisions, so they don't go
-  # through the workspace error formatter.
-  defp facade_error(:unauthorized),
-    do: "Not authorized: your role may not perform this operation."
+  # Whitelist mapping a client-supplied dismiss key → the scalar status assign to
+  # clear (BT-2612). This is the security boundary: only these exact strings
+  # resolve; everything else returns nil and is ignored by `dismiss_notice`.
+  # NEVER replace this with `String.to_atom/1` on the user-supplied key.
+  defp dismiss_key_to_assign("browser_error"), do: :browser_error
+  defp dismiss_key_to_assign("output"), do: :output
+  defp dismiss_key_to_assign("changes_error"), do: :changes_error
+  defp dismiss_key_to_assign("git_error"), do: :git_error
+  defp dismiss_key_to_assign("tests_error"), do: :tests_error
+  defp dismiss_key_to_assign("save_result"), do: :save_result
+  defp dismiss_key_to_assign("save_error"), do: :save_error
+  defp dismiss_key_to_assign("flush_result"), do: :flush_result
+  defp dismiss_key_to_assign("flush_error"), do: :flush_error
+  defp dismiss_key_to_assign("bindings_error"), do: :bindings_error
+  defp dismiss_key_to_assign("inspect_error"), do: :inspect_error
+  defp dismiss_key_to_assign(_unknown), do: nil
 
-  defp facade_error(:forbidden_op), do: "Operation not permitted."
-  defp facade_error(reason), do: Workspace.render_error(reason)
+  # `facade_error/1` moved to `BtAttachWeb.Live.FacadeError` (BT-3291) so
+  # extracted panes (e.g. `BtAttachWeb.Live.Inspector`) render the same
+  # facade-error copy instead of keeping their own.
+  defp facade_error(reason), do: FacadeError.render(reason)
 
   # Run a mutating git op through the Facade (Owner-gated) and refresh the panel
   # so the new status/log is reflected. An :unauthorized/error result surfaces in
@@ -3235,9 +2980,9 @@ defmodule BtAttachWeb.WorkspaceLive do
     # `→ result` term rather than driving the docked pane; docked mode keeps the
     # original single-pane behaviour.
     if socket.assigns.inspector_mode == "float" do
-      open_window_for_term(socket, "→ result", term)
+      Inspector.open_window_for_term(socket, "→ result", term)
     else
-      inspect_term(socket, "→ result", term, [%{label: "→ result", term: term}])
+      Inspector.inspect_term(socket, "→ result", term, [%{label: "→ result", term: term}])
     end
   end
 
@@ -4941,8 +4686,12 @@ defmodule BtAttachWeb.WorkspaceLive do
   # is only for the unsolicited push burst.
   defp schedule_source_refresh(%{assigns: %{source_refresh_pending: true}} = socket), do: socket
 
+  # The coalescing window (ms): independently tunable from the Inspector's own
+  # `{:object_changed, …}` debounce (`BtAttachWeb.Live.Inspector`) even though
+  # both currently use the same 60ms value — the two features debounce
+  # unrelated push streams.
   defp schedule_source_refresh(socket) do
-    Process.send_after(self(), :do_source_refresh, refresh_debounce_ms())
+    Process.send_after(self(), :do_source_refresh, 60)
     assign(socket, source_refresh_pending: true)
   end
 
@@ -7560,7 +7309,7 @@ defmodule BtAttachWeb.WorkspaceLive do
           name: name,
           value: Workspace.render_term(term),
           inspectable: Workspace.inspectable?(term),
-          kind: term_kind(term)
+          kind: Inspector.term_kind(term)
         }
       end)
 
@@ -7576,1178 +7325,6 @@ defmodule BtAttachWeb.WorkspaceLive do
     )
 
     assign(socket, bindings: [], bindings_error: Workspace.render_error(:unexpected_response))
-  end
-
-  # Inspect a binding selected by name: resolve its live term from the current
-  # binding list, then inspect that term. The term — not a string — drives the op.
-  defp inspect_binding(socket, pid, name) do
-    case Facade.dispatch(:bindings, %{session_pid: pid}, ctx(socket)) do
-      pairs when is_list(pairs) ->
-        case List.keyfind(pairs, name, 0) do
-          # Inspecting a binding starts a fresh drill breadcrumb at this object.
-          {^name, term} ->
-            inspect_term(socket, name, term, [%{label: to_string(name), term: term}])
-
-          nil ->
-            assign(socket, inspect_error: "binding not found: #{name}")
-        end
-
-      {:error, reason} ->
-        assign(socket, inspect_error: Workspace.render_error(reason))
-    end
-  end
-
-  # Inspect a single live term via the read-surface `inspect` op and assign the
-  # resulting structured-field rows plus the drill breadcrumb (`crumbs`). Object-
-  # valued fields are flagged drillable, carrying their live term so the next
-  # drill follows the reference one level deeper. Non-object terms are not
-  # inspectable, so we say so rather than guess.
-  defp inspect_term(socket, label, term, crumbs) do
-    if Workspace.inspectable?(term) do
-      case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
-        # BT-2634: a supervisor's content is its CHILDREN / supervision tree, not
-        # actor instance vars. Each child row carries a live `{:beamtalk_supervisor,
-        # …}` / `{:beamtalk_object, …}` handle, so the existing "drill" event
-        # follows it as its own reference (ADR 0095), and the crumb walk-back
-        # re-inspects the supervisor handle (re-listing its children). Live-tracking
-        # is deliberately NOT armed for a supervisor (`track_object/2`'s catch-all):
-        # no field-flash, no per-object watch, no pid-stats poll against a supervisor.
-        {:ok, {:supervisor_children, child_rows}} ->
-          socket
-          |> assign(
-            inspect_target: target_info(label, term),
-            inspect_rows: supervisor_child_rows(child_rows),
-            inspect_crumbs: crumbs,
-            inspect_error: nil
-          )
-          |> track_object(term)
-
-        {:ok, fields} when is_map(fields) ->
-          socket
-          |> assign(
-            inspect_target: target_info(label, term),
-            inspect_rows: field_rows(fields),
-            inspect_crumbs: crumbs,
-            inspect_error: nil
-          )
-          |> track_object(term)
-
-        {:ok, scalar} ->
-          socket
-          |> assign(
-            inspect_target: target_info(label, term),
-            inspect_rows: [
-              %{
-                name: "value",
-                value: Workspace.format_value(scalar),
-                term: scalar,
-                drillable: false,
-                kind: term_kind(scalar)
-              }
-            ],
-            inspect_crumbs: crumbs,
-            inspect_error: nil
-          )
-          |> track_object(term)
-
-        {:error, reason} ->
-          # A failed inspect leaves no coherent head: reset the crumbs + rows so a
-          # later freeze/poke doesn't act on a stale level, and drop any watch.
-          socket
-          |> assign(
-            inspect_target: nil,
-            inspect_rows: [],
-            inspect_crumbs: [],
-            inspect_error: Workspace.render_error(reason)
-          )
-          |> track_object(nil)
-      end
-    else
-      socket
-      |> assign(
-        inspect_target: target_info(label, term),
-        inspect_rows: [],
-        inspect_crumbs: crumbs,
-        inspect_error: "#{label} is a #{scalar_kind(term)} — no fields to inspect"
-      )
-      |> track_object(term)
-    end
-  end
-
-  # ── live Inspector tracking (BT-2492, backend BT-2489 / ADR 0095 §5) ─────────
-
-  # Arm (or tear down) the per-object change subscription + pid-stats read for the
-  # newly-inspected `term`, called on every `inspect_term/4` so re-inspecting a
-  # different object (a drill, a crumb walk-back, a fresh binding) rebinds the
-  # watch onto the *current* object and drops the previous one. The flow keeps the
-  # contract honest:
-  #
-  #   * A pid-backed object → subscribe THIS LiveView pid (over distribution) to
-  #     its `{:object_changed, …}` stream, read its pid stats now, and clear any
-  #     stale poke result. A frozen pane does NOT subscribe (it holds a snapshot)
-  #     but still reads stats once so the chips reflect the snapshot.
-  #   * A non-pid term (a scalar field, a drilled value) has nothing to watch:
-  #     drop any prior subscription and clear the stats/watch.
-  #
-  # The previously-watched term (`:inspect_watch`) is always unsubscribed first so
-  # the workspace never keeps pushing changes for an object we navigated away from.
-  defp track_object(socket, {:beamtalk_object, _class, _module, pid} = term) when is_pid(pid) do
-    # Reset any in-flight coalesced-refresh flag: a pending `:do_object_refresh`
-    # timer was scheduled for the *previous* object, so clearing the flag lets the
-    # NEW object's first change push schedule its own refresh immediately (the
-    # stale timer, if it still fires, is a harmless no-op on the fresh watch).
-    socket = unwatch(assign(socket, refresh_pending: false))
-
-    socket =
-      if socket.assigns.inspect_frozen do
-        # Frozen: hold the snapshot — no live subscription, but read stats once so
-        # the chips populate. `:inspect_watch` stays nil (nothing to unsubscribe).
-        assign(socket, inspect_watch: nil)
-      else
-        case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
-          :ok -> assign(socket, inspect_watch: term)
-          # A non-:ok (term not watchable, dist hiccup) leaves the pane un-watched
-          # rather than claiming a live subscription that isn't there.
-          _ -> assign(socket, inspect_watch: nil)
-        end
-      end
-
-    socket
-    |> refresh_stats(term)
-    |> assign(poke_result: nil, poke_error: nil)
-  end
-
-  # Non-object target: nothing to track. Drop any prior watch and clear stats.
-  defp track_object(socket, _term) do
-    socket
-    |> unwatch()
-    |> assign(inspect_stats: nil, poke_result: nil, poke_error: nil)
-  end
-
-  # Drop the docked Inspector's per-object subscription (if any) and forget the
-  # watched term. Idempotent: a nil watch unsubscribes nothing.
-  #
-  # Reference-aware (BT-2493): the workspace keys subscriptions by `(pid,
-  # subscriber)` and our subscriber is always this LiveView, so one unsubscribe
-  # would silence EVERY this-pid watcher in this process. If a floating window
-  # still watches the same actor, we must NOT unsubscribe here — the window still
-  # needs the push. (Before floating windows existed the docked pane was the sole
-  # watcher, so this collapses to the original unconditional unsubscribe.)
-  defp unwatch(%{assigns: %{inspect_watch: term}} = socket)
-       when not is_nil(term) do
-    unless docked_pid_watched_by_window?(socket, term) do
-      Facade.dispatch(:unsubscribe_object, %{term: term, pid: self()}, ctx(socket))
-    end
-
-    assign(socket, inspect_watch: nil)
-  end
-
-  defp unwatch(socket), do: assign(socket, inspect_watch: nil)
-
-  # True when the pid backing the docked pane's `term` is also watched by an open
-  # floating window — so the docked pane releasing it must keep the subscription
-  # alive for the window.
-  defp docked_pid_watched_by_window?(socket, {:beamtalk_object, _c, _m, pid})
-       when is_pid(pid) do
-    Enum.any?(socket.assigns[:windows] || [], fn w -> watched_pid?(w.watch, pid) end)
-  end
-
-  defp docked_pid_watched_by_window?(_socket, _term), do: false
-
-  # Read the inspected actor's live process metrics (mailbox/reductions/status/…)
-  # and assign the snapshot for the head chips. A read failure clears the chips
-  # rather than rendering stale numbers — the change stream still drives the field
-  # flash, so the pane stays useful even when stats are momentarily unavailable.
-  defp refresh_stats(socket, term) do
-    case Facade.dispatch(:pid_stats, %{term: term}, ctx(socket)) do
-      {:ok, stats} when is_map(stats) -> assign(socket, inspect_stats: stats)
-      _ -> assign(socket, inspect_stats: nil)
-    end
-  end
-
-  # Re-read the *already-watched* object's fields + stats after a change push
-  # (BT-2492) WITHOUT re-arming the subscription — the watch is still live, so
-  # `track_object/2` would needlessly unsubscribe + resubscribe. The drill
-  # breadcrumb is preserved (same level); only the field values + stats refresh.
-  # `:flash_gen` bumps so the FieldFlash hook flashes the changed cells. The
-  # target label/crumbs come from the current head (the last crumb's label).
-  defp refresh_inspector(socket, {:beamtalk_object, _class, _module, pid} = term)
-       when is_pid(pid) do
-    label = current_inspect_label(socket)
-
-    case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
-      {:ok, fields} when is_map(fields) ->
-        socket
-        |> assign(
-          inspect_target: target_info(label, term),
-          inspect_rows: field_rows(fields),
-          inspect_error: nil
-        )
-        |> refresh_stats(term)
-        |> bump_flash()
-
-      {:ok, _scalar} ->
-        # The object resolved to a scalar (no fields) — refresh stats + flash; the
-        # row already reflects the value the next render reads.
-        socket |> refresh_stats(term) |> bump_flash()
-
-      {:error, _reason} ->
-        # A transient read failure on a live refresh: keep the existing rows rather
-        # than blanking the pane mid-track; the next push retries.
-        socket
-    end
-  end
-
-  defp refresh_inspector(socket, _term), do: socket
-
-  # The label of the inspector head right now — the last drill crumb, falling back
-  # to the target label. Used so a live refresh re-renders the head with the same
-  # label the user navigated to.
-  defp current_inspect_label(socket) do
-    case List.last(socket.assigns.inspect_crumbs) do
-      %{label: label} -> label
-      _ -> (socket.assigns.inspect_target || %{})[:label] || "value"
-    end
-  end
-
-  defp bump_flash(socket), do: assign(socket, :flash_gen, socket.assigns.flash_gen + 1)
-
-  # The coalescing window for a burst of `{:object_changed, …}` pushes. A small
-  # delay collapses a flurry of rapid writes into a single re-read + flash. Kept as
-  # a function so a test can drive it deterministically if needed.
-  defp refresh_debounce_ms, do: 60
-
-  # ── floating inspector windows (BT-2493, epic BT-2482 Phase 3) ───────────────
-  #
-  # Each floating window is a self-contained inspector: its own drill `crumbs`,
-  # `rows`, `target`, live `watch`/`stats`/`frozen` and a `flash_gen`, plus its
-  # `x`/`y`/`z` placement (client-reported by the WindowDrag hook on drop / focus).
-  # The window-list lives in `:windows`; helpers below open / drill / close / focus
-  # / freeze a window by id and route change pushes to the right window. They reuse
-  # the same read-surface ops (`:inspect`, `:subscribe_object`, `:pid_stats`) and
-  # the same `target_info` / `field_rows` builders as the docked pane (BT-2486), so
-  # a window's content is the docked Inspector parameterised by window id.
-
-  # The window placement step (px): each new window is offset down-right from the
-  # last so a burst of opens cascades rather than stacking dead-on (the spike's
-  # `+24` cascade). The first window opens near the top-left of the overlay.
-  defp window_origin_x, do: 120
-  defp window_origin_y, do: 96
-  defp window_cascade, do: 28
-
-  # Open a floating window on a session binding selected by name: resolve its live
-  # term (same path as the docked `inspect_binding/3`), then build a window on it.
-  # A binding that no longer resolves opens a window showing the error rather than
-  # silently doing nothing.
-  defp open_window(socket, pid, name) do
-    case Facade.dispatch(:bindings, %{session_pid: pid}, ctx(socket)) do
-      pairs when is_list(pairs) ->
-        case List.keyfind(pairs, name, 0) do
-          {^name, term} -> open_window_for_term(socket, to_string(name), term)
-          nil -> open_window_error(socket, to_string(name), "binding not found: #{name}")
-        end
-
-      {:error, reason} ->
-        open_window_error(socket, to_string(name), Workspace.render_error(reason))
-    end
-  end
-
-  # Open a floating window on an already-resolved live `term` (used by Inspect-it,
-  # whose head is the `→ result`, and by `open_window/3`). Mints a fresh id +
-  # cascade position, fills its first inspector level, and arms its watch.
-  defp open_window_for_term(socket, label, term) do
-    {id, socket} = mint_window_id(socket)
-    {x, y, socket} = next_window_pos(socket)
-    z = socket.assigns.window_z + 1
-
-    win = %{
-      id: id,
-      label: to_string(label),
-      crumbs: [%{label: to_string(label), term: term}],
-      target: nil,
-      rows: [],
-      error: nil,
-      watch: nil,
-      stats: nil,
-      frozen: false,
-      refresh_pending: false,
-      flash_gen: 0,
-      poke_result: nil,
-      poke_error: nil,
-      x: x,
-      y: y,
-      z: z
-    }
-
-    win = inspect_window(socket, win, label, term, win.crumbs)
-
-    socket
-    |> assign(:windows, socket.assigns.windows ++ [win])
-    |> assign(:window_z, z)
-  end
-
-  # Open a window that carries only an error head (a binding that vanished): still
-  # gives the user a closable window explaining what happened rather than a no-op.
-  defp open_window_error(socket, label, message) do
-    {id, socket} = mint_window_id(socket)
-    {x, y, socket} = next_window_pos(socket)
-    z = socket.assigns.window_z + 1
-
-    win = %{
-      id: id,
-      label: to_string(label),
-      crumbs: [],
-      target: nil,
-      rows: [],
-      error: message,
-      watch: nil,
-      stats: nil,
-      frozen: false,
-      refresh_pending: false,
-      flash_gen: 0,
-      poke_result: nil,
-      poke_error: nil,
-      x: x,
-      y: y,
-      z: z
-    }
-
-    socket
-    |> assign(:windows, socket.assigns.windows ++ [win])
-    |> assign(:window_z, z)
-  end
-
-  # ── reconnect persistence (BT-2527 #3) ──────────────────────────────────────
-  #
-  # A LiveView reconnect (transient socket drop / page reload) mounts a brand-new
-  # process whose assigns — including the open floating-window list — start empty,
-  # even though the underlying workspace session resumes with its bindings intact.
-  # Without help, a desk full of inspector windows silently vanishes on a blip. So
-  # `terminate/2` stashes the open windows' ROOTS in the registry (Phoenix-node
-  # memory that outlives the reconnect) and the resuming mount rebuilds them here.
-
-  # Snapshot the open floating windows into a resume stash: each window's root
-  # (its first crumb — label + live term) plus placement and freeze, alongside the
-  # inspector mode. Drilled levels are intentionally dropped — a resume restores
-  # each window to its root (the issue's "or at least the roots"). Error-only
-  # windows carry no root term, so there's nothing live to reopen — they're
-  # skipped by the crumb pattern.
-  defp build_window_stash(socket) do
-    roots =
-      for %{crumbs: [%{label: label, term: term} | _]} = w <- socket.assigns[:windows] || [] do
-        %{label: to_string(label), term: term, x: w.x, y: w.y, z: w.z, frozen: w.frozen}
-      end
-
-    %{windows: roots, mode: socket.assigns[:inspector_mode] || "docked"}
-  end
-
-  # Rebuild the stashed desk on a genuine session resume. A fresh session or a
-  # failed bind (not connected) leaves the empty desk untouched. Each stashed root
-  # is reopened from its still-live term — the inspected actor lives on the
-  # workspace node and survives the LiveView reconnect — which re-reads its fields
-  # and re-arms its per-object watch for the NEW LiveView pid, then it is placed at
-  # its saved position and re-frozen. The mode is restored too so a resumed Float
-  # desk comes back in Float.
-  defp restore_windows(socket, _token, :fresh), do: socket
-
-  defp restore_windows(socket, token, :resumed) do
-    with true <- socket.assigns[:connected],
-         %{windows: [_ | _] = roots, mode: mode} <- SessionRegistry.window_stash(token) do
-      socket = assign(socket, :inspector_mode, mode)
-      Enum.reduce(roots, socket, &restore_window/2)
-    else
-      _ -> socket
-    end
-  end
-
-  # Reopen one stashed root, then override the cascade position `open_window_for_term`
-  # assigned with the stashed placement and re-apply its freeze.
-  defp restore_window(root, socket) do
-    socket = open_window_for_term(socket, root.label, root.term)
-
-    case List.last(socket.assigns.windows) do
-      %{id: id} ->
-        socket
-        |> update_window(id, fn w -> %{w | x: root.x, y: root.y, z: root.z} end)
-        |> assign(:window_z, max(socket.assigns.window_z, root.z))
-        |> restore_window_freeze(id, root.frozen)
-
-      _ ->
-        socket
-    end
-  end
-
-  # Restore the method-editor doc-block expand state on a genuine session resume
-  # (BT-2570). The block's `:doc_expanded` is a socket assign that a fresh mount —
-  # which every reconnect is — re-inits to its collapsed default, so a user who
-  # expanded it would lose that on any transient socket drop, redeploy, or laptop
-  # wake. `terminate/2` stashes the flag in the registry (Phoenix-node memory that
-  # outlives the reconnect); here we read it back and re-apply it. A fresh session
-  # or a failed bind (not connected) leaves the collapsed default untouched; a
-  # missing stash (nothing was expanded) likewise leaves the default.
-  defp restore_doc(socket, _token, :fresh), do: socket
-
-  defp restore_doc(socket, token, :resumed) do
-    with true <- socket.assigns[:connected],
-         expanded when is_boolean(expanded) <- SessionRegistry.doc_stash(token) do
-      assign(socket, :doc_expanded, expanded)
-    else
-      _ -> socket
-    end
-  end
-
-  defp restore_window_freeze(socket, _id, false), do: socket
-
-  defp restore_window_freeze(socket, id, true) do
-    update_window(socket, id, fn w -> toggle_window_freeze(socket, w) end)
-  end
-
-  # Re-cascade every open window back onto the default on-screen ladder (BT-2527
-  # #4): a recovery affordance for a window dragged to (or restored at) a spot
-  # outside the visible viewport. Positions only — drill state, watches, stats and
-  # freeze are untouched.
-  defp reset_window_positions(socket) do
-    {windows, _} =
-      Enum.map_reduce(socket.assigns.windows, 0, fn w, i ->
-        step = rem(i, 8)
-        x = window_origin_x() + step * window_cascade()
-        y = window_origin_y() + step * window_cascade()
-        {%{w | x: x, y: y}, i + 1}
-      end)
-
-    assign(socket, :windows, windows)
-  end
-
-  # Inspect a live `term` into a window `w` (parameterised twin of the docked
-  # `inspect_term/4`): read the object's fields via the read-surface, set the
-  # window's target/rows/crumbs/error, then (re)arm its per-object watch + stats.
-  # A re-inspect (drill / crumb walk-back) rebinds the watch onto the new head and
-  # releases the previous one — but only if no OTHER watcher (window or docked
-  # pane) still needs that pid (so closing one of two windows on the same actor
-  # doesn't silence the other).
-  defp inspect_window(socket, w, label, term, crumbs) do
-    if Workspace.inspectable?(term) do
-      case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
-        # BT-2634: a supervisor renders its children / supervision tree (drillable
-        # child handles), not actor instance vars — the float-window twin of the
-        # docked supervisor case. `track_window/3` does not arm a watch for a
-        # supervisor term (its no-track catch-all), so no field-flash / pid-stats.
-        {:ok, {:supervisor_children, child_rows}} ->
-          %{
-            w
-            | target: target_info(label, term),
-              rows: supervisor_child_rows(child_rows),
-              crumbs: crumbs,
-              error: nil
-          }
-          |> track_window(socket, term)
-
-        {:ok, fields} when is_map(fields) ->
-          %{
-            w
-            | target: target_info(label, term),
-              rows: field_rows(fields),
-              crumbs: crumbs,
-              error: nil
-          }
-          |> track_window(socket, term)
-
-        {:ok, scalar} ->
-          %{
-            w
-            | target: target_info(label, term),
-              rows: [
-                %{
-                  name: "value",
-                  value: Workspace.format_value(scalar),
-                  term: scalar,
-                  drillable: false,
-                  kind: term_kind(scalar)
-                }
-              ],
-              crumbs: crumbs,
-              error: nil
-          }
-          |> track_window(socket, scalar)
-
-        {:error, reason} ->
-          %{
-            w
-            | target: nil,
-              rows: [],
-              crumbs: [],
-              error: Workspace.render_error(reason)
-          }
-          |> track_window(socket, nil)
-      end
-    else
-      %{
-        w
-        | target: target_info(label, term),
-          rows: [],
-          crumbs: crumbs,
-          error: "#{label} is a #{scalar_kind(term)} — no fields to inspect"
-      }
-      |> track_window(socket, term)
-    end
-  end
-
-  # Arm (or tear down) a window's per-object change subscription + pid-stats read
-  # for `term`, called on every `inspect_window/5`. Mirrors the docked
-  # `track_object/2` but scoped to one window's `watch`. The previously-watched
-  # term is released first (guarded so a pid another watcher still needs is kept
-  # subscribed), then a non-frozen pid-backed head re-subscribes + reads stats.
-  defp track_window(w, socket, {:beamtalk_object, _c, _m, pid} = term) when is_pid(pid) do
-    w = unwatch_window(w, socket)
-
-    w =
-      if w.frozen do
-        %{w | watch: nil}
-      else
-        case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
-          :ok -> %{w | watch: term}
-          _ -> %{w | watch: nil}
-        end
-      end
-
-    %{w | refresh_pending: false}
-    |> refresh_window_stats(socket, term)
-    |> Map.merge(%{poke_result: nil, poke_error: nil})
-  end
-
-  defp track_window(w, socket, _term) do
-    w
-    |> unwatch_window(socket)
-    |> Map.merge(%{stats: nil, poke_result: nil, poke_error: nil})
-  end
-
-  # Drop a window's per-object subscription, unless the same pid is still watched
-  # by another window or the docked pane (reference-aware unsubscribe). Idempotent.
-  defp unwatch_window(%{watch: nil} = w, _socket), do: w
-
-  defp unwatch_window(%{watch: term} = w, socket) do
-    unless pid_watched_elsewhere?(socket, term, w.id) do
-      Facade.dispatch(:unsubscribe_object, %{term: term, pid: self()}, ctx(socket))
-    end
-
-    %{w | watch: nil}
-  end
-
-  # True when the pid backing `term` is still watched by some watcher OTHER than
-  # window `except_id` — another floating window, or the docked Inspector. Used to
-  # avoid unsubscribing a pid a sibling watcher still depends on (the workspace
-  # keys subscriptions by `(pid, subscriber)`, so one unsubscribe would silence all
-  # this-pid watchers in this LiveView).
-  defp pid_watched_elsewhere?(socket, {:beamtalk_object, _c, _m, pid}, except_id)
-       when is_pid(pid) do
-    docked = watched_pid?(socket.assigns[:inspect_watch], pid)
-
-    windowed =
-      Enum.any?(socket.assigns.windows, fn w ->
-        w.id != except_id and watched_pid?(w.watch, pid)
-      end)
-
-    docked or windowed
-  end
-
-  defp pid_watched_elsewhere?(_socket, _term, _except_id), do: false
-
-  # Read a window's inspected actor's live pid stats for its head chips. A failure
-  # clears the chips rather than rendering stale numbers (same contract as the
-  # docked `refresh_stats/2`).
-  defp refresh_window_stats(w, socket, term) do
-    case Facade.dispatch(:pid_stats, %{term: term}, ctx(socket)) do
-      {:ok, stats} when is_map(stats) -> %{w | stats: stats}
-      _ -> %{w | stats: nil}
-    end
-  end
-
-  # Re-read a window's *already-watched* object after a change push WITHOUT
-  # re-arming the subscription (the watch is still live). Bumps the window's
-  # `flash_gen` so its FieldFlash hook flashes the changed cells. Mirrors the
-  # docked `refresh_inspector/2`.
-  defp refresh_window(w, socket, {:beamtalk_object, _c, _m, pid} = term) when is_pid(pid) do
-    label = window_label(w)
-
-    case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
-      {:ok, fields} when is_map(fields) ->
-        %{
-          w
-          | target: target_info(label, term),
-            rows: field_rows(fields),
-            error: nil
-        }
-        |> refresh_window_stats(socket, term)
-        |> bump_window_flash()
-
-      {:ok, _scalar} ->
-        w |> refresh_window_stats(socket, term) |> bump_window_flash()
-
-      {:error, _reason} ->
-        w
-    end
-  end
-
-  # The label at a window's current head: its last drill crumb, falling back to its
-  # target label.
-  defp window_label(w) do
-    case List.last(w.crumbs) do
-      %{label: label} -> label
-      _ -> (w.target || %{})[:label] || "value"
-    end
-  end
-
-  defp bump_window_flash(w), do: %{w | flash_gen: w.flash_gen + 1}
-
-  # Per-window freeze toggle (the docked `toggle_freeze/1`, scoped to one window).
-  # Unfreeze re-arms the window's watch on its current head and catches up; freeze
-  # drops its subscription (reference-aware) and holds the snapshot.
-  defp toggle_window_freeze(socket, %{frozen: true} = w) do
-    w = %{w | frozen: false, refresh_pending: false}
-
-    case window_head_term(w) do
-      {:beamtalk_object, _c, _m, pid} = term when is_pid(pid) ->
-        w
-        |> rearm_window_watch(socket, term)
-        |> refresh_window(socket, term)
-
-      _ ->
-        w
-    end
-  end
-
-  defp toggle_window_freeze(socket, w) do
-    w
-    |> unwatch_window(socket)
-    |> Map.put(:frozen, true)
-  end
-
-  defp rearm_window_watch(w, socket, term) do
-    case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
-      :ok -> %{w | watch: term}
-      _ -> %{w | watch: nil}
-    end
-  end
-
-  # The live term at a window's current head (its last crumb), or nil.
-  defp window_head_term(w) do
-    case List.last(w.crumbs) do
-      %{term: term} -> term
-      _ -> nil
-    end
-  end
-
-  # Send `message` to a window's inspected actor by eval'ing `<binding> <message>`
-  # against the session (the docked `poke_object/2`, scoped to one window). The
-  # actor is addressed by its window's single-crumb binding label; a window not at
-  # a named-binding root can't be poked. On success the window re-reads so its
-  # fields reflect the write synchronously (the docked `refresh_poked_inspector`).
-  defp poke_window(socket, w, message) do
-    message = String.trim(message)
-    pid = socket.assigns[:session_pid]
-    label = window_poke_label(w)
-
-    cond do
-      not is_pid(pid) ->
-        %{w | poke_result: nil, poke_error: "not attached to workspace"}
-
-      message == "" ->
-        %{w | poke_result: nil, poke_error: "Enter a message to send."}
-
-      is_nil(label) ->
-        %{
-          w
-          | poke_result: nil,
-            poke_error: "Can only send to a bound object — inspect a binding to poke it."
-        }
-
-      true ->
-        send_window_poke(socket, w, pid, label, message)
-    end
-  end
-
-  defp send_window_poke(socket, w, pid, label, message) do
-    code = "#{label} #{message}"
-
-    case Facade.dispatch(:eval, %{session_pid: pid, code: code}, ctx(socket)) do
-      {:ok, term, _output, _warnings} ->
-        w = %{w | poke_result: "→ #{Workspace.render_term(term)}", poke_error: nil}
-
-        # Re-read only when this window is live (`watch` is a pid). A FROZEN window
-        # shows the poke result but deliberately does NOT re-read its field rows
-        # (BT-2527 #6, reviewed): frozen means "snapshot", and overriding it here
-        # would diverge from the docked poke, which is governed by the same rule —
-        # surface parity over a one-off exception. Unfreeze to see the new state.
-        case w.watch do
-          {:beamtalk_object, _c, _m, p} = watched when is_pid(p) ->
-            refresh_window(w, socket, watched)
-
-          _ ->
-            w
-        end
-
-      {:error, reason, _output, _warnings} ->
-        %{w | poke_result: nil, poke_error: Workspace.render_error(reason)}
-
-      {:error, reason} ->
-        %{w | poke_result: nil, poke_error: facade_error(reason)}
-    end
-  end
-
-  # The binding name to address a window poke to (its single-crumb root label), or
-  # nil — the same well-formedness gate as the docked `poke_label/1`.
-  defp window_poke_label(%{crumbs: [%{label: label}]}) when is_binary(label) do
-    if valid_receiver?(label), do: label, else: nil
-  end
-
-  defp window_poke_label(_w), do: nil
-
-  # ── window-list manipulation (pure view state, no workspace round-trip) ──────
-
-  # Mint the next unique window id (a string so it rides DOM ids + phx-value cleanly)
-  # and advance the counter.
-  defp mint_window_id(socket) do
-    n = socket.assigns.next_window_id
-    {"win-#{n}", assign(socket, :next_window_id, n + 1)}
-  end
-
-  # The cascade position for the next window: offset down-right by one step per
-  # already-open window, wrapping after a few so a long-lived session doesn't march
-  # windows off-screen. Returns {x, y, socket} (socket unchanged — kept symmetric
-  # with `mint_window_id/1` for a tidy call site).
-  defp next_window_pos(socket) do
-    step = rem(length(socket.assigns.windows), 8)
-    x = window_origin_x() + step * window_cascade()
-    y = window_origin_y() + step * window_cascade()
-    {x, y, socket}
-  end
-
-  # Look up a window by id, or nil.
-  defp find_window(socket, id), do: Enum.find(socket.assigns.windows, &(&1.id == id))
-
-  # Whitelist mapping a client-supplied dismiss key → the scalar status assign to
-  # clear (BT-2612). This is the security boundary: only these exact strings
-  # resolve; everything else returns nil and is ignored by `dismiss_notice`.
-  # NEVER replace this with `String.to_atom/1` on the user-supplied key.
-  defp dismiss_key_to_assign("browser_error"), do: :browser_error
-  defp dismiss_key_to_assign("output"), do: :output
-  defp dismiss_key_to_assign("changes_error"), do: :changes_error
-  defp dismiss_key_to_assign("git_error"), do: :git_error
-  defp dismiss_key_to_assign("tests_error"), do: :tests_error
-  defp dismiss_key_to_assign("save_result"), do: :save_result
-  defp dismiss_key_to_assign("save_error"), do: :save_error
-  defp dismiss_key_to_assign("flush_result"), do: :flush_result
-  defp dismiss_key_to_assign("flush_error"), do: :flush_error
-  defp dismiss_key_to_assign("bindings_error"), do: :bindings_error
-  defp dismiss_key_to_assign("inspect_error"), do: :inspect_error
-  defp dismiss_key_to_assign(_unknown), do: nil
-
-  # Replace the window `id` with `fun.(window)`, leaving the list order (and so the
-  # DOM order) stable — z-order is carried by each window's `:z`, not list position,
-  # so an update never reshuffles the windows and resets their drag positions.
-  defp update_window(socket, id, fun) do
-    windows =
-      Enum.map(socket.assigns.windows, fn w ->
-        if w.id == id, do: fun.(w), else: w
-      end)
-
-    assign(socket, :windows, windows)
-  end
-
-  # Close a window: release its watch (reference-aware) and drop it from the list.
-  defp close_window(socket, id) do
-    case find_window(socket, id) do
-      nil ->
-        socket
-
-      w ->
-        _ = unwatch_window(w, socket)
-        assign(socket, :windows, Enum.reject(socket.assigns.windows, &(&1.id == id)))
-    end
-  end
-
-  # Bring window `id` to the front: bump its z above the current max so it overlays
-  # the others. No-op for an unknown id.
-  defp focus_window(socket, id) do
-    case find_window(socket, id) do
-      nil ->
-        socket
-
-      _w ->
-        z = socket.assigns.window_z + 1
-
-        socket
-        |> assign(:window_z, z)
-        |> update_window(id, fn w -> %{w | z: z} end)
-    end
-  end
-
-  # Clamp a client-reported drag coordinate to a non-negative integer (a crafted
-  # payload could send a float/NaN/negative).
-  defp clamp_coord(n) when is_integer(n) and n >= 0, do: n
-  defp clamp_coord(n) when is_float(n) and n >= 0.0, do: trunc(n)
-
-  defp clamp_coord(n) when is_binary(n) do
-    case Integer.parse(n) do
-      {i, _} when i >= 0 -> i
-      _ -> 0
-    end
-  end
-
-  defp clamp_coord(_), do: 0
-
-  # Route an `{:object_changed, pid, …}` push to every open floating window whose
-  # watched head is that pid (a non-frozen, currently-watching window). Each such
-  # window coalesces its own burst via its `:refresh_pending` flag and schedules a
-  # per-window deferred refresh. Windows watching a different pid (or frozen) are
-  # untouched. Returns the updated socket.
-  defp notify_windows_changed(socket, pid) do
-    {windows, scheduled} =
-      Enum.map_reduce(socket.assigns.windows, false, fn w, sched ->
-        cond do
-          w.frozen or not watched_pid?(w.watch, pid) ->
-            {w, sched}
-
-          w.refresh_pending ->
-            {w, sched}
-
-          true ->
-            {%{w | refresh_pending: true}, true}
-        end
-      end)
-
-    if scheduled do
-      Process.send_after(self(), {:do_window_refresh, pid}, refresh_debounce_ms())
-    end
-
-    assign(socket, :windows, windows)
-  end
-
-  # Flip the freeze flag and (un)arm tracking accordingly. Freezing unsubscribes
-  # the live object change stream (the pane now holds a snapshot). Unfreezing
-  # re-subscribes the current head object and refreshes it so it catches up.
-  defp toggle_freeze(%{assigns: %{inspect_frozen: true}} = socket) do
-    # Unfreeze: re-arm tracking on the current head term (if any) and catch up.
-    # Clear any stale `refresh_pending` too: a timer scheduled before the freeze
-    # could otherwise fire a redundant second refresh (double flash) right after
-    # this catch-up re-read.
-    socket = assign(socket, inspect_frozen: false, refresh_pending: false)
-
-    case head_term(socket) do
-      {:beamtalk_object, _c, _m, pid} = term when is_pid(pid) ->
-        socket
-        |> rearm_watch(term)
-        |> refresh_inspector(term)
-
-      _ ->
-        socket
-    end
-  end
-
-  defp toggle_freeze(socket) do
-    # Freeze: drop the subscription, keep the current rows/stats as the snapshot.
-    socket
-    |> unwatch()
-    |> assign(inspect_frozen: true)
-  end
-
-  # Subscribe the current head object for change pushes without touching the rows
-  # (used by unfreeze, which re-reads separately). A non-:ok result leaves the
-  # watch nil rather than claiming a live subscription.
-  defp rearm_watch(socket, term) do
-    case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
-      :ok -> assign(socket, inspect_watch: term)
-      _ -> assign(socket, inspect_watch: nil)
-    end
-  end
-
-  # The live term at the current inspector head: the last drill crumb carries it.
-  # nil when nothing is inspected.
-  defp head_term(socket) do
-    case List.last(socket.assigns.inspect_crumbs) do
-      %{term: term} -> term
-      _ -> nil
-    end
-  end
-
-  # Send `message` to the inspected actor by eval'ing `<binding> <message>` against
-  # the session (the spike's poke). The actor is addressed by its binding name —
-  # the head crumb's label — so a poke only makes sense when the head IS a named
-  # binding (not a drilled field or the `→ result` of an inspectIt). A successful
-  # send renders a terse confirmation and lets the change stream flash the updated
-  # field; a failure renders the structured error.
-  defp poke_object(socket, message) do
-    message = String.trim(message)
-    pid = socket.assigns[:session_pid]
-    label = poke_target_label(socket)
-
-    cond do
-      not is_pid(pid) ->
-        assign(socket, poke_result: nil, poke_error: "not attached to workspace")
-
-      message == "" ->
-        assign(socket, poke_result: nil, poke_error: "Enter a message to send.")
-
-      is_nil(label) ->
-        assign(socket,
-          poke_result: nil,
-          poke_error: "Can only send to a bound object — inspect a binding to poke it."
-        )
-
-      true ->
-        send_poke(socket, pid, label, message)
-    end
-  end
-
-  defp send_poke(socket, pid, label, message) do
-    code = "#{label} #{message}"
-
-    case Facade.dispatch(:eval, %{session_pid: pid, code: code}, ctx(socket)) do
-      {:ok, term, _output, _warnings} ->
-        socket
-        |> assign(poke_result: "→ #{Workspace.render_term(term)}", poke_error: nil)
-        # A poke is a user-initiated mutation — re-read the inspected object now so
-        # its fields reflect the write immediately, rather than waiting on the async
-        # `{:object_changed, …}` change-stream push (which is coalesced/delayed, and
-        # is the live-tracking path tracked separately by BT-2524). No-op when the
-        # pane is frozen or nothing is watched.
-        |> refresh_poked_inspector()
-
-      {:error, reason, _output, _warnings} ->
-        assign(socket, poke_result: nil, poke_error: Workspace.render_error(reason))
-
-      {:error, reason} ->
-        assign(socket, poke_result: nil, poke_error: facade_error(reason))
-    end
-  end
-
-  # Re-read the inspected object after a successful poke so the pane reflects the
-  # mutation synchronously. Only when an object is actively watched (a live,
-  # non-frozen pid-backed head) — a frozen pane holds its snapshot, and a
-  # non-object head has nothing to re-read.
-  defp refresh_poked_inspector(%{assigns: %{inspect_watch: term}} = socket)
-       when not is_nil(term) do
-    refresh_inspector(socket, term)
-  end
-
-  defp refresh_poked_inspector(socket), do: socket
-
-  # The binding name to address a poke to. A poke eval's `<receiver> <message>`
-  # against the session, so the receiver must be a *source-addressable* name — a
-  # session binding. That holds only at the inspection root (a single crumb whose
-  # label IS the binding the inspection started from): once you drill into a field
-  # the head is a referenced object with no session binding to name, and an
-  # inspectIt `→ result` has no name at all. So poke is offered only when there's a
-  # single crumb with a valid-identifier label; otherwise nil (the bar reports it
-  # can't send, and the markup can hide it). This keeps the eval well-formed and
-  # honest rather than sending to a name that isn't bound.
-  defp poke_target_label(socket), do: poke_label(socket.assigns)
-
-  # Whether the current Inspector head can be poked: a pid-backed object at the
-  # inspection root with a valid-identifier binding name. Takes the bare `assigns`
-  # so the render template can gate the poke bar with it directly.
-  defp pokeable?(assigns), do: poke_label(assigns) != nil
-
-  # The session-binding name to address a poke to, or nil (see `poke_target_label`).
-  defp poke_label(assigns) do
-    case assigns[:inspect_crumbs] do
-      [%{label: label}] when is_binary(label) ->
-        if valid_receiver?(label), do: label, else: nil
-
-      _ ->
-        nil
-    end
-  end
-
-  # A poke receiver must be a plain lowercase Beamtalk identifier (a binding name)
-  # — not the `→ result` synthetic label or anything with spaces/punctuation that
-  # would make `<label> <message>` ill-formed source. This is a well-formedness
-  # gate, not an injection guard: the poke eval is RBAC-gated (owner-only) and the
-  # label comes from the crumb the *server* set from the inspected binding name,
-  # never raw browser input. A pseudo-keyword binding (`self`/`nil`/…) that slips
-  # through just produces a normal eval that DNUs or no-ops — no escalation.
-  defp valid_receiver?(label), do: Regex.match?(~r/\A[a-z_][A-Za-z0-9_]*\z/, label)
-
-  # Build the Inspector head's target descriptor: the binding/field label, the
-  # live printString header, and the class/pid type chips. For a live actor the
-  # term is `{:beamtalk_object, class, _module, pid}` (over distribution), so the
-  # class atom and pid render straight into the spike's `proc-chips`. Non-object
-  # values carry no pid and report their scalar kind as the class chip.
-  defp target_info(label, {:beamtalk_object, class, _module, pid} = term) when is_pid(pid) do
-    %{
-      label: to_string(label),
-      header: Workspace.render_term(term),
-      class_name: to_string(class),
-      pid: inspect(pid)
-    }
-  end
-
-  # Supervisor handles are pid-backed live refs too: chip the class + pid the same
-  # way as objects so the head renders as a drillable target (content/children is
-  # a follow-up — see `Workspace.inspect_value/1`).
-  defp target_info(label, {:beamtalk_supervisor, class, _module, pid} = term) when is_pid(pid) do
-    %{
-      label: to_string(label),
-      header: Workspace.render_term(term),
-      class_name: to_string(class),
-      pid: inspect(pid)
-    }
-  end
-
-  defp target_info(label, term) do
-    %{
-      label: to_string(label),
-      header: Workspace.render_term(term),
-      class_name: scalar_kind(term),
-      pid: nil
-    }
-  end
-
-  # Turn an inspect fields map (live terms) into ordered display rows. Each row
-  # keeps the live field `term` so a drill on an object-valued slot follows the
-  # real reference; `drillable` marks the object-valued ones.
-  defp field_rows(fields) do
-    fields
-    |> Enum.map(fn {key, term} ->
-      %{
-        name: to_string(key),
-        value: Workspace.render_term(term),
-        term: term,
-        drillable: Workspace.inspectable?(term),
-        kind: term_kind(term)
-      }
-    end)
-    |> Enum.sort_by(& &1.name)
-  end
-
-  # BT-2634: turn the runtime's supervisor-child maps (binary-keyed, from
-  # `beamtalk_process_navigation:child_handles/1`) into Inspector display rows. A
-  # child with a live `handle` (a Beamtalk actor / supervisor child) is drillable —
-  # its `term` is the live `{:beamtalk_supervisor, …}` / `{:beamtalk_object, …}`
-  # reference the "drill" event follows (ADR 0095). A foreign / restarting child
-  # has `handle => :null`: it renders (so the tree is complete) but is not
-  # drillable. The value column shows kind + pid + child count so the supervision
-  # structure is legible at a glance.
-  defp supervisor_child_rows(child_rows) when is_list(child_rows) do
-    Enum.map(child_rows, &supervisor_child_row/1)
-  end
-
-  defp supervisor_child_row(row) when is_map(row) do
-    handle = Map.get(row, "handle", :null)
-    drillable = handle != :null and handle != nil
-
-    %{
-      name: to_string(Map.get(row, "label", "child")),
-      value: supervisor_child_value(row),
-      term: if(drillable, do: handle, else: nil),
-      drillable: drillable,
-      kind: "ref"
-    }
-  end
-
-  # The value-column text for a supervisor child row: "kind · pid · N children"
-  # (child count only for supervisors), or "kind · restarting" for a child caught
-  # mid-restart (no pid).
-  defp supervisor_child_value(row) do
-    kind = to_string(Map.get(row, "kind", "process"))
-    pid = supervisor_child_pid_text(Map.get(row, "pid", :null))
-
-    if Map.get(row, "isSupervisor", false) do
-      count = Map.get(row, "childCount", 0)
-      "#{kind} · #{pid} · #{count} #{pluralize_children(count)}"
-    else
-      "#{kind} · #{pid}"
-    end
-  end
-
-  defp supervisor_child_pid_text(:null), do: "restarting"
-  defp supervisor_child_pid_text(nil), do: "restarting"
-  defp supervisor_child_pid_text(pid) when is_binary(pid), do: pid
-  defp supervisor_child_pid_text(pid), do: to_string(pid)
-
-  defp pluralize_children(1), do: "child"
-  defp pluralize_children(_), do: "children"
-
-  # Map a live term to the Inspector's "no fields to inspect" type word ("X is a
-  # <scalar_kind>"). Derives from the single classifier `Workspace.term_class/1`
-  # (BT-2635), so this is purely a presentation mapping of its `{:scalar, kind}`
-  # output — it does not re-enumerate term shapes. `{:ref, _}` terms never reach
-  # here from the non-inspectable else-branch; they can reach it from
-  # `target_info/2`'s fallback, where they fall through to "value". The `:value`
-  # / unmapped-scalar cases all render "value".
-  defp scalar_kind(term) do
-    case Workspace.term_class(term) do
-      {:scalar, :integer} -> "number"
-      {:scalar, :float} -> "number"
-      {:scalar, :string} -> "string"
-      {:scalar, :boolean} -> "boolean"
-      {:scalar, :list} -> "collection"
-      {:scalar, :map} -> "map"
-      _ -> "value"
-    end
-  end
-
-  # Map a live term to the spike Inspector's value-kind class (inspector.jsx
-  # `valueClass`), driving the type-chip / value colour. Derives from the single
-  # classifier `Workspace.term_class/1` (BT-2635): any live ref (object,
-  # supervisor, future, pid) chips as the drillable `ref`; scalars map to their
-  # CSS class. Booleans classify as `{:scalar, :boolean}` (matched before the
-  # atom guard inside `term_class/1`), so they chip as "bool", not "symbol".
-  # Lists/maps and any unrecognised term fall through to "value", exactly as
-  # before centralisation.
-  defp term_kind(term) do
-    case Workspace.term_class(term) do
-      {:ref, _kind} -> "ref"
-      {:scalar, :boolean} -> "bool"
-      {:scalar, :integer} -> "int"
-      {:scalar, :float} -> "int"
-      {:scalar, :string} -> "string"
-      {:scalar, :atom} -> "symbol"
-      _ -> "value"
-    end
-  end
-
-  # ── pid-stats chip accessors (BT-2492) ──────────────────────────────────────
-  #
-  # The `pid_stats` op returns a binary-keyed map (`beamtalk_repl_ops_watch`):
-  # `status`, `queue_depth`, `memory_bytes`, `reductions`, `current_function`, plus
-  # `alive`. These read the head chips off that snapshot, returning nil when the
-  # stat is absent (so the chip's `:if` hides it) — a dead pid reports only
-  # `status: "dead"`, so the mailbox/reductions chips vanish rather than show 0.
-
-  # Process scheduling status (`running`/`waiting`/`runnable`/`dead`/…), always
-  # shown when stats are present — it's the live "is it ticking" tell.
-  defp stat_status(stats) when is_map(stats), do: Map.get(stats, "status")
-  defp stat_status(_), do: nil
-
-  # Mailbox (message queue) depth — only when the pid is alive (a dead pid has no
-  # queue, and the map omits it).
-  defp stat_mailbox(stats) when is_map(stats), do: Map.get(stats, "queue_depth")
-  defp stat_mailbox(_), do: nil
-
-  # Reduction count (a coarse "how much work has it done" gauge), thousands-
-  # separated for readability like the spike. Absent on a dead pid.
-  defp stat_reductions(stats) when is_map(stats) do
-    case Map.get(stats, "reductions") do
-      n when is_integer(n) -> format_thousands(n)
-      _ -> nil
-    end
-  end
-
-  defp stat_reductions(_), do: nil
-
-  # Group an integer with thousands separators (the spike's `toLocaleString()`),
-  # e.g. 1234567 → "1,234,567".
-  defp format_thousands(n) when is_integer(n) and n < 0, do: "-" <> format_thousands(-n)
-
-  defp format_thousands(n) when is_integer(n) do
-    n
-    |> Integer.to_string()
-    |> String.graphemes()
-    |> Enum.reverse()
-    |> Enum.chunk_every(3)
-    |> Enum.map_join(",", &Enum.join/1)
-    |> String.reverse()
   end
 
   # ── Tweaks panel (BT-2487) ──────────────────────────────────────────────────
@@ -9845,42 +8422,10 @@ defmodule BtAttachWeb.WorkspaceLive do
     """
   end
 
-  # ── dismissable status notices (BT-2612) ────────────────────────────────────
-  #
-  # A single reusable notice component for every `io-block` status banner
-  # (err/ok/warn/plain). Each notice carries a keyboard-accessible `×` dismiss
-  # control. The dismiss is wired by the *caller* via `dismiss_attrs` — a map of
-  # `phx-*` attributes (e.g. `%{"phx-click" => "dismiss_notice", "phx-value-key"
-  # => "git_error"}`) so top-level scalar assigns route through the generic
-  # `dismiss_notice` event while nested/per-window notices route through their own
-  # targeted events. Variant maps to the `io-block` modifier class.
-  attr :variant, :atom, default: :plain, values: [:err, :ok, :warn, :plain]
-  attr :message, :string, required: true
-  # Map of phx-* attributes rendered onto the dismiss button. The caller decides
-  # which event/values clear the right backing assign.
-  attr :dismiss_attrs, :map, required: true
-
-  defp notice(assigns) do
-    ~H"""
-    <div class={["io-block", notice_variant_class(@variant)]}>
-      <span class="io-block-msg">{@message}</span>
-      <button
-        type="button"
-        class="io-block-dismiss"
-        aria-label="Dismiss notification"
-        title="Dismiss"
-        {@dismiss_attrs}
-      >
-        ×
-      </button>
-    </div>
-    """
-  end
-
-  defp notice_variant_class(:err), do: "err"
-  defp notice_variant_class(:ok), do: "ok"
-  defp notice_variant_class(:warn), do: "warn"
-  defp notice_variant_class(:plain), do: nil
+  # `<.notice>` (dismissable status banner, BT-2612) moved to
+  # `BtAttachWeb.CoreComponents` (BT-3291) so extracted panes can render it
+  # too — auto-imported here via `use BtAttachWeb, :live_view`, so every
+  # existing `<.notice ...>` call site below is unchanged.
 
   @impl true
   def render(assigns) do
@@ -11991,17 +10536,23 @@ defmodule BtAttachWeb.WorkspaceLive do
                         <span :if={@inspect_target.pid} class="chip">
                           pid <b>{@inspect_target.pid}</b>
                         </span>
-                        <span :if={stat_status(@inspect_stats)} class="chip pid-stat">
-                          <span class="dot"></span>{stat_status(@inspect_stats)}
+                        <span :if={Inspector.stat_status(@inspect_stats)} class="chip pid-stat">
+                          <span class="dot"></span>{Inspector.stat_status(@inspect_stats)}
                         </span>
                         <%!-- not is_nil, not truthiness: a mailbox depth of 0 (the
                              actor drained) is the most reassuring reading and must
                              still show, but 0 is falsy in a HEEx `:if`. --%>
-                        <span :if={not is_nil(stat_mailbox(@inspect_stats))} class="chip pid-stat">
-                          mailbox <b>{stat_mailbox(@inspect_stats)}</b>
+                        <span
+                          :if={not is_nil(Inspector.stat_mailbox(@inspect_stats))}
+                          class="chip pid-stat"
+                        >
+                          mailbox <b>{Inspector.stat_mailbox(@inspect_stats)}</b>
                         </span>
-                        <span :if={not is_nil(stat_reductions(@inspect_stats))} class="chip pid-stat">
-                          reductions <b>{stat_reductions(@inspect_stats)}</b>
+                        <span
+                          :if={not is_nil(Inspector.stat_reductions(@inspect_stats))}
+                          class="chip pid-stat"
+                        >
+                          reductions <b>{Inspector.stat_reductions(@inspect_stats)}</b>
                         </span>
                       </div>
                     </div>
@@ -12071,7 +10622,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                     <div
                       :if={
                         @inspect_target && @inspect_target.pid && @role == :owner &&
-                          pokeable?(assigns)
+                          Inspector.pokeable?(assigns)
                       }
                       class="poke"
                     >
@@ -12102,7 +10653,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                eats clicks on the cockpit beneath when empty. Each window reuses the
                docked Inspector's content (target/crumbs/rows/chips/poke) keyed by
                its id, with its own drag handle, close button and z-order. --%>
-          <.inspector_windows :if={@windows != []} windows={@windows} role={@role} />
+          <Inspector.inspector_windows :if={@windows != []} windows={@windows} role={@role} />
           <%!-- The Changes (ChangeLog) viewer and the live Transcript stream now
                live in the tabbed Workspace dock above (BT-2490), not a separate
                full-width footer. --%>
@@ -12132,187 +10683,4 @@ defmodule BtAttachWeb.WorkspaceLive do
     </div>
     """
   end
-
-  # ── floating inspector windows (BT-2493, epic BT-2482 Phase 3) ───────────────
-  #
-  # The overlay layer: one draggable, stackable inspector window per `:windows`
-  # entry. The layer itself is pointer-inert so it never eats clicks on the
-  # cockpit beneath; each window re-enables pointer events on itself. Window
-  # position (`left`/`top`) and stacking (`z-index`) come straight from the
-  # per-window state the WindowDrag hook reports on drop / focus, so they survive an
-  # unrelated re-render. Each window's content reuses the docked Inspector's markup
-  # (head + breadcrumb + chips + ivar table + poke), parameterised by window id so
-  # its drill/crumb/close/freeze/poke events carry the id back to the right window.
-
-  attr :windows, :list, required: true
-  attr :role, :atom, required: true
-
-  defp inspector_windows(assigns) do
-    ~H"""
-    <div class="insp-overlay" id="inspector-overlay">
-      <%!-- Off-screen recovery (BT-2527 #4): re-cascade every window back onto the
-           visible ladder. Shown only when a desk is open so it never floats over
-           an empty cockpit. --%>
-      <button
-        :if={@windows != []}
-        type="button"
-        class="insp-tidy"
-        phx-click="window_reset_positions"
-        title="Bring all inspector windows back on-screen"
-      >
-        Tidy windows
-      </button>
-      <.inspector_window :for={w <- @windows} win={w} role={@role} />
-    </div>
-    """
-  end
-
-  attr :win, :map, required: true
-  attr :role, :atom, required: true
-
-  defp inspector_window(assigns) do
-    ~H"""
-    <section
-      class="insp-window"
-      id={"inspector-window-#{@win.id}"}
-      style={"left:#{@win.x}px;top:#{@win.y}px;z-index:#{@win.z};"}
-      phx-hook="WindowDrag"
-      data-window-id={@win.id}
-    >
-      <%!-- Title bar: the drag handle (`.iw-title`, grabbed by the WindowDrag hook)
-           plus the live freeze toggle and the close button. Dragging the bar moves
-           the window client-side; the hook reports the final x/y on drop. --%>
-      <header class="iw-bar" data-window-drag-handle>
-        <span class="iw-title mono">
-          {(@win.target && @win.target.label) || @win.label}
-        </span>
-        <span class="spacer"></span>
-        <button
-          :if={@win.target && @win.target.pid}
-          type="button"
-          class={["insp-freeze", (@win.frozen && "frozen") || "live"]}
-          phx-click="window_freeze"
-          phx-value-id={@win.id}
-          title={
-            if @win.frozen,
-              do: "Frozen snapshot — click to track live",
-              else: "Tracking live (subscribed to changes) — click to freeze a snapshot"
-          }
-        >
-          <span class="iwf-dot"></span>{(@win.frozen && "frozen") || "live"}
-        </button>
-        <button
-          type="button"
-          class="iw-close"
-          phx-click="window_close"
-          phx-value-id={@win.id}
-          title="Close window"
-          aria-label="Close window"
-        >
-          ×
-        </button>
-      </header>
-      <div class="iw-body">
-        <%= if @win.target do %>
-          <div class="insp-head">
-            <div :if={length(@win.crumbs) > 1} class="insp-crumbs">
-              <%= for {crumb, i} <- Enum.with_index(@win.crumbs) do %>
-                <span :if={i > 0} class="sep">›</span>
-                <span class="c" phx-click="window_crumb" phx-value-id={@win.id} phx-value-index={i}>
-                  {crumb.label}
-                </span>
-              <% end %>
-            </div>
-            <div class="ps mono">
-              Inspecting <strong>{@win.target.label}</strong>
-              <span class="ps-header">{@win.target.header}</span>
-            </div>
-            <div class="proc-chips">
-              <span class="chip">class <b>{@win.target.class_name}</b></span>
-              <span :if={@win.target.pid} class="chip">
-                pid <b>{@win.target.pid}</b>
-              </span>
-              <span :if={stat_status(@win.stats)} class="chip pid-stat">
-                <span class="dot"></span>{stat_status(@win.stats)}
-              </span>
-              <span :if={not is_nil(stat_mailbox(@win.stats))} class="chip pid-stat">
-                mailbox <b>{stat_mailbox(@win.stats)}</b>
-              </span>
-              <span :if={not is_nil(stat_reductions(@win.stats))} class="chip pid-stat">
-                reductions <b>{stat_reductions(@win.stats)}</b>
-              </span>
-            </div>
-          </div>
-        <% end %>
-        <div class="iw-content">
-          <.notice
-            :if={@win.error}
-            variant={:warn}
-            message={@win.error}
-            dismiss_attrs={%{"phx-click" => "dismiss_window_error", "phx-value-id" => @win.id}}
-          />
-          <%= if @win.target && @win.rows != [] do %>
-            <table
-              id={"inspector-window-fields-#{@win.id}"}
-              class="ivar-table"
-              phx-hook="FieldFlash"
-              data-flash-gen={@win.flash_gen}
-            >
-              <tbody>
-                <tr
-                  :for={{row, i} <- Enum.with_index(@win.rows)}
-                  class={row.drillable && "drillable"}
-                  phx-click={row.drillable && "window_drill"}
-                  phx-value-id={row.drillable && @win.id}
-                  phx-value-index={row.drillable && i}
-                >
-                  <td class="k">{row.name}</td>
-                  <td class={["v", row.kind]} data-flash-key={row.name} data-flash-val={row.value}>
-                    {row.value}
-                  </td>
-                  <td class="follow">
-                    <span :if={row.drillable} class="follow-link">follow →</span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          <% else %>
-            <p :if={@win.target == nil && @win.error == nil} class="empty">
-              Nothing to inspect.
-            </p>
-          <% end %>
-          <%!-- Owner-only poke bar (BT-2492), per-window: pokeable only at a single
-               named-binding crumb root (the same well-formedness gate the docked
-               pane uses), and only for the owner role. --%>
-          <div
-            :if={@win.target && @win.target.pid && @role == :owner && window_pokeable?(@win)}
-            class="poke"
-          >
-            <div class="poke-label">Send a message to {@win.target.label}</div>
-            <form class="poke-row" phx-submit="window_poke" phx-value-id={@win.id}>
-              <span class="poke-recv mono">‹recv›</span>
-              <input
-                class="field mono"
-                name="message"
-                autocomplete="off"
-                placeholder="increment   ·   incrementBy: 10"
-              />
-              <button type="submit" class="btn">Send</button>
-            </form>
-            <div :if={@win.poke_result} class="poke-out ok mono">{@win.poke_result}</div>
-            <div :if={@win.poke_error} class="poke-out warn mono">{@win.poke_error}</div>
-          </div>
-        </div>
-      </div>
-    </section>
-    """
-  end
-
-  # Whether a floating window's head can be poked: a pid-backed object at the
-  # inspection root with a valid-identifier binding name (the same contract as the
-  # docked `pokeable?/1`, scoped to one window's crumbs).
-  defp window_pokeable?(%{crumbs: [%{label: label}]}) when is_binary(label),
-    do: valid_receiver?(label)
-
-  defp window_pokeable?(_w), do: false
 end

--- a/editors/liveview/test/bt_attach_web/inspector_test.exs
+++ b/editors/liveview/test/bt_attach_web/inspector_test.exs
@@ -1,0 +1,448 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.Live.InspectorTest do
+  @moduledoc """
+  Direct unit tests for `BtAttachWeb.Live.Inspector` (BT-3291), driving its
+  `handle_event/3` / `handle_info/2` clauses and pure helpers against a
+  hand-built `%Phoenix.LiveView.Socket{}` and the fully-stubbed workspace
+  client (`BtAttachWeb.StubWorkspaceClient`, BT-2554) — no full LiveView
+  mount, no real workspace node.
+
+  These cover the branches BT-3291's acceptance criteria calls out
+  specifically: drill/crumb navigation, freeze/unfreeze, field-flash
+  coalescing, the owner-only poke RBAC gate, and window position reset —
+  previously reachable only through the `:workspace`-tagged full-stack
+  `WorkspaceLiveTest`, which is excluded from the default `mix test` lane.
+  """
+  use ExUnit.Case, async: false
+
+  alias BtAttachWeb.Live.Inspector
+  alias BtAttachWeb.StubWorkspaceClient
+
+  setup do
+    Application.put_env(:bt_attach, :workspace_client, StubWorkspaceClient)
+    {:ok, _} = StubWorkspaceClient.start_state()
+
+    on_exit(fn ->
+      Application.delete_env(:bt_attach, :workspace_client)
+      StubWorkspaceClient.stop_state(2_000)
+    end)
+
+    :ok
+  end
+
+  # A bare socket carrying exactly the assigns Inspector's functions read —
+  # the subset of `WorkspaceLive.bind_session/3`'s init relevant to the
+  # docked Inspector + floating windows. `role: :owner` by default (most
+  # tests aren't about RBAC); override per test.
+  defp base_socket(overrides \\ %{}) do
+    assigns =
+      %{
+        __changed__: %{},
+        current_user: nil,
+        role: :owner,
+        session_id: "sess-1",
+        session_pid: self(),
+        inspector_mode: "docked",
+        inspect_target: nil,
+        inspect_rows: [],
+        inspect_crumbs: [],
+        inspect_error: nil,
+        inspect_watch: nil,
+        inspect_stats: nil,
+        inspect_frozen: false,
+        flash_gen: 0,
+        refresh_pending: false,
+        poke_result: nil,
+        poke_error: nil,
+        windows: [],
+        window_z: 10,
+        next_window_id: 1
+      }
+      |> Map.merge(overrides)
+
+    %Phoenix.LiveView.Socket{assigns: assigns}
+  end
+
+  # A synthetic live-object term backed by the test process's own pid — safe
+  # to "subscribe"/"inspect" against the stub client without a real node.
+  defp object_term(pid \\ self()), do: {:beamtalk_object, TestClass, TestClass, pid}
+
+  describe "pure classifiers" do
+    test "term_kind/1 maps object refs to \"ref\" and scalars to their chip" do
+      assert Inspector.term_kind(object_term()) == "ref"
+      assert Inspector.term_kind(42) == "int"
+      assert Inspector.term_kind("hi") == "string"
+      assert Inspector.term_kind(true) == "bool"
+    end
+
+    test "stat_status/mailbox/reductions read the pid_stats snapshot, nil when absent" do
+      assert Inspector.stat_status(%{"status" => "running"}) == "running"
+      assert Inspector.stat_status(nil) == nil
+      assert Inspector.stat_mailbox(%{"queue_depth" => 0}) == 0
+      assert Inspector.stat_mailbox(nil) == nil
+      assert Inspector.stat_reductions(%{"reductions" => 1_234_567}) == "1,234,567"
+      assert Inspector.stat_reductions(%{}) == nil
+    end
+
+    test "pokeable?/1 requires a single named-binding crumb with a valid identifier" do
+      refute Inspector.pokeable?(%{inspect_crumbs: []})
+      refute Inspector.pokeable?(%{inspect_crumbs: [%{label: "→ result"}]})
+      assert Inspector.pokeable?(%{inspect_crumbs: [%{label: "counter"}]})
+    end
+  end
+
+  describe "inspect / drill / crumb navigation" do
+    test "inspect resolves a session binding and starts a fresh drill breadcrumb" do
+      pid = self()
+      term = object_term(pid)
+      StubWorkspaceClient.put_bindings([{"counter", term}])
+
+      {:noreply, socket} =
+        Inspector.handle_event("inspect", %{"name" => "counter"}, base_socket())
+
+      assert socket.assigns.inspect_target.label == "counter"
+      assert socket.assigns.inspect_crumbs == [%{label: "counter", term: term}]
+      assert socket.assigns.inspect_error == nil
+      # `track_object/2` armed the live subscription for a pid-backed head.
+      assert socket.assigns.inspect_watch == term
+    end
+
+    test "inspecting an unknown binding surfaces an error, not a crash" do
+      StubWorkspaceClient.put_bindings([])
+
+      {:noreply, socket} = Inspector.handle_event("inspect", %{"name" => "ghost"}, base_socket())
+
+      assert socket.assigns.inspect_error =~ "binding not found"
+    end
+
+    test "drill follows an object-valued row by index, extending the breadcrumb" do
+      inner = object_term()
+      row = %{term: inner, name: "child", drillable: true}
+
+      socket =
+        base_socket(%{
+          inspect_crumbs: [%{label: "counter", term: object_term()}],
+          inspect_rows: [row]
+        })
+
+      {:noreply, socket} = Inspector.handle_event("drill", %{"index" => "0"}, socket)
+
+      assert socket.assigns.inspect_target.label == "child"
+      assert length(socket.assigns.inspect_crumbs) == 2
+      assert List.last(socket.assigns.inspect_crumbs) == %{label: "child", term: inner}
+    end
+
+    test "drill with a malformed index is a no-op, not a crash" do
+      socket = base_socket(%{inspect_rows: [%{term: object_term(), name: "x"}]})
+
+      {:noreply, result} = Inspector.handle_event("drill", %{"index" => "not-a-number"}, socket)
+      assert result == socket
+
+      {:noreply, result2} = Inspector.handle_event("drill", %{}, socket)
+      assert result2 == socket
+    end
+
+    test "crumb walks the breadcrumb back to an earlier level, truncating the trail" do
+      root = object_term()
+      mid = object_term()
+
+      socket =
+        base_socket(%{
+          inspect_crumbs: [
+            %{label: "counter", term: root},
+            %{label: "child", term: mid}
+          ]
+        })
+
+      {:noreply, socket} = Inspector.handle_event("crumb", %{"index" => "0"}, socket)
+
+      assert socket.assigns.inspect_target.label == "counter"
+      assert socket.assigns.inspect_crumbs == [%{label: "counter", term: root}]
+    end
+  end
+
+  describe "close_inspector" do
+    test "resets target/rows/crumbs/error and unfreezes, leaving show_inspector untouched" do
+      socket =
+        base_socket(%{
+          inspect_target: %{label: "counter"},
+          inspect_rows: [%{name: "x"}],
+          inspect_crumbs: [%{label: "counter", term: object_term()}],
+          inspect_error: "boom",
+          inspect_frozen: true
+        })
+
+      {:noreply, socket} = Inspector.handle_event("close_inspector", %{}, socket)
+
+      assert socket.assigns.inspect_target == nil
+      assert socket.assigns.inspect_rows == []
+      assert socket.assigns.inspect_crumbs == []
+      assert socket.assigns.inspect_error == nil
+      assert socket.assigns.inspect_frozen == false
+    end
+  end
+
+  describe "freeze / unfreeze (BT-2492 live tracking)" do
+    test "freeze_toggle flips inspect_frozen when nothing is watched" do
+      {:noreply, socket} = Inspector.handle_event("freeze_toggle", %{}, base_socket())
+      assert socket.assigns.inspect_frozen == true
+
+      {:noreply, socket} = Inspector.handle_event("freeze_toggle", %{}, socket)
+      assert socket.assigns.inspect_frozen == false
+    end
+
+    test "unfreezing a watched head re-arms the subscription and refreshes it" do
+      term = object_term()
+
+      socket =
+        base_socket(%{
+          inspect_frozen: true,
+          inspect_crumbs: [%{label: "counter", term: term}],
+          flash_gen: 0
+        })
+
+      {:noreply, socket} = Inspector.handle_event("freeze_toggle", %{}, socket)
+
+      assert socket.assigns.inspect_frozen == false
+      assert socket.assigns.inspect_watch == term
+      # `refresh_inspector/2` bumped the flash generation on the catch-up read.
+      assert socket.assigns.flash_gen == 1
+    end
+  end
+
+  describe "owner-only poke RBAC gate (BT-2492)" do
+    test "an Observer's poke is refused by the facade, not sent" do
+      socket =
+        base_socket(%{
+          role: :observer,
+          inspect_crumbs: [%{label: "counter", term: object_term()}]
+        })
+
+      {:noreply, socket} = Inspector.handle_event("poke", %{"message" => "increment"}, socket)
+
+      assert socket.assigns.poke_result == nil
+      assert socket.assigns.poke_error =~ "Not authorized"
+    end
+
+    test "an Owner's poke against a named binding succeeds" do
+      socket =
+        base_socket(%{
+          role: :owner,
+          inspect_crumbs: [%{label: "counter", term: object_term()}]
+        })
+
+      {:noreply, socket} = Inspector.handle_event("poke", %{"message" => "increment"}, socket)
+
+      assert socket.assigns.poke_error == nil
+      assert socket.assigns.poke_result =~ "→ "
+    end
+
+    test "poke with no addressable binding (a drilled field) reports it can't send" do
+      socket =
+        base_socket(%{
+          inspect_crumbs: [
+            %{label: "counter", term: object_term()},
+            %{label: "child", term: object_term()}
+          ]
+        })
+
+      {:noreply, socket} = Inspector.handle_event("poke", %{"message" => "increment"}, socket)
+
+      assert socket.assigns.poke_error =~ "Can only send to a bound object"
+    end
+
+    test "poke with a blank message is a local validation error" do
+      socket = base_socket(%{inspect_crumbs: [%{label: "counter", term: object_term()}]})
+
+      {:noreply, socket} = Inspector.handle_event("poke", %{"message" => "   "}, socket)
+
+      assert socket.assigns.poke_error == "Enter a message to send."
+    end
+  end
+
+  describe "field-flash coalescing ({:object_changed, …} → :do_object_refresh)" do
+    test "the first push schedules a deferred refresh and sets refresh_pending" do
+      pid = self()
+      term = object_term(pid)
+      socket = base_socket(%{inspect_watch: term, inspect_frozen: false})
+
+      {:noreply, socket} = Inspector.handle_info({:object_changed, pid, %{}}, socket)
+
+      assert socket.assigns.refresh_pending == true
+      assert_receive :do_object_refresh, 200
+    end
+
+    test "a burst collapses into the queued refresh (no second timer)" do
+      pid = self()
+      term = object_term(pid)
+      socket = base_socket(%{inspect_watch: term, inspect_frozen: false, refresh_pending: true})
+
+      {:noreply, socket} = Inspector.handle_info({:object_changed, pid, %{}}, socket)
+
+      assert socket.assigns.refresh_pending == true
+      refute_received :do_object_refresh
+    end
+
+    test "a frozen pane ignores the push" do
+      pid = self()
+      term = object_term(pid)
+      socket = base_socket(%{inspect_watch: term, inspect_frozen: true})
+
+      {:noreply, socket} = Inspector.handle_info({:object_changed, pid, %{}}, socket)
+
+      assert socket.assigns.refresh_pending == false
+      refute_received :do_object_refresh
+    end
+
+    test "the deferred refresh re-reads the object and bumps flash_gen" do
+      term = object_term()
+      socket = base_socket(%{inspect_watch: term, refresh_pending: true, flash_gen: 0})
+
+      {:noreply, socket} = Inspector.handle_info(:do_object_refresh, socket)
+
+      assert socket.assigns.refresh_pending == false
+      assert socket.assigns.flash_gen == 1
+    end
+
+    test "a stale :do_object_refresh with nothing watched is a harmless no-op" do
+      socket = base_socket(%{inspect_watch: nil, refresh_pending: true})
+
+      {:noreply, socket} = Inspector.handle_info(:do_object_refresh, socket)
+
+      assert socket.assigns.refresh_pending == false
+    end
+  end
+
+  describe "floating windows: open / drill / poke / close / focus" do
+    test "inspect in float mode opens a window instead of driving the docked pane" do
+      term = object_term()
+      StubWorkspaceClient.put_bindings([{"counter", term}])
+      socket = base_socket(%{inspector_mode: "float"})
+
+      {:noreply, socket} = Inspector.handle_event("inspect", %{"name" => "counter"}, socket)
+
+      assert socket.assigns.inspect_target == nil
+      assert [win] = socket.assigns.windows
+      assert win.id == "win-1"
+      assert win.crumbs == [%{label: "counter", term: term}]
+      assert socket.assigns.next_window_id == 2
+    end
+
+    test "window_close drops the window and releases its watch" do
+      win = %{
+        id: "win-1",
+        watch: nil,
+        crumbs: [],
+        rows: [],
+        target: nil,
+        error: nil,
+        stats: nil,
+        frozen: false,
+        refresh_pending: false,
+        flash_gen: 0,
+        poke_result: nil,
+        poke_error: nil,
+        x: 0,
+        y: 0,
+        z: 10
+      }
+
+      socket = base_socket(%{windows: [win]})
+      {:noreply, socket} = Inspector.handle_event("window_close", %{"id" => "win-1"}, socket)
+
+      assert socket.assigns.windows == []
+    end
+
+    test "window_close for an unknown id is a no-op" do
+      socket = base_socket()
+      {:noreply, result} = Inspector.handle_event("window_close", %{"id" => "nope"}, socket)
+      assert result == socket
+    end
+
+    test "window_focus bumps the clicked window's z above the current max" do
+      win_a = %{id: "a", z: 10, watch: nil}
+      win_b = %{id: "b", z: 11, watch: nil}
+      socket = base_socket(%{windows: [win_a, win_b], window_z: 11})
+
+      {:noreply, socket} = Inspector.handle_event("window_focus", %{"id" => "a"}, socket)
+
+      assert socket.assigns.window_z == 12
+      assert Enum.find(socket.assigns.windows, &(&1.id == "a")).z == 12
+    end
+  end
+
+  describe "window position reset (BT-2527 #4)" do
+    test "re-cascades every open window back onto the default on-screen ladder" do
+      windows = [
+        %{id: "a", x: 999, y: 999},
+        %{id: "b", x: -5, y: 42}
+      ]
+
+      socket = base_socket(%{windows: windows})
+      {:noreply, socket} = Inspector.handle_event("window_reset_positions", %{}, socket)
+
+      assert [%{x: 120, y: 96}, %{x: 148, y: 124}] =
+               Enum.map(socket.assigns.windows, &Map.take(&1, [:x, :y]))
+    end
+  end
+
+  describe "window_moved clamps client-reported coordinates" do
+    test "negative/float/non-numeric drag coordinates never place a window off into NaN-land" do
+      win = %{id: "a", x: 0, y: 0}
+      socket = base_socket(%{windows: [win]})
+
+      {:noreply, socket} =
+        Inspector.handle_event("window_moved", %{"id" => "a", "x" => -5, "y" => 12.7}, socket)
+
+      moved = Enum.find(socket.assigns.windows, &(&1.id == "a"))
+      assert moved.x == 0
+      assert moved.y == 12
+    end
+  end
+
+  describe "set_inspector_mode" do
+    test "flips between docked and float, ignoring an invalid value" do
+      {:noreply, socket} =
+        Inspector.handle_event("set_inspector_mode", %{"mode" => "float"}, base_socket())
+
+      assert socket.assigns.inspector_mode == "float"
+
+      {:noreply, result} =
+        Inspector.handle_event("set_inspector_mode", %{"mode" => "bogus"}, socket)
+
+      assert result == socket
+    end
+  end
+
+  describe "inspector_windows/1 function component" do
+    test "renders the tidy-windows control only when a window is open" do
+      import Phoenix.LiveViewTest
+
+      empty = render_component(&Inspector.inspector_windows/1, windows: [], role: :owner)
+      refute empty =~ "insp-tidy"
+
+      win = %{
+        id: "win-1",
+        label: "counter",
+        target: nil,
+        crumbs: [],
+        rows: [],
+        error: nil,
+        stats: nil,
+        frozen: false,
+        flash_gen: 0,
+        poke_result: nil,
+        poke_error: nil,
+        x: 0,
+        y: 0,
+        z: 10
+      }
+
+      html = render_component(&Inspector.inspector_windows/1, windows: [win], role: :owner)
+      assert html =~ "insp-tidy"
+      assert html =~ ~s(id="inspector-window-win-1")
+    end
+  end
+end

--- a/editors/liveview/test/bt_attach_web/inspector_test.exs
+++ b/editors/liveview/test/bt_attach_web/inspector_test.exs
@@ -282,7 +282,7 @@ defmodule BtAttachWeb.Live.InspectorTest do
       {:noreply, socket} = Inspector.handle_info({:object_changed, pid, %{}}, socket)
 
       assert socket.assigns.refresh_pending == true
-      refute_received :do_object_refresh
+      refute_receive :do_object_refresh, 200
     end
 
     test "a frozen pane ignores the push" do
@@ -293,7 +293,7 @@ defmodule BtAttachWeb.Live.InspectorTest do
       {:noreply, socket} = Inspector.handle_info({:object_changed, pid, %{}}, socket)
 
       assert socket.assigns.refresh_pending == false
-      refute_received :do_object_refresh
+      refute_receive :do_object_refresh, 200
     end
 
     test "the deferred refresh re-reads the object and bumps flash_gen" do


### PR DESCRIPTION
## Summary

Part of [BT-3290](https://linear.app/beamtalk/issue/BT-3290) (decompose `workspace_live.ex`, 12,318 lines, to close the Elixir coverage gap to >80%). This is the first extraction: the docked Inspector + floating object-window pane and its live-tracking machinery.

Linear: https://linear.app/beamtalk/issue/BT-3291

- Extracted the Inspector/window `handle_event`/`handle_info` clauses and their supporting helpers out of `BtAttachWeb.WorkspaceLive` into a new `BtAttachWeb.Live.Inspector` module. `WorkspaceLive` now delegates by event/message name via a single guard clause (`@inspector_events`) instead of ~16 individual clauses.
- Two small pieces of logic used by both modules (`ctx/1`'s RBAC context builder, the facade-error renderer) were pulled into shared leaf modules (`BtAttachWeb.Live.RequestContext`, `BtAttachWeb.Live.FacadeError`) rather than duplicated.
- The `<.notice>` dismissable-banner component moved from a `WorkspaceLive`-private component into `CoreComponents` (already auto-imported everywhere) so the extracted Inspector's floating-window components can render it too.
- Added `test/bt_attach_web/inspector_test.exs`: 28 direct unit tests against a hand-built `%Phoenix.LiveView.Socket{}` + the existing stubbed workspace client, covering drill/crumb navigation, freeze/unfreeze, field-flash coalescing, the owner-only poke RBAC gate, and window position reset — previously reachable only through the `:workspace`-tagged full-stack integration test.

## Results

- `workspace_live.ex`: 12,318 → 10,686 lines; `handle_event` clause count: 171 → 144.
- `BtAttachWeb.Live.Inspector` coverage: ~10% → ~49%; project total coverage: 59.85% → 64.23% (threshold 55%).
- `mix test --cover`: 549 passed, 0 failed. Full `just build && just clippy && just fmt-check && just test`: all green.

## Review

A local 3-pass `/review-code` was run, including an adversarial pass. No blockers found. One test-quality fix from that pass is included (zero-timeout `refute_received` → `refute_receive .../2`). Three follow-up hardening issues were filed and linked under the epic:
- [BT-3301](https://linear.app/beamtalk/issue/BT-3301) — tie `@inspector_events` to `Inspector.handle_event/3`'s clause list so drift fails at compile/test time, not silently at runtime.
- [BT-3302](https://linear.app/beamtalk/issue/BT-3302) — tether Inspector's socket-assign contract to `WorkspaceLive.bind_session/3` with a shared source of truth.
- [BT-3303](https://linear.app/beamtalk/issue/BT-3303) — parameterize `StubWorkspaceClient` so window drill/crumb/freeze/poke and the reference-counted unsubscribe logic get real (non-vacuous) test coverage.

## Test plan

- [x] `mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] `mix test --cover` (549 passed, coverage 64.23% > 55% threshold)
- [x] `mix assets.build`
- [x] `just build && just clippy && just fmt-check && just test` (full repo, unaffected by this Elixir-only change)
- [ ] `workspace_live_test.exs` / `workspace_browser_test.exs` (the `:workspace`/`:playwright`-tagged integration suites) — not runnable in this sandbox (no live workspace node/browser); no assertions in those files were modified, and no event-name/DOM-id contracts changed, so they're expected to pass in the gated CI job — will confirm via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5q2yqPv9qLJ4ALmR6Rf9Q