### PR TITLE
Enforce BtAttachWeb.Live.Inspector event/message contract at compile or test time (BT-3301)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/inspector.ex
+++ b/editors/liveview/lib/bt_attach_web/live/inspector.ex
@@ -35,7 +35,9 @@ defmodule BtAttachWeb.Live.Inspector do
   delivered straight to the LiveView pid. `WorkspaceLive` still owns
   `handle_event/3`/`handle_info/2` (a `Phoenix.LiveView` callback contract),
   but delegates every inspector/window event and push to the functions here
-  by name — see the `@inspector_events` guard clause in `WorkspaceLive`.
+  by name — see the `@inspector_events` guard clause in `WorkspaceLive`,
+  which reads its event list from `__inspector_events__/0` below (BT-3301)
+  rather than hand-maintaining a second copy.
 
   Every workspace read/write goes through `BtAttach.Facade.dispatch/3` (ADR
   0091 Decision 3) with the RBAC-relevant `BtAttachWeb.Live.RequestContext` —
@@ -55,11 +57,35 @@ defmodule BtAttachWeb.Live.Inspector do
 
   defp ctx(socket), do: RequestContext.build(socket)
 
+  # ── canonical event list (BT-3301) ───────────────────────────────────────
+  #
+  # The single source of truth for which event names `handle_event/3` below
+  # implements. Before BT-3301, `WorkspaceLive`'s `@inspector_events` was an
+  # independently hand-maintained copy of these same 16 names — nothing tied
+  # the two lists together, so a name added/renamed/removed on one side
+  # without the other failed silently at runtime (a `FunctionClauseError` on
+  # click, or dead code never reached), not at compile/test time. Now
+  # `WorkspaceLive` reads `__inspector_events__/0` directly instead of
+  # hand-copying the list, so there is only one list to keep in sync with the
+  # clauses below — `inspector_test.exs`'s "@inspector_events coverage" test
+  # scans this file's `handle_event/3` clause heads and asserts the two stay
+  # identical, plus that every name here resolves to a working, non-crashing
+  # clause.
+  @inspector_events ~w(
+    inspect drill crumb freeze_toggle poke close_inspector set_inspector_mode
+    window_close window_crumb window_drill window_focus window_freeze
+    window_moved window_poke window_reset_positions dismiss_window_error
+  )
+
+  @doc false
+  def __inspector_events__, do: @inspector_events
+
   # ── handle_event dispatch ────────────────────────────────────────────────
   #
   # `WorkspaceLive.handle_event/3` forwards every event whose name is in
-  # `@inspector_events` here unchanged (same event name, params, socket), so
-  # each clause below is exactly the body the LiveView used to run directly.
+  # `__inspector_events__/0` here unchanged (same event name, params, socket),
+  # so each clause below is exactly the body the LiveView used to run
+  # directly.
 
   # Inspect a binding by name: look up its live term and drill into it via the
   # read-surface `inspect` op. Reference-following starts here. In `"float"`

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -1006,11 +1006,16 @@ defmodule BtAttachWeb.WorkspaceLive do
   # `BtAttachWeb.Live.Inspector`, extracted out of this module so they're
   # directly unit-testable. See that module's `handle_event/3` for the full
   # per-event behaviour (each clause below is exactly what used to run here).
-  @inspector_events ~w(
-    inspect drill crumb freeze_toggle poke close_inspector set_inspector_mode
-    window_close window_crumb window_drill window_focus window_freeze
-    window_moved window_poke window_reset_positions dismiss_window_error
-  )
+  #
+  # Unlike `@dock_events`/`@method_editor_events` below, this is NOT a
+  # separately hand-maintained list of event names: BT-3291 left two
+  # independent copies of the same 16 strings (this attribute, and
+  # `Inspector.handle_event/3`'s own clause heads) with nothing tying them
+  # together, so a name added/renamed/removed on one side without the other
+  # failed silently at runtime instead of at compile/test time (BT-3301).
+  # Reading `Inspector.__inspector_events__/0` here — the module that owns
+  # the clauses — eliminates the second copy entirely.
+  @inspector_events Inspector.__inspector_events__()
 
   @impl true
   def handle_event(event, params, socket) when event in @inspector_events do
@@ -7788,4 +7793,12 @@ defmodule BtAttachWeb.WorkspaceLive do
   # module — mirrors `dock_events/0`'s rationale: a test asserts every name
   # here resolves to an implemented `MethodEditor.handle_event/3` clause.
   def method_editor_events, do: @method_editor_events
+
+  @doc false
+  # Unlike `dock_events/0`/`method_editor_events/0` above, `@inspector_events`
+  # is not an independent hand-maintained copy — it IS
+  # `Inspector.__inspector_events__/0` (BT-3301). This accessor exists only
+  # so a test can assert the two stay literally identical, guarding against a
+  # future edit that reintroduces a second hardcoded list here.
+  def inspector_events, do: @inspector_events
 end

--- a/editors/liveview/test/bt_attach_web/inspector_test.exs
+++ b/editors/liveview/test/bt_attach_web/inspector_test.exs
@@ -732,7 +732,7 @@ defmodule BtAttachWeb.Live.InspectorTest do
       source = File.read!(@inspector_source)
 
       clause_names =
-        ~r/def handle_event\("([a-z_]+)"/
+        ~r/def handle_event\("([a-z0-9_]+)"/
         |> Regex.scan(source)
         |> Enum.map(fn [_, name] -> name end)
         |> MapSet.new()

--- a/editors/liveview/test/bt_attach_web/inspector_test.exs
+++ b/editors/liveview/test/bt_attach_web/inspector_test.exs
@@ -19,6 +19,9 @@ defmodule BtAttachWeb.Live.InspectorTest do
 
   alias BtAttachWeb.Live.Inspector
   alias BtAttachWeb.StubWorkspaceClient
+  alias BtAttachWeb.WorkspaceLive
+
+  @inspector_source Path.expand("../../lib/bt_attach_web/live/inspector.ex", __DIR__)
 
   setup do
     Application.put_env(:bt_attach, :workspace_client, StubWorkspaceClient)
@@ -672,6 +675,69 @@ defmodule BtAttachWeb.Live.InspectorTest do
       html = render_component(&Inspector.inspector_windows/1, windows: [win], role: :owner)
       assert html =~ "insp-tidy"
       assert html =~ ~s(id="inspector-window-win-1")
+    end
+  end
+
+  describe "@inspector_events coverage (BT-3301)" do
+    test "WorkspaceLive's @inspector_events IS Inspector's canonical list, not a copy" do
+      assert WorkspaceLive.inspector_events() == Inspector.__inspector_events__()
+    end
+
+    test "every event WorkspaceLive delegates to Inspector resolves to an implemented clause" do
+      params_by_event = %{
+        "inspect" => %{"name" => "counter"},
+        "drill" => %{"index" => "0"},
+        "crumb" => %{"index" => "0"},
+        "freeze_toggle" => %{},
+        "poke" => %{"message" => "increment"},
+        "close_inspector" => %{},
+        "set_inspector_mode" => %{"mode" => "float"},
+        "window_close" => %{"id" => "win-1"},
+        "window_crumb" => %{"id" => "win-1", "index" => "0"},
+        "window_drill" => %{"id" => "win-1", "index" => "0"},
+        "window_focus" => %{"id" => "win-1"},
+        "window_freeze" => %{"id" => "win-1"},
+        "window_moved" => %{"id" => "win-1", "x" => 5, "y" => 5},
+        "window_poke" => %{"id" => "win-1", "message" => "increment"},
+        "window_reset_positions" => %{},
+        "dismiss_window_error" => %{"id" => "win-1"}
+      }
+
+      # A hardcoded event-name list here would itself be an unenforced "keep
+      # in sync" copy of `@inspector_events` — read it from `Inspector`
+      # instead (the module both `WorkspaceLive` and this test now derive
+      # from), so adding/renaming/removing a name fails here rather than only
+      # at runtime in the browser.
+      for event <- Inspector.__inspector_events__() do
+        params = Map.fetch!(params_by_event, event)
+
+        assert {:noreply, %Phoenix.LiveView.Socket{}} =
+                 Inspector.handle_event(event, params, base_socket()),
+               "Inspector.handle_event/3 has no clause for #{inspect(event)} (or it crashed)"
+      end
+    end
+
+    test "no handle_event/3 clause head names an event missing from the canonical list" do
+      # The test above only catches a name in the canonical list with no
+      # matching clause (a rename/removal that leaves the list stale). It
+      # can't catch the OTHER direction: a brand-new
+      # `Inspector.handle_event("some_new_event", ...)` clause added without
+      # adding "some_new_event" to `__inspector_events__/0` is unreachable
+      # dead code (`WorkspaceLive`'s `when event in @inspector_events` guard
+      # never lets it through) rather than a crash, so nothing above would
+      # fail. Elixir doesn't expose clause-head literals through module
+      # reflection, so this scans the module's own source text for
+      # `handle_event("...", ...)` clause heads instead and asserts the
+      # literal name set matches the canonical list exactly.
+      source = File.read!(@inspector_source)
+
+      clause_names =
+        ~r/def handle_event\("([a-z_]+)"/
+        |> Regex.scan(source)
+        |> Enum.map(fn [_, name] -> name end)
+        |> MapSet.new()
+
+      assert clause_names == MapSet.new(Inspector.__inspector_events__())
     end
   end
 end


### PR DESCRIPTION
## Summary

Linear: https://linear.app/beamtalk/issue/BT-3301

`BT-3291` extracted the docked Inspector + floating object-window pane out of `WorkspaceLive` into `BtAttachWeb.Live.Inspector`, leaving two independently hand-maintained lists of the same 16 event names: `WorkspaceLive`'s `@inspector_events` guard clause, and `Inspector.handle_event/3`'s own clause heads. Nothing tied them together, so a drift (add/rename/remove on one side only) failed silently at runtime — a `FunctionClauseError` on click, or dead code never reached — rather than at compile/test time.

- `Inspector` now owns the canonical event list via `Inspector.__inspector_events__/0`.
- `WorkspaceLive`'s `@inspector_events` reads that function directly instead of hand-copying the list, eliminating the second copy entirely (no behavior change — same 16 names, same order).
- Added `test/bt_attach_web/inspector_test.exs` coverage:
  - asserts `WorkspaceLive.inspector_events() == Inspector.__inspector_events__()` (the two are literally the same list, not a copy)
  - a per-event dispatch test (mirroring the existing `Dock`/`MethodEditor` precedent) asserting every canonical event name resolves to an implemented, non-crashing `Inspector.handle_event/3` clause
  - a source-text scan asserting the canonical list and the actual `handle_event/3` clause heads name exactly the same events in **both** directions — closing the "vice versa" gap the existing `Dock`/`MethodEditor` tests don't cover (a new clause added without a matching list entry would otherwise be silent dead code)

## Files Changed

- `editors/liveview/lib/bt_attach_web/live/inspector.ex` — canonical `@inspector_events` + `__inspector_events__/0`
- `editors/liveview/lib/bt_attach_web/live/workspace_live.ex` — `@inspector_events` now references `Inspector.__inspector_events__()`; added `inspector_events/0` accessor for the test
- `editors/liveview/test/bt_attach_web/inspector_test.exs` — new drift-coverage tests

## Test plan

- [x] `mix test` (839 passed, 133 excluded)
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] Pre-push hook (full repo CI incl. Dialyzer) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4sgH136eGzDughfRsVbAG)_