### PR TITLE
refactor: expose synthetic_selectors helpers as pub, use them in build_stdlib

### DIFF
--- a/crates/beamtalk-cli/src/commands/build_stdlib.rs
+++ b/crates/beamtalk-cli/src/commands/build_stdlib.rs
@@ -703,16 +703,7 @@ fn synthesize_value_auto_methods(
         }
 
         // Auto functional updater: `withFieldName:` → Self type
-        let with_sel = {
-            let mut chars = slot_name.chars();
-            match chars.next() {
-                None => "with:".to_string(),
-                Some(first) => {
-                    let cap: String = first.to_uppercase().collect();
-                    format!("with{}{}:", cap, chars.as_str())
-                }
-            }
-        };
+        let with_sel = beamtalk_core::synthetic_selectors::with_star_selector(slot_name);
         if !user_selectors.contains(&with_sel) {
             let param_type = slot.type_annotation.as_ref().map(DeclaredType::from);
             let setter_doc = format!(
@@ -733,11 +724,9 @@ fn synthesize_value_auto_methods(
     }
 
     // Auto keyword constructor on the class side: `field1:field2:...`
-    let kw_sel: String = class.state.iter().fold(String::new(), |mut acc, s| {
-        acc.push_str(s.name.name.as_str());
-        acc.push(':');
-        acc
-    });
+    let kw_sel: String = beamtalk_core::synthetic_selectors::keyword_constructor_selector(
+        class.state.iter().map(|s| s.name.name.as_str()),
+    );
     if !user_class_selectors.contains(&kw_sel) {
         let arity = class.state.len();
         let param_types = class

--- a/crates/beamtalk-core/src/lib.rs
+++ b/crates/beamtalk-core/src/lib.rs
@@ -31,7 +31,7 @@ pub mod repl;
 pub mod semantic_analysis;
 pub mod source_analysis;
 pub(crate) mod state_threading_selectors;
-pub(crate) mod synthetic_selectors;
+pub mod synthetic_selectors;
 pub mod test_helpers;
 pub mod tool_expr;
 pub mod unparse;

--- a/crates/beamtalk-core/src/synthetic_selectors.rs
+++ b/crates/beamtalk-core/src/synthetic_selectors.rs
@@ -23,7 +23,7 @@
 /// - `"firstName"` → `"withFirstName:"`
 /// - `""` → `"with:"`
 #[must_use]
-pub(crate) fn with_star_selector(field_name: &str) -> String {
+pub fn with_star_selector(field_name: &str) -> String {
     let mut chars = field_name.chars();
     match chars.next() {
         None => "with:".to_string(),
@@ -40,9 +40,7 @@ pub(crate) fn with_star_selector(field_name: &str) -> String {
 /// An empty slot list yields the empty string; callers should treat a class
 /// with no slots as having no keyword constructor.
 #[must_use]
-pub(crate) fn keyword_constructor_selector<'a>(
-    slot_names: impl IntoIterator<Item = &'a str>,
-) -> String {
+pub fn keyword_constructor_selector<'a>(slot_names: impl IntoIterator<Item = &'a str>) -> String {
     let mut sel = String::new();
     for name in slot_names {
         sel.push_str(name);


### PR DESCRIPTION
## Summary

`crates/beamtalk-core/src/synthetic_selectors.rs` documents itself as "the single source of truth" for Value-class selector names (`with_star_selector`, `keyword_constructor_selector`), but both functions were `pub(crate)`. This made them unreachable from `beamtalk-cli`, so `synthesize_value_auto_methods` in `build_stdlib.rs` duplicated both algorithms inline instead of calling the shared helpers.

This PR fixes the visibility gate so the shared module can actually be used as intended.

## Changes

- **`crates/beamtalk-core/src/lib.rs`**: `pub(crate) mod synthetic_selectors` → `pub mod synthetic_selectors`
- **`crates/beamtalk-core/src/synthetic_selectors.rs`**: both functions `pub(crate)` → `pub`
- **`crates/beamtalk-cli/src/commands/build_stdlib.rs`**: replace the 9-line inline `with_sel` computation and the 5-line inline `kw_sel` fold with calls to `beamtalk_core::synthetic_selectors::with_star_selector` and `beamtalk_core::synthetic_selectors::keyword_constructor_selector`

## Why this matters

`synthesize_value_auto_methods` generates the selector names baked into `generated_builtins.rs`, which the type checker uses at compile time. If the inline logic in `build_stdlib.rs` diverged from `synthetic_selectors` (e.g., a Unicode edge case, matching the BT-3090 fix in `beamtalk_recheck.erl`), the stdlib metadata would contain selector names the type checker doesn't recognise — silently wrong hover/completion/error data for all stdlib Value classes. Now the stdlib builder and the type checker use the same code path.

## Safety

No logic change — both inline algorithms were byte-identical to the helpers. `beamtalk-cli` already depended on `beamtalk-core`. The existing tests in `synthetic_selectors.rs` (including `with_star_selector_matches_shared_corpus` which pins against the Erlang-side cross-language corpus) cover any regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJ4n9kVhgdrW5PvtK2eSht)_