### PR TITLE
Tether Inspector's socket-assign contract to bind_session/3 (BT-3302)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/inspector.ex
+++ b/editors/liveview/lib/bt_attach_web/live/inspector.ex
@@ -25,13 +25,11 @@ defmodule BtAttachWeb.Live.Inspector do
       overlay.
     * Reconnect persistence for the open window desk (BT-2527 #3).
 
-  State (`:inspect_target`, `:inspect_rows`, `:inspect_crumbs`,
-  `:inspect_watch`, `:inspect_stats`, `:inspect_frozen`, `:flash_gen`,
-  `:refresh_pending`, `:poke_result`, `:poke_error`, `:windows`, `:window_z`,
-  `:next_window_id`, `:inspector_mode`) stays on the LiveView's own socket —
-  it is threaded today as plain `WorkspaceLive` assigns (not a
-  `Phoenix.LiveComponent`'s isolated assigns), initialised in
-  `WorkspaceLive.bind_session/3` and read live by object-change pushes
+  State stays on the LiveView's own socket — it is threaded today as plain
+  `WorkspaceLive` assigns (not a `Phoenix.LiveComponent`'s isolated
+  assigns), initialised in `WorkspaceLive.bind_session/3` from this module's
+  `init_assigns/0` (BT-3302 — the canonical key list + defaults live there,
+  not hand-copied here as prose) and read live by object-change pushes
   delivered straight to the LiveView pid. `WorkspaceLive` still owns
   `handle_event/3`/`handle_info/2` (a `Phoenix.LiveView` callback contract),
   but delegates every inspector/window event and push to the functions here
@@ -79,6 +77,54 @@ defmodule BtAttachWeb.Live.Inspector do
 
   @doc false
   def __inspector_events__, do: @inspector_events
+
+  # ── canonical default-assigns map (BT-3302) ─────────────────────────────
+  #
+  # The single source of truth for which socket-assign keys the docked
+  # Inspector + floating windows own, and their fresh-session defaults.
+  # Before BT-3302, `WorkspaceLive.bind_session/3` initialised these 15 keys
+  # as one hand-written `assign/3` pipe with no tether back to the keys this
+  # module actually reads/writes (its own `@moduledoc` carried an
+  # independently hand-maintained — and, it turned out, already stale, since
+  # it omitted `:inspect_error` — prose copy of the same list). A rename here
+  # that missed a call site in this file (or vice versa) had no compile/test
+  # signal, only a `KeyError`/nil-pattern-match crash the first time a user
+  # drove the affected code path.
+  #
+  # `bind_session/3` now assigns this map directly instead of hand-copying
+  # the keys, and `InspectorTest`'s `base_socket/1` fixture is built from it
+  # too (merged with the WorkspaceLive-context keys Inspector only reads,
+  # never initialises: `:session_pid`, `:current_user`, `:role`,
+  # `:session_id`). With both the production init path and the test fixture
+  # deriving from this one map, a key this module's functions actually
+  # pattern-match/assign on but that goes missing here fails the very next
+  # `mix test` run (a `KeyError` reading a socket assign that no longer
+  # exists) rather than waiting for a user to hit it live.
+  @default_assigns %{
+    inspect_target: nil,
+    inspect_rows: [],
+    inspect_crumbs: [],
+    inspect_error: nil,
+    inspect_watch: nil,
+    inspect_stats: nil,
+    inspect_frozen: false,
+    flash_gen: 0,
+    refresh_pending: false,
+    poke_result: nil,
+    poke_error: nil,
+    windows: [],
+    window_z: 10,
+    next_window_id: 1,
+    inspector_mode: "docked"
+  }
+
+  @doc """
+  The default assigns for the docked Inspector + floating windows on a
+  freshly-bound `WorkspaceLive` socket (BT-3302). Called from
+  `WorkspaceLive.bind_session/3` via `assign/2` — see the module doc for why
+  this replaced a hand-written `assign/3` pipe there.
+  """
+  def init_assigns, do: @default_assigns
 
   # ── handle_event dispatch ────────────────────────────────────────────────
   #

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -457,49 +457,25 @@ defmodule BtAttachWeb.WorkspaceLive do
       |> assign(:repl_terms, %{})
       |> assign(:repl_history, [])
       |> assign(:repl_history_pos, nil)
-      |> assign(:inspect_target, nil)
-      |> assign(:inspect_rows, [])
-      |> assign(:inspect_error, nil)
-      # Drill breadcrumb (BT-2486): the trail of references followed so far, each
-      # carrying the live term so a crumb click re-inspects that level. Reset when
-      # inspection starts from a binding, appended to when a field is drilled.
-      |> assign(:inspect_crumbs, [])
-      # Live Inspector tracking (BT-2492, epic BT-2482 Phase 3): the per-object
-      # change subscription + pid stats + freeze toggle + owner poke wired onto
-      # the docked Inspector (backend BT-2489, ADR 0095 §5).
-      #
-      #   * `:inspect_watch` — the live `{:beamtalk_object, …}` term currently
-      #     subscribed for `{:object_changed, …}` pushes (nil = nothing watched,
-      #     e.g. a scalar target or a frozen pane). Held so we can unsubscribe it
-      #     exactly when the target changes / the pane freezes / the LiveView dies.
-      #   * `:inspect_stats` — the last `pid_stats` snapshot (binary-keyed metrics)
-      #     driving the mailbox/reductions/status chips; nil when none read yet.
-      #   * `:inspect_frozen` — when true the pane holds a snapshot: we drop the
-      #     change subscription so pushes stop re-reading, and the freeze toggle
-      #     re-subscribes + refreshes on unfreeze.
-      #   * `:flash_gen` — a monotonic counter bumped on each *live refresh*; it
-      #     rides the ivar table as `data-flash-gen` so the FieldFlash JS hook
-      #     flashes only the value cells that *changed* this refresh (debounced
-      #     client-side, no flash storm). Server-side the `{:object_changed, …}`
-      #     push is itself coalesced via `:refresh_pending` so a burst of writes
-      #     collapses into one re-read.
-      #   * `:poke_result` / `:poke_error` — the owner-only "send a message" quick
-      #     action's outcome (an `eval` of `<binding> <message>` against the
-      #     inspected actor); rendered under the poke bar.
-      |> assign(:inspect_watch, nil)
-      |> assign(:inspect_stats, nil)
-      |> assign(:inspect_frozen, false)
-      |> assign(:flash_gen, 0)
-      |> assign(:refresh_pending, false)
+      # Docked Inspector + floating windows (BT-2486/BT-2492/BT-2493, epic
+      # BT-2482 Phase 3): drill breadcrumb, live per-object tracking (change
+      # subscription, pid stats, freeze, field-flash coalescing), owner poke,
+      # and the floating-window desk. `Inspector.init_assigns/0` is the single
+      # source of truth for this key list + its fresh-session defaults
+      # (BT-3302) — see that function's doc and `Inspector`'s `@moduledoc` for
+      # what each key drives; assigning the map here (rather than hand-copying
+      # its keys into a local `assign/3` pipe) is the tether back to
+      # `Inspector`'s own read/write sites, so a rename that misses one side
+      # fails a `mix test` run instead of only a live user's click.
+      |> assign(Inspector.init_assigns())
       # BT-2600: coalesce `ClassLoaded`/`ClassRemoved` refresh bursts. A project
       # sync / `Workspace load:` reloading N files fires N consecutive pushes;
       # rather than running `refresh_after_source_change` (N source re-reads ×
       # open tabs) per push, the first push schedules one deferred
       # `:do_source_refresh` and sets this flag, collapsing the burst into a
-      # single refresh — mirroring the `:refresh_pending` object-change coalescing.
+      # single refresh — mirroring the Inspector's own `:refresh_pending`
+      # object-change coalescing.
       |> assign(:source_refresh_pending, false)
-      |> assign(:poke_result, nil)
-      |> assign(:poke_error, nil)
       # Method editor (Wave 3): the write-surface edit/save/flush pane.
       |> assign(:edit_class, "")
       |> assign(:edit_selector, "")
@@ -658,20 +634,10 @@ defmodule BtAttachWeb.WorkspaceLive do
       # Dock/Float toggle (spikes/cockpit-ux-spike/app.jsx). In `"float"` mode a
       # binding click / Inspect-it opens a *floating, draggable, stackable*
       # inspector window instead of driving the docked pane; `"docked"` (the
-      # default) keeps the single right-column Inspector.
-      #
-      #   * `:inspector_mode` — `"docked"` | `"float"`. Persisted in LV state so it
-      #     survives re-render; the top-bar toggle flips it.
-      #   * `:windows` — the open floating windows, each a self-contained inspector
-      #     (its own drill `crumbs`, `rows`, `target`, live `watch`/`stats`/`frozen`
-      #     + `flash_gen`, and `x`/`y`/`z` placement). The window list (id + drill
-      #     stack + content) lives server-side; only x/y/z are client-reported by
-      #     the WindowDrag hook on drop / focus, so there is no per-mousemove
-      #     round-trip and positions survive an unrelated re-render.
-      #   * `:next_window_id` — a monotonic counter minting unique window ids.
-      #   * `:window_z` — the running max z-index; a click bumps the focused window
-      #     to `window_z + 1` so z-order follows focus (the spike's stacking).
-      |> assign(:inspector_mode, "docked")
+      # default) keeps the single right-column Inspector. `:inspector_mode`,
+      # `:windows`, `:next_window_id` and `:window_z` are already set above by
+      # `Inspector.init_assigns()` (BT-3302) — see `Inspector`'s `@moduledoc`
+      # for what each drives.
       # Panel visibility toggles (BT-2559): dismissable side panels + collapsible
       # dock. Each panel can be hidden via a close button; toggle buttons in the
       # top bar re-show them. The dock can be collapsed/expanded.
@@ -689,9 +655,6 @@ defmodule BtAttachWeb.WorkspaceLive do
       # `restore_doc/3`, so an expanded block stays expanded across a socket drop,
       # redeploy, or laptop wake (BT-2570).
       |> assign(:doc_expanded, false)
-      |> assign(:windows, [])
-      |> assign(:next_window_id, 1)
-      |> assign(:window_z, 10)
       |> assign_browser_native_modules()
       |> assign_browser_type_aliases()
       # BT-2636: the set of expanded Changes-pane rows (keyed by the row's

--- a/editors/liveview/test/bt_attach_web/inspector_test.exs
+++ b/editors/liveview/test/bt_attach_web/inspector_test.exs
@@ -22,6 +22,7 @@ defmodule BtAttachWeb.Live.InspectorTest do
   alias BtAttachWeb.WorkspaceLive
 
   @inspector_source Path.expand("../../lib/bt_attach_web/live/inspector.ex", __DIR__)
+  @workspace_live_source Path.expand("../../lib/bt_attach_web/live/workspace_live.ex", __DIR__)
 
   setup do
     Application.put_env(:bt_attach, :workspace_client, StubWorkspaceClient)
@@ -37,32 +38,28 @@ defmodule BtAttachWeb.Live.InspectorTest do
 
   # A bare socket carrying exactly the assigns Inspector's functions read —
   # the subset of `WorkspaceLive.bind_session/3`'s init relevant to the
-  # docked Inspector + floating windows. `role: :owner` by default (most
-  # tests aren't about RBAC); override per test.
+  # docked Inspector + floating windows, PLUS the handful of WorkspaceLive-
+  # context keys Inspector only ever reads (never initialises):
+  # `:current_user`/`:role`/`:session_id`/`:session_pid`/`:__changed__`.
+  # `role: :owner` by default (most tests aren't about RBAC); override per
+  # test.
+  #
+  # The Inspector-owned half comes straight from `Inspector.init_assigns/0`
+  # (BT-3302) rather than a hand-copied literal map — the same function
+  # `bind_session/3` itself calls — so this fixture and production init
+  # can never drift apart: a key this module's `handle_event`/`handle_info`
+  # clauses read but `init_assigns/0` no longer provides shows up here as a
+  # `KeyError` on the very next `mix test`, not only live in a browser.
   defp base_socket(overrides \\ %{}) do
     assigns =
-      %{
+      Inspector.init_assigns()
+      |> Map.merge(%{
         __changed__: %{},
         current_user: nil,
         role: :owner,
         session_id: "sess-1",
-        session_pid: self(),
-        inspector_mode: "docked",
-        inspect_target: nil,
-        inspect_rows: [],
-        inspect_crumbs: [],
-        inspect_error: nil,
-        inspect_watch: nil,
-        inspect_stats: nil,
-        inspect_frozen: false,
-        flash_gen: 0,
-        refresh_pending: false,
-        poke_result: nil,
-        poke_error: nil,
-        windows: [],
-        window_z: 10,
-        next_window_id: 1
-      }
+        session_pid: self()
+      })
       |> Map.merge(overrides)
 
     %Phoenix.LiveView.Socket{assigns: assigns}
@@ -738,6 +735,45 @@ defmodule BtAttachWeb.Live.InspectorTest do
         |> MapSet.new()
 
       assert clause_names == MapSet.new(Inspector.__inspector_events__())
+    end
+  end
+
+  describe "init_assigns/0 (BT-3302 socket-assign contract)" do
+    test "returns exactly the keys the docked Inspector + floating windows own" do
+      # Pins the canonical key SET (not just its use as a socket-assign
+      # source elsewhere in this file) so an accidental key removal/rename
+      # inside `Inspector.init_assigns/0` itself — with no other call site
+      # touched — still fails here, rather than silently starting to omit an
+      # assign `bind_session/3` used to initialise.
+      expected =
+        MapSet.new(~w(
+          inspect_target inspect_rows inspect_crumbs inspect_error
+          inspect_watch inspect_stats inspect_frozen flash_gen
+          refresh_pending poke_result poke_error windows window_z
+          next_window_id inspector_mode
+        )a)
+
+      assert MapSet.new(Map.keys(Inspector.init_assigns())) == expected
+    end
+
+    test "WorkspaceLive.bind_session/3 assigns come from Inspector.init_assigns/0, not a copy" do
+      # `bind_session/3` is private, so this asserts the tether the same way
+      # the `@inspector_events` coverage test above does for events: scan
+      # `workspace_live.ex`'s own source and confirm it calls
+      # `Inspector.init_assigns()` rather than hand-listing the keys via a
+      # local `assign/3` pipe (the pre-BT-3302 shape this guards against
+      # regressing to).
+      source = File.read!(@workspace_live_source)
+
+      assert source =~ "assign(Inspector.init_assigns())"
+
+      # And none of the canonical keys are hand-assigned as a literal
+      # `assign(:key, ...)` call elsewhere in the file — that would be
+      # exactly the second, unenforced copy BT-3302 removed.
+      for key <- Map.keys(Inspector.init_assigns()) do
+        refute source =~ "assign(:#{key},",
+               "workspace_live.ex still hand-assigns :#{key} instead of getting it from Inspector.init_assigns/0"
+      end
     end
   end
 end


### PR DESCRIPTION
Linear: https://linear.app/beamtalk/issue/BT-3302/tether-inspectors-socket-assign-contract-to-workspacelivebind-session3

## Summary

`WorkspaceLive.bind_session/3` used to initialise the 15 docked-Inspector/
floating-window socket-assign keys as one hand-written `assign/3` pipe, with
no tether back to the keys `BtAttachWeb.Live.Inspector`'s functions actually
read/write. A rename on one side that missed the other had no compile/test
signal — only a `KeyError`/nil-pattern-match crash the first time a user hit
the affected Inspector code path (flagged by BT-3291's adversarial review,
Pass 3 finding #2).

This closes that gap by giving the key list + defaults exactly one home,
mirroring the `__inspector_events__/0` pattern BT-3301 already established
for the event-name list:

- `Inspector.init_assigns/0` is now the single source of truth for the 15
  keys (`:inspect_target`, `:inspect_rows`, `:inspect_crumbs`,
  `:inspect_error`, `:inspect_watch`, `:inspect_stats`, `:inspect_frozen`,
  `:flash_gen`, `:refresh_pending`, `:poke_result`, `:poke_error`,
  `:windows`, `:window_z`, `:next_window_id`, `:inspector_mode`) and their
  fresh-session defaults.
- `WorkspaceLive.bind_session/3` now assigns that map directly
  (`|> assign(Inspector.init_assigns())`) instead of hand-copying the keys
  into a local pipe.
- `InspectorTest`'s `base_socket/1` fixture is built from the same map
  (merged with the WorkspaceLive-context keys Inspector only reads, never
  initialises), so production init and the test fixture can't drift apart.
- Two new tests pin the canonical key set and assert `bind_session/3` gets
  it from `Inspector.init_assigns()` rather than a hand-copied literal.

Along the way this surfaced (and fixes) a real doc gap: `Inspector`'s
`@moduledoc` prose key list omitted `:inspect_error`, even though the code
has read/written it throughout.

## Key changes

- `editors/liveview/lib/bt_attach_web/live/inspector.ex` — add
  `@default_assigns` / `init_assigns/0`; fix the moduledoc's stale key list.
- `editors/liveview/lib/bt_attach_web/live/workspace_live.ex` —
  `bind_session/3` now calls `Inspector.init_assigns()` instead of 15
  individual `assign/3` calls spread across two places in the pipe.
- `editors/liveview/test/bt_attach_web/inspector_test.exs` — `base_socket/1`
  derives from `Inspector.init_assigns()`; new `init_assigns/0` coverage
  tests.

## Test plan

- [x] `mix test` — 841 passed, 133 excluded (`:playwright`/`:workspace`,
      excluded by default per existing tag conventions)
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors` (clean for `bt_attach`; pre-existing
      warnings are all inside the `phoenix_live_view` dependency itself)
- [x] `just fmt-check` (Rust/Erlang/JS/Beamtalk — unaffected, confirms no
      regression)


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4sgH136eGzDughfRsVbAG)_