### PR TITLE
fix: save/restore current_method_params across nested classBuilder cascades (BT-3300)

### DIFF
--- a/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/mod.rs
@@ -1421,6 +1421,17 @@ pub(super) struct SavedClassMethodCtx {
     // version, producing two bindings for the same version — caught by the
     // ADR-0111 verifier as `NonLinearVersion`.
     state_version: usize,
+    // BT-3300: same unguarded-reset shape as `state_version` above, for the
+    // enclosing method's own parameter list/types. `generate_class_method_fun_from_block`
+    // unconditionally clears both (`current_method_params.clear()` /
+    // `clear_method_param_types()`) to give the class-method fun its own fresh
+    // set — but they too live outside `ClassContext`, so a builder cascade
+    // nested inside an enclosing method's body would wipe out the enclosing
+    // method's real parameters/types for any later statement that reads them
+    // (e.g. the `erlangApply`/`erlangModuleLookup` FFI intrinsics, or
+    // primitive-BIF codegen).
+    current_method_params: Vec<String>,
+    current_method_param_types: std::collections::HashMap<String, String>,
 }
 
 impl ClassContext {
@@ -2170,6 +2181,8 @@ impl CoreErlangGenerator {
             class_slot_constructor_selector: self.class_slot_constructor_selector().cloned(),
             builder_class_method_class: self.builder_class_method_class(),
             state_version: self.state_version(),
+            current_method_params: self.current_method_params.clone(),
+            current_method_param_types: self.current_method_param_types.clone(),
         };
         self.set_in_class_method(true);
         *self.class_var_names_mut() = class_var_names.iter().cloned().collect();
@@ -2220,6 +2233,10 @@ impl CoreErlangGenerator {
         // value leaves that method's `State` version counter reset to 0
         // instead of wherever it legitimately was.
         self.set_state_version(saved.state_version);
+        // BT-3300: same reasoning as `state_version` above — restore
+        // unconditionally, independent of `had_context`.
+        self.current_method_params = saved.current_method_params;
+        self.current_method_param_types = saved.current_method_param_types;
     }
 
     /// BT-2709: Clears per-method parameter-type tracking. Call alongside

--- a/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
+++ b/crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs
@@ -7663,3 +7663,54 @@ fn test_class_builder_cascade_in_second_field_assignment_does_not_corrupt_state_
          whose value contains a classBuilder addClassMethod:body: cascade. Got: {result:?}"
     );
 }
+
+#[test]
+fn test_nested_class_builder_cascade_does_not_corrupt_current_method_params() {
+    // BT-3300: the same unguarded-reset shape as BT-3289's `state_version` leak
+    // above, for `current_method_params`/`current_method_param_types` instead.
+    // `generate_class_method_fun_from_block` unconditionally clears both at its
+    // start to give the class-method fun its own fresh parameter list — but
+    // neither is captured in `SavedClassMethodCtx`, so a builder cascade nested
+    // INSIDE another builder class-method fun's own body clobbers the outer
+    // fun's parameter list for any later statement in that same body that
+    // reads `current_method_params` (e.g. the `erlangApply`/`erlangModuleLookup`
+    // FFI intrinsics, or primitive-BIF codegen).
+    //
+    // Here the outer `greeting:` class-method fun has one parameter (`a`). Its
+    // body first runs an inner `classBuilder … addClassMethod:body:` cascade
+    // (building an unrelated `Inner` class), then ends with `@intrinsic
+    // erlangApply`, which reads `current_method_params` to find the selector
+    // argument to forward. Before the fix, the inner cascade's clear() wiped
+    // out the outer fun's `a` parameter, so `erlangApply` fell back to a
+    // hardcoded `"Selector"` var name that was never bound in this scope —
+    // `beamtalk_erlang_proxy:dispatch(Selector, Arguments, Self)` — which
+    // would fail `erlc` with an unbound-variable error rather than a clean
+    // Rust-side panic (so, unlike BT-3289, this isn't caught by the ADR-0111
+    // ThreadedIr verifier). Same reachability caveat as BT-3289: unreachable
+    // through the CLI (one class per `.bt` file) or the REPL (one expression
+    // per turn) — only direct `generate_module` library use, as fuzzing does,
+    // can construct this AST shape.
+    let src = "Actor subclass: SlwActor\n  state: value = 41\n\nTestCase subclass: FooTest\n  field: cls = nil\n  field: parentCls = nil\n\n  testX =>\n    self.parentCls := 1\n    self.cls := Object classBuilder name: #Outer;\n      superclass: Object;\n      addClassMethod: #greeting: body: [:self :a |\n        Object classBuilder name: #Inner;\n          superclass: Object;\n          addClassMethod: #answer body: [:self2 | 42];\n          register\n        @intrinsic erlangApply\n      ];\n      register\n";
+    let tokens = crate::source_analysis::lex_with_eof(src);
+    let (module, diags) = crate::source_analysis::parse(tokens);
+    assert!(
+        diags.is_empty(),
+        "Reproducer must parse cleanly. Got diagnostics: {diags:?}"
+    );
+
+    let result = generate_module(&module, CodegenOptions::new("bt3300_params_repro"));
+    let code = result.expect("generate_module must not fail on a nested classBuilder cascade");
+
+    let marker = "'beamtalk_erlang_proxy':'dispatch'(";
+    let call_pos = code
+        .find(marker)
+        .expect("expected an erlangApply-generated dispatch call in the output");
+    let after = &code[call_pos + marker.len()..];
+    assert!(
+        !after.starts_with("Selector,"),
+        "current_method_params leaked across the nested classBuilder cascade: the \
+         outer `greeting:` fun's own `a` parameter should have been threaded into \
+         the erlangApply call, not the hardcoded \"Selector\" fallback (which is \
+         unbound in this scope and would fail erlc). Generated code:\n{code}"
+    );
+}


### PR DESCRIPTION
## Summary

- `generate_class_method_fun_from_block` clears `current_method_params`/`current_method_param_types` to give a class-method fun its own fresh parameter list, but neither field was captured in `SavedClassMethodCtx` — so a `classBuilder … addClassMethod:body:` cascade nested inside another builder class-method fun's body would clobber the outer fun's real parameters for any later statement reading them (e.g. the `erlangApply`/`erlangModuleLookup` FFI intrinsics). This is the identical unguarded-reset shape BT-3289 fixed for `state_version`, just for a different pair of fields.
- Investigated (BT-3300's own acceptance criteria required confirming a real defect before fixing, since it was filed as `needs-spec`): constructed a repro with a nested `classBuilder` cascade inside a one-parameter class-method fun, followed by `@intrinsic erlangApply`. Confirmed the leak produces a reference to an unbound variable (`Arguments`) in the generated Core Erlang — a real defect that would fail `erlc`, not just a theoretical concern.
- Fix mirrors BT-3289 exactly: added `current_method_params: Vec<String>` and `current_method_param_types: HashMap<String, String>` to `SavedClassMethodCtx`, captured in `enter_builder_class_method_context`, restored unconditionally (independent of `had_context`, since both fields live outside `ClassContext`) in `exit_builder_class_method_context`.

## Test plan

- [x] Added `test_nested_class_builder_cascade_does_not_corrupt_current_method_params` (`crates/beamtalk-core/src/codegen/core_erlang/tests/gen_server.rs`), modeled on BT-3289's `test_class_builder_cascade_in_second_field_assignment_does_not_corrupt_state_version`. Verified it fails without the fix and passes with it.
- [x] `just test` — full suite green (Rust, stdlib, BUnit, runtime, metamorphic).
- [x] Pre-push hook's full lint suite (clippy, fmt, dialyzer, spec validation, erlfmt, biome, elixir format) passed.

Fixes BT-3300.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHYqBuzzQkTsNoheo43gd4)_