### PR TITLE
Extract Workspace Dock (eval/REPL/Transcript/Changes/git) out of WorkspaceLive (BT-3295)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/dock.ex
+++ b/editors/liveview/lib/bt_attach_web/live/dock.ex
@@ -1186,22 +1186,12 @@ defmodule BtAttachWeb.Live.Dock do
     reloaded = MapSet.new(class_names)
 
     for tab <- tabs,
-        key = tab_disk_key(tab),
+        key = WorkspaceLive.tab_disk_key(tab),
         key != nil,
         MapSet.member?(reloaded, elem(key, 0)),
         into: MapSet.new(),
         do: key
   end
-
-  # The disk key a tab is cleared by: `{class, selector}` for a `:method`
-  # tab, `{class, :def}` for a `:def` tab (the `:def` sentinel can't collide
-  # with a real binary selector) — mirrors `WorkspaceLive`'s own
-  # (necessarily private, since it pattern-matches its `:tabs` shape)
-  # `tab_disk_key/1`. Any other shape yields `nil`, which is never a set
-  # member.
-  defp tab_disk_key(%{kind: :method, class: class, selector: selector}), do: {class, selector}
-  defp tab_disk_key(%{kind: :def, class: class}), do: {class, :def}
-  defp tab_disk_key(_tab), do: nil
 
   # Whether the file `path` git is about to revert has unflushed in-memory
   # ChangeLog edits (BT-2598 decision 2). The cockpit `changes` rows carry

--- a/editors/liveview/lib/bt_attach_web/live/dock.ex
+++ b/editors/liveview/lib/bt_attach_web/live/dock.ex
@@ -1,0 +1,1471 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.Live.Dock do
+  @moduledoc """
+  The tabbed "Workspace dock" (BT-2490, epic BT-2482 Phase 1) — Workspace
+  (eval), REPL, Transcript, and Changes/Git — extracted out of
+  `BtAttachWeb.WorkspaceLive` (BT-3295, epic BT-3290) so its `handle_event/3`
+  / `handle_async/3` clauses and their supporting helpers are directly
+  unit-testable instead of only reachable through a full-LiveView integration
+  test. Follows the same extraction shape `BtAttachWeb.Live.Inspector`
+  (BT-3291) established.
+
+  This module owns:
+
+    * **Workspace** — the eval `<form>`'s doIt/printIt/inspectIt actions
+      (`"eval"`), evaluating the tracked selection or the whole buffer via the
+      SAME `eval` facade op the REPL uses, and selection tracking
+      (`"select_workspace"`).
+    * **REPL** (BT-2543) — `"repl_eval"`, history recall
+      (`"repl_history_prev"`/`"repl_history_next"`), inspecting a `→ result`
+      term (`"repl_inspect"`), and the `:`-prefixed meta-command dispatch.
+    * **Changes** — the workspace ChangeLog viewer: `"revert"`, `"flush"`,
+      `"flush_destructive"`, `"toggle_change_diff"`.
+    * **Git** (ADR 0082 Amendment 1, BT-2586) — `"git_refresh"`, `"git_diff"`,
+      `"git_stage"`, `"git_unstage"`, `"git_revert"`, `"git_commit"`, plus the
+      off-socket `:git_load` async panel refresh (`handle_async/3`).
+    * **`"dock_tab"`** — switches the dock's active tab, including the lazy
+      first-open refreshes for the Git/Changes/Tests tabs.
+
+  Every workspace read/write goes through `BtAttach.Facade.dispatch/3` (ADR
+  0091 Decision 3) with `BtAttachWeb.Live.RequestContext` — never a raw
+  `BtAttach.Workspace`/`:rpc` call — so this module never reimplements the
+  `eval`/`changes`/`git_*` ops or the RBAC gates they ride (CLAUDE.md
+  no-duplicate-implementations).
+
+  **Transcript** has no events of its own (a push-only stream driven by
+  `Transcript show:` subscriptions) and stays entirely in `WorkspaceLive`,
+  untouched by this extraction.
+
+  State (`:dock_tab`, `:ws_selection`, `:result`/`:output`/`:error`/`:expr`,
+  `:eval_seq`, `:repl_seq`, `:repl_terms`, `:repl_history`,
+  `:repl_history_pos`, `:changes`, `:expanded_changes`, `:git_status`,
+  `:git_log`, `:git_diff`, `:git_diff_path`, `:git_error`, `:flush_result`,
+  `:flush_error`, `:save_result`, `:save_error`) stays on the LiveView's own
+  socket — initialised in `WorkspaceLive.bind_session/3` and mount, same as
+  the Inspector's assigns. `WorkspaceLive` still owns `handle_event/3` /
+  `handle_async/3` (`Phoenix.LiveView` callback contracts), but delegates
+  every dock event/async tag to the functions here by name — see the
+  `@dock_events` guard clause and the `:git_load` forward in `WorkspaceLive`.
+
+  Several dock branches reach into state other panes still own (the System
+  Browser's `open_class`/`symbol_rows`, the Tests pane's
+  `discover_test_classes`, the Method Editor's tab-refresh helpers) because
+  those panes have not been extracted yet (BT-3296/BT-3297 land later in the
+  BT-3290 epic) — this module calls the still-`WorkspaceLive`-owned public
+  functions for those rather than duplicating their logic, exactly the
+  temporary cross-call shape a sequential decomposition produces.
+  """
+
+  use BtAttachWeb, :html
+
+  import Phoenix.LiveView,
+    only: [
+      push_event: 3,
+      stream_insert: 4,
+      start_async: 3,
+      cancel_async: 3
+    ]
+
+  require Logger
+
+  alias BtAttach.Facade
+  alias BtAttach.Workspace
+  alias BtAttachWeb.Live.FacadeError
+  alias BtAttachWeb.Live.Inspector
+  alias BtAttachWeb.Live.RequestContext
+  alias BtAttachWeb.WorkspaceLive
+
+  defp ctx(socket), do: RequestContext.build(socket)
+  defp facade_error(reason), do: FacadeError.render(reason)
+
+  # ── handle_event dispatch ────────────────────────────────────────────────
+  #
+  # `WorkspaceLive.handle_event/3` forwards every event whose name is in
+  # `@dock_events` here unchanged (same event name, params, socket), so each
+  # clause below is exactly the body the LiveView used to run directly.
+
+  # The Workspace dock's three actions (BT-2490) all evaluate the entered code
+  # (or the tracked selection, the spike's "evaluates selection vs buffer")
+  # and differ only in what they do with the result term — so they ride the
+  # SAME `eval` facade op and the existing `render_term` formatting rather
+  # than inventing new server ops:
+  #
+  #   * doIt      (⌘D) — evaluate for side effects; show a terse "✓ evaluated".
+  #   * printIt   (⌘P) — evaluate and show the result term (the classic eval).
+  #   * inspectIt (⌘I) — evaluate, then inspect the *result term* in the
+  #     Inspector (reuses `Inspector.inspect_term/4`, the same read-surface
+  #     path bindings drill into).
+  #
+  # The clicked action rides the eval `<form>` submit as the `action` field; a
+  # plain submit (or the e2e test's `render_submit(%{expr: …})`) carries no
+  # action and defaults to printIt — the historical eval behaviour the tests
+  # assert on.
+  def handle_event("eval", %{"expr" => expr} = params, %{assigns: %{session_pid: pid}} = socket)
+      when is_pid(pid) do
+    action = eval_action(params)
+    target = eval_target(expr, socket)
+
+    case Facade.dispatch(:eval, %{session_pid: pid, code: target}, ctx(socket)) do
+      {:ok, term, output, _warnings} ->
+        # eval returns the live term; rendering is display-only and reuses the
+        # workspace's own formatter for surface-consistency with the browser.
+        {:noreply, eval_success(socket, action, term, output, expr)}
+
+      {:error, reason, output, _warnings} ->
+        {:noreply,
+         assign(socket,
+           result: nil,
+           output: present(output),
+           error: Workspace.render_error(reason),
+           expr: expr
+         )}
+
+      # The facade (BT-2420/2421) can short-circuit BEFORE dispatching to the
+      # workspace — an RBAC denial (`:unauthorized`, e.g. an Observer) or an
+      # off-vocabulary op (`:forbidden_op`) — returning a 2-tuple the
+      # workspace eval contract never produces. Render it as an actionable
+      # message rather than crashing the LiveView on an unmatched case clause.
+      {:error, reason} ->
+        {:noreply,
+         assign(socket, result: nil, output: nil, error: facade_error(reason), expr: expr)}
+    end
+  end
+
+  # No session (attach failed) — don't crash on a missing assign.
+  def handle_event("eval", %{"expr" => expr}, socket) do
+    {:noreply,
+     assign(socket, result: nil, output: nil, error: "not attached to workspace", expr: expr)}
+  end
+
+  # Switch the Workspace dock's active tab (Workspace / REPL / Transcript /
+  # Changes / Tests, BT-2490, REPL added BT-2543, Tests BT-2557). Pure view
+  # state — no workspace round-trip — EXCEPT the Tests tab lazily loads its
+  # test catalogue the first time it is opened (discovery is a cheap `:read`
+  # op, but there is no point running it for users who never open the tab).
+  # An unknown tab is ignored rather than rendered, so a crafted value can't
+  # blank the dock.
+  def handle_event("dock_tab", %{"tab" => "tests"}, socket) do
+    {:noreply, socket |> assign(dock_tab: "tests") |> ensure_test_classes()}
+  end
+
+  # ADR 0082 Amendment 1 (BT-2586): opening the Git tab refreshes the panel
+  # from real git on the workspace project root (lazy first-open, like Tests).
+  def handle_event("dock_tab", %{"tab" => "git"}, socket) do
+    {:noreply, socket |> assign(dock_tab: "git") |> assign_git()}
+  end
+
+  # ADR 0113 (BT-3210): every *dedicated* Changes-affecting action (save,
+  # revert, flush, remove class/method, new class) already refreshes
+  # `@changes` itself via `assign_changes/1` — but a ChangeLog-mutating op run
+  # through raw eval (`#eval-form`), e.g. `SomeClass removeFromSystem` typed
+  # directly, has no such hook to call it. Refresh on open too (lazy
+  # first-open, like Tests/Git above) so opening the tab is always a reliable
+  # way to see current state, not just an implicit side effect of which
+  # action you last took.
+  def handle_event("dock_tab", %{"tab" => "changes"}, socket) do
+    {:noreply, socket |> assign(dock_tab: "changes") |> WorkspaceLive.assign_changes()}
+  end
+
+  def handle_event("dock_tab", %{"tab" => tab}, socket)
+      when tab in ~w(workspace repl transcript) do
+    {:noreply, assign(socket, dock_tab: tab)}
+  end
+
+  def handle_event("dock_tab", _params, socket), do: {:noreply, socket}
+
+  # ── Git panel events (ADR 0082 Amendment 1, BT-2586) ─────────────────────────
+  # Read events (refresh, diff) are available to every role; the mutating
+  # events (stage/unstage/commit/revert) are gated by the Facade `:execute`
+  # capability *and* hidden in the template for the Observer role.
+
+  def handle_event("git_refresh", _params, socket) do
+    {:noreply, assign_git(socket)}
+  end
+
+  # Toggle the inline diff for one path: a second click on the same path
+  # closes it.
+  def handle_event("git_diff", %{"path" => path}, socket) when is_binary(path) do
+    if socket.assigns.git_diff_path == path do
+      {:noreply, assign(socket, git_diff_path: nil, git_diff: nil)}
+    else
+      case Facade.dispatch(:git_diff, %{path: path}, ctx(socket)) do
+        {:ok, diff} when is_map(diff) ->
+          {:noreply, assign(socket, git_diff_path: path, git_diff: diff, git_error: nil)}
+
+        {:error, reason} ->
+          {:noreply, assign(socket, git_error: facade_error(reason))}
+      end
+    end
+  end
+
+  def handle_event("git_stage", %{"path" => path}, socket) when is_binary(path) do
+    {:noreply, git_mutate_event(socket, :git_stage, %{path: path})}
+  end
+
+  def handle_event("git_unstage", %{"path" => path}, socket) when is_binary(path) do
+    {:noreply, git_mutate_event(socket, :git_unstage, %{path: path})}
+  end
+
+  def handle_event("git_revert", %{"path" => path}, socket) when is_binary(path) do
+    {:noreply, git_mutate_event(socket, :git_revert_file, %{path: path})}
+  end
+
+  def handle_event("git_commit", %{"message" => message}, socket) when is_binary(message) do
+    if String.trim(message) == "" do
+      {:noreply, assign(socket, git_error: "Enter a commit message.")}
+    else
+      {:noreply, git_mutate_event(socket, :git_commit, %{message: message})}
+    end
+  end
+
+  # Malformed git payloads (missing key / non-binary value): surface a
+  # git-panel validation error rather than letting a crafted WebSocket event
+  # crash the LiveView, consistent with the `new_class` / `revert` fallbacks
+  # in `WorkspaceLive`.
+  def handle_event("git_diff", _params, socket) do
+    {:noreply, assign(socket, git_error: "Invalid diff request.")}
+  end
+
+  def handle_event("git_stage", _params, socket) do
+    {:noreply, assign(socket, git_error: "Invalid stage request.")}
+  end
+
+  def handle_event("git_unstage", _params, socket) do
+    {:noreply, assign(socket, git_error: "Invalid unstage request.")}
+  end
+
+  def handle_event("git_revert", _params, socket) do
+    {:noreply, assign(socket, git_error: "Invalid revert request.")}
+  end
+
+  def handle_event("git_commit", _params, socket) do
+    {:noreply, assign(socket, git_error: "Invalid commit request.")}
+  end
+
+  # ── REPL tab (BT-2543) ───────────────────────────────────────────────────────
+  #
+  # The REPL is the *conversational, line-at-a-time* idiom (distinct from the
+  # editor-primary Workspace and the ambient-log Transcript): a
+  # request→response scrollback with the input pinned at the bottom.
+  # Submitting shares the SAME `eval` facade op + session as the Workspace —
+  # same structured result, same surface-shared `render_term` display rules —
+  # and only differs in presentation: each submit appends a `› request` /
+  # `→ response` pair to the `:repl` stream instead of inserting inline.
+  # Ambient `Transcript show:` output keeps streaming to the Transcript tab
+  # over the existing subscription; it is NOT duplicated into the scrollback
+  # here. Per the BT-2543 confirmation, Enter submits in the REPL (terminal
+  # convention) while Shift/⌘-Enter inserts a newline — the divergence is
+  # enforced by the ReplInput hook, not here.
+  def handle_event("repl_eval", %{"expr" => expr}, %{assigns: %{session_pid: pid}} = socket)
+      when is_pid(pid) do
+    trimmed = String.trim(expr)
+
+    cond do
+      trimmed == "" ->
+        # Empty submit (bare Enter) is a no-op — never append a blank entry or
+        # disturb the history cursor.
+        {:noreply, socket}
+
+      meta = repl_meta_command(trimmed) ->
+        # A `:`-prefixed meta-command (BT-2543 follow-up). The IDE handles
+        # these itself — driving the matching pane or pointing at it — and
+        # NEVER sends them to `eval`, which would choke trying to compile
+        # `:h` as Beamtalk.
+        {:noreply,
+         socket
+         |> handle_repl_meta(meta, expr)
+         |> repl_record_history(expr)
+         |> repl_clear_input()}
+
+      true ->
+        socket =
+          case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
+            {:ok, term, _output, _warnings} ->
+              socket |> repl_append_ok(expr, term) |> repl_help_followup(expr)
+
+            {:error, reason, _output, _warnings} ->
+              repl_append_error(socket, expr, Workspace.render_error(reason))
+
+            # Facade short-circuit (RBAC denial / off-vocabulary op) — a
+            # 2-tuple the eval contract never produces; render it as the
+            # entry's response rather than crashing the LiveView.
+            {:error, reason} ->
+              repl_append_error(socket, expr, facade_error(reason))
+          end
+
+        {:noreply, socket |> repl_record_history(expr) |> repl_clear_input()}
+    end
+  end
+
+  # No session — the first clause's `is_pid(pid)` guard only fails when
+  # bind_session never ran, so the REPL stream + assigns (`:repl_seq`,
+  # `:repl_terms`, `:repl_history`, `:repl_history_pos`) don't exist and the
+  # pane isn't rendered. A crafted `repl_eval` during the attach-failure
+  # window must NOT touch the REPL helpers (which read those assigns) — that
+  # would KeyError / crash the LiveView. Guard on the assigns' presence and
+  # no-op when absent, otherwise surface the "not attached" entry (the
+  # defensive path for any future state where the assigns exist but the
+  # session pid is gone).
+  def handle_event("repl_eval", %{"expr" => expr}, socket) do
+    cond do
+      not Map.has_key?(socket.assigns, :repl_seq) ->
+        {:noreply, socket}
+
+      String.trim(expr) == "" ->
+        {:noreply, socket}
+
+      true ->
+        {:noreply,
+         socket
+         |> repl_append_error(expr, "not attached to workspace")
+         |> repl_record_history(expr)
+         |> repl_clear_input()}
+    end
+  end
+
+  def handle_event("repl_eval", _params, socket), do: {:noreply, socket}
+
+  # ↑/↓ history recall (BT-2543). The ReplInput hook only fires these at the
+  # composer's edges (↑ on the first line, ↓ on the last), so mid-buffer
+  # cursor navigation is untouched. `repl_history_pos` walks the
+  # most-recent-first ring: ↑ moves further back (toward older entries), ↓
+  # moves toward the present and past the newest restores the empty live
+  # input. The recalled text is pushed to the hook (the input is hook-owned /
+  # phx-update=ignore, so the server can't set it through morphdom).
+  def handle_event("repl_history_prev", _params, socket) do
+    {:noreply, repl_recall(socket, :prev)}
+  end
+
+  def handle_event("repl_history_next", _params, socket) do
+    {:noreply, repl_recall(socket, :next)}
+  end
+
+  # Inspect a `→ result` term in the Inspector (BT-2543): results stay live
+  # objects even in the terminal idiom. The term was stashed server-side
+  # under the entry id at append time (the scrollback DOM is display-only);
+  # look it up and drive the same `inspect_term` path bindings/Print-it use.
+  # In `"float"` mode (BT-2493) it opens a floating window instead of the
+  # docked pane. An unknown id (a stale entry after a reconnect dropped the
+  # term map) is ignored.
+  def handle_event("repl_inspect", %{"id" => id}, %{assigns: %{repl_terms: terms}} = socket) do
+    case Map.fetch(terms, id) do
+      {:ok, term} ->
+        label = "REPL result"
+
+        socket =
+          if socket.assigns.inspector_mode == "float" do
+            Inspector.open_window_for_term(socket, label, term)
+          else
+            Inspector.inspect_term(socket, label, term, [%{label: label, term: term}])
+          end
+
+        {:noreply, socket}
+
+      :error ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("repl_inspect", _params, socket), do: {:noreply, socket}
+
+  # Selection tracking for the Workspace dock's editor (BT-2490). Tracked in a
+  # SEPARATE assign (`ws_selection`) from the method editor's `edit_selection`
+  # so the dock's doIt/printIt/inspectIt evaluate *this* editor's selection —
+  # a selection left in the method editor must not leak into a Workspace
+  # eval. Same defensive shape as `WorkspaceLive`'s `select_source`.
+  def handle_event("select_workspace", %{"text" => text} = params, socket)
+      when is_binary(text) do
+    selection = %{
+      text: text,
+      start: WorkspaceLive.clamp_offset(params["start"]),
+      end: WorkspaceLive.clamp_offset(params["end"])
+    }
+
+    {:noreply, assign(socket, ws_selection: selection)}
+  end
+
+  def handle_event("select_workspace", _params, socket), do: {:noreply, socket}
+
+  # Flush all pending durable changes to disk ("Save All to Disk", ADR 0082
+  # `Workspace flush`). The summary's conflicts/skipped lists carry
+  # recoverable conditions; a hard runtime failure renders as a structured
+  # error.
+  #
+  # Deliberately Tier-1-only, unchanged by ADR 0113: a pending `remove-class`
+  # entry is reported in the summary as `skipped: destructive`
+  # (`beamtalk_workspace_flush`'s own vocabulary, unmodified by this
+  # surface — see `Workspace.format_flush_summary/1`) rather than silently
+  # deleted, so this one button staying textually the same `Workspace flush`
+  # call it always was is itself the safety property ADR 0113 relies on for
+  # every unmodified caller. Reaching Tier 2 is the `flush_destructive`
+  # handler below (per-row "Delete file" button, ADR 0113 Surface: browser
+  # row).
+  def handle_event("flush", _params, socket) do
+    {:noreply, flush_changes(socket)}
+  end
+
+  # "Delete file" / "Apply rename" — the browser's second, independently-
+  # confirmed gesture for one pending `remove-class`/`rename-class`/
+  # `rename-method` ChangeLog row (ADR 0113 Phase 4 BT-3210, extended by ADR
+  # 0114 Phase 5 BT-3277's Surface table). Scoped to the one class the row
+  # names, mirroring the REPL's `:flush-destructive <Class>` and the MCP
+  # `flush` tool's scoped `confirm_destructive: true` form — never the
+  # unscoped `flushIncludingDestructive`, since a browser click always
+  # targets one named row, not "every destructive entry in the workspace".
+  # `kind` rides its own `phx-value-*` attribute (defaulting to
+  # `"remove-class"`, this button's original — and still most common — row)
+  # only to pick the right status message on success; it plays no role in
+  # which entry actually gets flushed (the `class` Symbol alone scopes that).
+  def handle_event(
+        "flush_destructive",
+        %{"class" => class} = params,
+        %{assigns: %{role: :owner}} = socket
+      )
+      when is_binary(class) and class != "" do
+    kind = Map.get(params, "kind", "remove-class")
+    {:noreply, flush_destructive(socket, class, kind)}
+  end
+
+  # Non-owner (Observer), or a crafted event with a missing/blank class: a
+  # no-op — the button is rendered only for `:owner` against a real row's
+  # class, mirroring `remove_class`/`revert`.
+  def handle_event("flush_destructive", _params, socket), do: {:noreply, socket}
+
+  # Revert one pending in-memory method patch (ADR 0082 Phase 5 `Workspace
+  # changes revert:`, BT-2293), keyed by the `(class, selector)` carried on
+  # the ChangeLog row's revert button. `side` (ADR 0112, BT-3187) is the same
+  # row's `side` — required to disambiguate a same-selector instance-side
+  # entry from a class-side one, which are otherwise indistinguishable by
+  # `(class, selector)` alone. Refreshes the Changes pane so the fresh revert
+  # entry is visible.
+  def handle_event("revert", %{"class" => class, "selector" => selector} = params, socket)
+      when is_binary(class) and is_binary(selector) do
+    side = present_side_param(Map.get(params, "entry-side"))
+    {:noreply, revert_change(socket, class, selector, side)}
+  end
+
+  # Malformed payload (missing keys / non-binary values): surface a
+  # validation error rather than silently no-op'ing, consistent with
+  # `new_class`/`save_method`.
+  def handle_event("revert", _params, socket) do
+    {:noreply, WorkspaceLive.status_error(socket, "Invalid revert request.")}
+  end
+
+  # Toggle the structured diff disclosure for one Changes-pane row (BT-2636),
+  # keyed by the row's `{class, selector, side}` carried on the leading caret
+  # (`phx-value-entry-side`, BT-3195 — reuses `present_side_param/1`'s `""` →
+  # `nil` normalisation, the same one the revert button's
+  # `phx-value-entry-side` already relies on, so both controls agree on what
+  # "no side" means). Named `entry-side`, not `side`, for the same reason the
+  # revert button is: it doesn't collide with the browser's `phx-value-side`
+  # instance/class toggle (BT-2491), so a `button[phx-value-side=...]`
+  # selector in a test doesn't match this caret too. Pure view state — no
+  # workspace round-trip; flips the key in/out of `:expanded_changes`,
+  # showing/hiding that row's `unified_diff` body. Before BT-3195 this keyed
+  # on `{class, selector}` alone, so a same-selector instance-side and
+  # class-side row (possible since BT-3187's shadow-key fix) shared one
+  # toggle — expanding one flipped the other too.
+  def handle_event(
+        "toggle_change_diff",
+        %{"class" => class, "selector" => selector} = params,
+        socket
+      )
+      when is_binary(class) and is_binary(selector) do
+    key = {class, selector, present_side_param(Map.get(params, "entry-side"))}
+
+    expanded =
+      if MapSet.member?(socket.assigns.expanded_changes, key) do
+        MapSet.delete(socket.assigns.expanded_changes, key)
+      else
+        MapSet.put(socket.assigns.expanded_changes, key)
+      end
+
+    {:noreply, assign(socket, expanded_changes: expanded)}
+  end
+
+  def handle_event("toggle_change_diff", _params, socket), do: {:noreply, socket}
+
+  # ── handle_async dispatch (:git_load) ────────────────────────────────────
+  #
+  # `WorkspaceLive.handle_async/3` forwards every `:git_load` tag here
+  # unchanged, mirroring the `handle_event` dispatch above.
+
+  # BT-2590 (S1): the off-socket git load (`assign_git/1`'s `start_async`)
+  # completed. The task returned `{status_result, log_result}` — the raw
+  # `Facade.dispatch` outcomes — which we fold into the panel assigns here, on
+  # the LiveView process, so the render is driven from a single coherent
+  # update.
+  def handle_async(:git_load, {:ok, {status_result, log_result}}, socket) do
+    socket =
+      socket
+      |> apply_git_status(status_result)
+      |> apply_git_log(log_result)
+
+    {:noreply, socket}
+  end
+
+  # The git-load task exited. A real crash surfaces as a git-panel error
+  # rather than taking down the LiveView. The `:cancelled` clause is a
+  # defensive no-op: `assign_git/1` `cancel_async`-es the prior load before
+  # starting a new one, and while LiveView normally prunes that stale ref
+  # before its exit is delivered, we guard the atom explicitly so a
+  # cancellation can never render a spurious error. On a genuine failure we
+  # reset BOTH status and log so the panel can't show a stale commit list
+  # beside the error banner (a torn read).
+  def handle_async(:git_load, {:exit, :cancelled}, socket), do: {:noreply, socket}
+
+  def handle_async(:git_load, {:exit, reason}, socket) do
+    Logger.error("git panel load crashed: #{inspect(reason)}", domain: [:beamtalk, :liveview])
+
+    {:noreply,
+     assign(socket,
+       git_status: nil,
+       git_log: [],
+       git_error: "Couldn't load git status — the load failed unexpectedly."
+     )}
+  end
+
+  # ── Workspace dock actions (BT-2490) ────────────────────────────────────────
+
+  # Which dock action the eval submit carried. The clicked action button rides
+  # the form as `action`; a plain submit (the e2e `render_submit(%{expr: …})`)
+  # carries none and defaults to printIt — the historical eval behaviour.
+  defp eval_action(%{"action" => action}) when action in ~w(do_it print_it inspect_it),
+    do: action
+
+  defp eval_action(_params), do: "print_it"
+
+  # The code an action evaluates: the Workspace editor's tracked selection if
+  # there is one (the spike's "evaluates selection"), else the whole entered
+  # buffer ("evaluates buffer"). The Workspace editor's CmEditor hook keeps
+  # `ws_selection` current (distinct from the method editor's
+  # `edit_selection`); an empty or whitespace-only selection falls back to
+  # the buffer.
+  defp eval_target(expr, socket) do
+    if ws_selection?(socket.assigns), do: socket.assigns.ws_selection.text, else: expr
+  end
+
+  # Whether the Workspace editor has a non-blank selection to evaluate. Takes
+  # the bare `assigns` so `WorkspaceLive`'s render template can call it
+  # directly too (public for that reason — mirrors `Inspector`'s
+  # template-facing helpers).
+  def ws_selection?(assigns) do
+    case assigns[:ws_selection] do
+      %{text: text} when is_binary(text) -> String.trim(text) != ""
+      _ -> false
+    end
+  end
+
+  # Render an eval success according to the chosen action (BT-2542 Workspace
+  # rebuild). The growing below-editor `.ws-result` success bubble is gone;
+  # the Workspace is now editor-primary, so feedback is split:
+  #
+  #   * print_it   — the classic Workspace "Print it": the result is inserted
+  #     INLINE into the CodeMirror buffer after the evaluated region (pushed
+  #     to the `CmEditor` hook as `ws_insert_result`, rendered as a
+  #     collapsible block widget — NOT doc text, so "evaluate buffer" never
+  #     re-runs it). A terse `→ result` also flashes in the transient status
+  #     line.
+  #   * do_it      — evaluate for side effects; a subtle, self-clearing
+  #     `✓ evaluated` status only (no buffer insert; ambient output →
+  #     Transcript).
+  #   * inspect_it — show the term in the status AND open it in the
+  #     Inspector.
+  #
+  # All three carry the result/confirmation in `result` (rendered as the thin
+  # `.eval-status` line) and bump `eval_seq` to restart its fade.
+  defp eval_success(socket, "do_it", _term, output, expr) do
+    eval_status(socket, "✓ evaluated", output, expr)
+  end
+
+  defp eval_success(socket, "inspect_it", term, output, expr) do
+    socket = eval_status(socket, "→ " <> Workspace.render_term(term), output, expr)
+
+    # In `"float"` mode (BT-2493) Inspect-it opens a floating window on the
+    # `→ result` term rather than driving the docked pane; docked mode keeps
+    # the original single-pane behaviour.
+    if socket.assigns.inspector_mode == "float" do
+      Inspector.open_window_for_term(socket, "→ result", term)
+    else
+      Inspector.inspect_term(socket, "→ result", term, [%{label: "→ result", term: term}])
+    end
+  end
+
+  # print_it (and the historical default): insert the result inline in the
+  # buffer AND flash it in the status line.
+  defp eval_success(socket, _print_it, term, output, expr) do
+    rendered = Workspace.render_term(term)
+    # Capture the anchor from the ORIGINAL socket before the pipe:
+    # `eval_status` doesn't touch `ws_selection`, but binding it here makes
+    # that independence explicit and survives a future pipe stage that might
+    # clear the selection.
+    anchor = ws_anchor(socket)
+
+    # `push_event` is page-wide — every CmEditor hook that registered the
+    # handler receives it. Scope it to the Workspace editor by element id
+    # (the client drops a mismatched target) so a second inline editor
+    # (BT-2543) can't also insert this result. The id is the shared
+    # `workspace_editor_id/0` so the target and the template host can't
+    # drift apart.
+    socket
+    |> eval_status("→ " <> rendered, output, expr)
+    |> push_event("ws_insert_result", %{
+      text: rendered,
+      anchor: anchor,
+      target: workspace_editor_id()
+    })
+  end
+
+  # DOM id of the Workspace CodeMirror editor host — the single source of
+  # truth shared by the template element and the `ws_insert_result` push
+  # target, so a rename can't silently break inline results (the client
+  # guard discards a push whose target doesn't match `this.el.id`). Public:
+  # `WorkspaceLive`'s render template calls it directly.
+  def workspace_editor_id, do: "workspace-editor-overlay"
+
+  # The doc offset to anchor an inline result after: the end of the tracked
+  # selection (the evaluated region) when evaluating a selection, else nil so
+  # the client falls back to the live buffer end. Echoed in the
+  # `ws_insert_result` push so a cursor move during the eval round-trip
+  # (wider over a remote distribution node) can't drop the widget on the
+  # wrong line.
+  defp ws_anchor(socket) do
+    if ws_selection?(socket.assigns) do
+      case socket.assigns.ws_selection[:end] do
+        offset when is_integer(offset) -> offset
+        _ -> nil
+      end
+    end
+  end
+
+  # Assign the transient eval-status line + bump its re-key sequence. Shared
+  # by every success branch so the status fade restarts consistently per
+  # eval.
+  defp eval_status(socket, status, output, expr) do
+    assign(socket,
+      result: status,
+      output: present(output),
+      error: nil,
+      expr: expr,
+      eval_seq: socket.assigns.eval_seq + 1
+    )
+  end
+
+  # Blank captured output is not worth rendering a pane for.
+  defp present(""), do: nil
+  defp present(nil), do: nil
+  defp present(output) when is_binary(output), do: output
+
+  # ── REPL helpers (BT-2543) ───────────────────────────────────────────────────
+
+  # Cap on the REPL scrollback depth: the client keeps the most recent N
+  # entries (via `stream_insert(:repl, …, limit: -N)`) and `repl_terms` is
+  # evicted in lockstep, so a long session can't grow the DOM or the assigns
+  # map unbounded.
+  @repl_scrollback_limit 200
+
+  # Append a successful `› request` / `→ response` pair to the scrollback and
+  # stash the live result term under the entry id so a later Inspect click
+  # can re-open it. The response is the surface-shared `render_term`
+  # rendering — the SAME string the Workspace `→ result` shows — so the two
+  # surfaces stay display-consistent. Long responses are marked so the
+  # template can collapse them within the entry rather than letting one
+  # result flood the scrollback.
+  defp repl_append_ok(socket, request, term) do
+    seq = socket.assigns.repl_seq + 1
+    id = repl_entry_id(seq)
+    response = Workspace.render_term(term)
+
+    entry = %{
+      id: id,
+      request: request,
+      kind: :ok,
+      response: response,
+      inspectable: true,
+      long: repl_long?(response)
+    }
+
+    socket
+    |> assign(:repl_seq, seq)
+    # `repl_terms` is bounded in step with the scrollback (below): stash this
+    # term, then evict the one that just scrolled past the depth cap. Each
+    # entry is a small reference (the object lives in the workspace
+    # process), but a long session would still grow the map unboundedly
+    # without this.
+    |> update(:repl_terms, fn terms -> terms |> Map.put(id, term) |> repl_evict(seq) end)
+    |> stream_insert(:repl, entry, limit: -@repl_scrollback_limit)
+    |> repl_scroll_to_bottom()
+  end
+
+  # Append an error entry: the `→ response` carries the rendered error and
+  # there is no live term to inspect, so no Inspect affordance and nothing
+  # stashed.
+  defp repl_append_error(socket, request, message) do
+    seq = socket.assigns.repl_seq + 1
+    id = repl_entry_id(seq)
+
+    entry = %{
+      id: id,
+      request: request,
+      kind: :error,
+      response: message,
+      inspectable: false,
+      long: repl_long?(message)
+    }
+
+    socket
+    |> assign(:repl_seq, seq)
+    # An error entry stashes no term, but still bump the cap so an OK term
+    # that scrolled past the depth limit (counting errors too) is evicted in
+    # step.
+    |> update(:repl_terms, &repl_evict(&1, seq))
+    |> stream_insert(:repl, entry, limit: -@repl_scrollback_limit)
+    |> repl_scroll_to_bottom()
+  end
+
+  # Cap the scrollback depth (client DOM via `stream_insert(limit:)`) and the
+  # `repl_terms` map in lockstep. Entry ids are monotonic (`repl-entry-N`, N
+  # = seq), so the entry now `@repl_scrollback_limit` positions back is
+  # exactly the one the client dropped — evict its term (a no-op for an
+  # error entry, which was never stashed).
+  defp repl_evict(terms, seq) do
+    evicted = seq - @repl_scrollback_limit
+    if evicted > 0, do: Map.delete(terms, repl_entry_id(evicted)), else: terms
+  end
+
+  # Scroll the scrollback to the newest entry on each append (classic
+  # terminal behaviour): a new submission should reveal its result even if
+  # the user had scrolled up to read older output. The scroll is a pure
+  # client effect, so it rides a push to the ReplInput hook rather than a
+  # re-render.
+  defp repl_scroll_to_bottom(socket) do
+    push_event(socket, "repl_scroll_bottom", %{})
+  end
+
+  defp repl_entry_id(seq), do: "repl-entry-#{seq}"
+
+  # DOM id of the REPL input editor host — the single source of truth shared
+  # by the template element and the `repl_set_input` push target, so a
+  # rename can't silently break history recall / submit-clear. (There is a
+  # single ReplInput instance on the page; `push_event/3` reaches every hook
+  # registered for the event, so this id is for template/push-target
+  # consistency, not filtering.) Public: `WorkspaceLive`'s render template
+  # calls it directly.
+  def repl_input_id, do: "repl-input"
+
+  # First-line (capped) preview shown in a collapsed long response's
+  # `<summary>`: enough to recognise the result without expanding, with an
+  # ellipsis when the full text is longer. Public: `WorkspaceLive`'s render
+  # template calls it directly.
+  def repl_preview(text) when is_binary(text) do
+    first = text |> String.split("\n", parts: 2) |> hd()
+
+    cond do
+      String.length(first) > 80 -> String.slice(first, 0, 80) <> "…"
+      first != text -> first <> " …"
+      true -> first
+    end
+  end
+
+  # A response is "long" (worth collapsing within its entry) when it spills
+  # past a handful of lines or a few hundred chars — the threshold that
+  # keeps a single verbose result from pushing the rest of the scrollback
+  # off-screen.
+  defp repl_long?(text) when is_binary(text) do
+    # `parts: 7` short-circuits the split after 6 newlines instead of
+    # materialising every line just to count past six.
+    String.length(text) > 320 or length(String.split(text, "\n", parts: 7)) > 6
+  end
+
+  # Record a submitted expression at the head of the recall ring and reset
+  # the ↑/↓ cursor to the live input. Every prior occurrence of the
+  # expression is dropped first so re-running the same expression doesn't
+  # bloat the ring (all earlier copies collapse onto the new head, shell
+  # `HISTCONTROL=erasedups` style — not just consecutive runs); the ring is
+  # capped so a long session can't grow the assigns unbounded.
+  @repl_history_limit 100
+  defp repl_record_history(socket, expr) do
+    history =
+      [expr | Enum.reject(socket.assigns.repl_history, &(&1 == expr))]
+      |> Enum.take(@repl_history_limit)
+
+    assign(socket, repl_history: history, repl_history_pos: nil)
+  end
+
+  # Walk the recall ring and push the recalled text to the input. `:prev` (↑)
+  # moves toward older entries; `:next` (↓) moves toward the present, and
+  # stepping past the newest restores the empty live input (pos = nil). An
+  # empty ring or a ↓ while already at the live input is a no-op (no push,
+  # so the hook keeps the in-progress text the user was typing).
+  #
+  # The first clause also covers the attach-failure window: when
+  # bind_session never ran, `:repl_history` is absent, so a crafted ↑/↓ must
+  # NOT fall through to `socket.assigns.repl_history` (a KeyError that would
+  # crash the LiveView) — `is_map_key/2` guards it to a no-op.
+  defp repl_recall(socket, _dir) when not is_map_key(socket.assigns, :repl_history),
+    do: socket
+
+  defp repl_recall(%{assigns: %{repl_history: []}} = socket, _dir), do: socket
+
+  defp repl_recall(socket, dir) do
+    history = socket.assigns.repl_history
+    pos = socket.assigns.repl_history_pos
+    last = length(history) - 1
+
+    new_pos =
+      case {dir, pos} do
+        {:prev, nil} -> 0
+        {:prev, p} -> min(p + 1, last)
+        {:next, nil} -> :live
+        {:next, 0} -> nil
+        {:next, p} -> p - 1
+      end
+
+    case new_pos do
+      :live ->
+        # ↓ at the live input: nothing to recall, leave the user's draft
+        # alone.
+        socket
+
+      nil ->
+        socket
+        |> assign(:repl_history_pos, nil)
+        |> push_event("repl_set_input", %{text: ""})
+
+      p ->
+        socket
+        |> assign(:repl_history_pos, p)
+        |> push_event("repl_set_input", %{text: Enum.at(history, p)})
+    end
+  end
+
+  # Clear the REPL input after a submit (REPL convention: submit empties the
+  # composer). The input is hook-owned (phx-update=ignore), so the server
+  # can only set it by pushing to the ReplInput hook.
+  defp repl_clear_input(socket) do
+    push_event(socket, "repl_set_input", %{text: ""})
+  end
+
+  # ── REPL meta-commands (BT-2543 follow-up) ──────────────────────────────────
+  #
+  # The CLI REPL parses `:`-prefixed meta-commands client-side (see
+  # crates/beamtalk-cli/src/commands/repl/mod.rs); the LiveView REPL
+  # historically forwarded them straight to `eval`, which choked trying to
+  # compile `:h` as a Beamtalk expression. In a graphical IDE most of those
+  # commands map onto a pane that already exists (the System Browser, the
+  # Bindings pane, the Changes tab), so rather than re-implement the CLI's
+  # command DSL we recognise the leading colon and either DRIVE the matching
+  # pane (`:help X` focuses the System Browser) or POINT the user at it.
+  # Input without a leading colon is real code and falls through to `eval`
+  # untouched.
+  #
+  # Returns `nil` for non-meta input (the overwhelmingly common path) so the
+  # caller's `cond` falls through to eval; otherwise a parsed `{kind, …}`
+  # tuple `handle_repl_meta/3` routes.
+  defp repl_meta_command(input) do
+    if String.starts_with?(input, ":") do
+      # `input` starts with ":", so splitting on whitespace always yields at
+      # least the command token (a bare ":" splits to `[":"]`, routed to the
+      # catch-all).
+      [cmd | rest] = String.split(input, ~r/\s+/, parts: 2, trim: true)
+      repl_meta_dispatch(cmd, meta_arg(rest))
+    else
+      nil
+    end
+  end
+
+  # First whitespace-delimited token of a meta-command's argument, with a
+  # leading `#` stripped so `:help #Counter` and `:help Counter` agree. `nil`
+  # when the command had no argument.
+  defp meta_arg([]), do: nil
+
+  defp meta_arg([arg]) do
+    # `arg` is the non-empty second part of the outer `parts: 2, trim: true`
+    # split, so this inner split always yields at least the first token.
+    [token | _] = String.split(arg, ~r/\s+/, parts: 2, trim: true)
+
+    case String.trim_leading(token, "#") do
+      "" -> nil
+      stripped -> stripped
+    end
+  end
+
+  defp repl_meta_dispatch(cmd, arg) when cmd in [":help", ":h", ":?"], do: {:help, arg}
+
+  defp repl_meta_dispatch(cmd, _) when cmd in [":bindings", ":b"],
+    do:
+      {:point,
+       "Bindings are listed live in the Bindings pane on the right — click one to inspect it."}
+
+  defp repl_meta_dispatch(cmd, _) when cmd in [":changes", ":dirty"],
+    do: {:point, "Pending changes are shown in the Changes tab of this dock."}
+
+  defp repl_meta_dispatch(":flush", _),
+    do: {:point, "Use the Flush control in the Changes tab to write pending changes to disk."}
+
+  defp repl_meta_dispatch(cmd, _) when cmd in [":sync", ":s"],
+    do:
+      {:point,
+       "The IDE tracks the live image as you work, so there is no manual sync step — project files from `beamtalk.toml` load when you connect."}
+
+  defp repl_meta_dispatch(cmd, _) when cmd in [":test", ":t"],
+    do: {:tab, "tests", "Opened the Tests pane in this dock — Run all, or run a single class. ◂"}
+
+  defp repl_meta_dispatch(":clear", _),
+    do:
+      {:point,
+       "Session bindings clear with the workspace. To clear them now, evaluate: Session current clear"}
+
+  defp repl_meta_dispatch(cmd, _) when cmd in [":show-codegen", ":sc"],
+    do:
+      {:point,
+       "Generated-code inspection (:show-codegen) is CLI-only for now — run it from `beamtalk repl`."}
+
+  defp repl_meta_dispatch(cmd, _) when cmd in [":exit", ":quit", ":q"],
+    do:
+      {:point,
+       "Close the browser tab to disconnect — there is no REPL process to exit in the IDE."}
+
+  defp repl_meta_dispatch(cmd, _), do: {:unknown, cmd}
+
+  # Route a parsed meta-command. `:help X` drives the System Browser;
+  # everything else appends an informational scrollback entry (a third
+  # `kind`, `:info`, the template styles muted rather than as an error).
+  defp handle_repl_meta(socket, {:help, nil}, expr),
+    do: repl_append_info(socket, expr, repl_help_text())
+
+  defp handle_repl_meta(socket, {:help, class}, expr),
+    do: repl_focus_class(socket, expr, class)
+
+  defp handle_repl_meta(socket, {:point, message}, expr),
+    do: repl_append_info(socket, expr, message)
+
+  # Route a meta-command to a dock tab (BT-2557: `:test` → Tests pane).
+  # Switches the dock to `tab`, lazily loads the Tests catalogue when that is
+  # the target, and appends a confirming info entry — the GUI equivalent of
+  # the CLI command.
+  defp handle_repl_meta(socket, {:tab, tab, message}, expr) do
+    socket
+    |> assign(dock_tab: tab)
+    |> then(fn s -> if tab == "tests", do: ensure_test_classes(s), else: s end)
+    |> repl_append_info(expr, message)
+  end
+
+  defp handle_repl_meta(socket, {:unknown, cmd}, expr) do
+    repl_append_info(
+      socket,
+      expr,
+      "Unknown command #{cmd}. This is the IDE REPL — type :help for what's available, " <>
+        ":help <Class> to open a class in the System Browser, or just evaluate an expression."
+    )
+  end
+
+  # Focus the System Browser on `class` (the GUI equivalent of the CLI's
+  # `:help Class` → `Beamtalk help: Class`). We validate against the live
+  # symbol index first so an unknown name gives a clean message instead of
+  # pointing the browser at a class that doesn't exist.
+  defp repl_focus_class(socket, expr, class) do
+    if class in browser_class_names(socket) do
+      socket
+      |> WorkspaceLive.open_class(class)
+      |> repl_append_info(expr, "Opened #{class} in the System Browser ◂")
+    else
+      # "No class named X" is feedback about a meta-command, not a
+      # code-evaluation failure, so it uses the muted `:info` styling (like
+      # an unknown `:cmd`) rather than the red error arrow reserved for eval
+      # errors.
+      repl_append_info(
+        socket,
+        expr,
+        "No class named #{class}. Browse classes in the System Browser, or search with the omni bar (top)."
+      )
+    end
+  end
+
+  # The class names known to the live image, from the same symbol index the
+  # omni search uses, as a MapSet so the `class in browser_class_names(socket)`
+  # membership check in `repl_focus_class/3` is O(1). An empty index
+  # (dispatch failure / RBAC denial) just means every `:help X` reports "no
+  # such class" rather than crashing.
+  defp browser_class_names(socket) do
+    socket
+    |> WorkspaceLive.symbol_rows()
+    |> Enum.filter(&(&1.kind == "class"))
+    |> MapSet.new(& &1.class)
+  end
+
+  # `:help` with no argument: a short tour of where the CLI REPL's commands
+  # live in the IDE, so a muscle-memory `:h` lands somewhere useful instead
+  # of erroring.
+  defp repl_help_text do
+    """
+    IDE REPL — evaluate any expression (Enter runs it, ↑/↓ recall history).
+    :help / :h / :?        show this help
+    :help <Class>          open a class in the System Browser (left)
+    :bindings / :b         → Bindings pane (right)
+    :changes / :dirty      → Changes tab (this dock)
+    :flush                 → Flush control (Changes tab)
+    :sync / :s             tracks the live image (loads beamtalk.toml on connect)
+    :clear                 evaluates `Session current clear`
+    :show-codegen / :sc    CLI-only — run from `beamtalk repl`
+    :test / :t             → Tests pane (this dock) — run all or a class
+    :exit / :quit / :q     close the browser tab to disconnect
+    Inspect results with the Inspect button; browse classes/methods on the left.\
+    """
+  end
+
+  # After a successful eval, if the expression was a `Beamtalk help: Class`
+  # send (the CLI's `:help` desugaring, and a natural thing to type
+  # directly), focus the System Browser on that class too — the help text
+  # stays in the scrollback AND the browser navigates to the subject.
+  # Non-help evals pass through untouched.
+  #
+  # Unlike `repl_focus_class/3`, this skips the `browser_class_names/1`
+  # validation and calls `WorkspaceLive.open_class/2` directly: the `eval`
+  # already succeeded, which proves the class exists in the runtime, so a
+  # symbol-index lookup would be redundant (and would falsely reject a class
+  # defined moments earlier if the index is briefly stale). `load_protocols`
+  # handles an empty result gracefully regardless.
+  defp repl_help_followup(socket, expr) do
+    case Regex.run(~r/^\s*Beamtalk\s+help:\s+#?([A-Z]\w*)/, expr) do
+      [_, class] -> WorkspaceLive.open_class(socket, class)
+      _ -> socket
+    end
+  end
+
+  # Append an informational meta-command response (`kind: :info`): no live
+  # term, so no Inspect affordance and nothing stashed. Mirrors
+  # `repl_append_error/3`'s bookkeeping (seq bump + term-map eviction in
+  # lockstep with the scrollback cap).
+  defp repl_append_info(socket, request, message) do
+    seq = socket.assigns.repl_seq + 1
+    id = repl_entry_id(seq)
+
+    entry = %{
+      id: id,
+      request: request,
+      kind: :info,
+      response: message,
+      inspectable: false,
+      long: repl_long?(message)
+    }
+
+    socket
+    |> assign(:repl_seq, seq)
+    |> update(:repl_terms, &repl_evict(&1, seq))
+    |> stream_insert(:repl, entry, limit: -@repl_scrollback_limit)
+    |> repl_scroll_to_bottom()
+  end
+
+  # ── Test-runner pane hand-off (BT-2557) ─────────────────────────────────────
+  #
+  # `dock_tab`'s "tests" clause and the `:test` REPL meta-command both lazily
+  # load the test catalogue on first open — the Tests pane's own events
+  # (`tests_refresh`/`run_tests`/`load_tests`/`run_test_class`/
+  # `open_test_method`) are NOT part of this extraction (BT-3295's "Events to
+  # move" list) and stay on `WorkspaceLive`, so the actual discovery RPC
+  # (`WorkspaceLive.discover_test_classes/1`) stays there too — this is a
+  # thin call-through, not a reimplementation.
+
+  # Load the test catalogue once (lazy first open of the Tests tab).
+  # Re-opening the tab keeps the already-loaded list — use `tests_refresh` to
+  # re-discover.
+  defp ensure_test_classes(socket) do
+    if is_nil(socket.assigns.test_classes),
+      do: WorkspaceLive.discover_test_classes(socket),
+      else: socket
+  end
+
+  # ── Git panel (ADR 0082 Amendment 1, BT-2586) ────────────────────────────────
+
+  # Run a mutating git op through the Facade (Owner-gated) and refresh the
+  # panel so the new status/log is reflected. An :unauthorized/error result
+  # surfaces in the panel rather than crashing it.
+  # A content-mutating git op (revert / `git restore -- <path>`) needs more
+  # than a git-panel refresh: it changes the on-disk working tree, so it must
+  # (1) not silently clobber unflushed in-memory edits for that path, and (2)
+  # reload the affected module(s) into the live image so image == disk and
+  # open windows reflect the reverted code (BT-2598). Routed through
+  # `git_revert_event/2`.
+  defp git_mutate_event(socket, :git_revert_file, %{path: path} = params) do
+    if path_has_pending_edits?(socket, path) do
+      # Decision 2: do not revert under unflushed in-memory ChangeLog edits —
+      # live work would be silently lost. Block and tell the user to flush or
+      # discard the pending entry first. No git call is made.
+      assign(socket, git_error: pending_revert_warning(path))
+    else
+      git_revert_event(socket, params)
+    end
+  end
+
+  # Stage / unstage / commit do not change working-tree *content* (the file
+  # the user is editing), so they keep the original behaviour: dispatch and
+  # refresh the git panel only.
+  defp git_mutate_event(socket, op, params) do
+    case Facade.dispatch(op, params, ctx(socket)) do
+      {:ok, _} -> assign_git(socket)
+      {:error, reason} -> assign(socket, git_error: facade_error(reason))
+    end
+  end
+
+  # Revert the working-tree change, then reload the reverted file into the
+  # live image and refresh every source-dependent surface (browser,
+  # ChangeLog, open editor tabs) plus the git panel. The reload's
+  # `ClassLoaded` push *also* drives the refresh for other connected
+  # sessions; reloading + refreshing here makes the acting session update
+  # synchronously rather than waiting on its own push.
+  defp git_revert_event(socket, %{path: path} = params) do
+    case Facade.dispatch(:git_revert_file, params, ctx(socket)) do
+      {:ok, _} ->
+        {reloaded, reload_note} = reload_reverted_path(socket, path)
+
+        socket
+        # The reload reconciled the image to the reverted (disk) body, so the
+        # reloaded class' open tabs are no longer divergent — clear their
+        # `unflushed` badge before the re-read (which would otherwise
+        # preserve the already-set divergence, mirroring
+        # `clear_disk_differs/2` after a flush).
+        |> assign(:tabs, WorkspaceLive.clear_disk_differs(socket.assigns.tabs, reloaded))
+        # BT-2655: re-read the reverted `:def` tabs' *editable* definition
+        # buffer so the visible editor shows the reverted header without a
+        # close/reopen. `WorkspaceLive.refresh_after_source_change/1` below
+        # re-reads `:method` tab bodies on its own (and bumps `editor_rev` to
+        # remount the editor), but it deliberately leaves a `:def` tab's
+        # editable definition buffer untouched (a generic push must not
+        # clobber a concurrent edit). A revert is the safe exception: it is
+        # blocked for this path under pending edits
+        # (`path_has_pending_edits?/2`, BT-2598 d2), so overwriting the
+        # editable buffer for exactly the reloaded `:def` set is both safe
+        # and expected. Method tabs are intentionally left to the refresh
+        # below to avoid a redundant second `browse_method_source`
+        # round-trip per tab.
+        |> WorkspaceLive.reload_reverted_def_buffers(reloaded)
+        |> WorkspaceLive.refresh_after_source_change()
+        |> assign_git()
+        # A clean revert whose reload failed surfaces its note in the shared
+        # status area (the same slot revert / new-class outcomes use), NOT
+        # `git_error` — `assign_git/1` and the async git load both clear
+        # `git_error`, so the note would not survive there. The working tree
+        # was reverted, but the image may not have reloaded.
+        |> maybe_status_error(reload_note)
+
+      {:error, reason} ->
+        assign(socket, git_error: facade_error(reason))
+    end
+  end
+
+  defp maybe_status_error(socket, nil), do: socket
+  defp maybe_status_error(socket, note), do: WorkspaceLive.status_error(socket, note)
+
+  # Reload the reverted file from disk into the live image (image == disk,
+  # BT-2585), returning the `{class, selector}` set of the reloaded class'
+  # currently-open `:method` tabs (so their `unflushed` badge can be
+  # cleared) and a reload-failure note (or nil). A reload failure (a deleted
+  # file, a file with a compile error at HEAD) is non-fatal: the working
+  # tree was still reverted, and the subsequent refresh re-reads what the
+  # image can serve; the note is surfaced afterwards.
+  defp reload_reverted_path(socket, path) do
+    case Facade.dispatch(:reload, %{path: path}, ctx(socket)) do
+      {:ok, class_names} when is_list(class_names) ->
+        {reloaded_tab_keys(socket.assigns.tabs, class_names), nil}
+
+      {:error, reason} ->
+        {MapSet.new(), "Reverted #{path}, but reload failed: #{facade_error(reason)}"}
+    end
+  end
+
+  # The disk keys of open `:method` and `:def` tabs whose class is among the
+  # just-reloaded class names — the tabs whose `unflushed` badge a revert
+  # should clear (their image now matches the reverted disk body). Method
+  # tabs key on `{class, selector}`; a `:def` tab keys on `{class, :def}` so
+  # a revert that changed a class header (state, superclass) also clears the
+  # open def tab's badge without needing a re-open (BT-2600).
+  defp reloaded_tab_keys(tabs, class_names) do
+    reloaded = MapSet.new(class_names)
+
+    for tab <- tabs,
+        key = tab_disk_key(tab),
+        key != nil,
+        MapSet.member?(reloaded, elem(key, 0)),
+        into: MapSet.new(),
+        do: key
+  end
+
+  # The disk key a tab is cleared by: `{class, selector}` for a `:method`
+  # tab, `{class, :def}` for a `:def` tab (the `:def` sentinel can't collide
+  # with a real binary selector) — mirrors `WorkspaceLive`'s own
+  # (necessarily private, since it pattern-matches its `:tabs` shape)
+  # `tab_disk_key/1`. Any other shape yields `nil`, which is never a set
+  # member.
+  defp tab_disk_key(%{kind: :method, class: class, selector: selector}), do: {class, selector}
+  defp tab_disk_key(%{kind: :def, class: class}), do: {class, :def}
+  defp tab_disk_key(_tab), do: nil
+
+  # Whether the file `path` git is about to revert has unflushed in-memory
+  # ChangeLog edits (BT-2598 decision 2). The cockpit `changes` rows carry
+  # only `class`/`selector`, so map each pending class to its source file
+  # via the browser class list (which carries `source_file`) and compare
+  # against `path`. Path comparison is by trailing-segment match so a
+  # project-relative `path` (`src/Foo.bt`) matches an absolute or
+  # differently-rooted `source_file`.
+  defp path_has_pending_edits?(socket, path) do
+    pending_classes =
+      for %{class: class} <- socket.assigns[:changes] || [],
+          is_binary(class),
+          into: MapSet.new(),
+          do: class
+
+    if MapSet.size(pending_classes) == 0 do
+      false
+    else
+      Enum.any?(socket.assigns[:browser_classes] || [], fn row ->
+        is_map(row) and MapSet.member?(pending_classes, row["name"]) and
+          paths_match?(row["source_file"], path)
+      end)
+    end
+  end
+
+  # Two paths refer to the same file when one is a trailing-segment suffix of
+  # the other (so `src/Foo.bt` matches `/abs/project/src/Foo.bt`). Both
+  # nil/non-binary → no match.
+  defp paths_match?(a, b) when is_binary(a) and is_binary(b) do
+    a == b or String.ends_with?(a, "/" <> b) or String.ends_with?(b, "/" <> a)
+  end
+
+  defp paths_match?(_a, _b), do: false
+
+  # The git-panel message shown when a revert is blocked because the file has
+  # unflushed in-memory edits (BT-2598 decision 2) — names the path and the
+  # two ways forward (flush to keep the work on disk, or discard the pending
+  # change in the Changes pane first).
+  defp pending_revert_warning(path) do
+    "Cannot revert #{path}: it has unflushed in-memory edits. " <>
+      "Flush (Save All to Disk) to keep them, or discard the pending change in the Changes pane first."
+  end
+
+  # BT-2590 (S1): read the git status + recent log off-socket so a slow
+  # `git`/large-history repo never blocks the LiveView call — blocking tab
+  # switches, saves, and clicks. We therefore run the two reads off-socket in
+  # a single `start_async` task: the socket stays responsive while git runs,
+  # the panel shows its "Loading git status…" placeholder, and the results
+  # land in `handle_async(:git_load, …)`. A rapid second Refresh first
+  # `cancel_async`-es the in-flight load (killing the LiveView-side Task so
+  # only the latest load can update the panel — the workspace-side RPC may
+  # still complete, but its response is discarded) and then starts the fresh
+  # one — only the latest load wins the panel, and the LiveView is never
+  # blocked.
+  #
+  # A workspace that is unreachable, not a git repo, or missing `git`
+  # renders an error rather than crashing the pane — the graceful-
+  # degradation requirement. We clear any stale per-file diff and reset to
+  # the loading state on each refresh. Public: `WorkspaceLive.maybe_refresh_git/1`
+  # (used by the not-yet-extracted save/flush paths) calls it directly.
+  def assign_git(socket) do
+    ctx = ctx(socket)
+
+    socket
+    |> assign(git_diff_path: nil, git_diff: nil, git_status: nil, git_log: [], git_error: nil)
+    |> cancel_async(:git_load, :cancelled)
+    |> start_async(:git_load, fn ->
+      # Runs in a Task off the LiveView process — never touch `socket` here,
+      # only the captured `ctx`. Both reads are gathered so the panel
+      # updates atomically.
+      {Facade.dispatch(:git_status, %{}, ctx), Facade.dispatch(:git_log, %{count: 20}, ctx)}
+    end)
+  end
+
+  # Apply a completed git status read to the socket. Pure (no dispatch);
+  # shared by `handle_async/3` so the async result path and any future sync
+  # caller agree. Kept total — an unexpected shape (an off-vocabulary facade
+  # reply, a malformed status) degrades to a panel error rather than
+  # crashing the LiveView.
+  defp apply_git_status(socket, {:ok, status}) when is_map(status),
+    do: assign(socket, git_status: status, git_error: nil)
+
+  defp apply_git_status(socket, {:error, reason}),
+    do: assign(socket, git_status: nil, git_error: facade_error(reason))
+
+  defp apply_git_status(socket, _other),
+    do: assign(socket, git_status: nil, git_error: facade_error(:unexpected_git_status))
+
+  # Apply a completed git log read.
+  defp apply_git_log(socket, {:ok, commits}) when is_list(commits),
+    do: assign(socket, git_log: commits)
+
+  defp apply_git_log(socket, {:error, reason}),
+    do: log_failed(socket, facade_error(reason))
+
+  defp apply_git_log(socket, _other),
+    do: log_failed(socket, facade_error(:unexpected_git_log))
+
+  # A git-log read failed. Clear the list, and surface the error only if the
+  # status read hasn't already reported one — when both fail together the
+  # status pane already shows the degraded state, but a fast status beside
+  # an independently-failed log (e.g. a large-history timeout) would
+  # otherwise leave a valid branch next to a mysteriously empty commit list
+  # with no explanation.
+  defp log_failed(socket, error) do
+    socket = assign(socket, git_log: [])
+
+    if socket.assigns.git_error,
+      do: socket,
+      else: assign(socket, git_error: error)
+  end
+
+  # ── Changes pane (ADR 0082) ──────────────────────────────────────────────────
+
+  # `present_side_param/1` normalises a client-supplied `entry-side` payload
+  # value (`""` from an absent hidden field) to `nil` so `revert`/
+  # `toggle_change_diff` agree on what "no side" means.
+  defp present_side_param(side) when is_binary(side) and side != "", do: side
+  defp present_side_param(_), do: nil
+
+  # Revert one pending method patch (BT-2293). On success the prior body is
+  # re-installed (a fresh durable entry) and the Changes pane refreshes; a
+  # non-revertable entry (new-class, class-side, no prior body) renders the
+  # structured error the workspace returns. `side` (ADR 0112, BT-3187)
+  # disambiguates a same-selector instance-side entry from a class-side one.
+  defp revert_change(socket, class, selector, side) do
+    case Facade.dispatch(:revert, %{class: class, selector: selector, side: side}, ctx(socket)) do
+      {:ok, reverted_class} ->
+        socket
+        |> assign(
+          save_result: "Reverted #{selector} on #{reverted_class}",
+          save_error: nil,
+          flush_result: nil,
+          flush_error: nil
+        )
+        |> WorkspaceLive.assign_changes()
+
+      {:error, reason} ->
+        WorkspaceLive.status_error(socket, facade_error(reason))
+    end
+  end
+
+  # Drive the write-surface flush and render its summary, then refresh
+  # changes so the (now-flushed) entries drop out of the active view.
+  #
+  # The flush reconciles every pending live `>>` patch with its on-disk
+  # body, so an open `:method` tab whose patch was just written is no longer
+  # divergent — clear its `unflushed` (`disk_differs`) breadcrumb badge
+  # (BT-2545). We diff the pending method set captured *before* the flush
+  # against the set still pending *after* (`WorkspaceLive.assign_changes/1`
+  # already refreshed it): the difference is exactly what this flush wrote,
+  # so a conflicted / non-flushable method keeps its badge and a method
+  # untouched by this flush is never cleared.
+  defp flush_changes(socket) do
+    was_pending = WorkspaceLive.pending_method_keys(socket.assigns.changes)
+
+    case Facade.dispatch(:flush, %{}, ctx(socket)) do
+      {:ok, summary} ->
+        socket
+        |> assign(flush_result: Workspace.format_flush_summary(summary), flush_error: nil)
+        |> WorkspaceLive.assign_changes()
+        |> clear_flushed_badges(was_pending)
+        # BT-2586: a flush writes pending edits to disk, so the post-flush
+        # git panel must reflect them immediately (the pre→post-flush
+        # handoff).
+        |> WorkspaceLive.maybe_refresh_git()
+
+      {:error, reason} ->
+        assign(socket, flush_result: nil, flush_error: facade_error(reason))
+    end
+  end
+
+  # "Delete file" / "Apply rename" (ADR 0113 Phase 4 BT-3210, extended by ADR
+  # 0114 Phase 5 BT-3277) — the scoped Tier-2 flush for one `remove-class`/
+  # `rename-class`/`rename-method` row, submitted as `Workspace flush:
+  # #Class confirmDestructive: true` through the generic `evaluate` op (no
+  # dedicated workspace-side op, matching `remove_class`/`remove_method` and
+  # mirroring the REPL's `:flush-destructive #Class` / MCP `flush`'s scoped
+  # `confirm_destructive: true` form). All three kinds join the same Tier 2
+  # (ADR 0114 "Flush" reuses ADR 0113's tier verbatim), so one handler drives
+  # all three rows; only the confirmation prompt and the resulting status
+  # message differ by `kind`.
+  #
+  # Scoped by *Symbol* (`#Class`), not the bare class name: a `remove-class`
+  # row's class name is already unbound by the time this fires
+  # (`removeFromSystem` ran first) — a bare identifier would fail to
+  # *evaluate* before the `flush:` send ever runs. `beamtalk_workspace_flush`'s
+  # filter normalisation matches a Symbol against the ChangeLog entry's
+  # recorded `class` field by name, needing no live class to resolve, so the
+  # same Symbol form works uniformly for a `rename-class`/`rename-method` row
+  # too (both still-bound, but simpler to share one code path than
+  # special-case which kind can take a bare identifier).
+  #
+  # `class` rides a `phx-value-*` attribute, so — unlike `remove_class`'s
+  # `class` (read from server-tracked active-tab state) — it is
+  # client-controlled input reaching a raw, textually-interpolated Beamtalk
+  # expression: validated against `WorkspaceLive.valid_class_name?/1`, the
+  # same bare-PascalCase-identifier shape the New Class modal enforces, so a
+  # crafted event cannot inject arbitrary source into the `evaluate` call.
+  defp flush_destructive(socket, class, kind) do
+    if WorkspaceLive.valid_class_name?(class) do
+      expr = "Workspace flush: ##{class} confirmDestructive: true"
+      pid = socket.assigns[:session_pid]
+
+      if not is_pid(pid) do
+        WorkspaceLive.status_error(socket, "not attached to workspace")
+      else
+        flush_destructive_eval(socket, class, kind, expr, pid)
+      end
+    else
+      WorkspaceLive.status_error(socket, "Invalid class name.")
+    end
+  end
+
+  # The past-tense status line for a completed Tier-2 flush, by `kind` — an
+  # unrecognised future kind falls back to a generic phrase rather than
+  # crashing, matching `WorkspaceLive`'s own `change_kind_label/1` fallback.
+  defp rename_flush_message("rename-class", class), do: "Flushed the pending rename to #{class}"
+
+  defp rename_flush_message("rename-method", class),
+    do: "Flushed the pending method rename on #{class}"
+
+  defp rename_flush_message(_kind, class), do: "Flushed the pending removal for #{class}"
+
+  defp flush_destructive_eval(socket, class, kind, expr, pid) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
+      {:ok, _term, _output, _warnings} ->
+        socket
+        |> assign(
+          save_result: nil,
+          save_error: nil,
+          flush_result: rename_flush_message(kind, class),
+          flush_error: nil
+        )
+        |> WorkspaceLive.assign_changes()
+        # BT-2586: a successful destructive flush can delete a tracked file,
+        # so the git panel must reflect it immediately, same as an ordinary
+        # "Save All to Disk" flush.
+        |> WorkspaceLive.maybe_refresh_git()
+
+      {:error, reason, _output, _warnings} ->
+        WorkspaceLive.status_error(socket, Workspace.render_error(reason))
+
+      {:error, reason} ->
+        WorkspaceLive.status_error(socket, facade_error(reason))
+    end
+  end
+
+  # After a flush, clear the `unflushed` badge on the `:method` tabs this
+  # flush wrote to disk (BT-2545), scoped by `WorkspaceLive.flushed_method_keys/3`
+  # so conflicts / skips keep their badge and methods untouched by this
+  # flush are never cleared.
+  defp clear_flushed_badges(socket, was_pending) do
+    flushed =
+      WorkspaceLive.flushed_method_keys(
+        was_pending,
+        socket.assigns.changes,
+        socket.assigns[:changes_error]
+      )
+
+    if MapSet.size(flushed) == 0 do
+      socket
+    else
+      assign(socket, :tabs, WorkspaceLive.clear_disk_differs(socket.assigns.tabs, flushed))
+    end
+  end
+end

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -3389,9 +3389,12 @@ defmodule BtAttachWeb.WorkspaceLive do
   # The disk key a tab is cleared by: `{class, selector}` for a `:method` tab,
   # `{class, :def}` for a `:def` tab (the `:def` sentinel can't collide with a real
   # binary selector). Any other shape yields `nil`, which is never a set member.
-  defp tab_disk_key(%{kind: :method, class: class, selector: selector}), do: {class, selector}
-  defp tab_disk_key(%{kind: :def, class: class}), do: {class, :def}
-  defp tab_disk_key(_tab), do: nil
+  # Public: `BtAttachWeb.Live.Dock`'s `reloaded_tab_keys/2` (BT-3295, the git
+  # revert path) calls it directly rather than keeping its own copy — a tab
+  # shape change (BT-3296) must not risk the two silently diverging.
+  def tab_disk_key(%{kind: :method, class: class, selector: selector}), do: {class, selector}
+  def tab_disk_key(%{kind: :def, class: class}), do: {class, :def}
+  def tab_disk_key(_tab), do: nil
 
   # Read the active ChangeLog ("Workspace changes", ADR 0082) and assign display
   # rows. A workspace that is unreachable or returns an unexpected shape renders an
@@ -9439,4 +9442,15 @@ defmodule BtAttachWeb.WorkspaceLive do
     </div>
     """
   end
+
+  @doc false
+  # The single source of truth for `@dock_events` outside this module — a
+  # test asserts every name here resolves to an implemented
+  # `Dock.handle_event/3` clause (not a `FunctionClauseError`), so a name
+  # added/removed on one side without the other fails CI instead of only a
+  # crafted WebSocket event in production. Kept away from the `handle_event/3`
+  # clause group (rather than beside `@dock_events`'s own definition) since a
+  # `def` of a different name interposed between two `handle_event/3` clauses
+  # trips the compiler's "clauses should be grouped together" warning.
+  def dock_events, do: @dock_events
 end

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -243,6 +243,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   alias BtAttach.Facade
   alias BtAttach.SessionRegistry
   alias BtAttach.Workspace
+  alias BtAttachWeb.Live.Dock
   alias BtAttachWeb.Live.FacadeError
   alias BtAttachWeb.Live.Inspector
   alias BtAttachWeb.Live.RequestContext
@@ -856,58 +857,6 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   defp force_close(_token, _pid), do: :ok
 
-  # The Workspace dock's three actions (BT-2490) all evaluate the entered code (or
-  # the tracked selection, the spike's "evaluates selection vs buffer") and differ
-  # only in what they do with the result term — so they ride the SAME `eval`
-  # facade op and the existing `render_term` formatting rather than inventing new
-  # server ops:
-  #
-  #   * doIt      (⌘D) — evaluate for side effects; show a terse "✓ evaluated".
-  #   * printIt   (⌘P) — evaluate and show the result term (the classic eval).
-  #   * inspectIt (⌘I) — evaluate, then inspect the *result term* in the Inspector
-  #     (reuses `inspect_term/4`, the same read-surface path bindings drill into).
-  #
-  # The clicked action rides the eval `<form>` submit as the `action` field; a
-  # plain submit (or the e2e test's `render_submit(%{expr: …})`) carries no action
-  # and defaults to printIt — the historical eval behaviour the tests assert on.
-  @impl true
-  def handle_event("eval", %{"expr" => expr} = params, %{assigns: %{session_pid: pid}} = socket)
-      when is_pid(pid) do
-    action = eval_action(params)
-    target = eval_target(expr, socket)
-
-    case Facade.dispatch(:eval, %{session_pid: pid, code: target}, ctx(socket)) do
-      {:ok, term, output, _warnings} ->
-        # eval returns the live term; rendering is display-only and reuses the
-        # workspace's own formatter for surface-consistency with the browser.
-        {:noreply, eval_success(socket, action, term, output, expr)}
-
-      {:error, reason, output, _warnings} ->
-        {:noreply,
-         assign(socket,
-           result: nil,
-           output: present(output),
-           error: Workspace.render_error(reason),
-           expr: expr
-         )}
-
-      # The facade (BT-2420/2421) can short-circuit BEFORE dispatching to the
-      # workspace — an RBAC denial (`:unauthorized`, e.g. an Observer) or an
-      # off-vocabulary op (`:forbidden_op`) — returning a 2-tuple the workspace
-      # eval contract never produces. Render it as an actionable message rather
-      # than crashing the LiveView on an unmatched case clause.
-      {:error, reason} ->
-        {:noreply,
-         assign(socket, result: nil, output: nil, error: facade_error(reason), expr: expr)}
-    end
-  end
-
-  # No session (attach failed) — don't crash on a missing assign.
-  def handle_event("eval", %{"expr" => expr}, socket) do
-    {:noreply,
-     assign(socket, result: nil, output: nil, error: "not attached to workspace", expr: expr)}
-  end
-
   # Backend-driven autocomplete (BT-2544): the CodeMirror editors' autocomplete
   # CompletionSource round-trips the current line up to the caret; we answer with
   # ranked candidates from the live session via the `complete` op (receiver-aware:
@@ -997,108 +946,6 @@ defmodule BtAttachWeb.WorkspaceLive do
     {:reply, %{"diagnostics" => []}, socket}
   end
 
-  # Switch the Workspace dock's active tab (Workspace / REPL / Transcript /
-  # Changes / Tests, BT-2490, REPL added BT-2543, Tests BT-2557). Pure view state
-  # — no workspace round-trip — EXCEPT the Tests tab lazily loads its test
-  # catalogue the first time it is opened (discovery is a cheap `:read` op, but
-  # there is no point running it for users who never open the tab). An unknown
-  # tab is ignored rather than rendered, so a crafted value can't blank the dock.
-  @impl true
-  def handle_event("dock_tab", %{"tab" => "tests"}, socket) do
-    {:noreply, socket |> assign(dock_tab: "tests") |> ensure_test_classes()}
-  end
-
-  # ADR 0082 Amendment 1 (BT-2586): opening the Git tab refreshes the panel from
-  # real git on the workspace project root (lazy first-open, like Tests).
-  def handle_event("dock_tab", %{"tab" => "git"}, socket) do
-    {:noreply, socket |> assign(dock_tab: "git") |> assign_git()}
-  end
-
-  # ADR 0113 (BT-3210): every *dedicated* Changes-affecting action (save,
-  # revert, flush, remove class/method, new class) already refreshes `@changes`
-  # itself via `assign_changes/1` — but a ChangeLog-mutating op run through raw
-  # eval (`#eval-form`), e.g. `SomeClass removeFromSystem` typed directly, has
-  # no such hook to call it. Refresh on open too (lazy first-open, like
-  # Tests/Git above) so opening the tab is always a reliable way to see current
-  # state, not just an implicit side effect of which action you last took.
-  def handle_event("dock_tab", %{"tab" => "changes"}, socket) do
-    {:noreply, socket |> assign(dock_tab: "changes") |> assign_changes()}
-  end
-
-  def handle_event("dock_tab", %{"tab" => tab}, socket)
-      when tab in ~w(workspace repl transcript) do
-    {:noreply, assign(socket, dock_tab: tab)}
-  end
-
-  def handle_event("dock_tab", _params, socket), do: {:noreply, socket}
-
-  # ── Git panel events (ADR 0082 Amendment 1, BT-2586) ─────────────────────────
-  # Read events (refresh, diff) are available to every role; the mutating events
-  # (stage/unstage/commit/revert) are gated by the Facade `:execute` capability
-  # *and* hidden in the template for the Observer role.
-
-  def handle_event("git_refresh", _params, socket) do
-    {:noreply, assign_git(socket)}
-  end
-
-  # Toggle the inline diff for one path: a second click on the same path closes it.
-  def handle_event("git_diff", %{"path" => path}, socket) when is_binary(path) do
-    if socket.assigns.git_diff_path == path do
-      {:noreply, assign(socket, git_diff_path: nil, git_diff: nil)}
-    else
-      case Facade.dispatch(:git_diff, %{path: path}, ctx(socket)) do
-        {:ok, diff} when is_map(diff) ->
-          {:noreply, assign(socket, git_diff_path: path, git_diff: diff, git_error: nil)}
-
-        {:error, reason} ->
-          {:noreply, assign(socket, git_error: facade_error(reason))}
-      end
-    end
-  end
-
-  def handle_event("git_stage", %{"path" => path}, socket) when is_binary(path) do
-    {:noreply, git_mutate_event(socket, :git_stage, %{path: path})}
-  end
-
-  def handle_event("git_unstage", %{"path" => path}, socket) when is_binary(path) do
-    {:noreply, git_mutate_event(socket, :git_unstage, %{path: path})}
-  end
-
-  def handle_event("git_revert", %{"path" => path}, socket) when is_binary(path) do
-    {:noreply, git_mutate_event(socket, :git_revert_file, %{path: path})}
-  end
-
-  def handle_event("git_commit", %{"message" => message}, socket) when is_binary(message) do
-    if String.trim(message) == "" do
-      {:noreply, assign(socket, git_error: "Enter a commit message.")}
-    else
-      {:noreply, git_mutate_event(socket, :git_commit, %{message: message})}
-    end
-  end
-
-  # Malformed git payloads (missing key / non-binary value): surface a git-panel
-  # validation error rather than letting a crafted WebSocket event crash the
-  # LiveView, consistent with the `new_class` / `revert` fallbacks above.
-  def handle_event("git_diff", _params, socket) do
-    {:noreply, assign(socket, git_error: "Invalid diff request.")}
-  end
-
-  def handle_event("git_stage", _params, socket) do
-    {:noreply, assign(socket, git_error: "Invalid stage request.")}
-  end
-
-  def handle_event("git_unstage", _params, socket) do
-    {:noreply, assign(socket, git_error: "Invalid unstage request.")}
-  end
-
-  def handle_event("git_revert", _params, socket) do
-    {:noreply, assign(socket, git_error: "Invalid revert request.")}
-  end
-
-  def handle_event("git_commit", _params, socket) do
-    {:noreply, assign(socket, git_error: "Invalid commit request.")}
-  end
-
   # ── Test-runner pane (BT-2557) ───────────────────────────────────────────────
   #
   # The GUI equivalent of a Smalltalk Test Runner: a dock tab that lists the live
@@ -1153,130 +1000,23 @@ defmodule BtAttachWeb.WorkspaceLive do
   def handle_event("run_test_class", _params, socket), do: {:noreply, socket}
   def handle_event("open_test_method", _params, socket), do: {:noreply, socket}
 
-  # ── REPL tab (BT-2543) ───────────────────────────────────────────────────────
-  #
-  # The REPL is the *conversational, line-at-a-time* idiom (distinct from the
-  # editor-primary Workspace and the ambient-log Transcript): a request→response
-  # scrollback with the input pinned at the bottom. Submitting shares the SAME
-  # `eval` facade op + session as the Workspace — same structured result, same
-  # surface-shared `render_term` display rules — and only differs in presentation:
-  # each submit appends a `› request` / `→ response` pair to the `:repl` stream
-  # instead of inserting inline. Ambient `Transcript show:` output keeps streaming
-  # to the Transcript tab over the existing subscription; it is NOT duplicated
-  # into the scrollback here. Per the BT-2543 confirmation, Enter submits in the
-  # REPL (terminal convention) while Shift/⌘-Enter inserts a newline — the
-  # divergence is enforced by the ReplInput hook, not here.
+  # Workspace dock events (BT-3295, epic BT-3290): the eval/Workspace tab,
+  # REPL tab, Transcript tab (push-only, no events), and Changes/Git tabs all
+  # delegate to `BtAttachWeb.Live.Dock`, extracted out of this module so its
+  # `handle_event/3`/`handle_async/3` branches are directly unit-testable.
+  # See that module's docs for the full per-event behaviour (each clause used
+  # to run here).
+  @dock_events ~w(
+    dock_tab eval select_workspace repl_eval repl_history_prev
+    repl_history_next repl_inspect git_refresh git_diff git_stage
+    git_unstage git_revert git_commit toggle_change_diff revert flush
+    flush_destructive
+  )
+
   @impl true
-  def handle_event("repl_eval", %{"expr" => expr}, %{assigns: %{session_pid: pid}} = socket)
-      when is_pid(pid) do
-    trimmed = String.trim(expr)
-
-    cond do
-      trimmed == "" ->
-        # Empty submit (bare Enter) is a no-op — never append a blank entry or
-        # disturb the history cursor.
-        {:noreply, socket}
-
-      meta = repl_meta_command(trimmed) ->
-        # A `:`-prefixed meta-command (BT-2543 follow-up). The IDE handles these
-        # itself — driving the matching pane or pointing at it — and NEVER sends
-        # them to `eval`, which would choke trying to compile `:h` as Beamtalk.
-        {:noreply,
-         socket
-         |> handle_repl_meta(meta, expr)
-         |> repl_record_history(expr)
-         |> repl_clear_input()}
-
-      true ->
-        socket =
-          case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
-            {:ok, term, _output, _warnings} ->
-              socket |> repl_append_ok(expr, term) |> repl_help_followup(expr)
-
-            {:error, reason, _output, _warnings} ->
-              repl_append_error(socket, expr, Workspace.render_error(reason))
-
-            # Facade short-circuit (RBAC denial / off-vocabulary op) — a 2-tuple the
-            # eval contract never produces; render it as the entry's response rather
-            # than crashing the LiveView.
-            {:error, reason} ->
-              repl_append_error(socket, expr, facade_error(reason))
-          end
-
-        {:noreply, socket |> repl_record_history(expr) |> repl_clear_input()}
-    end
+  def handle_event(event, params, socket) when event in @dock_events do
+    Dock.handle_event(event, params, socket)
   end
-
-  # No session — the first clause's `is_pid(pid)` guard only fails when
-  # bind_session never ran, so the REPL stream + assigns (`:repl_seq`,
-  # `:repl_terms`, `:repl_history`, `:repl_history_pos`) don't exist and the pane
-  # isn't rendered. A crafted `repl_eval` during the attach-failure window must
-  # NOT touch the REPL helpers (which read those assigns) — that would KeyError /
-  # crash the LiveView. Guard on the assigns' presence and no-op when absent,
-  # otherwise surface the "not attached" entry (the defensive path for any future
-  # state where the assigns exist but the session pid is gone).
-  def handle_event("repl_eval", %{"expr" => expr}, socket) do
-    cond do
-      not Map.has_key?(socket.assigns, :repl_seq) ->
-        {:noreply, socket}
-
-      String.trim(expr) == "" ->
-        {:noreply, socket}
-
-      true ->
-        {:noreply,
-         socket
-         |> repl_append_error(expr, "not attached to workspace")
-         |> repl_record_history(expr)
-         |> repl_clear_input()}
-    end
-  end
-
-  def handle_event("repl_eval", _params, socket), do: {:noreply, socket}
-
-  # ↑/↓ history recall (BT-2543). The ReplInput hook only fires these at the
-  # composer's edges (↑ on the first line, ↓ on the last), so mid-buffer cursor
-  # navigation is untouched. `repl_history_pos` walks the most-recent-first ring:
-  # ↑ moves further back (toward older entries), ↓ moves toward the present and
-  # past the newest restores the empty live input. The recalled text is pushed to
-  # the hook (the input is hook-owned / phx-update=ignore, so the server can't set
-  # it through morphdom).
-  @impl true
-  def handle_event("repl_history_prev", _params, socket) do
-    {:noreply, repl_recall(socket, :prev)}
-  end
-
-  def handle_event("repl_history_next", _params, socket) do
-    {:noreply, repl_recall(socket, :next)}
-  end
-
-  # Inspect a `→ result` term in the Inspector (BT-2543): results stay live
-  # objects even in the terminal idiom. The term was stashed server-side under the
-  # entry id at append time (the scrollback DOM is display-only); look it up and
-  # drive the same `inspect_term` path bindings/Print-it use. In `"float"` mode
-  # (BT-2493) it opens a floating window instead of the docked pane. An unknown id
-  # (a stale entry after a reconnect dropped the term map) is ignored.
-  @impl true
-  def handle_event("repl_inspect", %{"id" => id}, %{assigns: %{repl_terms: terms}} = socket) do
-    case Map.fetch(terms, id) do
-      {:ok, term} ->
-        label = "REPL result"
-
-        socket =
-          if socket.assigns.inspector_mode == "float" do
-            Inspector.open_window_for_term(socket, label, term)
-          else
-            Inspector.inspect_term(socket, label, term, [%{label: label, term: term}])
-          end
-
-        {:noreply, socket}
-
-      :error ->
-        {:noreply, socket}
-    end
-  end
-
-  def handle_event("repl_inspect", _params, socket), do: {:noreply, socket}
 
   # Inspector + object-window events (BT-3291, epic BT-3290): the docked
   # Inspector's inspect/drill/crumb/freeze/poke navigation and the floating
@@ -1655,49 +1395,6 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   def handle_event("edit_source", _params, socket), do: {:noreply, socket}
 
-  # Flush all pending durable changes to disk ("Save All to Disk", ADR 0082
-  # `Workspace flush`). The summary's conflicts/skipped lists carry recoverable
-  # conditions; a hard runtime failure renders as a structured error.
-  #
-  # Deliberately Tier-1-only, unchanged by ADR 0113: a pending `remove-class`
-  # entry is reported in the summary as `skipped: destructive`
-  # (`beamtalk_workspace_flush`'s own vocabulary, unmodified by this
-  # surface — see `format_flush_summary/1`) rather than silently deleted, so
-  # this one button staying textually the same `Workspace flush` call it
-  # always was is itself the safety property ADR 0113 relies on for every
-  # unmodified caller. Reaching Tier 2 is the `flush_destructive` handler
-  # below (per-row "Delete file" button, ADR 0113 Surface: browser row).
-  def handle_event("flush", _params, socket) do
-    {:noreply, flush_changes(socket)}
-  end
-
-  # "Delete file" / "Apply rename" — the browser's second, independently-
-  # confirmed gesture for one pending `remove-class`/`rename-class`/
-  # `rename-method` ChangeLog row (ADR 0113 Phase 4 BT-3210, extended by ADR
-  # 0114 Phase 5 BT-3277's Surface table). Scoped to the one class the row
-  # names, mirroring the REPL's `:flush-destructive <Class>` and the MCP
-  # `flush` tool's scoped `confirm_destructive: true` form — never the
-  # unscoped `flushIncludingDestructive`, since a browser click always
-  # targets one named row, not "every destructive entry in the workspace".
-  # `kind` rides its own `phx-value-*` attribute (defaulting to
-  # `"remove-class"`, this button's original — and still most common — row)
-  # only to pick the right status message on success; it plays no role in
-  # which entry actually gets flushed (the `class` Symbol alone scopes that).
-  def handle_event(
-        "flush_destructive",
-        %{"class" => class} = params,
-        %{assigns: %{role: :owner}} = socket
-      )
-      when is_binary(class) and class != "" do
-    kind = Map.get(params, "kind", "remove-class")
-    {:noreply, flush_destructive(socket, class, kind)}
-  end
-
-  # Non-owner (Observer), or a crafted event with a missing/blank class: a
-  # no-op — the button is rendered only for `:owner` against a real row's
-  # class, mirroring `remove_class`/`revert` above.
-  def handle_event("flush_destructive", _params, socket), do: {:noreply, socket}
-
   # Toggle the System Browser's "New Class" modal open/closed (BT-2293, BT-2645).
   # Closed by default; the ＋ button in the browser head flips it. Opening the
   # modal resets the field values + clears any stale in-modal validation error
@@ -1747,59 +1444,6 @@ defmodule BtAttachWeb.WorkspaceLive do
   def handle_event("new_class", _params, socket) do
     {:noreply, assign(socket, new_class_error: "Invalid new-class form payload.")}
   end
-
-  # Revert one pending in-memory method patch (ADR 0082 Phase 5 `Workspace
-  # changes revert:`, BT-2293), keyed by the `(class, selector)` carried on the
-  # ChangeLog row's revert button. `side` (ADR 0112, BT-3187) is the same
-  # row's `side` — required to disambiguate a same-selector instance-side
-  # entry from a class-side one, which are otherwise indistinguishable by
-  # `(class, selector)` alone. Refreshes the Changes pane so the fresh revert
-  # entry is visible.
-  def handle_event("revert", %{"class" => class, "selector" => selector} = params, socket)
-      when is_binary(class) and is_binary(selector) do
-    side = present_side_param(Map.get(params, "entry-side"))
-    {:noreply, revert_change(socket, class, selector, side)}
-  end
-
-  # Malformed payload (missing keys / non-binary values): surface a validation
-  # error rather than silently no-op'ing, consistent with `new_class`/`save_method`.
-  def handle_event("revert", _params, socket) do
-    {:noreply, status_error(socket, "Invalid revert request.")}
-  end
-
-  # Toggle the structured diff disclosure for one Changes-pane row (BT-2636),
-  # keyed by the row's `{class, selector, side}` carried on the leading caret
-  # (`phx-value-entry-side`, BT-3195 — reuses `present_side_param/1`'s `""` →
-  # `nil` normalisation, the same one the revert button's
-  # `phx-value-entry-side` already relies on, so both controls agree on what
-  # "no side" means). Named `entry-side`, not `side`, for the same reason the
-  # revert button is: it doesn't collide with the browser's `phx-value-side`
-  # instance/class toggle (BT-2491), so a `button[phx-value-side=...]`
-  # selector in a test doesn't match this caret too. Pure view state — no
-  # workspace round-trip; flips the key in/out of `:expanded_changes`,
-  # showing/hiding that row's `unified_diff` body. Before BT-3195 this keyed
-  # on `{class, selector}` alone, so a same-selector instance-side and
-  # class-side row (possible since BT-3187's shadow-key fix) shared one
-  # toggle — expanding one flipped the other too.
-  def handle_event(
-        "toggle_change_diff",
-        %{"class" => class, "selector" => selector} = params,
-        socket
-      )
-      when is_binary(class) and is_binary(selector) do
-    key = {class, selector, present_side_param(Map.get(params, "entry-side"))}
-
-    expanded =
-      if MapSet.member?(socket.assigns.expanded_changes, key) do
-        MapSet.delete(socket.assigns.expanded_changes, key)
-      else
-        MapSet.put(socket.assigns.expanded_changes, key)
-      end
-
-    {:noreply, assign(socket, expanded_changes: expanded)}
-  end
-
-  def handle_event("toggle_change_diff", _params, socket), do: {:noreply, socket}
 
   # ── System Browser (BT-2491, epic BT-2482 Phase 2) ──────────────────────────
 
@@ -2220,24 +1864,6 @@ defmodule BtAttachWeb.WorkspaceLive do
   # clause above, which drops it when it doesn't match the active tab.
   def handle_event("select_source", _params, socket), do: {:noreply, socket}
 
-  # Selection tracking for the Workspace dock's editor (BT-2490). Tracked in a
-  # SEPARATE assign (`ws_selection`) from the method editor's `edit_selection` so
-  # the dock's doIt/printIt/inspectIt evaluate *this* editor's selection — a
-  # selection left in the method editor must not leak into a Workspace eval. Same
-  # defensive shape as `select_source`.
-  def handle_event("select_workspace", %{"text" => text} = params, socket)
-      when is_binary(text) do
-    selection = %{
-      text: text,
-      start: clamp_offset(params["start"]),
-      end: clamp_offset(params["end"])
-    }
-
-    {:noreply, assign(socket, ws_selection: selection)}
-  end
-
-  def handle_event("select_workspace", _params, socket), do: {:noreply, socket}
-
   # Cap on the Transcript pane depth: the client keeps the most recent N lines
   # (via `stream_insert(:transcript, …, limit: -N)`), bounding the DOM in step
   # with the producer's 1000-entry ring buffer (`beamtalk_transcript_stream`).
@@ -2388,39 +2014,12 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   def handle_info(_msg, socket), do: {:noreply, socket}
 
-  # BT-2590 (S1): the off-socket git load (`assign_git/1`'s `start_async`)
-  # completed. The task returned `{status_result, log_result}` — the raw
-  # `Facade.dispatch` outcomes — which we fold into the panel assigns here, on the
-  # LiveView process, so the render is driven from a single coherent update.
+  # Git panel async load (BT-2590 S1, extracted BT-3295): the off-socket
+  # `assign_git/1` `start_async` result forwards to
+  # `BtAttachWeb.Live.Dock.handle_async/3` unchanged, mirroring the
+  # `handle_event`/`handle_info` delegation above.
   @impl true
-  def handle_async(:git_load, {:ok, {status_result, log_result}}, socket) do
-    socket =
-      socket
-      |> apply_git_status(status_result)
-      |> apply_git_log(log_result)
-
-    {:noreply, socket}
-  end
-
-  # The git-load task exited. A real crash surfaces as a git-panel error rather
-  # than taking down the LiveView. The `:cancelled` clause is a defensive no-op:
-  # `assign_git/1` `cancel_async`-es the prior load before starting a new one, and
-  # while LiveView normally prunes that stale ref before its exit is delivered, we
-  # guard the atom explicitly so a cancellation can never render a spurious error.
-  # On a genuine failure we reset BOTH status and log so the panel can't show a
-  # stale commit list beside the error banner (a torn read).
-  def handle_async(:git_load, {:exit, :cancelled}, socket), do: {:noreply, socket}
-
-  def handle_async(:git_load, {:exit, reason}, socket) do
-    Logger.error("git panel load crashed: #{inspect(reason)}", domain: [:beamtalk, :liveview])
-
-    {:noreply,
-     assign(socket,
-       git_status: nil,
-       git_log: [],
-       git_error: "Couldn't load git status — the load failed unexpectedly."
-     )}
-  end
+  def handle_async(:git_load, result, socket), do: Dock.handle_async(:git_load, result, socket)
 
   # BT-2591: the off-socket mount-time reads (`start_mount_load/2`'s `start_async`)
   # completed. The task returned the four raw `Facade.dispatch` outcomes; we fold
@@ -2636,113 +2235,6 @@ defmodule BtAttachWeb.WorkspaceLive do
   # facade-error copy instead of keeping their own.
   defp facade_error(reason), do: FacadeError.render(reason)
 
-  # Run a mutating git op through the Facade (Owner-gated) and refresh the panel
-  # so the new status/log is reflected. An :unauthorized/error result surfaces in
-  # the panel rather than crashing it.
-  # A content-mutating git op (revert / `git restore -- <path>`) needs more than a
-  # git-panel refresh: it changes the on-disk working tree, so it must (1) not
-  # silently clobber unflushed in-memory edits for that path, and (2) reload the
-  # affected module(s) into the live image so image == disk and open windows
-  # reflect the reverted code (BT-2598). Routed through `git_revert_event/2`.
-  defp git_mutate_event(socket, :git_revert_file, %{path: path} = params) do
-    if path_has_pending_edits?(socket, path) do
-      # Decision 2: do not revert under unflushed in-memory ChangeLog edits — live
-      # work would be silently lost. Block and tell the user to flush or discard
-      # the pending entry first. No git call is made.
-      assign(socket, git_error: pending_revert_warning(path))
-    else
-      git_revert_event(socket, params)
-    end
-  end
-
-  # Stage / unstage / commit do not change working-tree *content* (the file the
-  # user is editing), so they keep the original behaviour: dispatch and refresh
-  # the git panel only.
-  defp git_mutate_event(socket, op, params) do
-    case Facade.dispatch(op, params, ctx(socket)) do
-      {:ok, _} -> assign_git(socket)
-      {:error, reason} -> assign(socket, git_error: facade_error(reason))
-    end
-  end
-
-  # Revert the working-tree change, then reload the reverted file into the live
-  # image and refresh every source-dependent surface (browser, ChangeLog, open
-  # editor tabs) plus the git panel. The reload's `ClassLoaded` push *also* drives
-  # the refresh for other connected sessions; reloading + refreshing here makes the
-  # acting session update synchronously rather than waiting on its own push.
-  defp git_revert_event(socket, %{path: path} = params) do
-    case Facade.dispatch(:git_revert_file, params, ctx(socket)) do
-      {:ok, _} ->
-        {reloaded, reload_note} = reload_reverted_path(socket, path)
-
-        socket
-        # The reload reconciled the image to the reverted (disk) body, so the
-        # reloaded class' open tabs are no longer divergent — clear their
-        # `unflushed` badge before the re-read (which would otherwise preserve the
-        # already-set divergence, mirroring `clear_disk_differs/2` after a flush).
-        |> assign(:tabs, clear_disk_differs(socket.assigns.tabs, reloaded))
-        # BT-2655: re-read the reverted `:def` tabs' *editable* definition buffer so
-        # the visible editor shows the reverted header without a close/reopen.
-        # `refresh_after_source_change/1` below re-reads `:method` tab bodies on its
-        # own (and now bumps `editor_rev` to remount the editor — see
-        # `resync_active_tab/2`), but it deliberately leaves a `:def` tab's editable
-        # definition buffer untouched (a generic push must not clobber a concurrent
-        # edit). A revert is the safe exception: it is blocked for this path under
-        # pending edits (`path_has_pending_edits?/2`, BT-2598 d2), so overwriting the
-        # editable buffer for exactly the reloaded `:def` set is both safe and
-        # expected. Method tabs are intentionally left to the refresh below to avoid
-        # a redundant second `browse_method_source` round-trip per tab.
-        |> reload_reverted_def_buffers(reloaded)
-        |> refresh_after_source_change()
-        |> assign_git()
-        # A clean revert whose reload failed surfaces its note in the shared
-        # status area (the same slot revert / new-class outcomes use), NOT
-        # `git_error` — `assign_git/1` and the async git load both clear
-        # `git_error`, so the note would not survive there. The working tree was
-        # reverted, but the image may not have reloaded.
-        |> maybe_status_error(reload_note)
-
-      {:error, reason} ->
-        assign(socket, git_error: facade_error(reason))
-    end
-  end
-
-  defp maybe_status_error(socket, nil), do: socket
-  defp maybe_status_error(socket, note), do: status_error(socket, note)
-
-  # Reload the reverted file from disk into the live image (image == disk, BT-2585),
-  # returning the `{class, selector}` set of the reloaded class' currently-open
-  # `:method` tabs (so their `unflushed` badge can be cleared) and a reload-failure
-  # note (or nil). A reload failure (a deleted file, a file with a compile error at
-  # HEAD) is non-fatal: the working tree was still reverted, and the subsequent
-  # refresh re-reads what the image can serve; the note is surfaced afterwards.
-  defp reload_reverted_path(socket, path) do
-    case Facade.dispatch(:reload, %{path: path}, ctx(socket)) do
-      {:ok, class_names} when is_list(class_names) ->
-        {reloaded_tab_keys(socket.assigns.tabs, class_names), nil}
-
-      {:error, reason} ->
-        {MapSet.new(), "Reverted #{path}, but reload failed: #{facade_error(reason)}"}
-    end
-  end
-
-  # The disk keys of open `:method` and `:def` tabs whose class is among the
-  # just-reloaded class names — the tabs whose `unflushed` badge a revert should
-  # clear (their image now matches the reverted disk body). Method tabs key on
-  # `{class, selector}`; a `:def` tab keys on `{class, :def}` so a revert that
-  # changed a class header (state, superclass) also clears the open def tab's badge
-  # without needing a re-open (BT-2600).
-  defp reloaded_tab_keys(tabs, class_names) do
-    reloaded = MapSet.new(class_names)
-
-    for tab <- tabs,
-        key = tab_disk_key(tab),
-        key != nil,
-        MapSet.member?(reloaded, elem(key, 0)),
-        into: MapSet.new(),
-        do: key
-  end
-
   # BT-2655: re-read the editable *definition* buffer of every open clean `:def` tab
   # whose disk key is in `reloaded` (the reverted class' def tabs), so the visible
   # editor reflects the reverted class header without a close/reopen. This is the
@@ -2753,7 +2245,11 @@ defmodule BtAttachWeb.WorkspaceLive do
   # (`path_has_pending_edits?/2`, BT-2598 d2), so no in-progress edit can be lost.
   # A dirty tab is left untouched all the same (defence in depth); method tabs and
   # tabs outside `reloaded` pass through and are handled by the refresh that follows.
-  defp reload_reverted_def_buffers(socket, reloaded) do
+  # Public: `BtAttachWeb.Live.Dock`'s `git_revert_event/2` (BT-3295) calls it
+  # directly — the method-editor tab machinery it depends on
+  # (`resync_active_tab/2`, `class_definition_info/2`) hasn't been extracted
+  # out of this module yet (BT-3296).
+  def reload_reverted_def_buffers(socket, reloaded) do
     tabs =
       Enum.map(socket.assigns.tabs, fn tab ->
         if match?(%{kind: :def, dirty: false}, tab) and
@@ -2784,46 +2280,6 @@ defmodule BtAttachWeb.WorkspaceLive do
         # are refreshed by `refresh_source_tab/2` in the follow-up push refresh.
         %{tab | source: definition, base: definition, dirty: false, disk_differs: false}
     end
-  end
-
-  # Whether the file `path` git is about to revert has unflushed in-memory
-  # ChangeLog edits (BT-2598 decision 2). The cockpit `changes` rows carry only
-  # `class`/`selector`, so map each pending class to its source file via the
-  # browser class list (which carries `source_file`) and compare against `path`.
-  # Path comparison is by trailing-segment match so a project-relative `path`
-  # (`src/Foo.bt`) matches an absolute or differently-rooted `source_file`.
-  defp path_has_pending_edits?(socket, path) do
-    pending_classes =
-      for %{class: class} <- socket.assigns[:changes] || [],
-          is_binary(class),
-          into: MapSet.new(),
-          do: class
-
-    if MapSet.size(pending_classes) == 0 do
-      false
-    else
-      Enum.any?(socket.assigns[:browser_classes] || [], fn row ->
-        is_map(row) and MapSet.member?(pending_classes, row["name"]) and
-          paths_match?(row["source_file"], path)
-      end)
-    end
-  end
-
-  # Two paths refer to the same file when one is a trailing-segment suffix of the
-  # other (so `src/Foo.bt` matches `/abs/project/src/Foo.bt`). Both nil/non-binary
-  # → no match.
-  defp paths_match?(a, b) when is_binary(a) and is_binary(b) do
-    a == b or String.ends_with?(a, "/" <> b) or String.ends_with?(b, "/" <> a)
-  end
-
-  defp paths_match?(_a, _b), do: false
-
-  # The git-panel message shown when a revert is blocked because the file has
-  # unflushed in-memory edits (BT-2598 decision 2) — names the path and the two
-  # ways forward (flush to keep the work on disk, or discard the pending entry).
-  defp pending_revert_warning(path) do
-    "Cannot revert #{path}: it has unflushed in-memory edits. " <>
-      "Flush (Save All to Disk) to keep them, or discard the pending change in the Changes pane first."
   end
 
   # Human label for a porcelain status atom (BT-2586). `beamtalk_git` classifies
@@ -2926,131 +2382,13 @@ defmodule BtAttachWeb.WorkspaceLive do
     """
   end
 
-  # ── Workspace dock actions (BT-2490) ────────────────────────────────────────
-
-  # Which dock action the eval submit carried. The clicked action button rides
-  # the form as `action`; a plain submit (the e2e `render_submit(%{expr: …})`)
-  # carries none and defaults to printIt — the historical eval behaviour.
-  defp eval_action(%{"action" => action}) when action in ~w(do_it print_it inspect_it),
-    do: action
-
-  defp eval_action(_params), do: "print_it"
-
-  # The code an action evaluates: the Workspace editor's tracked selection if
-  # there is one (the spike's "evaluates selection"), else the whole entered
-  # buffer ("evaluates buffer"). The Workspace editor's CmEditor hook keeps
-  # `ws_selection` current (distinct from the method editor's `edit_selection`);
-  # an empty or whitespace-only selection falls back to the buffer.
-  defp eval_target(expr, socket) do
-    if ws_selection?(socket.assigns), do: socket.assigns.ws_selection.text, else: expr
-  end
-
-  # Whether the Workspace editor has a non-blank selection to evaluate. Takes the
-  # bare `assigns` so the render template can call it directly too.
-  defp ws_selection?(assigns) do
-    case assigns[:ws_selection] do
-      %{text: text} when is_binary(text) -> String.trim(text) != ""
-      _ -> false
-    end
-  end
-
-  # Render an eval success according to the chosen action (BT-2542 Workspace
-  # rebuild). The growing below-editor `.ws-result` success bubble is gone; the
-  # Workspace is now editor-primary, so feedback is split:
-  #
-  #   * print_it   — the classic Workspace "Print it": the result is inserted
-  #     INLINE into the CodeMirror buffer after the evaluated region (pushed to
-  #     the `CmEditor` hook as `ws_insert_result`, rendered as a collapsible
-  #     block widget — NOT doc text, so "evaluate buffer" never re-runs it). A
-  #     terse `→ result` also flashes in the transient status line.
-  #   * do_it      — evaluate for side effects; a subtle, self-clearing
-  #     `✓ evaluated` status only (no buffer insert; ambient output → Transcript).
-  #   * inspect_it — show the term in the status AND open it in the Inspector.
-  #
-  # All three carry the result/confirmation in `result` (rendered as the thin
-  # `.eval-status` line) and bump `eval_seq` to restart its fade.
-  defp eval_success(socket, "do_it", _term, output, expr) do
-    eval_status(socket, "✓ evaluated", output, expr)
-  end
-
-  defp eval_success(socket, "inspect_it", term, output, expr) do
-    socket = eval_status(socket, "→ " <> Workspace.render_term(term), output, expr)
-
-    # In `"float"` mode (BT-2493) Inspect-it opens a floating window on the
-    # `→ result` term rather than driving the docked pane; docked mode keeps the
-    # original single-pane behaviour.
-    if socket.assigns.inspector_mode == "float" do
-      Inspector.open_window_for_term(socket, "→ result", term)
-    else
-      Inspector.inspect_term(socket, "→ result", term, [%{label: "→ result", term: term}])
-    end
-  end
-
-  # print_it (and the historical default): insert the result inline in the buffer
-  # AND flash it in the status line.
-  defp eval_success(socket, _print_it, term, output, expr) do
-    rendered = Workspace.render_term(term)
-    # Capture the anchor from the ORIGINAL socket before the pipe: `eval_status`
-    # doesn't touch `ws_selection`, but binding it here makes that independence
-    # explicit and survives a future pipe stage that might clear the selection.
-    anchor = ws_anchor(socket)
-
-    # `push_event` is page-wide — every CmEditor hook that registered the
-    # handler receives it. Scope it to the Workspace editor by element id (the
-    # client drops a mismatched target) so a second inline editor (BT-2543) can't
-    # also insert this result. The id is the shared `workspace_editor_id/0` so the
-    # target and the template host can't drift apart.
-    socket
-    |> eval_status("→ " <> rendered, output, expr)
-    |> push_event("ws_insert_result", %{
-      text: rendered,
-      anchor: anchor,
-      target: workspace_editor_id()
-    })
-  end
-
-  # DOM id of the Workspace CodeMirror editor host — the single source of truth
-  # shared by the template element and the `ws_insert_result` push target, so a
-  # rename can't silently break inline results (the client guard discards a push
-  # whose target doesn't match `this.el.id`).
-  defp workspace_editor_id, do: "workspace-editor-overlay"
-
-  # The doc offset to anchor an inline result after: the end of the tracked
-  # selection (the evaluated region) when evaluating a selection, else nil so the
-  # client falls back to the live buffer end. Echoed in the `ws_insert_result`
-  # push so a cursor move during the eval round-trip (wider over a remote
-  # distribution node) can't drop the widget on the wrong line.
-  defp ws_anchor(socket) do
-    if ws_selection?(socket.assigns) do
-      case socket.assigns.ws_selection[:end] do
-        offset when is_integer(offset) -> offset
-        _ -> nil
-      end
-    end
-  end
-
-  # Assign the transient eval-status line + bump its re-key sequence. Shared by
-  # every success branch so the status fade restarts consistently per eval.
-  defp eval_status(socket, status, output, expr) do
-    assign(socket,
-      result: status,
-      output: present(output),
-      error: nil,
-      expr: expr,
-      eval_seq: socket.assigns.eval_seq + 1
-    )
-  end
-
-  # Blank captured output is not worth rendering a pane for.
-  defp present(""), do: nil
-  defp present(nil), do: nil
-  defp present(output) when is_binary(output), do: output
-
   # Normalise a client-supplied selection offset to a non-negative integer (or
   # nil). The CmEditor hook sends integer offsets, but the payload is
   # untrusted, so a missing / negative / non-integer value collapses to nil.
-  defp clamp_offset(n) when is_integer(n) and n >= 0, do: n
-  defp clamp_offset(_), do: nil
+  # Public: shared by `select_source` here and `BtAttachWeb.Live.Dock`'s
+  # `select_workspace` (BT-3295).
+  def clamp_offset(n) when is_integer(n) and n >= 0, do: n
+  def clamp_offset(_), do: nil
 
   # ── Transcript helpers (BT-2609) ─────────────────────────────────────────────
 
@@ -3090,389 +2428,6 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   defp transcript_line(text) do
     %{id: System.unique_integer([:positive]), text: to_string(text)}
-  end
-
-  # ── REPL helpers (BT-2543) ───────────────────────────────────────────────────
-
-  # Cap on the REPL scrollback depth: the client keeps the most recent N entries
-  # (via `stream_insert(:repl, …, limit: -N)`) and `repl_terms` is evicted in
-  # lockstep, so a long session can't grow the DOM or the assigns map unbounded.
-  @repl_scrollback_limit 200
-
-  # Append a successful `› request` / `→ response` pair to the scrollback and
-  # stash the live result term under the entry id so a later Inspect click can
-  # re-open it. The response is the surface-shared `render_term` rendering — the
-  # SAME string the Workspace `→ result` shows — so the two surfaces stay
-  # display-consistent. Long responses are marked so the template can collapse
-  # them within the entry rather than letting one result flood the scrollback.
-  defp repl_append_ok(socket, request, term) do
-    seq = socket.assigns.repl_seq + 1
-    id = repl_entry_id(seq)
-    response = Workspace.render_term(term)
-
-    entry = %{
-      id: id,
-      request: request,
-      kind: :ok,
-      response: response,
-      inspectable: true,
-      long: repl_long?(response)
-    }
-
-    socket
-    |> assign(:repl_seq, seq)
-    # `repl_terms` is bounded in step with the scrollback (below): stash this
-    # term, then evict the one that just scrolled past the depth cap. Each entry
-    # is a small reference (the object lives in the workspace process), but a long
-    # session would still grow the map unboundedly without this.
-    |> update(:repl_terms, fn terms -> terms |> Map.put(id, term) |> repl_evict(seq) end)
-    |> stream_insert(:repl, entry, limit: -@repl_scrollback_limit)
-    |> repl_scroll_to_bottom()
-  end
-
-  # Append an error entry: the `→ response` carries the rendered error and there
-  # is no live term to inspect, so no Inspect affordance and nothing stashed.
-  defp repl_append_error(socket, request, message) do
-    seq = socket.assigns.repl_seq + 1
-    id = repl_entry_id(seq)
-
-    entry = %{
-      id: id,
-      request: request,
-      kind: :error,
-      response: message,
-      inspectable: false,
-      long: repl_long?(message)
-    }
-
-    socket
-    |> assign(:repl_seq, seq)
-    # An error entry stashes no term, but still bump the cap so an OK term that
-    # scrolled past the depth limit (counting errors too) is evicted in step.
-    |> update(:repl_terms, &repl_evict(&1, seq))
-    |> stream_insert(:repl, entry, limit: -@repl_scrollback_limit)
-    |> repl_scroll_to_bottom()
-  end
-
-  # Cap the scrollback depth (client DOM via `stream_insert(limit:)`) and the
-  # `repl_terms` map in lockstep. Entry ids are monotonic (`repl-entry-N`, N =
-  # seq), so the entry now `@repl_scrollback_limit` positions back is exactly the
-  # one the client dropped — evict its term (a no-op for an error entry, which
-  # was never stashed).
-  defp repl_evict(terms, seq) do
-    evicted = seq - @repl_scrollback_limit
-    if evicted > 0, do: Map.delete(terms, repl_entry_id(evicted)), else: terms
-  end
-
-  # Scroll the scrollback to the newest entry on each append (classic terminal
-  # behaviour): a new submission should reveal its result even if the user had
-  # scrolled up to read older output. The scroll is a pure client effect, so it
-  # rides a push to the ReplInput hook rather than a re-render.
-  defp repl_scroll_to_bottom(socket) do
-    push_event(socket, "repl_scroll_bottom", %{})
-  end
-
-  defp repl_entry_id(seq), do: "repl-entry-#{seq}"
-
-  # DOM id of the REPL input editor host — the single source of truth shared by
-  # the template element and the `repl_set_input` push target, so a rename can't
-  # silently break history recall / submit-clear. (There is a single ReplInput
-  # instance on the page; `push_event/3` reaches every hook registered for the
-  # event, so this id is for template/push-target consistency, not filtering.)
-  defp repl_input_id, do: "repl-input"
-
-  # First-line (capped) preview shown in a collapsed long response's `<summary>`:
-  # enough to recognise the result without expanding, with an ellipsis when the
-  # full text is longer.
-  defp repl_preview(text) when is_binary(text) do
-    first = text |> String.split("\n", parts: 2) |> hd()
-
-    cond do
-      String.length(first) > 80 -> String.slice(first, 0, 80) <> "…"
-      first != text -> first <> " …"
-      true -> first
-    end
-  end
-
-  # A response is "long" (worth collapsing within its entry) when it spills past a
-  # handful of lines or a few hundred chars — the threshold that keeps a single
-  # verbose result from pushing the rest of the scrollback off-screen.
-  defp repl_long?(text) when is_binary(text) do
-    # `parts: 7` short-circuits the split after 6 newlines instead of
-    # materialising every line just to count past six.
-    String.length(text) > 320 or length(String.split(text, "\n", parts: 7)) > 6
-  end
-
-  # Record a submitted expression at the head of the recall ring and reset the
-  # ↑/↓ cursor to the live input. Every prior occurrence of the expression is
-  # dropped first so re-running the same expression doesn't bloat the ring (all
-  # earlier copies collapse onto the new head, shell `HISTCONTROL=erasedups`
-  # style — not just consecutive runs); the ring is capped so a long session
-  # can't grow the assigns unbounded.
-  @repl_history_limit 100
-  defp repl_record_history(socket, expr) do
-    history =
-      [expr | Enum.reject(socket.assigns.repl_history, &(&1 == expr))]
-      |> Enum.take(@repl_history_limit)
-
-    assign(socket, repl_history: history, repl_history_pos: nil)
-  end
-
-  # Walk the recall ring and push the recalled text to the input. `:prev` (↑)
-  # moves toward older entries; `:next` (↓) moves toward the present, and stepping
-  # past the newest restores the empty live input (pos = nil). An empty ring or a
-  # ↓ while already at the live input is a no-op (no push, so the hook keeps the
-  # in-progress text the user was typing).
-  #
-  # The first clause also covers the attach-failure window: when bind_session
-  # never ran, `:repl_history` is absent, so a crafted ↑/↓ must NOT fall through
-  # to `socket.assigns.repl_history` (a KeyError that would crash the LiveView) —
-  # `is_map_key/2` guards it to a no-op.
-  defp repl_recall(socket, _dir) when not is_map_key(socket.assigns, :repl_history),
-    do: socket
-
-  defp repl_recall(%{assigns: %{repl_history: []}} = socket, _dir), do: socket
-
-  defp repl_recall(socket, dir) do
-    history = socket.assigns.repl_history
-    pos = socket.assigns.repl_history_pos
-    last = length(history) - 1
-
-    new_pos =
-      case {dir, pos} do
-        {:prev, nil} -> 0
-        {:prev, p} -> min(p + 1, last)
-        {:next, nil} -> :live
-        {:next, 0} -> nil
-        {:next, p} -> p - 1
-      end
-
-    case new_pos do
-      :live ->
-        # ↓ at the live input: nothing to recall, leave the user's draft alone.
-        socket
-
-      nil ->
-        socket
-        |> assign(:repl_history_pos, nil)
-        |> push_event("repl_set_input", %{text: ""})
-
-      p ->
-        socket
-        |> assign(:repl_history_pos, p)
-        |> push_event("repl_set_input", %{text: Enum.at(history, p)})
-    end
-  end
-
-  # Clear the REPL input after a submit (REPL convention: submit empties the
-  # composer). The input is hook-owned (phx-update=ignore), so the server can only
-  # set it by pushing to the ReplInput hook.
-  defp repl_clear_input(socket) do
-    push_event(socket, "repl_set_input", %{text: ""})
-  end
-
-  # ── REPL meta-commands (BT-2543 follow-up) ──────────────────────────────────
-  #
-  # The CLI REPL parses `:`-prefixed meta-commands client-side (see
-  # crates/beamtalk-cli/src/commands/repl/mod.rs); the LiveView REPL historically
-  # forwarded them straight to `eval`, which choked trying to compile `:h` as a
-  # Beamtalk expression. In a graphical IDE most of those commands map onto a pane
-  # that already exists (the System Browser, the Bindings pane, the Changes tab),
-  # so rather than re-implement the CLI's command DSL we recognise the leading
-  # colon and either DRIVE the matching pane (`:help X` focuses the System
-  # Browser) or POINT the user at it. Input without a leading colon is real code
-  # and falls through to `eval` untouched.
-  #
-  # Returns `nil` for non-meta input (the overwhelmingly common path) so the
-  # caller's `cond` falls through to eval; otherwise a parsed `{kind, …}` tuple
-  # `handle_repl_meta/3` routes.
-  defp repl_meta_command(input) do
-    if String.starts_with?(input, ":") do
-      # `input` starts with ":", so splitting on whitespace always yields at least
-      # the command token (a bare ":" splits to `[":"]`, routed to the catch-all).
-      [cmd | rest] = String.split(input, ~r/\s+/, parts: 2, trim: true)
-      repl_meta_dispatch(cmd, meta_arg(rest))
-    else
-      nil
-    end
-  end
-
-  # First whitespace-delimited token of a meta-command's argument, with a leading
-  # `#` stripped so `:help #Counter` and `:help Counter` agree. `nil` when the
-  # command had no argument.
-  defp meta_arg([]), do: nil
-
-  defp meta_arg([arg]) do
-    # `arg` is the non-empty second part of the outer `parts: 2, trim: true` split,
-    # so this inner split always yields at least the first token.
-    [token | _] = String.split(arg, ~r/\s+/, parts: 2, trim: true)
-
-    case String.trim_leading(token, "#") do
-      "" -> nil
-      stripped -> stripped
-    end
-  end
-
-  defp repl_meta_dispatch(cmd, arg) when cmd in [":help", ":h", ":?"], do: {:help, arg}
-
-  defp repl_meta_dispatch(cmd, _) when cmd in [":bindings", ":b"],
-    do:
-      {:point,
-       "Bindings are listed live in the Bindings pane on the right — click one to inspect it."}
-
-  defp repl_meta_dispatch(cmd, _) when cmd in [":changes", ":dirty"],
-    do: {:point, "Pending changes are shown in the Changes tab of this dock."}
-
-  defp repl_meta_dispatch(":flush", _),
-    do: {:point, "Use the Flush control in the Changes tab to write pending changes to disk."}
-
-  defp repl_meta_dispatch(cmd, _) when cmd in [":sync", ":s"],
-    do:
-      {:point,
-       "The IDE tracks the live image as you work, so there is no manual sync step — project files from `beamtalk.toml` load when you connect."}
-
-  defp repl_meta_dispatch(cmd, _) when cmd in [":test", ":t"],
-    do: {:tab, "tests", "Opened the Tests pane in this dock — Run all, or run a single class. ◂"}
-
-  defp repl_meta_dispatch(":clear", _),
-    do:
-      {:point,
-       "Session bindings clear with the workspace. To clear them now, evaluate: Session current clear"}
-
-  defp repl_meta_dispatch(cmd, _) when cmd in [":show-codegen", ":sc"],
-    do:
-      {:point,
-       "Generated-code inspection (:show-codegen) is CLI-only for now — run it from `beamtalk repl`."}
-
-  defp repl_meta_dispatch(cmd, _) when cmd in [":exit", ":quit", ":q"],
-    do:
-      {:point,
-       "Close the browser tab to disconnect — there is no REPL process to exit in the IDE."}
-
-  defp repl_meta_dispatch(cmd, _), do: {:unknown, cmd}
-
-  # Route a parsed meta-command. `:help X` drives the System Browser; everything
-  # else appends an informational scrollback entry (a third `kind`, `:info`, the
-  # template styles muted rather than as an error).
-  defp handle_repl_meta(socket, {:help, nil}, expr),
-    do: repl_append_info(socket, expr, repl_help_text())
-
-  defp handle_repl_meta(socket, {:help, class}, expr),
-    do: repl_focus_class(socket, expr, class)
-
-  defp handle_repl_meta(socket, {:point, message}, expr),
-    do: repl_append_info(socket, expr, message)
-
-  # Route a meta-command to a dock tab (BT-2557: `:test` → Tests pane). Switches
-  # the dock to `tab`, lazily loads the Tests catalogue when that is the target,
-  # and appends a confirming info entry — the GUI equivalent of the CLI command.
-  defp handle_repl_meta(socket, {:tab, tab, message}, expr) do
-    socket
-    |> assign(dock_tab: tab)
-    |> then(fn s -> if tab == "tests", do: ensure_test_classes(s), else: s end)
-    |> repl_append_info(expr, message)
-  end
-
-  defp handle_repl_meta(socket, {:unknown, cmd}, expr) do
-    repl_append_info(
-      socket,
-      expr,
-      "Unknown command #{cmd}. This is the IDE REPL — type :help for what's available, " <>
-        ":help <Class> to open a class in the System Browser, or just evaluate an expression."
-    )
-  end
-
-  # Focus the System Browser on `class` (the GUI equivalent of the CLI's
-  # `:help Class` → `Beamtalk help: Class`). We validate against the live symbol
-  # index first so an unknown name gives a clean message instead of pointing the
-  # browser at a class that doesn't exist.
-  defp repl_focus_class(socket, expr, class) do
-    if class in browser_class_names(socket) do
-      socket
-      |> open_class(class)
-      |> repl_append_info(expr, "Opened #{class} in the System Browser ◂")
-    else
-      # "No class named X" is feedback about a meta-command, not a code-evaluation
-      # failure, so it uses the muted `:info` styling (like an unknown `:cmd`) rather
-      # than the red error arrow reserved for eval errors.
-      repl_append_info(
-        socket,
-        expr,
-        "No class named #{class}. Browse classes in the System Browser, or search with the omni bar (top)."
-      )
-    end
-  end
-
-  # The class names known to the live image, from the same symbol index the omni
-  # search uses, as a MapSet so the `class in browser_class_names(socket)`
-  # membership check in `repl_focus_class/3` is O(1). An empty index (dispatch
-  # failure / RBAC denial) just means every `:help X` reports "no such class"
-  # rather than crashing.
-  defp browser_class_names(socket) do
-    socket
-    |> symbol_rows()
-    |> Enum.filter(&(&1.kind == "class"))
-    |> MapSet.new(& &1.class)
-  end
-
-  # `:help` with no argument: a short tour of where the CLI REPL's commands live
-  # in the IDE, so a muscle-memory `:h` lands somewhere useful instead of erroring.
-  defp repl_help_text do
-    """
-    IDE REPL — evaluate any expression (Enter runs it, ↑/↓ recall history).
-    :help / :h / :?        show this help
-    :help <Class>          open a class in the System Browser (left)
-    :bindings / :b         → Bindings pane (right)
-    :changes / :dirty      → Changes tab (this dock)
-    :flush                 → Flush control (Changes tab)
-    :sync / :s             tracks the live image (loads beamtalk.toml on connect)
-    :clear                 evaluates `Session current clear`
-    :show-codegen / :sc    CLI-only — run from `beamtalk repl`
-    :test / :t             → Tests pane (this dock) — run all or a class
-    :exit / :quit / :q     close the browser tab to disconnect
-    Inspect results with the Inspect button; browse classes/methods on the left.\
-    """
-  end
-
-  # After a successful eval, if the expression was a `Beamtalk help: Class` send
-  # (the CLI's `:help` desugaring, and a natural thing to type directly), focus
-  # the System Browser on that class too — the help text stays in the scrollback
-  # AND the browser navigates to the subject. Non-help evals pass through
-  # untouched.
-  #
-  # Unlike `repl_focus_class/3`, this skips the `browser_class_names/1` validation
-  # and calls `open_class` directly: the `eval` already succeeded, which proves the
-  # class exists in the runtime, so a symbol-index lookup would be redundant (and
-  # would falsely reject a class defined moments earlier if the index is briefly
-  # stale). `load_protocols` handles an empty result gracefully regardless.
-  defp repl_help_followup(socket, expr) do
-    case Regex.run(~r/^\s*Beamtalk\s+help:\s+#?([A-Z]\w*)/, expr) do
-      [_, class] -> open_class(socket, class)
-      _ -> socket
-    end
-  end
-
-  # Append an informational meta-command response (`kind: :info`): no live term,
-  # so no Inspect affordance and nothing stashed. Mirrors `repl_append_error/3`'s
-  # bookkeeping (seq bump + term-map eviction in lockstep with the scrollback cap).
-  defp repl_append_info(socket, request, message) do
-    seq = socket.assigns.repl_seq + 1
-    id = repl_entry_id(seq)
-
-    entry = %{
-      id: id,
-      request: request,
-      kind: :info,
-      response: message,
-      inspectable: false,
-      long: repl_long?(message)
-    }
-
-    socket
-    |> assign(:repl_seq, seq)
-    |> update(:repl_terms, &repl_evict(&1, seq))
-    |> stream_insert(:repl, entry, limit: -@repl_scrollback_limit)
-    |> repl_scroll_to_bottom()
   end
 
   # ── method editor helpers (Wave 3) ──────────────────────────────────────────
@@ -3867,12 +2822,21 @@ defmodule BtAttachWeb.WorkspaceLive do
   # (`^[A-Z][A-Za-z0-9_]*$`), and not a duplicate of an existing class in the
   # browse list. Returns `:ok` or `{:error, message}` for an in-modal error.
   @new_class_name_re ~r/^[A-Z][A-Za-z0-9_]*$/
+
+  # Whether `name` is a bare PascalCase class-name identifier
+  # (`^[A-Z][A-Za-z0-9_]*$`) — the shape the New Class modal enforces. Public:
+  # `BtAttachWeb.Live.Dock`'s `flush_destructive/3` (BT-3295) validates a
+  # client-controlled `class` value against this same rule before
+  # interpolating it into a raw `evaluate` expression, so a crafted event
+  # can't inject arbitrary source.
+  def valid_class_name?(name), do: Regex.match?(@new_class_name_re, name)
+
   defp validate_new_class_name(socket, name) do
     cond do
       name == "" ->
         {:error, "Enter a class name to create a class."}
 
-      not Regex.match?(@new_class_name_re, name) ->
+      not valid_class_name?(name) ->
         {:error,
          "Class name must be PascalCase — start with an uppercase letter, e.g. `Greeter`."}
 
@@ -4296,16 +3260,6 @@ defmodule BtAttachWeb.WorkspaceLive do
     snake_chars(rest, c >= ?a and c <= ?z, [c | acc])
   end
 
-  # Normalise a `phx-value-entry-side` param (a plain HTML attribute string)
-  # back to the `side` the row's `c[:side]` carries: `""` (a sideless
-  # new-class row's `phx-value-entry-side={c[:side] || ""}`) and a
-  # missing/non-binary value both mean "no side" (ADR 0112, BT-3187). Shared
-  # by the revert button and the diff-toggle caret's `entry-side` param
-  # (BT-3195) so both controls agree on what "no side" means and neither
-  # duplicates the other's normalisation.
-  defp present_side_param(side) when is_binary(side) and side != "", do: side
-  defp present_side_param(_), do: nil
-
   # Human-readable Kind/Side label for one Changes-pane row (BT-3195): before
   # this, the table had no column distinguishing an instance-side patch from a
   # class-side patch/removal of the same selector, so the two rows — both
@@ -4338,33 +3292,13 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp change_kind_label(%{kind: "rename-method"} = c), do: "rename (#{c[:side] || "?"})"
   defp change_kind_label(%{kind: kind}), do: kind
 
-  # Revert one pending method patch (BT-2293). On success the prior body is
-  # re-installed (a fresh durable entry) and the Changes pane refreshes; a
-  # non-revertable entry (new-class, class-side, no prior body) renders the
-  # structured error the workspace returns. `side` (ADR 0112, BT-3187)
-  # disambiguates a same-selector instance-side entry from a class-side one.
-  defp revert_change(socket, class, selector, side) do
-    case Facade.dispatch(:revert, %{class: class, selector: selector, side: side}, ctx(socket)) do
-      {:ok, reverted_class} ->
-        socket
-        |> assign(
-          save_result: "Reverted #{selector} on #{reverted_class}",
-          save_error: nil,
-          flush_result: nil,
-          flush_error: nil
-        )
-        |> assign_changes()
-
-      {:error, reason} ->
-        status_error(socket, facade_error(reason))
-    end
-  end
-
   # Set the active error line, clearing the other three status assigns so only
   # the most recent New Class / revert outcome shows in the shared status area
   # (BT-2293). Keeps the validation/error branches from leaving a stale flush
   # banner visible — the success branches already clear all four inline.
-  defp status_error(socket, message) do
+  # Public: shared with `BtAttachWeb.Live.Dock`'s revert/git-revert paths
+  # (BT-3295).
+  def status_error(socket, message) do
     assign(socket,
       save_result: nil,
       save_error: message,
@@ -4372,87 +3306,6 @@ defmodule BtAttachWeb.WorkspaceLive do
       flush_error: nil
     )
   end
-
-  # Drive the write-surface flush and render its summary, then refresh changes so
-  # the (now-flushed) entries drop out of the active view.
-  #
-  # The flush reconciles every pending live `>>` patch with its on-disk body, so an
-  # open `:method` tab whose patch was just written is no longer divergent — clear
-  # its `unflushed` (`disk_differs`) breadcrumb badge (BT-2545). We diff the
-  # pending method set captured *before* the flush against the set still pending
-  # *after* (`assign_changes/1` already refreshed it): the difference is exactly
-  # what this flush wrote, so a conflicted / non-flushable method keeps its badge
-  # and a method untouched by this flush is never cleared.
-  defp flush_changes(socket) do
-    was_pending = pending_method_keys(socket.assigns.changes)
-
-    case Facade.dispatch(:flush, %{}, ctx(socket)) do
-      {:ok, summary} ->
-        socket
-        |> assign(flush_result: Workspace.format_flush_summary(summary), flush_error: nil)
-        |> assign_changes()
-        |> clear_flushed_badges(was_pending)
-        # BT-2586: a flush writes pending edits to disk, so the post-flush git
-        # panel must reflect them immediately (the pre→post-flush handoff).
-        |> maybe_refresh_git()
-
-      {:error, reason} ->
-        assign(socket, flush_result: nil, flush_error: facade_error(reason))
-    end
-  end
-
-  # "Delete file" / "Apply rename" (ADR 0113 Phase 4 BT-3210, extended by ADR
-  # 0114 Phase 5 BT-3277) — the scoped Tier-2 flush for one `remove-class`/
-  # `rename-class`/`rename-method` row, submitted as `Workspace flush: #Class
-  # confirmDestructive: true` through the generic `evaluate` op (no
-  # dedicated workspace-side op, matching `remove_class`/`remove_method`
-  # above and mirroring the REPL's `:flush-destructive #Class` / MCP
-  # `flush`'s scoped `confirm_destructive: true` form). All three kinds join
-  # the same Tier 2 (ADR 0114 "Flush" reuses ADR 0113's tier verbatim), so
-  # one handler drives all three rows; only the confirmation prompt and the
-  # resulting status message differ by `kind` (`rename_flush_verb/1`).
-  #
-  # Scoped by *Symbol* (`#Class`), not the bare class name: a `remove-class`
-  # row's class name is already unbound by the time this fires (`removeFromSystem`
-  # ran first) — a bare identifier would fail to *evaluate* before the
-  # `flush:` send ever runs. `beamtalk_workspace_flush`'s filter
-  # normalisation matches a Symbol against the ChangeLog entry's recorded
-  # `class` field by name, needing no live class to resolve, so the same
-  # Symbol form works uniformly for a `rename-class`/`rename-method` row too
-  # (both still-bound, but simpler to share one code path than special-case
-  # which kind can take a bare identifier).
-  #
-  # `class` rides a `phx-value-*` attribute, so — unlike `remove_class`'s
-  # `class` (read from server-tracked active-tab state) — it is
-  # client-controlled input reaching a raw, textually-interpolated Beamtalk
-  # expression: validated against the same bare-PascalCase-identifier shape
-  # `validate_new_class_name`/`validate_superclass` already enforce for the
-  # New Class modal's class-name fields (`@new_class_name_re`), so a crafted
-  # event cannot inject arbitrary source into the `evaluate` call.
-  defp flush_destructive(socket, class, kind) do
-    if Regex.match?(@new_class_name_re, class) do
-      expr = "Workspace flush: ##{class} confirmDestructive: true"
-      pid = socket.assigns[:session_pid]
-
-      if not is_pid(pid) do
-        status_error(socket, "not attached to workspace")
-      else
-        flush_destructive_eval(socket, class, kind, expr, pid)
-      end
-    else
-      status_error(socket, "Invalid class name.")
-    end
-  end
-
-  # The past-tense status line for a completed Tier-2 flush, by `kind` — an
-  # unrecognised future kind falls back to a generic phrase rather than
-  # crashing, matching `change_kind_label/1`'s own fallback.
-  defp rename_flush_message("rename-class", class), do: "Flushed the pending rename to #{class}"
-
-  defp rename_flush_message("rename-method", class),
-    do: "Flushed the pending method rename on #{class}"
-
-  defp rename_flush_message(_kind, class), do: "Flushed the pending removal for #{class}"
 
   # The `data-confirm` prompt for the "apply rename" button (ADR 0114 Phase
   # 5, BT-3277) — mirrors "delete file"'s prompt above, worded per kind since
@@ -4466,36 +3319,14 @@ defmodule BtAttachWeb.WorkspaceLive do
     "Rename #{c.selector} on #{c.class}#{if c[:side] == "class", do: " class", else: ""} on disk? This edits one or more files and cannot be undone from here (use \"revert\" first if you change your mind)."
   end
 
-  defp flush_destructive_eval(socket, class, kind, expr, pid) do
-    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
-      {:ok, _term, _output, _warnings} ->
-        socket
-        |> assign(
-          save_result: nil,
-          save_error: nil,
-          flush_result: rename_flush_message(kind, class),
-          flush_error: nil
-        )
-        |> assign_changes()
-        # BT-2586: a successful destructive flush can delete a tracked file,
-        # so the git panel must reflect it immediately, same as an ordinary
-        # "Save All to Disk" flush.
-        |> maybe_refresh_git()
-
-      {:error, reason, _output, _warnings} ->
-        status_error(socket, Workspace.render_error(reason))
-
-      {:error, reason} ->
-        status_error(socket, facade_error(reason))
-    end
-  end
-
   # Refresh the git panel only when it is the active dock tab. A flush that
   # happens while the user is on another tab leaves git untouched (it reloads
   # lazily on next open), so the common edit loop never pays for an extra git
   # shell-out it can't see. Used by the flush path, which always changes disk.
-  defp maybe_refresh_git(socket) do
-    if socket.assigns.dock_tab == "git", do: assign_git(socket), else: socket
+  # Public: shared with `BtAttachWeb.Live.Dock`'s flush paths (BT-3295) — the
+  # git panel's own `assign_git/1` now lives there.
+  def maybe_refresh_git(socket) do
+    if socket.assigns.dock_tab == "git", do: Dock.assign_git(socket), else: socket
   end
 
   # BT-2590 (S2): refresh the git panel after a *save* only when autoflush is on.
@@ -4562,20 +3393,6 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp tab_disk_key(%{kind: :def, class: class}), do: {class, :def}
   defp tab_disk_key(_tab), do: nil
 
-  # After a flush, clear the `unflushed` badge on the `:method` tabs this flush wrote
-  # to disk (BT-2545), scoped by `flushed_method_keys/3` so conflicts / skips keep
-  # their badge and methods untouched by this flush are never cleared.
-  defp clear_flushed_badges(socket, was_pending) do
-    flushed =
-      flushed_method_keys(was_pending, socket.assigns.changes, socket.assigns[:changes_error])
-
-    if MapSet.size(flushed) == 0 do
-      socket
-    else
-      assign(socket, :tabs, clear_disk_differs(socket.assigns.tabs, flushed))
-    end
-  end
-
   # Read the active ChangeLog ("Workspace changes", ADR 0082) and assign display
   # rows. A workspace that is unreachable or returns an unexpected shape renders an
   # error rather than crashing the pane.
@@ -4583,7 +3400,9 @@ defmodule BtAttachWeb.WorkspaceLive do
   # Split into the off-socket read (`read_changes/1`) + the pure on-socket fold
   # (`apply_changes/2`) so the mount-time async load (BT-2591) and the post-action
   # refresh callers share one fold. The sync helper keeps its old signature.
-  defp assign_changes(socket), do: apply_changes(socket, read_changes(socket))
+  # Public: shared with `BtAttachWeb.Live.Dock`'s eval/REPL/Changes/git paths
+  # (BT-3295).
+  def assign_changes(socket), do: apply_changes(socket, read_changes(socket))
 
   # The raw `:changes` dispatch result — runs off the LiveView process in the
   # mount-load task, so it captures only `ctx`, never `socket`.
@@ -4668,7 +3487,9 @@ defmodule BtAttachWeb.WorkspaceLive do
   # dock tab (a revert's reload follows a disk change git should reflect too).
   # Driven by the `classes` push handler, so a git revert, another session's
   # flush, or an external edit reloaded into the image all converge here.
-  defp refresh_after_source_change(socket) do
+  # Public: `BtAttachWeb.Live.Dock`'s `git_revert_event/2` (BT-3295) calls it
+  # directly.
+  def refresh_after_source_change(socket) do
     socket
     |> assign_browser_classes()
     |> assign_changes()
@@ -4829,75 +3650,6 @@ defmodule BtAttachWeb.WorkspaceLive do
     end
   end
 
-  # ── Git panel data source (ADR 0082 Amendment 1, BT-2586) ────────────────────
-
-  # Load the post-flush git surface: working-tree status + recent log from real
-  # git on the workspace project root.
-  #
-  # BT-2590 (S1): both git ops cross the node boundary into the workspace's
-  # `collect/5` loop, each bounded by the workspace's `GIT_TIMEOUT_MS = 30_000`, so
-  # a hung git could otherwise leave the LiveView socket unresponsive for ~60s per
-  # call — blocking tab switches, saves, and clicks. We therefore run the two reads
-  # off-socket in a single `start_async` task: the socket stays responsive while
-  # git runs, the panel shows its "Loading git status…" placeholder, and the
-  # results land in `handle_async(:git_load, …)`. A rapid second Refresh first
-  # `cancel_async`-es the in-flight load (killing the LiveView-side Task so only
-  # the latest load can update the panel — the workspace-side RPC may still
-  # complete, but its response is discarded) and then starts the fresh
-  # one — only the latest load wins the panel, and the LiveView is never blocked.
-  #
-  # A workspace that is unreachable, not a git repo, or missing `git` renders an
-  # error rather than crashing the pane — the graceful-degradation requirement. We
-  # clear any stale per-file diff and reset to the loading state on each refresh.
-  defp assign_git(socket) do
-    ctx = ctx(socket)
-
-    socket
-    |> assign(git_diff_path: nil, git_diff: nil, git_status: nil, git_log: [], git_error: nil)
-    |> cancel_async(:git_load, :cancelled)
-    |> start_async(:git_load, fn ->
-      # Runs in a Task off the LiveView process — never touch `socket` here, only
-      # the captured `ctx`. Both reads are gathered so the panel updates atomically.
-      {Facade.dispatch(:git_status, %{}, ctx), Facade.dispatch(:git_log, %{count: 20}, ctx)}
-    end)
-  end
-
-  # Apply a completed git status read to the socket. Pure (no dispatch); shared by
-  # `handle_async/3` so the async result path and any future sync caller agree.
-  # Kept total — an unexpected shape (an off-vocabulary facade reply, a malformed
-  # status) degrades to a panel error rather than crashing the LiveView.
-  defp apply_git_status(socket, {:ok, status}) when is_map(status),
-    do: assign(socket, git_status: status, git_error: nil)
-
-  defp apply_git_status(socket, {:error, reason}),
-    do: assign(socket, git_status: nil, git_error: facade_error(reason))
-
-  defp apply_git_status(socket, _other),
-    do: assign(socket, git_status: nil, git_error: facade_error(:unexpected_git_status))
-
-  # Apply a completed git log read.
-  defp apply_git_log(socket, {:ok, commits}) when is_list(commits),
-    do: assign(socket, git_log: commits)
-
-  defp apply_git_log(socket, {:error, reason}),
-    do: log_failed(socket, facade_error(reason))
-
-  defp apply_git_log(socket, _other),
-    do: log_failed(socket, facade_error(:unexpected_git_log))
-
-  # A git-log read failed. Clear the list, and surface the error only if the
-  # status read hasn't already reported one — when both fail together the status
-  # pane already shows the degraded state, but a fast status beside an
-  # independently-failed log (e.g. a large-history timeout) would otherwise leave
-  # a valid branch next to a mysteriously empty commit list with no explanation.
-  defp log_failed(socket, error) do
-    socket = assign(socket, git_log: [])
-
-    if socket.assigns.git_error,
-      do: socket,
-      else: assign(socket, git_error: error)
-  end
-
   # BT-2590 (S2): read the workspace `autoflush` flag once at mount via the read
   # facade (so RBAC/audit apply uniformly). The client defaults a degraded read to
   # `false`, and an off-vocabulary/denied dispatch (`{:error, _}`) also falls back
@@ -4969,14 +3721,6 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   # ── Test-runner pane data source (BT-2557) ──────────────────────────────────
 
-  # Load the test catalogue once (lazy first open of the Tests tab). Re-opening
-  # the tab keeps the already-loaded list — use `tests_refresh` to re-discover.
-  defp ensure_test_classes(socket) do
-    if is_nil(socket.assigns.test_classes),
-      do: discover_test_classes(socket),
-      else: socket
-  end
-
   # Discover the live image's TestCase subclasses + selectors (`list_tests`,
   # `:read`). Although `:read` reflection is usually fast, it is still a blocking
   # workspace RPC: against a slow/unresponsive node the ~5s timeout would stall
@@ -4992,7 +3736,10 @@ defmodule BtAttachWeb.WorkspaceLive do
   # already populated `tests_error` with its compile-error summary, and a
   # *successful* discovery must NOT clear it (it would swallow the partial-load
   # banner). The flag rides a transient assign that `handle_async/3` consumes.
-  defp discover_test_classes(socket, keep_error? \\ false) do
+  # Public: `BtAttachWeb.Live.Dock`'s `ensure_test_classes/1` (BT-3295, the
+  # `dock_tab`/`:test` meta-command lazy-load) calls it directly — the Tests
+  # pane's own events haven't been extracted out of this module yet.
+  def discover_test_classes(socket, keep_error? \\ false) do
     ctx = ctx(socket)
 
     socket
@@ -5430,8 +4177,11 @@ defmodule BtAttachWeb.WorkspaceLive do
   # one per locally-defined selector (instance- and class-side). Each row carries
   # the identity the popover needs to open it — a class row opens the System
   # Browser, a selector row opens an editable method tab. A dispatch failure /
-  # RBAC denial yields an empty index rather than crashing the search.
-  defp symbol_rows(socket) do
+  # RBAC denial yields an empty index rather than crashing the search. Public:
+  # `BtAttachWeb.Live.Dock`'s REPL `:help <Class>` meta-command (BT-3295)
+  # calls it directly — the System Browser hasn't been extracted out of this
+  # module yet (BT-3297).
+  def symbol_rows(socket) do
     case Facade.dispatch(:symbols, %{scope: "all"}, ctx(socket)) do
       {:value, %{"classes" => classes}} when is_list(classes) ->
         Enum.flat_map(classes, &class_symbol_rows/1)
@@ -5494,8 +4244,10 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   # Open a class in the System Browser (the omni-search "class" result): select it
   # in the tree and load its protocols for the current side, exactly as a click in
-  # the class tree would.
-  defp open_class(socket, class) do
+  # the class tree would. Public: `BtAttachWeb.Live.Dock`'s REPL `:help` /
+  # `Beamtalk help:` follow-up (BT-3295) calls it directly (System Browser not
+  # yet extracted, BT-3297).
+  def open_class(socket, class) do
     socket
     |> assign(selected_class: class, selected_protocol: nil)
     |> load_protocols(class, socket.assigns.browser_side)
@@ -8753,7 +7505,9 @@ defmodule BtAttachWeb.WorkspaceLive do
                     </span>
                     <span class="spacer"></span>
                     <span :if={@dock_tab == "workspace"} class="count">
-                      {if ws_selection?(assigns), do: "evaluates selection", else: "evaluates buffer"}
+                      {if Dock.ws_selection?(assigns),
+                        do: "evaluates selection",
+                        else: "evaluates buffer"}
                     </span>
                     <button
                       type="button"
@@ -8802,7 +7556,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                              submit a stale value). ⌘D/⌘P/⌘I ride the form's
                              KeyboardShortcuts hook (keydown bubbles out). --%>
                         <div
-                          id={workspace_editor_id()}
+                          id={Dock.workspace_editor_id()}
                           class="cm-wrap ws-wrap"
                           phx-hook="CmEditor"
                           data-select-event="select_workspace"
@@ -8907,7 +7661,9 @@ defmodule BtAttachWeb.WorkspaceLive do
                           <span class="repl-arrow">→</span>
                           <%= if entry.long do %>
                             <details class="repl-collapse">
-                              <summary class="repl-summary">{repl_preview(entry.response)}</summary>
+                              <summary class="repl-summary">
+                                {Dock.repl_preview(entry.response)}
+                              </summary>
                               <span class="repl-val">{entry.response}</span>
                             </details>
                           <% else %>
@@ -8936,7 +7692,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                            like the Workspace eval form. --%>
                       <form id="repl-form" class="repl-input-form" phx-submit="repl_eval">
                         <div
-                          id={repl_input_id()}
+                          id={Dock.repl_input_id()}
                           class="cm-wrap repl-wrap"
                           phx-hook="ReplInput"
                           data-placeholder="Evaluate an expression…"

--- a/editors/liveview/test/bt_attach_web/dock_test.exs
+++ b/editors/liveview/test/bt_attach_web/dock_test.exs
@@ -1,0 +1,500 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.Live.DockTest do
+  @moduledoc """
+  Direct unit tests for `BtAttachWeb.Live.Dock` (BT-3295), driving its
+  `handle_event/3` / `handle_async/3` clauses and pure helpers against a
+  hand-built `%Phoenix.LiveView.Socket{}` and the fully-stubbed workspace
+  client (`BtAttachWeb.StubWorkspaceClient`, BT-2554) — no full LiveView
+  mount, no real workspace node. Mirrors `BtAttachWeb.Live.InspectorTest`
+  (BT-3291), the precedent this extraction follows.
+
+  Covers the branches BT-3295's acceptance criteria calls out specifically:
+  the REPL history ring at the composer's edges, eval action routing (Do
+  it/Print it/Inspect it), the git stage/unstage/commit/revert error paths,
+  and the destructive-flush confirmation path — previously reachable only
+  through the `:workspace`-tagged full-stack `WorkspaceLiveTest`, which needs
+  a live workspace node and is excluded from the default `mix test` lane.
+  """
+  use ExUnit.Case, async: false
+
+  alias BtAttachWeb.Live.Dock
+  alias BtAttachWeb.StubWorkspaceClient
+
+  setup do
+    Application.put_env(:bt_attach, :workspace_client, StubWorkspaceClient)
+    {:ok, _} = StubWorkspaceClient.start_state()
+
+    on_exit(fn ->
+      Application.delete_env(:bt_attach, :workspace_client)
+      StubWorkspaceClient.stop_state(2_000)
+    end)
+
+    :ok
+  end
+
+  # A bare, disconnected socket carrying exactly the assigns Dock's functions
+  # read — the subset of `WorkspaceLive.bind_session/3`'s init relevant to the
+  # eval/REPL/Changes/Git dock. `role: :owner` by default (most tests aren't
+  # about RBAC); override per test. Disconnected (`Phoenix.LiveView.connected?/1`
+  # is false), so `start_async`/`cancel_async` (the git panel's async load)
+  # degrade to synchronous no-ops rather than spawning a linked Task — exactly
+  # the behaviour `Phoenix.LiveView.Async` documents for a disconnected socket,
+  # so `assign_git/1`'s synchronous reset assigns are still directly
+  # assertable. The `:repl` stream is pre-configured (`Phoenix.LiveView.stream/3`)
+  # since `stream_insert/3` raises against an unconfigured stream name.
+  defp base_socket(overrides \\ %{}) do
+    assigns =
+      %{
+        __changed__: %{},
+        current_user: nil,
+        role: :owner,
+        session_id: "sess-1",
+        session_pid: self(),
+        dock_tab: "workspace",
+        result: nil,
+        output: nil,
+        error: nil,
+        expr: "3 + 4",
+        eval_seq: 0,
+        ws_selection: nil,
+        inspector_mode: "docked",
+        inspect_target: nil,
+        inspect_rows: [],
+        inspect_crumbs: [],
+        inspect_error: nil,
+        inspect_watch: nil,
+        inspect_stats: nil,
+        inspect_frozen: false,
+        flash_gen: 0,
+        refresh_pending: false,
+        poke_result: nil,
+        poke_error: nil,
+        windows: [],
+        window_z: 10,
+        next_window_id: 1,
+        repl_seq: 0,
+        repl_terms: %{},
+        repl_history: [],
+        repl_history_pos: nil,
+        changes: [],
+        changes_error: nil,
+        expanded_changes: MapSet.new(),
+        browser_classes: [],
+        tabs: [],
+        autoflush: false,
+        git_status: nil,
+        git_log: [],
+        git_error: nil,
+        git_diff: nil,
+        git_diff_path: nil,
+        flush_result: nil,
+        flush_error: nil,
+        save_result: nil,
+        save_error: nil,
+        test_classes: nil
+      }
+      |> Map.merge(overrides)
+
+    %Phoenix.LiveView.Socket{
+      assigns: assigns,
+      private: %{live_temp: %{}, lifecycle: %Phoenix.LiveView.Lifecycle{}}
+    }
+    |> Phoenix.LiveView.stream(:repl, [])
+  end
+
+  describe "eval action routing (Do it / Print it / Inspect it)" do
+    test "do_it evaluates for side effects and shows a terse confirmation, no buffer insert" do
+      {:noreply, socket} =
+        Dock.handle_event("eval", %{"expr" => "1 + 1", "action" => "do_it"}, base_socket())
+
+      assert socket.assigns.result == "✓ evaluated"
+      assert socket.assigns.error == nil
+      # `eval_status/4` bumps the re-key sequence on every success.
+      assert socket.assigns.eval_seq == 1
+      # do_it never pushes the inline-insert event (print_it's affordance).
+      assert socket.private.live_temp[:push_events] in [nil, []]
+    end
+
+    test "print_it (default, no action field) inserts the result inline and flashes the status" do
+      {:noreply, socket} = Dock.handle_event("eval", %{"expr" => "1 + 1"}, base_socket())
+
+      assert socket.assigns.result =~ "→ "
+
+      assert [["ws_insert_result", %{text: _, target: "workspace-editor-overlay"}]] =
+               socket.private.live_temp[:push_events]
+    end
+
+    test "inspect_it evaluates then opens the result in the docked Inspector" do
+      {:noreply, socket} =
+        Dock.handle_event("eval", %{"expr" => "1 + 1", "action" => "inspect_it"}, base_socket())
+
+      assert socket.assigns.result =~ "→ "
+      # Inspector.inspect_term/4 ran against the eval's result term (a scalar
+      # stub value) and set the docked pane's target.
+      assert socket.assigns.inspect_target != nil
+      assert socket.assigns.inspect_crumbs == [%{label: "→ result", term: "stub-result"}]
+    end
+
+    test "inspect_it in float mode opens a floating window instead of the docked pane" do
+      {:noreply, socket} =
+        Dock.handle_event(
+          "eval",
+          %{"expr" => "1 + 1", "action" => "inspect_it"},
+          base_socket(%{inspector_mode: "float"})
+        )
+
+      assert socket.assigns.inspect_target == nil
+      assert [%{label: "→ result"}] = socket.assigns.windows
+    end
+
+    test "no session (attach failed) reports 'not attached' rather than crashing" do
+      socket = base_socket(%{session_pid: nil})
+
+      {:noreply, socket} = Dock.handle_event("eval", %{"expr" => "1 + 1"}, socket)
+
+      assert socket.assigns.error == "not attached to workspace"
+      assert socket.assigns.result == nil
+    end
+
+    test "an RBAC-denied eval (Observer) surfaces the facade's short-circuit error" do
+      {:noreply, socket} =
+        Dock.handle_event("eval", %{"expr" => "1 + 1"}, base_socket(%{role: :observer}))
+
+      assert socket.assigns.error =~ "not"
+      assert socket.assigns.result == nil
+    end
+  end
+
+  describe "select_workspace" do
+    test "a well-formed selection is tracked separately from the method editor's" do
+      {:noreply, socket} =
+        Dock.handle_event(
+          "select_workspace",
+          %{"text" => "1 + 1", "start" => 0, "end" => 5},
+          base_socket()
+        )
+
+      assert socket.assigns.ws_selection == %{text: "1 + 1", start: 0, end: 5}
+    end
+
+    test "a malformed payload is a no-op" do
+      socket = base_socket()
+
+      assert {:noreply, ^socket} = Dock.handle_event("select_workspace", %{}, socket)
+    end
+  end
+
+  describe "REPL history ring at the composer's edges" do
+    test "↑ walks back through the ring; ↓ past the newest restores the live input" do
+      socket = base_socket(%{repl_history: ["third", "second", "first"], repl_history_pos: nil})
+
+      # First ↑: the most recent entry.
+      {:noreply, socket} = Dock.handle_event("repl_history_prev", %{}, socket)
+      assert socket.assigns.repl_history_pos == 0
+      assert [["repl_set_input", %{text: "third"}]] = socket.private.live_temp[:push_events]
+
+      socket = clear_push_events(socket)
+
+      # Second ↑: one further back.
+      {:noreply, socket} = Dock.handle_event("repl_history_prev", %{}, socket)
+      assert socket.assigns.repl_history_pos == 1
+      assert [["repl_set_input", %{text: "second"}]] = socket.private.live_temp[:push_events]
+
+      socket = clear_push_events(socket)
+
+      # A further ↑ at the oldest entry clamps — does not walk off the ring.
+      {:noreply, socket} = Dock.handle_event("repl_history_prev", %{}, socket)
+      {:noreply, socket} = Dock.handle_event("repl_history_prev", %{}, socket)
+      assert socket.assigns.repl_history_pos == 2
+
+      socket = clear_push_events(socket)
+
+      # Walking ↓ back past the newest restores the empty live input (pos: nil).
+      # `push_event/3` prepends, so the LAST push (the empty-input restore) is
+      # the head of the accumulated list.
+      {:noreply, socket} = Dock.handle_event("repl_history_next", %{}, socket)
+      {:noreply, socket} = Dock.handle_event("repl_history_next", %{}, socket)
+      {:noreply, socket} = Dock.handle_event("repl_history_next", %{}, socket)
+      assert socket.assigns.repl_history_pos == nil
+      assert [["repl_set_input", %{text: ""}] | _] = socket.private.live_temp[:push_events]
+    end
+
+    test "↓ at the live input (pos: nil) is a no-op — never disturbs an in-progress draft" do
+      socket = base_socket(%{repl_history: ["only"], repl_history_pos: nil})
+
+      {:noreply, result} = Dock.handle_event("repl_history_next", %{}, socket)
+
+      assert result == socket
+    end
+
+    test "an empty ring is a no-op for both directions" do
+      socket = base_socket(%{repl_history: []})
+
+      assert {:noreply, ^socket} = Dock.handle_event("repl_history_prev", %{}, socket)
+      assert {:noreply, ^socket} = Dock.handle_event("repl_history_next", %{}, socket)
+    end
+
+    test "a crafted history recall during the attach-failure window (no :repl_history) is a no-op" do
+      socket = %Phoenix.LiveView.Socket{assigns: %{__changed__: %{}}}
+
+      assert {:noreply, ^socket} = Dock.handle_event("repl_history_prev", %{}, socket)
+      assert {:noreply, ^socket} = Dock.handle_event("repl_history_next", %{}, socket)
+    end
+
+    defp clear_push_events(socket), do: put_in(socket.private.live_temp[:push_events], [])
+  end
+
+  describe "repl_eval" do
+    test "a successful eval appends a › request / → response pair and records history" do
+      {:noreply, socket} = Dock.handle_event("repl_eval", %{"expr" => "1 + 1"}, base_socket())
+
+      assert socket.assigns.repl_seq == 1
+      assert socket.assigns.repl_history == ["1 + 1"]
+      assert map_size(socket.assigns.repl_terms) == 1
+    end
+
+    test "an empty submit is a no-op — never appends a blank entry" do
+      socket = base_socket()
+
+      assert {:noreply, ^socket} = Dock.handle_event("repl_eval", %{"expr" => "   "}, socket)
+    end
+
+    test "a `:help` meta-command appends an info entry instead of evaluating" do
+      {:noreply, socket} = Dock.handle_event("repl_eval", %{"expr" => ":help"}, base_socket())
+
+      assert socket.assigns.repl_seq == 1
+      # Meta-commands never reach `eval` (no live term stashed).
+      assert socket.assigns.repl_terms == %{}
+    end
+
+    test "a `:test` meta-command switches the dock to the Tests tab" do
+      {:noreply, socket} = Dock.handle_event("repl_eval", %{"expr" => ":test"}, base_socket())
+
+      assert socket.assigns.dock_tab == "tests"
+    end
+  end
+
+  describe "dock_tab" do
+    test "switching to changes refreshes the ChangeLog" do
+      {:noreply, socket} = Dock.handle_event("dock_tab", %{"tab" => "changes"}, base_socket())
+
+      assert socket.assigns.dock_tab == "changes"
+      assert socket.assigns.changes == []
+    end
+
+    test "switching to git resets the panel to its loading state" do
+      socket =
+        base_socket(%{git_status: %{branch: "stale"}, git_diff_path: "src/Foo.bt"})
+
+      {:noreply, socket} = Dock.handle_event("dock_tab", %{"tab" => "git"}, socket)
+
+      assert socket.assigns.dock_tab == "git"
+      assert socket.assigns.git_status == nil
+      assert socket.assigns.git_diff_path == nil
+    end
+
+    test "an unknown tab is ignored rather than blanking the dock" do
+      socket = base_socket()
+
+      assert {:noreply, ^socket} = Dock.handle_event("dock_tab", %{"tab" => "bogus"}, socket)
+    end
+  end
+
+  describe "git panel — stage/unstage/commit/revert error paths" do
+    test "git_stage is refused for the Observer role (RBAC gate)" do
+      {:noreply, socket} =
+        Dock.handle_event(
+          "git_stage",
+          %{"path" => "src/Foo.bt"},
+          base_socket(%{role: :observer})
+        )
+
+      assert socket.assigns.git_error != nil
+    end
+
+    test "git_unstage is refused for the Observer role" do
+      {:noreply, socket} =
+        Dock.handle_event(
+          "git_unstage",
+          %{"path" => "src/Foo.bt"},
+          base_socket(%{role: :observer})
+        )
+
+      assert socket.assigns.git_error != nil
+    end
+
+    test "git_commit is refused for the Observer role" do
+      {:noreply, socket} =
+        Dock.handle_event(
+          "git_commit",
+          %{"message" => "fix"},
+          base_socket(%{role: :observer})
+        )
+
+      assert socket.assigns.git_error != nil
+    end
+
+    test "git_commit with a blank message is a validation error, no dispatch" do
+      {:noreply, socket} =
+        Dock.handle_event("git_commit", %{"message" => "   "}, base_socket())
+
+      assert socket.assigns.git_error == "Enter a commit message."
+    end
+
+    test "git_revert is blocked while the path has unflushed in-memory ChangeLog edits" do
+      socket =
+        base_socket(%{
+          changes: [%{class: "Foo", selector: "bar"}],
+          browser_classes: [%{"name" => "Foo", "source_file" => "src/Foo.bt"}]
+        })
+
+      {:noreply, socket} =
+        Dock.handle_event("git_revert", %{"path" => "src/Foo.bt"}, socket)
+
+      assert socket.assigns.git_error =~ "unflushed in-memory edits"
+    end
+
+    test "a malformed git_diff payload surfaces a validation error, not a crash" do
+      {:noreply, socket} = Dock.handle_event("git_diff", %{}, base_socket())
+
+      assert socket.assigns.git_error == "Invalid diff request."
+    end
+
+    test "a malformed git_stage payload surfaces a validation error" do
+      {:noreply, socket} = Dock.handle_event("git_stage", %{}, base_socket())
+
+      assert socket.assigns.git_error == "Invalid stage request."
+    end
+
+    test "git_refresh resets the panel to its loading state" do
+      socket = base_socket(%{git_error: "stale error"})
+
+      {:noreply, socket} = Dock.handle_event("git_refresh", %{}, socket)
+
+      assert socket.assigns.git_error == nil
+      assert socket.assigns.git_status == nil
+    end
+  end
+
+  describe "destructive-flush confirmation path" do
+    test "a non-owner (Observer) click is a no-op — the button isn't even rendered for them" do
+      socket = base_socket(%{role: :observer})
+
+      assert {:noreply, ^socket} =
+               Dock.handle_event("flush_destructive", %{"class" => "Foo"}, socket)
+    end
+
+    test "a crafted event with a missing class is a no-op" do
+      socket = base_socket()
+
+      assert {:noreply, ^socket} = Dock.handle_event("flush_destructive", %{}, socket)
+    end
+
+    test "an invalid (non-PascalCase) class name is rejected before any dispatch" do
+      {:noreply, socket} =
+        Dock.handle_event("flush_destructive", %{"class" => "not_a_class!"}, base_socket())
+
+      assert socket.assigns.save_error == "Invalid class name."
+    end
+
+    test "no session (attach failed) reports 'not attached'" do
+      socket = base_socket(%{session_pid: nil})
+
+      {:noreply, socket} =
+        Dock.handle_event("flush_destructive", %{"class" => "Foo"}, socket)
+
+      assert socket.assigns.save_error == "not attached to workspace"
+    end
+
+    test "a successful destructive flush of a remove-class row reports the default message" do
+      {:noreply, socket} =
+        Dock.handle_event("flush_destructive", %{"class" => "Foo"}, base_socket())
+
+      assert socket.assigns.flush_result == "Flushed the pending removal for Foo"
+      assert socket.assigns.flush_error == nil
+    end
+
+    test "a successful destructive flush of a rename-class row reports the rename message" do
+      {:noreply, socket} =
+        Dock.handle_event(
+          "flush_destructive",
+          %{"class" => "Foo", "kind" => "rename-class"},
+          base_socket()
+        )
+
+      assert socket.assigns.flush_result == "Flushed the pending rename to Foo"
+    end
+  end
+
+  describe "flush / revert / toggle_change_diff" do
+    test "flush drives the write-surface flush and renders its summary" do
+      {:noreply, socket} = Dock.handle_event("flush", %{}, base_socket())
+
+      assert socket.assigns.flush_result != nil
+      assert socket.assigns.flush_error == nil
+    end
+
+    test "revert re-installs the prior body and refreshes the Changes pane" do
+      {:noreply, socket} =
+        Dock.handle_event(
+          "revert",
+          %{"class" => "Foo", "selector" => "bar"},
+          base_socket()
+        )
+
+      assert socket.assigns.save_result =~ "Reverted bar on Foo"
+      assert socket.assigns.save_error == nil
+    end
+
+    test "a malformed revert payload surfaces a validation error" do
+      {:noreply, socket} = Dock.handle_event("revert", %{}, base_socket())
+
+      assert socket.assigns.save_error == "Invalid revert request."
+    end
+
+    test "toggle_change_diff flips a row's expanded key in and back out" do
+      params = %{"class" => "Foo", "selector" => "bar"}
+      socket = base_socket()
+
+      {:noreply, socket} = Dock.handle_event("toggle_change_diff", params, socket)
+      assert MapSet.member?(socket.assigns.expanded_changes, {"Foo", "bar", nil})
+
+      {:noreply, socket} = Dock.handle_event("toggle_change_diff", params, socket)
+      refute MapSet.member?(socket.assigns.expanded_changes, {"Foo", "bar", nil})
+    end
+  end
+
+  describe "handle_async(:git_load, …)" do
+    test "a successful load folds the status + log into the panel assigns" do
+      status = %{branch: "main", upstream: nil, ahead: 0, behind: 0, files: []}
+
+      {:noreply, socket} =
+        Dock.handle_async(
+          :git_load,
+          {:ok, {{:ok, status}, {:ok, [%{sha: "abc"}]}}},
+          base_socket()
+        )
+
+      assert socket.assigns.git_status == status
+      assert socket.assigns.git_log == [%{sha: "abc"}]
+      assert socket.assigns.git_error == nil
+    end
+
+    test "a cancelled load is a no-op" do
+      socket = base_socket()
+
+      assert {:noreply, ^socket} = Dock.handle_async(:git_load, {:exit, :cancelled}, socket)
+    end
+
+    test "a crashed load surfaces a panel error and clears stale data" do
+      {:noreply, socket} =
+        Dock.handle_async(:git_load, {:exit, :boom}, base_socket(%{git_log: [%{sha: "stale"}]}))
+
+      assert socket.assigns.git_status == nil
+      assert socket.assigns.git_log == []
+      assert socket.assigns.git_error =~ "failed unexpectedly"
+    end
+  end
+end

--- a/editors/liveview/test/bt_attach_web/dock_test.exs
+++ b/editors/liveview/test/bt_attach_web/dock_test.exs
@@ -113,8 +113,11 @@ defmodule BtAttachWeb.Live.DockTest do
       assert socket.assigns.error == nil
       # `eval_status/4` bumps the re-key sequence on every success.
       assert socket.assigns.eval_seq == 1
-      # do_it never pushes the inline-insert event (print_it's affordance).
-      assert socket.private.live_temp[:push_events] in [nil, []]
+      # do_it never pushes the inline-insert event (print_it's affordance) —
+      # assert the specific event is absent rather than the whole push list,
+      # so an unrelated future push doesn't make this pass vacuously.
+      pushed_events = socket.private.live_temp[:push_events] || []
+      refute Enum.any?(pushed_events, &match?(["ws_insert_result", _], &1))
     end
 
     test "print_it (default, no action field) inserts the result inline and flashes the status" do
@@ -399,6 +402,20 @@ defmodule BtAttachWeb.Live.DockTest do
       assert socket.assigns.save_error == "Invalid class name."
     end
 
+    test "a class name shaped as an injection attempt is rejected — `valid_class_name?/1` is the only guard before it is interpolated into a raw `evaluate` expression" do
+      {:noreply, socket} =
+        Dock.handle_event(
+          "flush_destructive",
+          %{"class" => "Foo. Session current clear"},
+          base_socket()
+        )
+
+      assert socket.assigns.save_error == "Invalid class name."
+      # The flush_result stays nil: rejected before any eval dispatch, so
+      # nothing this class-shape check exists to prevent actually ran.
+      assert socket.assigns.flush_result == nil
+    end
+
     test "no session (attach failed) reports 'not attached'" do
       socket = base_socket(%{session_pid: nil})
 
@@ -495,6 +512,136 @@ defmodule BtAttachWeb.Live.DockTest do
       assert socket.assigns.git_status == nil
       assert socket.assigns.git_log == []
       assert socket.assigns.git_error =~ "failed unexpectedly"
+    end
+  end
+
+  describe "repl_inspect" do
+    test "docked mode inspects the stashed REPL result term" do
+      socket = base_socket(%{repl_terms: %{"repl-entry-1" => 42}})
+
+      {:noreply, socket} =
+        Dock.handle_event("repl_inspect", %{"id" => "repl-entry-1"}, socket)
+
+      assert socket.assigns.inspect_target != nil
+      assert socket.assigns.inspect_crumbs == [%{label: "REPL result", term: 42}]
+    end
+
+    test "float mode opens a floating window instead of the docked pane" do
+      socket =
+        base_socket(%{repl_terms: %{"repl-entry-1" => 42}, inspector_mode: "float"})
+
+      {:noreply, socket} =
+        Dock.handle_event("repl_inspect", %{"id" => "repl-entry-1"}, socket)
+
+      assert socket.assigns.inspect_target == nil
+      assert [%{label: "REPL result"}] = socket.assigns.windows
+    end
+
+    test "an unknown / stale entry id is a no-op, not a crash" do
+      socket = base_socket(%{repl_terms: %{}})
+
+      assert {:noreply, ^socket} =
+               Dock.handle_event("repl_inspect", %{"id" => "repl-entry-99"}, socket)
+    end
+  end
+
+  describe "eval target — tracked selection vs whole buffer" do
+    test "a non-blank selection is evaluated instead of the submitted expr" do
+      socket = base_socket(%{ws_selection: %{text: "Object subclass: Foo", start: 0, end: 20}})
+
+      {:noreply, socket} = Dock.handle_event("eval", %{"expr" => "ignored buffer text"}, socket)
+
+      # The stub only recognises a class-defining send, so the result
+      # reflects the SELECTION having been evaluated, not the literal expr.
+      assert socket.assigns.result =~ "Foo"
+    end
+
+    test "a blank/whitespace-only selection falls back to the submitted expr" do
+      socket = base_socket(%{ws_selection: %{text: "   ", start: 0, end: 3}})
+
+      {:noreply, socket} =
+        Dock.handle_event("eval", %{"expr" => "Object subclass: Bar"}, socket)
+
+      assert socket.assigns.result =~ "Bar"
+    end
+  end
+
+  describe "git panel mutations — success path (Owner)" do
+    test "git_stage dispatches to the workspace and refreshes the panel" do
+      {:noreply, socket} =
+        Dock.handle_event("git_stage", %{"path" => "src/Foo.bt"}, base_socket())
+
+      assert socket.assigns.git_error == nil
+      assert {:git_stage, "src/Foo.bt"} in StubWorkspaceClient.calls()
+    end
+
+    test "git_unstage dispatches to the workspace" do
+      {:noreply, socket} =
+        Dock.handle_event("git_unstage", %{"path" => "src/Foo.bt"}, base_socket())
+
+      assert socket.assigns.git_error == nil
+      assert {:git_unstage, "src/Foo.bt"} in StubWorkspaceClient.calls()
+    end
+
+    test "git_commit dispatches to the workspace with the message" do
+      {:noreply, socket} =
+        Dock.handle_event("git_commit", %{"message" => "fix bug"}, base_socket())
+
+      assert socket.assigns.git_error == nil
+      assert {:git_commit, "fix bug"} in StubWorkspaceClient.calls()
+    end
+  end
+
+  describe "flush clears the unflushed badge on only the tabs it actually wrote" do
+    test "a method whose entry stopped being pending is cleared; an unrelated dirty tab is not" do
+      tabs = [
+        %{kind: :method, class: "Foo", selector: "bar", disk_differs: true},
+        %{kind: :method, class: "Foo", selector: "untouched", disk_differs: true}
+      ]
+
+      socket = base_socket(%{changes: [%{class: "Foo", selector: "bar"}], tabs: tabs})
+
+      {:noreply, socket} = Dock.handle_event("flush", %{}, socket)
+
+      assert [
+               %{selector: "bar", disk_differs: false},
+               %{selector: "untouched", disk_differs: true}
+             ] = socket.assigns.tabs
+    end
+  end
+
+  describe "@dock_events coverage" do
+    test "every event WorkspaceLive delegates to Dock resolves to an implemented clause" do
+      params_by_event = %{
+        "dock_tab" => %{"tab" => "workspace"},
+        "eval" => %{"expr" => "1 + 1"},
+        "select_workspace" => %{"text" => "1"},
+        "repl_eval" => %{"expr" => "1 + 1"},
+        "repl_history_prev" => %{},
+        "repl_history_next" => %{},
+        "repl_inspect" => %{"id" => "repl-entry-1"},
+        "git_refresh" => %{},
+        "git_diff" => %{"path" => "src/Foo.bt"},
+        "git_stage" => %{"path" => "src/Foo.bt"},
+        "git_unstage" => %{"path" => "src/Foo.bt"},
+        "git_revert" => %{"path" => "src/Foo.bt"},
+        "git_commit" => %{"message" => "msg"},
+        "toggle_change_diff" => %{"class" => "Foo", "selector" => "bar"},
+        "revert" => %{"class" => "Foo", "selector" => "bar"},
+        "flush" => %{},
+        "flush_destructive" => %{"class" => "Foo"}
+      }
+
+      # A hardcoded event-name list would itself be an unenforced "keep in
+      # sync" copy of `@dock_events` — read it from `WorkspaceLive` instead,
+      # so adding/removing a name on one side without the other fails here.
+      for event <- BtAttachWeb.WorkspaceLive.dock_events() do
+        params = Map.fetch!(params_by_event, event)
+
+        assert {:noreply, %Phoenix.LiveView.Socket{}} =
+                 Dock.handle_event(event, params, base_socket()),
+               "Dock.handle_event/3 has no clause for #{inspect(event)} (or it crashed)"
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Part of BT-3290 (epic: decompose WorkspaceLive god module). Second extraction from `workspace_live.ex`, following the BT-3291 Inspector precedent: moves the tabbed "Workspace dock" (eval/Workspace tab, REPL tab, Transcript tab, Changes/Git tabs) event-handling logic into a new `BtAttachWeb.Live.Dock` module.

Linear: https://linear.app/beamtalk/issue/BT-3295

## Key changes

- New `BtAttachWeb.Live.Dock` module owns `handle_event/3` for `dock_tab`, `eval`, `select_workspace`, `repl_eval`, `repl_history_prev`/`repl_history_next`, `repl_inspect`, `git_refresh`/`git_diff`/`git_stage`/`git_unstage`/`git_revert`/`git_commit`, `toggle_change_diff`, `revert`, `flush`, `flush_destructive` — plus the git panel's `handle_async(:git_load, …)`.
- `WorkspaceLive` delegates by event name via a `@dock_events` guard clause (mirroring `@inspector_events`) and forwards `handle_async(:git_load, …)` unchanged; the render template stays in `WorkspaceLive` and calls Dock's few template-facing helpers qualified (`Dock.ws_selection?/1`, `Dock.workspace_editor_id/0`, `Dock.repl_preview/1`, `Dock.repl_input_id/0`).
- Cross-cutting helpers still needed by panes not yet extracted (Method Editor tabs — BT-3296, System Browser — BT-3297, Tests pane) were made public on `WorkspaceLive` rather than duplicated: `assign_changes/1`, `status_error/2`, `maybe_refresh_git/1`, `clamp_offset/1`, `symbol_rows/1`, `open_class/2`, `discover_test_classes/2`, `refresh_after_source_change/1`, `reload_reverted_def_buffers/2`, `tab_disk_key/1`, and a new `valid_class_name?/1` (also the sole injection guard for the destructive-flush eval).
- No duplicate implementations: every shared piece of logic has exactly one definition, exposed publicly for the sibling module to call — a deliberate, temporary cross-call shape a sequential decomposition produces (documented in both modules' docs).
- Direct `BtAttachWeb.Live.DockTest` unit tests (StubWorkspaceClient, no live workspace node) cover eval action routing (Do it/Print it/Inspect it), the REPL history ring at the composer's edges, git stage/unstage/commit/revert error + success paths, the destructive-flush confirmation path (including an injection-shaped class-name rejection), `repl_inspect`, the tracked-selection-vs-buffer eval target, and post-flush badge clearing — plus a coverage test asserting every `@dock_events` name resolves to an implemented `Dock` clause.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix test` — 787 passed, 133 excluded (`:workspace`/`:playwright`, unchanged exclusion set)
- [x] `just ci-changed` — full Rust/Erlang/stdlib/BUnit/runtime suite green; `check-corpus`/`check-surface-drift` pass; workspace/REPL/MCP/parity suites correctly skipped (untouched paths)
- [x] Pre-push hook (clippy, dialyzer, erlfmt, mix format) green on both pushes
- [ ] CI's `:workspace`-tagged `workspace_live_test.exs` e2e suite (`liveview-e2e.yml`, needs a live workspace node not available in this sandbox) — acceptance criteria requires these keep passing unmodified; verifying via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5q2yqPv9qLJ4ALmR6Rf9Q