### PR TITLE
test: cover Tier 2 block value call inside ifTrue: conditional branch (BT-912/ADR 0111 Addendum 5 C3)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -2598,3 +2598,65 @@ fn test_bt2815_named_local_var_cascade_captured_mutation_rebinds_after_call() {
          '__local__outer' in the cascade's final NewState. Got: {code}"
     );
 }
+
+#[test]
+fn test_local_var_assignment_with_tier2_block_value_call_inside_conditional_branch() {
+    // BT-912/ADR 0111 Addendum 5 C3: `lower_local_var_assignment_bind`'s Tier 2
+    // sub-branch — `result := aBlock value` where `aBlock` is a Tier 2 block
+    // parameter, inside an `ifTrue:` branch that also has field mutations.
+    //
+    // `scan_class_for_tier2_blocks` sees `self applyWith:ifTrue:` called from
+    // `runExample` with a literal block that has field writes, so `aBlock`
+    // (position 0) is registered as Tier 2. Inside the `ifTrue:` branch,
+    // `result := aBlock value` hits `is_tier2_value_call` → the Gensym two-hop
+    // extraction path (element(1,...) for value, element(2,...) for new state).
+    let src = concat!(
+        "Actor subclass: Applier\n",
+        "  state: count = 0\n\n",
+        "  applyWith: aBlock ifTrue: flag =>\n",
+        "    flag ifTrue: [\n",
+        "      result := aBlock value.\n",
+        "      self.count := self.count + result\n",
+        "    ].\n",
+        "    self.count\n\n",
+        "  runExample =>\n",
+        "    self applyWith: [self.count := self.count + 10] ifTrue: true\n",
+    );
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, _diags) = crate::source_analysis::parse(tokens);
+    let code = generate_module(
+        &module,
+        CodegenOptions::new("applier_tier2_in_cond").with_workspace_mode(true),
+    )
+    .expect("Tier 2 block value call inside ifTrue: branch with field mutation must compile");
+
+    eprintln!(
+        "Generated code for Tier 2 local-var assignment inside conditional:\n{code}"
+    );
+
+    // Tier 2 two-hop extraction: element(1, ...) for value, element(2, ...) for new state.
+    assert!(
+        code.contains("'erlang':'element'(1,"),
+        "Tier 2 path must extract the value from the {{Result, NewState}} tuple \
+         via erlang:element(1, ...). Got:\n{code}"
+    );
+    assert!(
+        code.contains("'erlang':'element'(2,"),
+        "Tier 2 path must extract the new state from the {{Result, NewState}} tuple \
+         via erlang:element(2, ...). Got:\n{code}"
+    );
+
+    // Field mutation `self.count := self.count + result` inside the branch.
+    assert!(
+        code.contains("maps':'put'('count'"),
+        "Field mutation inside the true branch must produce maps:put('count', ...). \
+         Got:\n{code}"
+    );
+
+    // The whole conditional must be inlined as a case expression.
+    assert!(
+        code.contains("case "),
+        "ifTrue: with field mutation must compile to an inline case expression. \
+         Got:\n{code}"
+    );
+}

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/control_flow.rs
@@ -2630,9 +2630,7 @@ fn test_local_var_assignment_with_tier2_block_value_call_inside_conditional_bran
     )
     .expect("Tier 2 block value call inside ifTrue: branch with field mutation must compile");
 
-    eprintln!(
-        "Generated code for Tier 2 local-var assignment inside conditional:\n{code}"
-    );
+    eprintln!("Generated code for Tier 2 local-var assignment inside conditional:\n{code}");
 
     // Tier 2 two-hop extraction: element(1, ...) for value, element(2, ...) for new state.
     assert!(


### PR DESCRIPTION
## Summary

- Adds a Rust codegen unit test for the previously uncovered C3 sub-branch of `lower_local_var_assignment_bind` (ADR 0111 Addendum 5): a local variable assignment whose RHS is a Tier 2 `aBlock value` call, nested inside an `ifTrue:` branch that also performs field mutations.
- This path (`conditionals.rs` lines 482–531) was identified via LLVM coverage data as a real untested gap at 63% file coverage / 333 missed lines.

## What the test exercises

The test constructs an actor class with two methods:

1. `applyWith:aBlock ifTrue:flag` — has an `ifTrue:` conditional where the true branch does:
   - `result := aBlock value` (local var assignment whose RHS is a Tier 2 block value call)
   - `self.count := self.count + result` (field mutation)

2. `runExample` — calls `self applyWith: [self.count := self.count + 10] ifTrue: true`

`scan_class_for_tier2_blocks` sees the literal block with field writes at position 0 of `applyWith:ifTrue:` and registers `aBlock` as Tier 2. When generating `applyWith:ifTrue:`, `aBlock` is in `tier2_block_params`, and `result := aBlock value` inside the conditional branch triggers the Gensym two-hop extraction path:

```erlang
let _T2N = <block call returning {Result, NewState}> in
let _ValN = call 'erlang':'element'(1, _T2N) in
...  % element(2,_T2N) bound via ThreadedStmt::Bind as the new state
let StateAccM = call 'maps':'put'('count', ..., StateAccN) in
```

The assertions verify the `element(1,...)` / `element(2,...)` two-hop pattern and the `maps:put('count',...)` field mutation, all inside an inlined `case` expression.

## Test plan

- [x] `cargo test -p beamtalk-core test_local_var_assignment_with_tier2_block_value_call_inside_conditional_branch` — passes
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy` — clean
- [x] All pre-push hooks (lint-rust, dialyzer, build, fmt) — passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdVEn8g1gKbpDE7YWigdAu)_