### PR TITLE
StubWorkspaceClient: parameterize inspect_value/pid_stats so window drill/crumb/freeze/poke get real coverage (BT-3303)

### DIFF
--- a/editors/liveview/test/bt_attach_web/inspector_test.exs
+++ b/editors/liveview/test/bt_attach_web/inspector_test.exs
@@ -67,7 +67,7 @@ defmodule BtAttachWeb.Live.InspectorTest do
 
   # A synthetic live-object term backed by the test process's own pid — safe
   # to "subscribe"/"inspect" against the stub client without a real node.
-  defp object_term(pid \\ self()), do: {:beamtalk_object, TestClass, TestClass, pid}
+  defp object_term(pid \\ self()), do: {:beamtalk_object, :TestClass, :TestClass, pid}
 
   describe "pure classifiers" do
     test "term_kind/1 maps object refs to \"ref\" and scalars to their chip" do
@@ -370,6 +370,235 @@ defmodule BtAttachWeb.Live.InspectorTest do
 
       assert socket.assigns.window_z == 12
       assert Enum.find(socket.assigns.windows, &(&1.id == "a")).z == 12
+    end
+  end
+
+  describe "window_drill into a non-empty field row (BT-3303)" do
+    test "follows an object-valued field into a further inspect, extending the window's crumbs" do
+      pid = self()
+      root = {:beamtalk_object, :Counter, :Counter, pid}
+      child = {:beamtalk_object, :Child, :Child, pid}
+      StubWorkspaceClient.seed_inspect_value("Counter", %{"count" => 1, "child" => child})
+      StubWorkspaceClient.seed_inspect_value("Child", %{"name" => "kid"})
+
+      socket = Inspector.open_window_for_term(base_socket(), "counter", root)
+      assert [win] = socket.assigns.windows
+      # `field_rows/1` sorts by name: "child" < "count".
+      assert Enum.map(win.rows, & &1.name) == ["child", "count"]
+      child_index = Enum.find_index(win.rows, &(&1.name == "child"))
+      assert Enum.at(win.rows, child_index).drillable
+
+      {:noreply, socket} =
+        Inspector.handle_event(
+          "window_drill",
+          %{"id" => win.id, "index" => to_string(child_index)},
+          socket
+        )
+
+      assert [win] = socket.assigns.windows
+      assert win.target.label == "child"
+      assert List.last(win.crumbs) == %{label: "child", term: child}
+      assert Enum.map(win.rows, & &1.name) == ["name"]
+    end
+
+    test "window_drill with a malformed index or unknown window id is a no-op" do
+      root = object_term()
+      StubWorkspaceClient.seed_inspect_value("TestClass", %{"count" => 1})
+      socket = Inspector.open_window_for_term(base_socket(), "counter", root)
+
+      {:noreply, result} =
+        Inspector.handle_event("window_drill", %{"id" => "nope", "index" => "0"}, socket)
+
+      assert result == socket
+
+      [win] = socket.assigns.windows
+
+      {:noreply, result2} =
+        Inspector.handle_event(
+          "window_drill",
+          %{"id" => win.id, "index" => "not-a-number"},
+          socket
+        )
+
+      assert result2 == socket
+    end
+  end
+
+  describe "reference-counted unsubscribe across windows (BT-3303)" do
+    test "closing one of two windows on the same pid keeps the subscription alive for the other, closing both releases it" do
+      pid = self()
+      term = object_term(pid)
+
+      socket =
+        base_socket()
+        |> Inspector.open_window_for_term("a", term)
+        |> Inspector.open_window_for_term("b", term)
+
+      assert [win_a, win_b] = socket.assigns.windows
+      assert win_a.watch == term
+      assert win_b.watch == term
+
+      StubWorkspaceClient.clear_calls()
+
+      {:noreply, socket} = Inspector.handle_event("window_close", %{"id" => win_a.id}, socket)
+
+      refute {:unsubscribe_object_changes, term, pid} in StubWorkspaceClient.calls()
+      assert [remaining] = socket.assigns.windows
+      assert remaining.id == win_b.id
+      assert remaining.watch == term
+
+      {:noreply, socket} = Inspector.handle_event("window_close", %{"id" => win_b.id}, socket)
+
+      assert {:unsubscribe_object_changes, term, pid} in StubWorkspaceClient.calls()
+      assert socket.assigns.windows == []
+    end
+
+    test "the docked pane watching the same pid also keeps a window's subscription alive" do
+      pid = self()
+      term = object_term(pid)
+      StubWorkspaceClient.put_bindings([{"counter", term}])
+
+      socket = Inspector.open_window_for_term(base_socket(), "counter", term)
+      {:noreply, socket} = Inspector.handle_event("inspect", %{"name" => "counter"}, socket)
+
+      assert socket.assigns.inspect_watch == term
+      [win] = socket.assigns.windows
+
+      StubWorkspaceClient.clear_calls()
+
+      {:noreply, socket} = Inspector.handle_event("window_close", %{"id" => win.id}, socket)
+
+      refute {:unsubscribe_object_changes, term, pid} in StubWorkspaceClient.calls()
+      assert socket.assigns.windows == []
+
+      # Closing the docked pane too — now nothing watches `term` — actually
+      # releases it.
+      {:noreply, socket} = Inspector.handle_event("close_inspector", %{}, socket)
+
+      assert {:unsubscribe_object_changes, term, pid} in StubWorkspaceClient.calls()
+      assert socket.assigns.inspect_watch == nil
+    end
+  end
+
+  describe "window_poke (BT-3303)" do
+    test "an owner's window poke sends eval, renders the real result, and refreshes the live window" do
+      pid = self()
+      term = object_term(pid)
+      StubWorkspaceClient.seed_inspect_value("TestClass", %{"count" => 1})
+
+      socket = Inspector.open_window_for_term(base_socket(), "counter", term)
+      [win] = socket.assigns.windows
+      assert win.watch == term
+      assert win.flash_gen == 0
+
+      {:noreply, socket} =
+        Inspector.handle_event(
+          "window_poke",
+          %{"id" => win.id, "message" => "Actor subclass: Gadget"},
+          socket
+        )
+
+      [win] = socket.assigns.windows
+      assert win.poke_error == nil
+      assert win.poke_result =~ "→ "
+      assert win.poke_result =~ "Gadget"
+      # A live (watched) window re-reads after a successful poke (send_window_poke),
+      # bumping its flash generation.
+      assert win.flash_gen == 1
+    end
+
+    test "window_poke with no addressable binding (a drilled window) reports it can't send" do
+      pid = self()
+      root = object_term(pid)
+      child = object_term(pid)
+      StubWorkspaceClient.seed_inspect_value("TestClass", %{"child" => child})
+
+      socket = Inspector.open_window_for_term(base_socket(), "counter", root)
+      [win] = socket.assigns.windows
+      child_index = Enum.find_index(win.rows, &(&1.name == "child"))
+
+      {:noreply, socket} =
+        Inspector.handle_event(
+          "window_drill",
+          %{"id" => win.id, "index" => to_string(child_index)},
+          socket
+        )
+
+      {:noreply, socket} =
+        Inspector.handle_event(
+          "window_poke",
+          %{"id" => win.id, "message" => "increment"},
+          socket
+        )
+
+      [win] = socket.assigns.windows
+      assert win.poke_result == nil
+      assert win.poke_error =~ "Can only send to a bound object"
+    end
+  end
+
+  describe "window_freeze (BT-3303)" do
+    test "freezing a live window drops its subscription and holds the snapshot; unfreezing re-arms and catches up" do
+      pid = self()
+      term = object_term(pid)
+      StubWorkspaceClient.seed_inspect_value("TestClass", %{"count" => 1})
+
+      socket = Inspector.open_window_for_term(base_socket(), "counter", term)
+      [win] = socket.assigns.windows
+      assert win.watch == term
+      assert win.frozen == false
+
+      StubWorkspaceClient.clear_calls()
+
+      {:noreply, socket} = Inspector.handle_event("window_freeze", %{"id" => win.id}, socket)
+
+      [win] = socket.assigns.windows
+      assert win.frozen == true
+      assert win.watch == nil
+      assert {:unsubscribe_object_changes, term, pid} in StubWorkspaceClient.calls()
+
+      {:noreply, socket} = Inspector.handle_event("window_freeze", %{"id" => win.id}, socket)
+
+      [win] = socket.assigns.windows
+      assert win.frozen == false
+      assert win.watch == term
+      # Unfreezing re-reads to catch up, bumping the flash generation.
+      assert win.flash_gen == 1
+    end
+  end
+
+  describe "pid_stats parameterization (BT-3303)" do
+    test "a window's head chips read a seeded pid_stats snapshot for its class" do
+      pid = self()
+      term = {:beamtalk_object, :Instance, :Instance, pid}
+      StubWorkspaceClient.seed_pid_stats("Instance", %{"status" => "running", "queue_depth" => 3})
+
+      socket = Inspector.open_window_for_term(base_socket(), "counter", term)
+      [win] = socket.assigns.windows
+
+      assert Inspector.stat_status(win.stats) == "running"
+      assert Inspector.stat_mailbox(win.stats) == 3
+    end
+
+    test "an unseeded class keeps the default empty stats" do
+      term = object_term()
+      socket = Inspector.open_window_for_term(base_socket(), "counter", term)
+      [win] = socket.assigns.windows
+
+      assert Inspector.stat_status(win.stats) == nil
+    end
+  end
+
+  describe "dismiss_window_error" do
+    test "clears only the matching window's error" do
+      win_a = %{id: "a", error: "boom"}
+      win_b = %{id: "b", error: "also boom"}
+      socket = base_socket(%{windows: [win_a, win_b]})
+
+      {:noreply, socket} = Inspector.handle_event("dismiss_window_error", %{"id" => "a"}, socket)
+
+      assert Enum.find(socket.assigns.windows, &(&1.id == "a")).error == nil
+      assert Enum.find(socket.assigns.windows, &(&1.id == "b")).error == "also boom"
     end
   end
 

--- a/editors/liveview/test/support/stub_workspace_client.ex
+++ b/editors/liveview/test/support/stub_workspace_client.ex
@@ -98,6 +98,17 @@ defmodule BtAttachWeb.StubWorkspaceClient do
               # `save_section/3` result (`nil` = report success).
               categories: %{},
               section_save_result: nil,
+              # BT-3303: seeded `inspect_value/1` field maps and `pid_stats/1`
+              # snapshots for a `{:beamtalk_object, class, _module, pid}` handle,
+              # keyed by `to_string(class)` (mirroring the existing
+              # `EmptySup`/`DeadSup` supervisor-keyed pattern in `inspect_value/1`
+              # above). `%{}` = every class keeps the prior default `{:ok, %{}}` —
+              # every existing test that never seeds a class is unaffected. Lets a
+              # test give an inspected object real fields (so a window/docked-pane
+              # drill has something non-empty to follow) and real pid-stats chips,
+              # without inventing a second test double.
+              object_fields: %{},
+              pid_stats_by_class: %{},
               calls: []
   end
 
@@ -164,8 +175,16 @@ defmodule BtAttachWeb.StubWorkspaceClient do
   # `subscribe_classes/1`.
   def subscribe_reload_check(_pid), do: record({:subscribe_reload_check}) && :ok
   def unsubscribe_reload_check(_pid), do: :ok
-  def subscribe_object_changes(_term, _pid), do: :ok
-  def unsubscribe_object_changes(_term, _pid), do: :ok
+  # BT-3303: record the (un)subscribe so a test can prove the reference-counted
+  # unsubscribe logic (`Inspector.unwatch_window/2`, `pid_watched_elsewhere?/3`,
+  # `docked_pid_watched_by_window?/2`) actually did or didn't call through for a
+  # given `{term, pid}` pair — e.g. that closing one of two windows watching the
+  # same actor pid does NOT unsubscribe while the sibling still watches it.
+  def subscribe_object_changes(term, pid),
+    do: record({:subscribe_object_changes, term, pid}) && :ok
+
+  def unsubscribe_object_changes(term, pid),
+    do: record({:unsubscribe_object_changes, term, pid}) && :ok
 
   # ── Eval + session ops ───────────────────────────────────────────────────
 
@@ -224,7 +243,30 @@ defmodule BtAttachWeb.StubWorkspaceClient do
     end
   end
 
+  # BT-3303: an actor object's inspection content — its instance fields — keyed
+  # by class so a test can seed a real (non-empty) fields map instead of the
+  # catch-all `{:ok, %{}}` below. Unseeded classes keep that empty-fields
+  # default, so no existing test (none of which seed a class) is affected.
+  def inspect_value({:beamtalk_object, class, _module, pid} = _term) when is_pid(pid) do
+    case Map.get(get(:object_fields) || %{}, to_string(class)) do
+      nil -> {:ok, %{}}
+      fields -> {:ok, fields}
+    end
+  end
+
   def inspect_value(_term), do: {:ok, %{}}
+
+  @doc """
+  Test helper (BT-3303): seed `inspect_value/1`'s fields-map response for a
+  `{:beamtalk_object, class, _module, pid}` handle whose class is `class` (a
+  string or atom, matched via `to_string/1`). `fields` is the binary/atom-keyed
+  live-term map the real `inspect` op returns — pass an object-valued entry to
+  drive a further drill from the seeded row. Unseeded classes keep the default
+  `{:ok, %{}}` (empty fields, nothing to drill).
+  """
+  def seed_inspect_value(class, fields) when is_map(fields) do
+    update(:object_fields, fn map -> Map.put(map || %{}, to_string(class), fields) end)
+  end
 
   # BT-2634: representative supervisor children (binary-keyed rows, mirroring
   # `beamtalk_process_navigation:child_handles/1`). The nested supervisor child
@@ -1255,7 +1297,29 @@ defmodule BtAttachWeb.StubWorkspaceClient do
   # ── Supervision tree ─────────────────────────────────────────────────────
 
   def supervision_tree(_pid, _scope), do: {:ok, []}
+
+  # BT-3303: a live actor's pid-stats snapshot, keyed by class (mirroring
+  # `inspect_value/1` above) so a test can seed real chip values instead of the
+  # catch-all `{:ok, %{}}`. Unseeded classes keep that empty default.
+  def pid_stats({:beamtalk_object, class, _module, pid} = _term) when is_pid(pid) do
+    case Map.get(get(:pid_stats_by_class) || %{}, to_string(class)) do
+      nil -> {:ok, %{}}
+      stats -> {:ok, stats}
+    end
+  end
+
   def pid_stats(_term), do: {:ok, %{}}
+
+  @doc """
+  Test helper (BT-3303): seed `pid_stats/1`'s response for a
+  `{:beamtalk_object, class, _module, pid}` handle whose class is `class` (a
+  string or atom). `stats` is the binary-keyed snapshot map (`status`,
+  `queue_depth`, `memory_bytes`, `reductions`, …) the real `pid_stats` op
+  returns. Unseeded classes keep the default `{:ok, %{}}`.
+  """
+  def seed_pid_stats(class, stats) when is_map(stats) do
+    update(:pid_stats_by_class, fn map -> Map.put(map || %{}, to_string(class), stats) end)
+  end
 
   # ── Pure utilities (delegated to real Workspace) ─────────────────────────
 


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-3303

Extends `BtAttachWeb.StubWorkspaceClient` (`editors/liveview/test/support/stub_workspace_client.ex`) so a test can seed a real, non-empty `inspect_value/1` fields map and `pid_stats/1` snapshot per object class — mirroring the existing `EmptySup`/`DeadSup` supervisor-keyed pattern — instead of the previous catch-all `{:ok, %{}}` for every non-supervisor term. Also records `subscribe_object_changes`/`unsubscribe_object_changes` calls so a test can prove the reference-counted unsubscribe logic actually did or didn't fire for a given `{term, pid}` pair.

This unblocks real coverage in `editors/liveview/test/bt_attach_web/inspector_test.exs` (BT-3291 follow-up, Pass 3 finding #4) for scenarios the stub previously couldn't drive:

- `window_drill` following a real object-valued field row into a further inspect
- The reference-counted unsubscribe invariant (`unwatch_window/2`, `pid_watched_elsewhere?/3`, `docked_pid_watched_by_window?/2`) with two windows — or a window + the docked pane — actually watching the same pid: closing one keeps the subscription alive for the sibling, closing both actually releases it
- `window_poke`'s `send_window_poke` path with a real eval-result string, including the live-window re-read/flash-bump afterward
- `window_freeze`'s subscribe/unsubscribe + catch-up refresh
- `dismiss_window_error` and the seeded `pid_stats` chips

## Key changes

- `stub_workspace_client.ex`: new `object_fields`/`pid_stats_by_class` state, `seed_inspect_value/2` / `seed_pid_stats/2` test helpers, class-keyed `inspect_value/1` and `pid_stats/1` clauses, and call-recording for `subscribe_object_changes`/`unsubscribe_object_changes`. Unseeded classes keep the prior `{:ok, %{}}` default, so no existing test is affected.
- `inspector_test.exs`: 10 new tests across 5 new `describe` blocks (window_drill, reference-counted unsubscribe, window_poke, window_freeze, pid_stats parameterization) plus one for `dismiss_window_error`.

## Coverage

`BtAttachWeb.Live.Inspector` coverage (measured via `mix test --cover test/bt_attach_web/inspector_test.exs`, this test file alone): **~49% → 56.9%**.

## Verification

In `editors/liveview/`:
- `mix test` — 836 passed, 133 excluded (playwright/workspace tags), 0 failures
- `mix format --check-formatted` — clean
- `mix compile --warnings-as-errors` — clean (no warnings in project code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4sgH136eGzDughfRsVbAG)_