### PR TITLE
Extract System Browser pane out of WorkspaceLive (BT-3297)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/dock.ex
+++ b/editors/liveview/lib/bt_attach_web/live/dock.ex
@@ -51,11 +51,13 @@ defmodule BtAttachWeb.Live.Dock do
 
   Several dock branches reach into state other panes own: the git-revert path
   calls `BtAttachWeb.Live.MethodEditor`'s tab-refresh helpers (extracted
-  BT-3296) directly, and the System Browser's `open_class`/`symbol_rows` and
-  the Tests pane's `discover_test_classes` are still `WorkspaceLive`-owned
-  (BT-3297 lands later in the BT-3290 epic) — this module calls those public
-  functions rather than duplicating their logic, exactly the temporary
-  cross-call shape a sequential decomposition produces.
+  BT-3296) directly, `BtAttachWeb.Live.SystemBrowser`'s `open_class/2`
+  (extracted BT-3297) focuses the System Browser on a class from the REPL
+  `:help` meta-command, and the top-bar omni search's `symbol_rows/1` and the
+  Tests pane's `discover_test_classes/1` are still `WorkspaceLive`-owned —
+  this module calls those public functions rather than duplicating their
+  logic, exactly the temporary cross-call shape a sequential decomposition
+  produces.
   """
 
   use BtAttachWeb, :html
@@ -76,6 +78,7 @@ defmodule BtAttachWeb.Live.Dock do
   alias BtAttachWeb.Live.Inspector
   alias BtAttachWeb.Live.MethodEditor
   alias BtAttachWeb.Live.RequestContext
+  alias BtAttachWeb.Live.SystemBrowser
   alias BtAttachWeb.WorkspaceLive
 
   defp ctx(socket), do: RequestContext.build(socket)
@@ -970,7 +973,7 @@ defmodule BtAttachWeb.Live.Dock do
   defp repl_focus_class(socket, expr, class) do
     if class in browser_class_names(socket) do
       socket
-      |> WorkspaceLive.open_class(class)
+      |> SystemBrowser.open_class(class)
       |> repl_append_info(expr, "Opened #{class} in the System Browser ◂")
     else
       # "No class named X" is feedback about a meta-command, not a
@@ -1024,14 +1027,14 @@ defmodule BtAttachWeb.Live.Dock do
   # Non-help evals pass through untouched.
   #
   # Unlike `repl_focus_class/3`, this skips the `browser_class_names/1`
-  # validation and calls `WorkspaceLive.open_class/2` directly: the `eval`
+  # validation and calls `SystemBrowser.open_class/2` directly: the `eval`
   # already succeeded, which proves the class exists in the runtime, so a
   # symbol-index lookup would be redundant (and would falsely reject a class
   # defined moments earlier if the index is briefly stale). `load_protocols`
   # handles an empty result gracefully regardless.
   defp repl_help_followup(socket, expr) do
     case Regex.run(~r/^\s*Beamtalk\s+help:\s+#?([A-Z]\w*)/, expr) do
-      [_, class] -> WorkspaceLive.open_class(socket, class)
+      [_, class] -> SystemBrowser.open_class(socket, class)
       _ -> socket
     end
   end

--- a/editors/liveview/lib/bt_attach_web/live/method_editor.ex
+++ b/editors/liveview/lib/bt_attach_web/live/method_editor.ex
@@ -44,18 +44,16 @@ defmodule BtAttachWeb.Live.MethodEditor do
   `open_method_tab/4`, `open_new_method/3`, `breadcrumb/1`,
   `modifier_badges/1`, `tab_disk_key/1`, `clear_disk_differs/2`,
   `reload_reverted_def_buffers/2`, `refresh_after_source_change/1`) — the
-  same data several *other*, not-yet-extracted or intentionally-elsewhere
-  features still reach into: the System Browser's method/definition
-  navigation (`browser_select_method`, `omni_open`, `nav_open`,
-  `open_test_method`, `open_implementor_site`, all BT-3297 territory),
-  Remove/Rename (`remove_method`, `remove_class`, the Rename modal), New
-  Class, and the standalone Native-module browser tab
-  (`browser_open_native_module`). Those stay in `WorkspaceLive` (none of
-  their *events* are in this extraction's scope) and cross-call the public
-  functions here by name — exactly the temporary cross-call shape a
-  sequential decomposition produces, mirrored from `Dock`'s own cross-calls
-  back into `WorkspaceLive` for the System Browser/Tests code not yet
-  extracted.
+  same data several *other* features reach into: `BtAttachWeb.Live.SystemBrowser`'s
+  method/definition navigation (`browser_select_method`, `nav_open`,
+  `open_implementor_site`, the standalone Native-module browser tab, all
+  extracted in BT-3297) and `WorkspaceLive`'s still-resident omni search
+  (`omni_open`), test runner (`open_test_method`), and Remove/Rename
+  (`remove_method`, `remove_class`, the Rename modal) / New Class code. Those
+  cross-call the public functions here by name — exactly the temporary
+  cross-call shape a sequential decomposition produces, mirrored from
+  `Dock`'s own cross-calls back into `WorkspaceLive` for the Tests-pane code
+  not yet extracted.
 
   Every workspace read/write goes through `BtAttach.Facade.dispatch/3` (ADR
   0091 Decision 3) with `BtAttachWeb.Live.RequestContext` — never a raw
@@ -84,6 +82,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
   alias BtAttach.Workspace
   alias BtAttachWeb.Live.FacadeError
   alias BtAttachWeb.Live.RequestContext
+  alias BtAttachWeb.Live.SystemBrowser
   alias BtAttachWeb.WorkspaceLive
 
   defp ctx(socket), do: RequestContext.build(socket)
@@ -526,7 +525,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
         %{
           source: if(is_binary(result["source"]), do: result["source"], else: ""),
           disk_differs: result["disk_differs"] == true,
-          runtime_only: WorkspaceLive.runtime_only?(result),
+          runtime_only: SystemBrowser.runtime_only?(result),
           # BT-2714: a compiler-derived method (value accessors /
           # `with<Field>:` setters / actor `new`/`spawn`) has no editable
           # source — the backend returns `source: null` but resolves the
@@ -731,11 +730,10 @@ defmodule BtAttachWeb.Live.MethodEditor do
   # existing write-surface handler reads them unchanged.
   #
   # A 4th kind, `:native` (standalone read/editable `.erl` module tabs,
-  # BT-2667/BT-2670), is constructed by `WorkspaceLive.add_native_module_tab/3`
-  # — that System Browser feature is still `WorkspaceLive`-owned (BT-3297
-  # lands the rest of it later in the BT-3290 epic) but shares this same tab
-  # list/shape, so a field added/renamed here must be mirrored there too
-  # (and vice versa) until that extraction lands.
+  # BT-2667/BT-2670), is constructed by
+  # `BtAttachWeb.Live.SystemBrowser`'s private `add_native_module_tab/3`
+  # (BT-3297) but shares this same tab list/shape, so a field added/renamed
+  # here must be mirrored there too (and vice versa).
   #
   #   %{
   #     id: stable string id (method-key, "def:<Class>", or "new:<Class>"),
@@ -784,10 +782,9 @@ defmodule BtAttachWeb.Live.MethodEditor do
     |> assign(:editor_rev, 0)
   end
 
-  # Public: `WorkspaceLive`'s still-resident System Browser / Native module
-  # navigation (`open_native_module_tab`, BT-3297) looks up a tab by id
-  # before deciding whether to (re)focus or create one, mirroring every
-  # find-or-create path in this module.
+  # Public: `BtAttachWeb.Live.SystemBrowser`'s private `open_native_module_tab`
+  # (BT-3297) looks up a tab by id before deciding whether to (re)focus or
+  # create one, mirroring every find-or-create path in this module.
   def find_tab(socket, id), do: Enum.find(socket.assigns.tabs, &(&1.id == id))
 
   # The focused tab, or `nil` when the strip is empty (startup, or after the
@@ -796,14 +793,14 @@ defmodule BtAttachWeb.Live.MethodEditor do
   # breadcrumb / dirty-state; falls back to the first tab if a non-nil
   # active id somehow no longer maps. Public: called throughout
   # `WorkspaceLive`'s render template and by its still-resident
-  # Remove/Rename/System-Browser code.
+  # Remove/Rename code, and by `BtAttachWeb.Live.SystemBrowser`.
   def active_tab(%{tabs: tabs, active_tab: id}) do
     (id && Enum.find(tabs, &(&1.id == id))) || List.first(tabs)
   end
 
   # Focus a tab by id and mirror its class/selector/source into the
   # form-backing assigns. Clears any stale save/flush result so switching
-  # tabs starts clean. Public: `WorkspaceLive`'s still-resident
+  # tabs starts clean. Public: `BtAttachWeb.Live.SystemBrowser`'s private
   # `open_native_module_tab` (BT-3297) cross-calls it.
   def activate_tab(socket, id) do
     case find_tab(socket, id) do
@@ -818,8 +815,8 @@ defmodule BtAttachWeb.Live.MethodEditor do
   # focus (a new tab's fields should start clean), but NOT when a push
   # refresh re-syncs the tab that's still focused (see `sync_active_fields/2`,
   # and `focus_tab_keep_banner/3` for the same "mid-save" carve-out). Public:
-  # `WorkspaceLive`'s still-resident `open_native_module_tab` (BT-3297)
-  # cross-calls it.
+  # `BtAttachWeb.Live.SystemBrowser`'s private `open_native_module_tab`
+  # (BT-3297) cross-calls it.
   def sync_active(socket, tab) do
     socket
     |> sync_active_fields(tab)
@@ -917,8 +914,8 @@ defmodule BtAttachWeb.Live.MethodEditor do
   # Open (or re-focus) a class-definition tab for a named class — the
   # System Browser's "class definition" entry opens the *selected* class's
   # definition, which need not be the active tab's class. Public:
-  # `WorkspaceLive`'s still-resident System Browser / Rename / New Class /
-  # go-to-definition code cross-calls it.
+  # `BtAttachWeb.Live.SystemBrowser`'s go-to-definition/nav code and
+  # `WorkspaceLive`'s still-resident Rename / New Class code cross-call it.
   def open_definition(socket, class) do
     id = "def:" <> class
 
@@ -1024,8 +1021,9 @@ defmodule BtAttachWeb.Live.MethodEditor do
   # `method:Class:side:selector` key the editor already uses, so opening
   # the same method twice de-dupes. The buffer is seeded with the method's
   # image-accurate source so editing starts from the live body. Public:
-  # `WorkspaceLive`'s still-resident System Browser / omni-search /
-  # senders-implementors / Tests-pane navigation cross-calls it.
+  # `BtAttachWeb.Live.SystemBrowser`'s browse/senders-implementors navigation
+  # and `WorkspaceLive`'s still-resident omni-search / Tests-pane navigation
+  # cross-call it.
   def open_method_tab(socket, class, side, selector) do
     id = "method:" <> class <> ":" <> side <> ":" <> selector
 
@@ -1661,7 +1659,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
   # BT-2642: editor-header package/origin badge for the active tab. The tab
   # carries `source_origin` ("stdlib" | "dependency" | "project" | nil) and
   # `package`, snapshotted at open from the class's browse row. The header
-  # badge reuses BT-2641's vocabulary (`WorkspaceLive.dependency_badge_label/1`,
+  # badge reuses BT-2641's vocabulary (`SystemBrowser.dependency_badge_label/1`,
   # shared with the System Browser tree) and extends it to project (which
   # the tree hides but the header shows): stdlib → "STDLIB", dependency →
   # "DEP · <pkg>" (or bare "DEP"), project → the bare project package name.
@@ -1671,7 +1669,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
   def header_package_label(%{source_origin: "stdlib"}), do: "STDLIB"
 
   def header_package_label(%{source_origin: "dependency"} = tab),
-    do: WorkspaceLive.dependency_badge_label(stringify_origin(tab))
+    do: SystemBrowser.dependency_badge_label(stringify_origin(tab))
 
   def header_package_label(%{source_origin: "project", package: pkg})
       when is_binary(pkg) and pkg != "",
@@ -1680,9 +1678,9 @@ defmodule BtAttachWeb.Live.MethodEditor do
   def header_package_label(_tab), do: ""
 
   # The CSS modifier class keying the header badge color, per origin.
-  # Mirrors `WorkspaceLive`'s `source_origin_class/1` but reads the tab's
-  # atom-keyed `source_origin`. Public: `WorkspaceLive`'s render template
-  # calls it directly.
+  # Mirrors `BtAttachWeb.Live.SystemBrowser`'s `source_origin_class/1` but
+  # reads the tab's atom-keyed `source_origin`. Public: `WorkspaceLive`'s
+  # render template calls it directly.
   def header_origin_class(%{source_origin: "stdlib"}), do: "stdlib"
   def header_origin_class(%{source_origin: "dependency"}), do: "dependency"
   def header_origin_class(_tab), do: "project"
@@ -1694,7 +1692,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
   def header_origin_title(%{source_origin: "stdlib"}), do: "Standard library"
 
   def header_origin_title(%{source_origin: "dependency"} = tab),
-    do: "Dependency: #{WorkspaceLive.package_name(stringify_origin(tab))}"
+    do: "Dependency: #{SystemBrowser.package_name(stringify_origin(tab))}"
 
   def header_origin_title(%{source_origin: "project", package: pkg})
       when is_binary(pkg) and pkg != "",
@@ -1703,8 +1701,8 @@ defmodule BtAttachWeb.Live.MethodEditor do
   def header_origin_title(_tab), do: "Project"
 
   # Bridge the tab's atom-keyed origin/package onto the string-keyed map the
-  # BT-2641 browse-row helpers (`WorkspaceLive.dependency_badge_label/1`,
-  # `WorkspaceLive.package_name/1`) expect, so the dependency badge text
+  # BT-2641 browse-row helpers (`SystemBrowser.dependency_badge_label/1`,
+  # `SystemBrowser.package_name/1`) expect, so the dependency badge text
   # stays in one place.
   defp stringify_origin(tab),
     do: %{"source_origin" => tab[:source_origin], "package" => tab[:package]}
@@ -1788,9 +1786,10 @@ defmodule BtAttachWeb.Live.MethodEditor do
 
   # BT-2598: the live image changed (a class was (re)loaded or removed).
   # Re-pull every source-dependent surface so open windows reflect the new
-  # image without a manual refresh: the browser class list and the active
-  # ChangeLog (cross-called back on `WorkspaceLive`, which still owns the
-  # System Browser / Changes pane), all open clean editor tabs (method +
+  # image without a manual refresh: the browser class list (cross-called back
+  # on `BtAttachWeb.Live.SystemBrowser`, BT-3297) and the active ChangeLog
+  # (cross-called back on `WorkspaceLive`, which still owns the Changes
+  # pane), all open clean editor tabs (method +
   # definition, owned here), and the git panel when it is the active dock
   # tab (also cross-called back, `BtAttachWeb.Live.Dock` owns it). Folded
   # together here — rather than split across callers — so every caller gets
@@ -1800,7 +1799,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
   # directly.
   def refresh_after_source_change(socket) do
     socket
-    |> WorkspaceLive.assign_browser_classes()
+    |> SystemBrowser.assign_browser_classes()
     |> WorkspaceLive.assign_changes()
     |> refresh_open_source_tabs()
     |> WorkspaceLive.maybe_refresh_git()

--- a/editors/liveview/lib/bt_attach_web/live/system_browser.ex
+++ b/editors/liveview/lib/bt_attach_web/live/system_browser.ex
@@ -1,0 +1,1570 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.Live.SystemBrowser do
+  @moduledoc """
+  The System Browser pane (BT-2491, epic BT-2482 Phase 2) — class tree,
+  instance/class side toggle, protocol + method list, method source opening,
+  and the source-navigation affordances (hover/goto-definition/senders/
+  implementors) — extracted out of `BtAttachWeb.WorkspaceLive` (BT-3297,
+  epic BT-3290) so its `handle_event/3` clauses and the browse/navigation
+  data model they drive are directly unit-testable instead of only reachable
+  through a full-LiveView integration test. Follows the same extraction shape
+  `BtAttachWeb.Live.Inspector` (BT-3291), `BtAttachWeb.Live.Dock` (BT-3295),
+  and `BtAttachWeb.Live.MethodEditor` (BT-3296) established.
+
+  This module owns:
+
+    * **Class tree** — two toggleable views (`"browser_view"`): Hierarchy
+      (indented by superclass depth) and Category (grouped by the class
+      annotation). Selecting a class (`"browser_select_class"`) fetches its
+      protocols for the current side. Hierarchy layout itself is NOT
+      reimplemented here — it delegates to `BtAttachWeb.ClassTree`
+      (`hierarchy_rows_with_context/2`), the existing extraction precedent.
+    * **Instance / class side toggle** (`"browser_side"`) — re-populates the
+      protocol + method list for the flipped side.
+    * **Protocol + method list** — `"browser_select_protocol"` (the filter
+      row), `"browser_select_method"` (opens the method editor tab via
+      `BtAttachWeb.Live.MethodEditor.open_method_tab/4`), and the grouped
+      method view's `// === Name ===` section-divider events
+      (`"browser_group_mode"`, `"browser_edit_section"`,
+      `"browser_cancel_section"`, `"browser_rename_section"`,
+      `"browser_add_section"`).
+    * **Class definitions + Native browser** — `"browser_open_definition"`,
+      `"browser_open_native"`, `"browser_mode"`, `"browser_open_native_module"`,
+      `"browser_jump_native"`.
+    * **Panel visibility** — `"close_browser"`, `"toggle_browser"`.
+    * **Source-navigation affordances** — `"complete"`/`"hover"`/
+      `"diagnostics"` (the CodeMirror editors' backend-driven autocomplete,
+      live-image hover, and parse-only lint sources), `"senders"` /
+      `"implementors"` / `"native_callers"` / `"required_methods"` /
+      `"conforming_classes"` (the Senders/Implementors/protocol-action result
+      popover), `"nav_open"` / `"nav_open_class"` / `"nav_required_open"` /
+      `"nav_close"` / `"dismiss_nav_error"` (opening/dismissing that
+      popover), and `"goto_definition"` (Ctrl/Cmd-click go-to-definition,
+      BT-2666).
+
+  Every workspace read/write goes through `BtAttach.Facade.dispatch/3` (ADR
+  0091 Decision 3) with `BtAttachWeb.Live.RequestContext` — never a raw
+  `BtAttach.Workspace`/`:rpc` call — so this module never reimplements the
+  `browse_*`/`senders`/`implementors`/… ops or the RBAC gates they ride
+  (CLAUDE.md no-duplicate-implementations), and reuses `BtAttachWeb.ClassTree`
+  directly for the Hierarchy walk rather than duplicating it.
+
+  State (`:browser_view`, `:browser_side`, `:browser_source`,
+  `:browser_source_chosen`, `:selected_class`, `:selected_protocol`,
+  `:browser_protocols`, `:browser_error`, `:browser_categories`,
+  `:browser_group_mode`, `:editing_section`, `:section_form_error`,
+  `:native_view`, `:browser_mode`, `:browser_native_modules`,
+  `:browser_type_aliases`, `:native_source`, `:native_source_chosen`,
+  `:nav_popover`, `:browser_classes`) stays on the LiveView's own socket —
+  initialised in `WorkspaceLive.bind_session/3` and mount, same as the
+  Dock/Inspector/MethodEditor assigns. `WorkspaceLive` still owns
+  `handle_event/3` (`Phoenix.LiveView` callback contracts) and `render/1`
+  (the System Browser panel markup is woven together with the top-bar omni
+  search and the still-resident New Class / Rename / Remove UI, so it does
+  not split cleanly along this extraction's event boundary — see
+  `Dock`'s/`Inspector`'s/`MethodEditor`'s moduledocs for the same call), but
+  delegates every System Browser event to the functions here by name — see
+  the `@system_browser_events` guard clause in `WorkspaceLive`, which reads
+  its event list from `__system_browser_events__/0` below (mirroring the
+  BT-3301 fix that keeps `WorkspaceLive` from hand-maintaining a second copy
+  of the event names).
+
+  The top-bar omni search (`"omni_search"`/`"omni_open"`/`"omni_close"`) is
+  a *different* navigator (a flat symbol index over every loaded class +
+  selector, not the tree/protocol/method browse ops) and stays
+  `WorkspaceLive`-owned; `open_class/2` here (which the omni search's class
+  result and `BtAttachWeb.Live.Dock`'s REPL `:help` meta-command both
+  cross-call) is the shared "point the System Browser at this class" primitive
+  the two navigators meet at.
+  """
+
+  use BtAttachWeb, :html
+
+  import Phoenix.LiveView, only: [put_flash: 3]
+
+  require Logger
+
+  alias BtAttach.Facade
+  alias BtAttachWeb.Live.FacadeError
+  alias BtAttachWeb.Live.MethodEditor
+  alias BtAttachWeb.Live.RequestContext
+
+  defp ctx(socket), do: RequestContext.build(socket)
+  defp facade_error(reason), do: FacadeError.render(reason)
+
+  # ── handle_event dispatch ────────────────────────────────────────────────
+  #
+  # `WorkspaceLive.handle_event/3` forwards every event whose name is in
+  # `@system_browser_events` (read from `__system_browser_events__/0` below)
+  # here unchanged (same event name, params, socket), so each clause below is
+  # exactly the body the LiveView used to run directly.
+  @system_browser_events ~w(
+    complete hover diagnostics
+    close_browser toggle_browser
+    browser_open_definition browser_open_native browser_mode
+    browser_open_native_module browser_jump_native
+    browser_view browser_source browser_side browser_select_class
+    browser_select_protocol browser_select_method browser_group_mode
+    browser_edit_section browser_cancel_section browser_rename_section
+    browser_add_section
+    senders implementors native_callers required_methods conforming_classes
+    nav_open_class nav_required_open nav_open nav_close goto_definition
+    dismiss_nav_error
+  )
+
+  @doc false
+  def __system_browser_events__, do: @system_browser_events
+
+  # Backend-driven autocomplete (BT-2544): the CodeMirror editors' autocomplete
+  # CompletionSource round-trips the current line up to the caret; we answer with
+  # ranked candidates from the live session via the `complete` op (receiver-aware:
+  # class names, selectors for a known receiver, session bindings, pseudo-vars).
+  # `:read` capability — completion runs no user code — so the Observer role
+  # completes too. We `{:reply, …}` on the same event so CodeMirror resolves its
+  # async source; an unreachable workspace, a denied op, or a missing session all
+  # degrade to an empty list (autocomplete simply shows nothing).
+  def handle_event("complete", %{"code" => code}, %{assigns: %{session_pid: pid}} = socket)
+      when is_pid(pid) and is_binary(code) do
+    completions =
+      case Facade.dispatch(:complete, %{session_pid: pid, code: code}, ctx(socket)) do
+        {:ok, list} when is_list(list) -> list
+        _ -> []
+      end
+
+    {:reply, %{"completions" => completions}, socket}
+  end
+
+  def handle_event("complete", _params, socket) do
+    {:reply, %{"completions" => []}, socket}
+  end
+
+  # Live-image hover (BT-2555): the CodeMirror editors' `hoverTooltip` source
+  # round-trips the editor line up to the hovered token; we answer with
+  # signature + doc-comment markdown from the live session via the `hover` op
+  # (a class name → its docs; a `Receiver selector` pair → that method's docs).
+  # `:read` capability — hover runs no user code — so the Observer role hovers
+  # too. We `{:reply, …}` on the same event so CodeMirror resolves its async
+  # tooltip source; an unreachable workspace, a denied op, a missing session, or
+  # nothing-to-show all degrade to an empty string (no tooltip is shown).
+  def handle_event("hover", %{"code" => code}, %{assigns: %{session_pid: pid}} = socket)
+      when is_pid(pid) and is_binary(code) do
+    hover =
+      case Facade.dispatch(:hover, %{session_pid: pid, code: code}, ctx(socket)) do
+        {:ok, docs} when is_binary(docs) -> docs
+        _ -> ""
+      end
+
+    {:reply, %{"hover" => hover}, socket}
+  end
+
+  def handle_event("hover", _params, socket) do
+    {:reply, %{"hover" => ""}, socket}
+  end
+
+  # Live parse-only diagnostics (BT-2556): the CodeMirror editors'
+  # `@codemirror/lint` source round-trips the FULL buffer; we answer with
+  # error/warning ranges from the compiler's side-effect-free `diagnostics` path
+  # (parse + semantic check, NO codegen / install / eval / ChangeLog), so it is
+  # safe to fire as the buffer changes and is a `:read` op — the Observer role
+  # sees diagnostics too. We `{:reply, …}` on the same event so CodeMirror
+  # resolves its async lint source; an unreachable workspace, a denied op, or a
+  # bad shape all degrade to an empty list (no squiggles shown). Diagnostics do
+  # not need a session pid — they analyse the buffer in isolation — so unlike
+  # `complete`/`hover` there is no `session_pid` guard.
+  #
+  # Debounce lives on the CLIENT: the `@codemirror/lint` `linter(…, {delay})`
+  # only invokes this source after the editor has been idle, so rapid keystrokes
+  # never flood the workspace (the same pattern the LSP uses to debounce
+  # `didChange`). A server-side *drop* debounce would break the request/reply
+  # contract — a coalesced request's reply would never arrive — so the throttle
+  # is deliberately upstream of the round-trip, not in this handler.
+  def handle_event("diagnostics", %{"code" => code} = params, socket) when is_binary(code) do
+    # `mode` (BT-2569) selects the parse grammar. The method-editor CmEditor sends
+    # "method" (a bare method body — `=>` is not a valid top-level token, so the
+    # default script grammar would false-positive); the Workspace + REPL editors
+    # send nothing. Forward the raw client value — the facade normalises it to a
+    # known binary ("method" | "expression"), the single boundary for every caller.
+    diagnostics =
+      case Facade.dispatch(
+             :diagnostics,
+             %{code: code, mode: Map.get(params, "mode")},
+             ctx(socket)
+           ) do
+        {:ok, list} when is_list(list) -> list
+        _ -> []
+      end
+
+    {:reply, %{"diagnostics" => diagnostics}, socket}
+  end
+
+  def handle_event("diagnostics", _params, socket) do
+    {:reply, %{"diagnostics" => []}, socket}
+  end
+
+  # Panel visibility toggles (BT-2559): close/toggle the System Browser panel.
+  def handle_event("toggle_browser", _params, socket) do
+    {:noreply, assign(socket, show_browser: !socket.assigns.show_browser)}
+  end
+
+  def handle_event("close_browser", _params, socket) do
+    {:noreply, assign(socket, show_browser: false)}
+  end
+
+  # Open the *selected* class's definition tab from the System Browser's "class
+  # definition" entry (BT-2491). The class rides the click; a malformed payload
+  # is ignored rather than crashing the LiveView.
+  def handle_event("browser_open_definition", %{"class" => class}, socket)
+      when is_binary(class) and class != "" do
+    {:noreply, MethodEditor.open_definition(socket, class)}
+  end
+
+  def handle_event("browser_open_definition", _params, socket), do: {:noreply, socket}
+
+  # BT-2578: toggle the read-only native backing-source pane on a class-definition
+  # tab. A native: class (ADR 0056) only has `self delegate` facade methods — the
+  # real logic lives in the backing gen_server module's `handle_call` clauses — so
+  # this surfaces that module's `.erl` read-only. The backing source is lazily
+  # fetched on first open (a `:read` op, safe for the Observer) and cached on
+  # `native_view`; a second click collapses it.
+  def handle_event("browser_open_native", %{"class" => class}, socket)
+      when is_binary(class) and class != "" do
+    if native_shown?(socket.assigns, class) do
+      {:noreply, assign(socket, native_view: nil)}
+    else
+      {:noreply, assign(socket, native_view: load_native_view(socket, class))}
+    end
+  end
+
+  def handle_event("browser_open_native", _params, socket), do: {:noreply, socket}
+
+  # BT-2656: switch the left browser column between the class tree (`classes`) and
+  # the separate Native browser (`native`) via the panel-head `Classes | Native`
+  # toggle. Switching into Native mode re-fetches the module list so a dependency
+  # loaded mid-session is discoverable; an unknown mode is ignored rather than
+  # blanking the panel.
+  def handle_event("browser_mode", %{"mode" => "native"}, socket) do
+    {:noreply, assign(assign_browser_native_modules(socket), browser_mode: :native)}
+  end
+
+  def handle_event("browser_mode", %{"mode" => "classes"}, socket) do
+    {:noreply, assign(socket, browser_mode: :classes)}
+  end
+
+  # BT-2903: switch into the "Type Aliases" panel, re-fetching so an alias
+  # declared mid-session is discoverable — mirroring the Native mode switch.
+  def handle_event("browser_mode", %{"mode" => "aliases"}, socket) do
+    {:noreply, assign(assign_browser_type_aliases(socket), browser_mode: :aliases)}
+  end
+
+  def handle_event("browser_mode", _params, socket), do: {:noreply, socket}
+
+  # BT-2667: open a standalone native module's `.erl` as a first-class read-only
+  # editor TAB (a `:native` tab kind) rather than the old single-slot overlay
+  # assign. The module source now coexists with class/method tabs, switches and
+  # closes like any tab, and scrolls inside the editor pane. A module already open
+  # is re-focused (keyed by `native:<module>`) rather than duplicated. A module
+  # with no readable source still opens — the tab body shows the honest "Erlang
+  # source not available" empty state (BT-2648/BT-2668).
+  def handle_event("browser_open_native_module", %{"module" => module}, socket)
+      when is_binary(module) and module != "" do
+    {:noreply, open_native_module_tab(socket, module)}
+  end
+
+  def handle_event("browser_open_native_module", _params, socket), do: {:noreply, socket}
+
+  # BT-2578: jump from a `self delegate` method to its Erlang implementation.
+  # Opens (or focuses) the class-definition tab and expands the native pane with
+  # the method's selector resolved to its matching `handle_call` clause (which the
+  # pane highlights). The selector→clause mapping is best-effort: a delegate that
+  # completes in `handle_info` resolves to no clause, and the pane says so rather
+  # than pretending.
+  def handle_event("browser_jump_native", %{"class" => class, "selector" => selector}, socket)
+      when is_binary(class) and class != "" and is_binary(selector) do
+    socket = MethodEditor.open_definition(socket, class)
+    {:noreply, assign(socket, native_view: load_native_view(socket, class, selector))}
+  end
+
+  def handle_event("browser_jump_native", _params, socket), do: {:noreply, socket}
+
+  # ── System Browser (BT-2491, epic BT-2482 Phase 2) ──────────────────────────
+
+  # Toggle the class tree between Hierarchy (indented by superclass) and Category
+  # (grouped by annotation). Pure view state over the already-loaded class rows —
+  # no workspace round-trip; an unknown view is ignored rather than blanking the
+  # tree.
+  def handle_event("browser_view", %{"view" => view}, socket)
+      when view in ~w(hierarchy category) do
+    {:noreply, assign(socket, browser_view: view)}
+  end
+
+  def handle_event("browser_view", _params, socket), do: {:noreply, socket}
+
+  # Narrow the class tree by source origin (project / deps / stdlib / all). Pure
+  # view state over the already-loaded rows — no workspace round-trip; an unknown
+  # value is ignored rather than blanking the tree (BT-2557).
+  #
+  # BT-2597: if the new filter hides the currently-selected class, clear the
+  # selection (and its protocol/method pane) so the right pane can't show a
+  # "ghost" selection for a class no longer visible in the tree.
+  def handle_event("browser_source", %{"src" => src}, socket)
+      when src in ~w(all project deps stdlib) do
+    # BT-2661: a deliberate pick marks the filter "chosen" so the BT-2661 initial
+    # default (applied once the async class load lands) can never override it.
+    socket = assign(socket, browser_source: src, browser_source_chosen: true)
+
+    socket =
+      if selected_class_visible?(socket) do
+        socket
+      else
+        assign(socket,
+          selected_class: nil,
+          selected_protocol: nil,
+          browser_protocols: [],
+          browser_categories: default_categories(),
+          browser_group_mode: "protocol",
+          editing_section: nil,
+          section_form_error: nil
+        )
+      end
+
+    {:noreply, socket}
+  end
+
+  def handle_event("browser_source", _params, socket), do: {:noreply, socket}
+
+  # Toggle the instance/class side. The protocol/method list is class-side
+  # specific (a class's instance methods differ from its class methods), so
+  # flipping the side re-fetches the selected class's protocols for the new side
+  # and clears the protocol filter. Pure toggle when no class is selected yet.
+  def handle_event("browser_side", %{"side" => side}, socket)
+      when side in ~w(instance class) do
+    socket = assign(socket, browser_side: side, selected_protocol: nil)
+
+    case socket.assigns.selected_class do
+      nil -> {:noreply, assign(socket, browser_protocols: [])}
+      class -> {:noreply, load_protocols(socket, class, side)}
+    end
+  end
+
+  def handle_event("browser_side", _params, socket), do: {:noreply, socket}
+
+  # Select a class in the tree: fetch its protocols (for the current side) and
+  # reset the protocol filter. A non-binary / absent class name is ignored rather
+  # than crashing the LiveView.
+  def handle_event("browser_select_class", %{"class" => class}, socket)
+      when is_binary(class) do
+    socket =
+      assign(socket, selected_class: class, selected_protocol: nil)
+      |> load_protocols(class, socket.assigns.browser_side)
+      |> load_categories(class)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("browser_select_class", _params, socket), do: {:noreply, socket}
+
+  # Set the protocol filter (the method list shows only that protocol's
+  # selectors). An empty value clears the filter back to "all" — the spike's ∗
+  # row. Pure view state over the already-loaded protocol tree.
+  def handle_event("browser_select_protocol", %{"protocol" => protocol}, socket)
+      when is_binary(protocol) do
+    filter = if protocol == "", do: nil, else: protocol
+    {:noreply, assign(socket, selected_protocol: filter)}
+  end
+
+  def handle_event("browser_select_protocol", _params, socket), do: {:noreply, socket}
+
+  # Select a method: open (or focus) it as a tab in the method editor, seeded with
+  # its image-accurate source. Browsing *is* editing — the Smalltalk idiom — so a
+  # browser click feeds the same write-surface the omni search and Senders /
+  # Implementors navigation already do (`open_method_tab`), rather than a separate
+  # read-only panel. The class/side/selector ride the click; a malformed payload is
+  # ignored.
+  def handle_event(
+        "browser_select_method",
+        %{"class" => class, "side" => side, "selector" => selector},
+        socket
+      )
+      when is_binary(class) and is_binary(side) and is_binary(selector) do
+    {:noreply, MethodEditor.open_method_tab(socket, class, side, selector)}
+  end
+
+  def handle_event("browser_select_method", _params, socket), do: {:noreply, socket}
+
+  # ── grouped method view: `// === Name ===` section dividers (BT-3238) ──────
+
+  # Toggle the method list between the existing per-protocol grouping and the
+  # divider-category grouping. The UI only renders this toggle when
+  # `browser_categories["has_dividers"]` is true (a divider-free class never
+  # shows it, so its method list renders exactly as before), but the handler
+  # itself just no-ops on an unrecognised mode rather than trusting that gate.
+  def handle_event("browser_group_mode", %{"mode" => mode}, socket)
+      when mode in ~w(protocol section) do
+    {:noreply,
+     assign(socket, browser_group_mode: mode, editing_section: nil, section_form_error: nil)}
+  end
+
+  def handle_event("browser_group_mode", _params, socket), do: {:noreply, socket}
+
+  # Open the inline section form: renaming an existing section (`name` is
+  # that section's current divider text) or adding a new one (`name` is
+  # empty, the `:new` sentinel). Owner-only, matching `new_method`'s gate —
+  # authoring is Owner-only, so the entry is rendered only for `:owner` and a
+  # crafted event from a read-only role is a no-op.
+  def handle_event(
+        "browser_edit_section",
+        %{"name" => name},
+        %{assigns: %{role: :owner}} = socket
+      )
+      when is_binary(name) do
+    target = if name == "", do: :new, else: name
+    {:noreply, assign(socket, editing_section: target, section_form_error: nil)}
+  end
+
+  def handle_event("browser_edit_section", _params, socket), do: {:noreply, socket}
+
+  # Close the inline section form without saving.
+  def handle_event("browser_cancel_section", _params, socket) do
+    {:noreply, assign(socket, editing_section: nil, section_form_error: nil)}
+  end
+
+  # Rename an existing section: `old_name` identifies the divider being
+  # edited, `new_name` is the submitted form text.
+  def handle_event(
+        "browser_rename_section",
+        %{"old_name" => old_name, "new_name" => new_name},
+        %{assigns: %{role: :owner, selected_class: class}} = socket
+      )
+      when is_binary(old_name) and is_binary(new_name) and is_binary(class) do
+    {:noreply, submit_section(socket, class, new_name, old_name: old_name)}
+  end
+
+  def handle_event("browser_rename_section", _params, socket), do: {:noreply, socket}
+
+  # Add a brand-new section directly above `before_selector` (the method
+  # picked in the inline "add section" form's dropdown).
+  def handle_event(
+        "browser_add_section",
+        %{"new_name" => new_name, "before_selector" => before_selector} = params,
+        %{assigns: %{role: :owner, selected_class: class, browser_side: side}} = socket
+      )
+      when is_binary(new_name) and is_binary(before_selector) and is_binary(class) do
+    before_side = Map.get(params, "before_side", side)
+
+    {:noreply,
+     submit_section(socket, class, new_name,
+       before_selector: before_selector,
+       before_side: before_side
+     )}
+  end
+
+  def handle_event("browser_add_section", _params, socket), do: {:noreply, socket}
+
+  # ── senders / implementors popovers (BT-2495) ───────────────────────────────
+
+  # The method editor's Senders / Implementors buttons: query the navigation
+  # channel for the active tab's selector and open the result popover. Both ride
+  # the same `nav-query` read (kinds `senders` / `implementors`); a missing
+  # selector (e.g. a class-definition tab) is ignored so the buttons no-op
+  # gracefully rather than querying an empty selector.
+  def handle_event("senders", _params, socket) do
+    {:noreply, run_nav_query(socket, :senders)}
+  end
+
+  def handle_event("implementors", _params, socket) do
+    {:noreply, run_nav_query(socket, :implementors)}
+  end
+
+  # ── native-module callers popover (BT-2669) ─────────────────────────────────
+  #
+  # The native-module viewer's Callers button: query the navigation channel for
+  # the Beamtalk methods that call into the focused `:native` tab's module via
+  # `(Erlang <module>) …` (the reverse of "go to native source") and open the
+  # same result popover the Senders/Implementors buttons use. A non-native tab is
+  # a graceful no-op so the button (only rendered on native tabs) never queries.
+  def handle_event("native_callers", _params, socket) do
+    {:noreply, run_native_callers_query(socket)}
+  end
+
+  # ── protocol actions (BT-2639) ──────────────────────────────────────────────
+  #
+  # The protocol equivalent of Senders/Implementors: on a class-definition tab
+  # whose class is a Protocol, query its required methods / conforming classes and
+  # open the same result popover. Both ride the `nav-query` channel (kinds
+  # `required_methods` / `conforming_classes`); a non-protocol def tab is a
+  # graceful no-op so the buttons (only rendered for protocols) never query a
+  # plain class.
+  def handle_event("required_methods", _params, socket) do
+    {:noreply, run_protocol_nav_query(socket, :required_methods)}
+  end
+
+  def handle_event("conforming_classes", _params, socket) do
+    {:noreply, run_protocol_nav_query(socket, :conforming_classes)}
+  end
+
+  # Open a conforming-class row (BT-2639): clicking a class in the Conforming
+  # classes popover opens that class's definition pane and points the System
+  # Browser tree at it, then closes the popover. Reuses the existing open-class
+  # definition path (`open_definition/2`).
+  def handle_event("nav_open_class", %{"class" => class}, socket) when is_binary(class) do
+    socket =
+      socket
+      |> MethodEditor.open_definition(class)
+      |> assign(nav_popover: nil)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("nav_open_class", _params, socket),
+    do: {:noreply, assign(socket, nav_popover: nil)}
+
+  # Open the Implementors of a required-method selector (BT-2639): clicking a row
+  # in the Required methods popover re-runs the `nav-query` `implementors` kind for
+  # that selector (reusing the BT-2495 nav path), replacing the popover contents
+  # with the implementing classes.
+  def handle_event("nav_required_open", %{"selector" => selector}, socket)
+      when is_binary(selector) and selector != "" do
+    {:noreply, run_nav_query_for(socket, :implementors, selector)}
+  end
+
+  def handle_event("nav_required_open", _params, socket),
+    do: {:noreply, assign(socket, nav_popover: nil)}
+
+  # Open a site from the Senders/Implementors popover in the method-editor tab
+  # strip (its class + selector + side) and point the System Browser at that
+  # class/side too, so a jump to another class navigates the tree alongside the
+  # editor, then close the popover.
+  def handle_event(
+        "nav_open",
+        %{"class" => class, "side" => side, "selector" => selector},
+        socket
+      )
+      when is_binary(class) and is_binary(side) and is_binary(selector) do
+    socket =
+      socket
+      |> MethodEditor.open_method_tab(class, side, selector)
+      |> navigate_browser(class, side)
+      |> assign(nav_popover: nil)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("nav_open", _params, socket), do: {:noreply, assign(socket, nav_popover: nil)}
+
+  # Dismiss the Senders/Implementors popover.
+  def handle_event("nav_close", _params, socket), do: {:noreply, assign(socket, nav_popover: nil)}
+
+  # ── Ctrl/Cmd-click go-to-definition (BT-2666) ───────────────────────────────
+  #
+  # The CodeMirror editors' `cm_goto.js` extension fires this when the user
+  # modifier-clicks a symbol. `token` is the bare identifier under the pointer;
+  # `code` is the editor line up to (and including) that token (the same
+  # `Receiver selector` line-prefix the `hover` op consumes). We resolve the
+  # clicked symbol to a definition target against the LIVE image, mirroring the
+  # LSP `definition_provider.rs` resolution order (class def, then selector send;
+  # locals/params are a future client-side resolve), and open it by REUSING the
+  # existing nav plumbing:
+  #
+  #   * a known CLASS name → open its `:def` definition tab (`open_definition/2`)
+  #     and point the System Browser at it, exactly as `nav_open_class` does.
+  #   * otherwise treat it as a SELECTOR send → run the BT-2495 `implementors`
+  #     `nav-query`. One implementor → open that method tab directly
+  #     (`open_method_tab/4` + `navigate_browser/3`, the `nav_open` path); several
+  #     → open the shared Senders/Implementors popover so the user picks; none →
+  #     a brief flash (the unresolved no-op), leaving the editor untouched.
+  #
+  # A class name takes priority over a same-named selector, matching the LSP
+  # (class declaration before selector). Unresolvable input (empty token, an
+  # unknown symbol with no implementors) flashes "No definition found" rather
+  # than crashing or silently doing nothing — the graceful no-op the AC asks for.
+  def handle_event("goto_definition", %{"token" => token} = params, socket)
+      when is_binary(token) do
+    code = Map.get(params, "code", "")
+    {:noreply, run_goto_definition(socket, token, code)}
+  end
+
+  def handle_event("goto_definition", _params, socket), do: {:noreply, socket}
+
+  # Dismiss the error inside the Senders/Implementors popover without closing the
+  # whole popover (which `nav_close` does). `@nav_popover` is a map; clear only
+  # its `:error` field.
+  def handle_event("dismiss_nav_error", _params, socket) do
+    case socket.assigns[:nav_popover] do
+      %{} = nav -> {:noreply, assign(socket, nav_popover: Map.put(nav, :error, nil))}
+      _ -> {:noreply, socket}
+    end
+  end
+
+  # ── System Browser data source (BT-2491, browse ops ADR 0096) ───────────────
+  #
+  # The four browse ops return a `{:value, json_value}` live term verbatim
+  # (wire-shaped maps/lists of binaries — JSON only at the WebSocket edge, never
+  # here) or `{:error, reason}`. Each `assign_*`/`load_*` helper unwraps that and
+  # holds the rows in browser assigns the render walks; a dispatch failure or an
+  # RBAC denial renders a `browser_error` rather than crashing the pane.
+
+  # Load every class in scope for the class tree (op 1, `browse-classes`). Sorted
+  # workspace-side; the rows carry `superclass`/`category`/`origin` so the
+  # Hierarchy and Category views and the runtime badge render off one fetch.
+  #
+  # Split into the off-socket read + pure fold (BT-2591) so the mount-load async
+  # task and the post-action refresh callers share one fold. Public:
+  # `BtAttachWeb.Live.MethodEditor`'s `refresh_after_source_change/1` (BT-3296)
+  # and `WorkspaceLive`'s Remove/Rename/New-Class code call it directly.
+  def assign_browser_classes(socket),
+    do: apply_browser_classes(socket, read_browser_classes(socket))
+
+  defp read_browser_classes(socket), do: Facade.dispatch(:browse_classes, %{}, ctx(socket))
+
+  # Public: `WorkspaceLive.handle_async(:mount_load, …)` folds the off-socket
+  # mount read through this directly (`&SystemBrowser.apply_browser_classes/2`).
+  def apply_browser_classes(socket, {:value, rows}) when is_list(rows) do
+    socket
+    |> assign(browser_classes: rows, browser_error: nil)
+    |> apply_default_browser_source(rows)
+  end
+
+  def apply_browser_classes(socket, {:error, reason}),
+    do: assign(socket, browser_classes: [], browser_error: facade_error(reason))
+
+  # Defensive catch-all (BT-2591): this fold runs in `handle_async(:mount_load,
+  # …)` AND on the sync `assign_browser_classes/1` refresh path. An unexpected
+  # dispatch shape (a facade evolution, a bare atom) would otherwise crash the
+  # LiveView — on the async path *after* the empty page rendered, harder to spot
+  # than the old mount-time crash. Degrade to an empty tree with an error instead.
+  def apply_browser_classes(socket, unexpected) do
+    Logger.warning("unexpected browse_classes result: #{inspect(unexpected)}",
+      domain: [:beamtalk, :liveview]
+    )
+
+    assign(socket, browser_classes: [], browser_error: facade_error(:unexpected_response))
+  end
+
+  # BT-2661: apply the one-shot initial origin-filter default once the class rows
+  # arrive. The tree opens scoped to the project's own classes ("show me my code")
+  # — but only on the FIRST successful load (`:browser_source_chosen` still false)
+  # and only when there is at least one project-origin class to show; a bare /
+  # stdlib-only workspace falls back to "all" so the tree isn't empty on open. The
+  # flag flips `true` here (and in the `browser_source` handler when the user picks
+  # a filter), so a later async refresh / live push never resets a deliberate
+  # choice — the chosen value always wins over the default.
+  defp apply_default_browser_source(%{assigns: %{browser_source_chosen: true}} = socket, _rows),
+    do: socket
+
+  defp apply_default_browser_source(socket, rows) do
+    assign(socket,
+      browser_source: default_browser_source(rows),
+      browser_source_chosen: true
+    )
+  end
+
+  # "project" when the workspace has any project-origin class, else "all" (the
+  # empty-project fallback). The `source_origin` field is the bare classification
+  # (BT-2643); project rows carry "project" (the `source_origin_class/1` default
+  # bucket), so an explicit equality match is enough.
+  defp default_browser_source(rows) do
+    if Enum.any?(rows, &(Map.get(&1, "source_origin") == "project")),
+      do: "project",
+      else: "all"
+  end
+
+  # BT-2648/BT-2656: load the loaded packages' hand-written native Erlang modules
+  # for the separate Native browser. Each row carries `module`, `source_file`,
+  # `package`, `source_origin`, and `openable`. A dispatch failure / RBAC denial
+  # yields an empty list rather than crashing the browser — the class tree (the
+  # primary navigator) must still render. Public: `WorkspaceLive.bind_session/3`
+  # calls it directly at mount.
+  def assign_browser_native_modules(socket) do
+    rows =
+      case Facade.dispatch(:browse_native_modules, %{}, ctx(socket)) do
+        {:value, rows} when is_list(rows) -> rows
+        _ -> []
+      end
+
+    socket
+    |> assign(browser_native_modules: rows)
+    |> apply_default_native_source(rows)
+  end
+
+  # BT-2903 (ADR 0108 Phase 8): load every loaded package's declared `type`
+  # aliases for the "Type Aliases" panel. Each row carries `name`,
+  # `expansion`, `doc`, `source_file`, `internal`, `package`, and
+  # `source_origin`. A dispatch failure / RBAC denial yields an empty list
+  # rather than crashing the browser — the class tree (the primary
+  # navigator) must still render. No client-side origin filter: unlike
+  # native modules, a dependency's `internal` alias is already excluded
+  # server-side at the seeding boundary, so there is nothing left to filter.
+  # Public: `WorkspaceLive.bind_session/3` calls it directly at mount.
+  def assign_browser_type_aliases(socket) do
+    rows =
+      case Facade.dispatch(:browse_type_aliases, %{}, ctx(socket)) do
+        {:value, rows} when is_list(rows) -> rows
+        _ -> []
+      end
+
+    assign(socket, browser_type_aliases: rows)
+  end
+
+  # BT-2656/BT-2661: apply the one-shot Project-origin default to the Native browser
+  # once the module rows arrive, mirroring `apply_default_browser_source/2` for the
+  # class tree. Only on the FIRST load (`:native_source_chosen` still false) and only
+  # when there is at least one project-origin native module to show; otherwise it
+  # falls back to "all" so the list isn't empty on open. A deliberate pick flips the
+  # flag in the `native_source` handler so a later refresh never resets it.
+  defp apply_default_native_source(%{assigns: %{native_source_chosen: true}} = socket, _rows),
+    do: socket
+
+  defp apply_default_native_source(socket, rows) do
+    assign(socket,
+      native_source: default_browser_source(rows),
+      native_source_chosen: true
+    )
+  end
+
+  # Load `class`/`side`'s selectors grouped by protocol (op 2, `browse-protocols`)
+  # for the protocol filter row + method list. The `protocols` list each carry a
+  # `name` and `selectors`; an unknown class / bad side comes back as a structured
+  # error we surface without blanking the rest of the pane.
+  defp load_protocols(socket, class, side) do
+    case Facade.dispatch(:browse_protocols, %{class: class, side: side}, ctx(socket)) do
+      {:value, %{"protocols" => protocols}} when is_list(protocols) ->
+        assign(socket, browser_protocols: protocols, browser_error: nil)
+
+      {:value, _other} ->
+        assign(socket, browser_protocols: [], browser_error: nil)
+
+      {:error, reason} ->
+        assign(socket, browser_protocols: [], browser_error: facade_error(reason))
+    end
+  end
+
+  # Load `class`'s methods grouped by `// === Name ===` section-divider
+  # category (op `browse-categories`, BT-3238) for the grouped method view.
+  # Class-wide (not per-side, unlike protocols) — a category can hold both
+  # instance- and class-side methods. Resets the group-mode toggle back to
+  # "protocol" and clears any in-progress section edit whenever the class
+  # changes, so switching classes never leaves a stale rename form open. A
+  # dispatch failure degrades to the default "unaffected" shape (`browser_categories`
+  # is a rendering aid, not something worth surfacing its own error banner for
+  # — the protocol/method list is still fully usable).
+  defp load_categories(socket, class) do
+    socket
+    |> refresh_categories(class)
+    |> assign(browser_group_mode: "protocol", editing_section: nil, section_form_error: nil)
+  end
+
+  # BT-3238: re-fetch `browse-categories` WITHOUT resetting `browser_group_mode`
+  # / `editing_section` — the post-save refresh path (`submit_section/4`) uses
+  # this alone, not `load_categories/2`, so a successful rename/add doesn't
+  # kick the viewer back to Protocol mode right after they used Sections mode
+  # to get there (review finding: `load_categories/2` used to reset the mode
+  # unconditionally on every call, including this one).
+  defp refresh_categories(socket, class) do
+    view =
+      case Facade.dispatch(:browse_categories, %{class: class}, ctx(socket)) do
+        {:value, %{"has_dividers" => _, "categories" => _} = view} -> view
+        _ -> default_categories()
+      end
+
+    assign(socket, browser_categories: view)
+  end
+
+  # Public: `WorkspaceLive.bind_session/3` calls it directly at mount.
+  def default_categories, do: %{"has_dividers" => false, "categories" => []}
+
+  # BT-3238: flattens `browse-categories`' category list into one ordered
+  # list of `side`-only method rows, in source order across every category —
+  # the section-mode method list renders from this (filtered per-category at
+  # render time), and the "has any methods at all" empty-state check uses it
+  # unfiltered. Public: `WorkspaceLive`'s `system_browser_methods/1` render
+  # component calls it directly.
+  def category_methods_for_side(categories, side) when is_list(categories) do
+    Enum.flat_map(categories, fn category ->
+      Enum.filter(category["methods"] || [], &(&1["side"] == side))
+    end)
+  end
+
+  def category_methods_for_side(_categories, _side), do: []
+
+  # BT-3238: the "add a new section" form's before-selector dropdown draws
+  # from this, NOT the full `category_methods_for_side/2` list — it excludes
+  # each named category's own first method. Inserting a new divider directly
+  # above a method that already starts a category would write two dividers
+  # back-to-back with nothing between them; `find_divider_span`'s own doc
+  # (`method_category.rs`) says only the nearer one survives, so the
+  # existing category's divider would be silently orphaned (its methods
+  # merging into whatever category preceded it) rather than cleanly split.
+  # Every method in the implicit (unnamed) leading group stays a valid
+  # insertion point — there is no divider there yet to collide with — and so
+  # does every method after a category's first, since a new divider there
+  # cleanly splits that category into two. Public: `WorkspaceLive`'s
+  # `system_browser_methods/1` render component calls it directly.
+  def insertable_methods_for_side(categories, side) when is_list(categories) do
+    Enum.flat_map(categories, fn category ->
+      same_side = Enum.filter(category["methods"] || [], &(&1["side"] == side))
+
+      case category["name"] do
+        nil ->
+          same_side
+
+        _named ->
+          # A category's "first method" is its first method OVERALL (any
+          # side), matching the server-side collision guard
+          # (`starts_named_category/3`, `beamtalk_repl_ops_load.erl`) — not
+          # the first *same-side* method. A category can legitimately open
+          # with a class-side method and continue with instance-side ones;
+          # filtering by side before dropping "the first" would wrongly
+          # treat that instance-side method as the category's start and
+          # exclude it, when the server would happily accept it.
+          case category["methods"] || [] do
+            [first_overall | _] -> Enum.reject(same_side, &(&1 == first_overall))
+            [] -> []
+          end
+      end
+    end)
+  end
+
+  def insertable_methods_for_side(_categories, _side), do: []
+
+  # BT-3238: dispatch `save-section` (rename via `old_name:`, or insert via
+  # `before_selector:`/`before_side:` — the caller passes exactly one shape
+  # via `opts`) and, on success, close the inline form and refresh the
+  # grouped view so the new/renamed divider shows up immediately. A failure
+  # surfaces inline on the form (`section_form_error`) rather than the
+  # page-wide `@save_error` notice, since it's scoped to the small form, not
+  # the whole editor.
+  defp submit_section(socket, class, new_name, opts) do
+    params = Map.merge(%{class: class, new_name: new_name}, Map.new(opts))
+
+    case Facade.dispatch(:save_section, params, ctx(socket)) do
+      {:value, %{"ok" => true}} ->
+        socket
+        |> assign(editing_section: nil, section_form_error: nil)
+        |> refresh_categories(class)
+
+      {:error, reason} ->
+        assign(socket, section_form_error: facade_error(reason))
+
+      _other ->
+        assign(socket, section_form_error: "Could not save the section.")
+    end
+  end
+
+  # Open a class in the System Browser (the omni-search "class" result): select it
+  # in the tree and load its protocols for the current side, exactly as a click in
+  # the class tree would. Public: `WorkspaceLive`'s own `omni_open` handler and
+  # `BtAttachWeb.Live.Dock`'s REPL `:help` / `Beamtalk help:` follow-up (BT-3295)
+  # call it directly (the omni search itself stays `WorkspaceLive`-owned — see
+  # this module's `@moduledoc`).
+  def open_class(socket, class) do
+    socket
+    |> assign(selected_class: class, selected_protocol: nil)
+    |> load_protocols(class, socket.assigns.browser_side)
+    |> load_categories(class)
+  end
+
+  # Point the System Browser at a class/side — select it in the tree, flip the
+  # instance/class toggle to match, clear the protocol filter, and load its
+  # protocols. Used when a method is opened from *outside* the browser (a
+  # Senders/Implementors jump to another class) so the pane tracks the focused
+  # tab, per the "browser highlights whatever the focused tab shows" design.
+  defp navigate_browser(socket, class, side)
+       when is_binary(class) and is_binary(side) do
+    socket
+    |> assign(selected_class: class, browser_side: side, selected_protocol: nil)
+    |> load_protocols(class, side)
+    |> load_categories(class)
+  end
+
+  # BT-2578: fetch a native class's backing Erlang source for the read-only pane.
+  # `content: nil` is the honest "source not available" empty state (a `.beam`-only
+  # build that shipped no `.erl`); a non-native class / dispatch failure carries an
+  # `error` string instead.
+  defp load_native_view(socket, class, selector \\ nil) do
+    base = %{
+      class: class,
+      backing_module: nil,
+      source_file: nil,
+      source_origin: nil,
+      editable: false,
+      content: nil,
+      clauses: [],
+      # The selector a method→clause jump asked for, and the matching clause the
+      # backend resolved (or nil — a delegate may complete in `handle_info`).
+      requested_selector: selector,
+      selected_clause: nil,
+      error: nil
+    }
+
+    params = if selector, do: %{class: class, selector: selector}, else: %{class: class}
+
+    case Facade.dispatch(:browse_native_source, params, ctx(socket)) do
+      {:value, %{} = r} ->
+        %{
+          base
+          | backing_module: Map.get(r, "backing_module"),
+            # The Erlang op returns the atom `null` for absent values, which
+            # arrives over distribution as the Elixir atom `:null` (NOT `nil`).
+            # Normalise so template `is_nil/1` guards and `:if` truthiness behave
+            # (a raw `:null` is truthy and `is_nil(:null)` is false) — otherwise
+            # the "no matching handle_call clause" explanation never renders and a
+            # stripped-source path would interpolate as ":null" (BT-2578).
+            # BT-2668: clean the path to project-relative — never the absolute host
+            # path.
+            source_file: clean_native_path(Map.get(r, "source_file")),
+            source_origin: Map.get(r, "source_origin"),
+            editable: Map.get(r, "editable") == true,
+            content: nonempty_string(Map.get(r, "content")),
+            clauses: Map.get(r, "clauses", []),
+            selected_clause: map_or_nil(Map.get(r, "selected_clause"))
+        }
+
+      {:error, reason} ->
+        %{base | error: facade_error(reason)}
+
+      _ ->
+        %{base | error: "Could not load Erlang source."}
+    end
+  end
+
+  # True when a clause row is the one a jump selected (selector + line match).
+  # Public: `WorkspaceLive`'s `native_source_body/1` render component calls it
+  # directly.
+  def clause_active?(%{"selector" => s, "line" => l}, %{"selector" => s, "line" => l}), do: true
+  def clause_active?(_clause, _selected), do: false
+
+  defp nonempty_string(s) when is_binary(s) and s != "", do: s
+  defp nonempty_string(_), do: nil
+
+  # Normalise the Erlang `null` atom (delivered as `:null` over distribution) and
+  # any non-conforming value to a clean Elixir `nil` / typed value, so template
+  # guards (`is_nil/1`, `:if`) and interpolation behave (BT-2578).
+  defp map_or_nil(m) when is_map(m), do: m
+  defp map_or_nil(_), do: nil
+
+  # True when the native pane is currently showing `class`'s backing source.
+  # Public: `WorkspaceLive`'s render template calls it directly (the def-tab
+  # native pane toggle).
+  def native_shown?(%{native_view: %{class: shown}}, class), do: shown == class
+  def native_shown?(_assigns, _class), do: false
+
+  # BT-2648: fetch a standalone native module's source for the read-only pane,
+  # keyed by `module` (not class). Same normalisation as `load_native_view/3`
+  # (the Erlang `null` atom arrives as `:null` over distribution); `content: nil`
+  # is the honest "source not available" empty state.
+  defp load_native_module_view(socket, module) do
+    base = %{
+      module: module,
+      backing_module: nil,
+      source_file: nil,
+      source_origin: nil,
+      editable: false,
+      content: nil,
+      clauses: [],
+      requested_selector: nil,
+      selected_clause: nil,
+      error: nil
+    }
+
+    case Facade.dispatch(:browse_native_module_source, %{module: module}, ctx(socket)) do
+      {:value, %{} = r} ->
+        %{
+          base
+          | backing_module: Map.get(r, "backing_module"),
+            # BT-2668: clean the path to project-relative — never the absolute host
+            # path (the workspace may be remote / another user's machine).
+            source_file: clean_native_path(Map.get(r, "source_file")),
+            source_origin: Map.get(r, "source_origin"),
+            editable: Map.get(r, "editable") == true,
+            content: nonempty_string(Map.get(r, "content")),
+            clauses: Map.get(r, "clauses", []),
+            selected_clause: map_or_nil(Map.get(r, "selected_clause"))
+        }
+
+      {:error, reason} ->
+        %{base | error: facade_error(reason)}
+
+      _ ->
+        %{base | error: "Could not load Erlang source."}
+    end
+  end
+
+  # BT-2667: open (or re-focus) a standalone native module's `.erl` as a read-only
+  # `:native` editor tab. The tab is keyed by `native:<module>` so re-opening the
+  # same module focuses the existing tab rather than stacking a duplicate, and a
+  # native tab coexists with class/method tabs in the strip. The source is fetched
+  # once at open and cached on the tab's `native_view`; a `:beam`-only module still
+  # opens (its body shows the "source not available" empty state).
+  defp open_native_module_tab(socket, module) do
+    id = "native:" <> module
+
+    case MethodEditor.find_tab(socket, id) do
+      %{} -> MethodEditor.activate_tab(socket, id)
+      nil -> add_native_module_tab(socket, id, module)
+    end
+  end
+
+  # Builds the 4th tab kind (`:native`) sharing `BtAttachWeb.Live.MethodEditor`'s
+  # `:tabs` list/shape (see that module's "tabbed method editor data model"
+  # comment). A field added/renamed on the MethodEditor side must be mirrored
+  # here too (and vice versa).
+  defp add_native_module_tab(socket, id, module) do
+    view = load_native_module_view(socket, module)
+    # BT-2670: a project-owned native (`view.editable == true`) opens as an
+    # EDITABLE tab — seed the write-surface `source`/`base` from the fetched
+    # `.erl` content so the CodeMirror editor shows it and dirty-tracking works
+    # (mirroring a method/class tab). Deps/stdlib natives keep `source: ""` and
+    # the read-only render branch.
+    initial_source = if view.editable, do: view.content || "", else: ""
+
+    tab = %{
+      id: id,
+      kind: :native,
+      class: module,
+      side: nil,
+      selector: nil,
+      # The fetched native Erlang source view (content/clauses/error/clean
+      # source_file/editable). For a project-owned native the tab is editable
+      # (compile + reload + write-back via `native_save`); deps/stdlib stay
+      # read-only and the editor render takes the read-only :native branch.
+      native_view: view,
+      source: initial_source,
+      base: initial_source,
+      dirty: false,
+      disk_differs: false,
+      runtime_only: false,
+      disk_source: nil,
+      doc: nil,
+      signature: nil,
+      is_protocol: false,
+      # No Beamtalk-class modifier/origin badges on a raw `.erl` tab; the source
+      # origin shows in the native pane header instead. Keys present so the shared
+      # tab helpers' dot-access never crashes.
+      native_module: nil,
+      native_delegate: false,
+      class_modifiers: nil,
+      class_native: false,
+      source_origin: nil,
+      package: nil,
+      new: false
+    }
+
+    socket
+    |> assign(:tabs, socket.assigns.tabs ++ [tab])
+    |> assign(:active_tab, id)
+    |> MethodEditor.sync_active(tab)
+  end
+
+  # BT-2667: the module name of the focused `:native` tab (or nil) — drives the
+  # "sel" highlight on the System Browser's Native modules list so it tracks the
+  # native tab the editor is showing, mirroring how the class tree tracks the
+  # active class/def tab. Public: `WorkspaceLive`'s render template calls it
+  # directly.
+  def active_native_module(assigns) do
+    case MethodEditor.active_tab(assigns) do
+      %{kind: :native, class: module} -> module
+      _ -> nil
+    end
+  end
+
+  # BT-2668: turn an absolute on-disk `.erl` path into a clean, project-relative
+  # one for display — never leak the host filesystem layout (the workspace may be
+  # remote / another user's machine). Strips the build/project prefix up to a
+  # recognisable source root (`apps/`, `deps/`, `src/`, `native/`, `lib/`) so a
+  # path like `/home/james/src/proj/deps/http/native/x.erl` shows as
+  # `deps/http/native/x.erl`. A path that is already relative is returned as-is; an
+  # absolute path with no recognisable root falls back to its basename so only the
+  # file name (not the directory tree) is shown. `nil`/`:null`/empty → nil (the
+  # honest "no path" state — the viewer then omits the path line).
+  @native_path_roots ~w(apps deps src native lib)
+  def clean_native_path(path) when is_binary(path) and path != "" do
+    if String.starts_with?(path, "/") do
+      segments = String.split(path, "/", trim: true)
+
+      case Enum.find_index(segments, &(&1 in @native_path_roots)) do
+        nil -> List.last(segments)
+        idx -> segments |> Enum.drop(idx) |> Enum.join("/")
+      end
+    else
+      # Already relative (no leading "/"): trust it as the project-relative form.
+      path
+    end
+  end
+
+  def clean_native_path(_), do: nil
+
+  # Query senders/implementors of the active method's selector (`nav-query`) and
+  # open the result popover. A tab with no selector (a class-definition tab) is a
+  # graceful no-op — there is nothing to query. `kind` is `:senders` |
+  # `:implementors`; the facade op name matches.
+  defp run_nav_query(socket, kind) do
+    selector =
+      case MethodEditor.active_tab(socket.assigns) do
+        %{selector: sel} -> sel
+        nil -> nil
+      end
+
+    run_nav_query_for(socket, kind, selector)
+  end
+
+  # Run a senders/implementors `nav-query` for an explicit selector (BT-2639
+  # reuses this for the Required-methods → Implementors jump; BT-2495's
+  # active-tab path delegates here). A nil/empty selector is a graceful no-op.
+  defp run_nav_query_for(socket, kind, selector) do
+    if is_binary(selector) and selector != "" do
+      case Facade.dispatch(kind, %{selector: selector}, ctx(socket)) do
+        {:value, %{"sites" => sites}} when is_list(sites) ->
+          assign(socket, nav_popover: %{kind: kind, selector: selector, sites: sites})
+
+        {:value, _other} ->
+          assign(socket, nav_popover: %{kind: kind, selector: selector, sites: []})
+
+        {:error, reason} ->
+          assign(socket,
+            nav_popover: %{kind: kind, selector: selector, sites: [], error: facade_error(reason)}
+          )
+
+        # Any other shape (version skew, an unexpected reply) degrades to an empty
+        # popover with a generic message rather than crashing the LiveView.
+        _other ->
+          assign(socket,
+            nav_popover: %{
+              kind: kind,
+              selector: selector,
+              sites: [],
+              error: "Navigation unavailable."
+            }
+          )
+      end
+    else
+      socket
+    end
+  end
+
+  # Query a protocol's required methods / conforming classes (`nav-query`
+  # `required_methods` / `conforming_classes`) and open the result popover
+  # (BT-2639). The protocol equivalent of `run_nav_query/2`; the active tab must
+  # be a class-definition tab for a Protocol — otherwise a graceful no-op (the
+  # buttons only render for protocols). The popover's `selector` slot carries the
+  # protocol name (the popover head shows it next to the kind label, mirroring the
+  # method-selector display for senders/implementors). `kind` is
+  # `:required_methods` | `:conforming_classes`; the facade op name matches.
+  defp run_protocol_nav_query(socket, kind) do
+    protocol =
+      case MethodEditor.active_tab(socket.assigns) do
+        %{kind: :def, class: class, is_protocol: true} -> class
+        _ -> nil
+      end
+
+    if is_binary(protocol) and protocol != "" do
+      case Facade.dispatch(kind, %{protocol: protocol}, ctx(socket)) do
+        {:value, %{"sites" => sites}} when is_list(sites) ->
+          assign(socket, nav_popover: %{kind: kind, selector: protocol, sites: sites})
+
+        {:value, _other} ->
+          assign(socket, nav_popover: %{kind: kind, selector: protocol, sites: []})
+
+        {:error, reason} ->
+          assign(socket,
+            nav_popover: %{kind: kind, selector: protocol, sites: [], error: facade_error(reason)}
+          )
+
+        _other ->
+          assign(socket,
+            nav_popover: %{
+              kind: kind,
+              selector: protocol,
+              sites: [],
+              error: "Navigation unavailable."
+            }
+          )
+      end
+    else
+      socket
+    end
+  end
+
+  # Query the Beamtalk callers of the focused native tab's module (`nav-query`
+  # `callers_of_native_module`, BT-2669) and open the result popover. The active
+  # tab must be a `:native` tab — otherwise a graceful no-op (the Callers button
+  # only renders on native tabs). The popover's `selector` slot carries the
+  # module name (shown next to the "Callers" head, mirroring the selector display
+  # for senders/implementors); each row opens the calling method via `nav_open`.
+  defp run_native_callers_query(socket) do
+    module =
+      case MethodEditor.active_tab(socket.assigns) do
+        %{kind: :native, class: class} -> class
+        _ -> nil
+      end
+
+    if is_binary(module) and module != "" do
+      kind = :callers_of_native_module
+
+      case Facade.dispatch(kind, %{module: module}, ctx(socket)) do
+        {:value, %{"sites" => sites}} when is_list(sites) ->
+          assign(socket, nav_popover: %{kind: kind, selector: module, sites: sites})
+
+        {:value, _other} ->
+          assign(socket, nav_popover: %{kind: kind, selector: module, sites: []})
+
+        {:error, reason} ->
+          assign(socket,
+            nav_popover: %{kind: kind, selector: module, sites: [], error: facade_error(reason)}
+          )
+
+        _other ->
+          assign(socket,
+            nav_popover: %{
+              kind: kind,
+              selector: module,
+              sites: [],
+              error: "Navigation unavailable."
+            }
+          )
+      end
+    else
+      socket
+    end
+  end
+
+  # ── go-to-definition resolution (BT-2666) ───────────────────────────────────
+  #
+  # Resolve a modifier-clicked symbol to a definition target and open it. The
+  # class-then-selector order mirrors the LSP `definition_provider.rs`: a name
+  # that is a loaded class is a class reference (→ its definition tab); anything
+  # else is treated as a message send (→ its implementor(s)).
+  defp run_goto_definition(socket, token, code) do
+    cond do
+      # An empty/blank token is a bare no-op (the JS never sends one — it only
+      # fires on an identifier — but guard it without even a flash).
+      String.trim(token) == "" ->
+        socket
+
+      known_class?(socket, token) ->
+        socket
+        |> MethodEditor.open_definition(token)
+        |> navigate_browser(token, "instance")
+        # Clear any open Implementors popover so it doesn't linger behind the
+        # newly-opened class tab (parity with nav_open_class/open_implementor_site).
+        |> assign(nav_popover: nil)
+
+      true ->
+        case goto_selector(token, code) do
+          nil -> goto_not_found(socket)
+          selector -> open_implementor(socket, selector)
+        end
+    end
+  end
+
+  # A loaded class name (matches the System Browser tree the editor already
+  # holds). Class lookup is case-sensitive and exact — Beamtalk class names are
+  # capitalised identifiers, so a clicked lowercase token never matches here and
+  # falls through to the selector path.
+  defp known_class?(socket, token) do
+    socket.assigns
+    |> Map.get(:browser_classes, [])
+    |> Enum.any?(fn row -> Map.get(row, "name") == token end)
+  end
+
+  # The message selector the clicked token denotes, derived from the `code`
+  # line-prefix (the line up to and including the token):
+  #
+  #   * a KEYWORD send — the prefix ends in `…word:` (optionally with a trailing
+  #     argument the click landed before) — resolves to the maximal trailing run
+  #     of `word:` parts, so clicking any part of `dict at: k put: v` resolves the
+  #     whole `at:put:` selector.
+  #   * otherwise the bare token is a UNARY selector (e.g. `factorial`).
+  #
+  # An empty/whitespace token yields nil (no selector to resolve). The result is
+  # only ever fed to the `implementors` nav-query, whose `binary_to_existing_atom`
+  # guard turns an unknown selector into an empty result set — so a wrong guess is
+  # a graceful "no definition", never a crash.
+  defp goto_selector(token, code) when is_binary(code) do
+    case keyword_selector(code) do
+      nil -> if token == "", do: nil, else: token
+      selector -> selector
+    end
+  end
+
+  defp goto_selector(token, _code), do: if(token == "", do: nil, else: token)
+
+  # Extract the trailing keyword selector (`word:word:…`) from a line prefix, or
+  # nil when it is not a keyword send. The clicked keyword belongs to the send
+  # that ends the prefix, so we first trim to the trailing segment — everything
+  # after the last statement/grouping breaker (`.`, `;`, brackets, `^`, `|`) —
+  # then join that segment's contiguous `word:` parts. This keeps unrelated sends
+  # earlier on the line out of the selector (e.g. `coll at: i. obj foo: x bar: y`
+  # clicked near `y` resolves to `foo:bar:`, not `at:foo:bar:`).
+  defp keyword_selector(code) do
+    segment = code |> String.split(~r/[.;()\[\]{}^|]/) |> List.last()
+    parts = Regex.scan(~r/([A-Za-z_][A-Za-z0-9_]*):/, segment) |> Enum.map(&Enum.at(&1, 1))
+
+    case parts do
+      [] -> nil
+      _ -> parts |> Enum.map(&(&1 <> ":")) |> Enum.join()
+    end
+  end
+
+  # Resolve a selector to its implementor(s) via the BT-2495 `implementors`
+  # nav-query and open the result. The single-hit case opens the method tab
+  # directly (the whole point of go-to-definition — no extra click); several hits
+  # fall back to the Senders/Implementors popover so the user disambiguates; none
+  # is the graceful unresolved no-op. Mirrors `run_nav_query_for/3` but acts on
+  # the result rather than always opening a popover.
+  defp open_implementor(socket, selector) do
+    case Facade.dispatch(:implementors, %{selector: selector}, ctx(socket)) do
+      {:value, %{"sites" => [site]}} when is_map(site) ->
+        open_implementor_site(socket, site)
+
+      {:value, %{"sites" => sites}} when is_list(sites) and sites != [] ->
+        # Ambiguous — reuse the BT-2495 popover so the user picks the implementor.
+        assign(socket, nav_popover: %{kind: :implementors, selector: selector, sites: sites})
+
+      _ ->
+        goto_not_found(socket)
+    end
+  end
+
+  # Open a single implementor site (a `{class, side, selector}` row) the same way
+  # the `nav_open` popover row does: open the method tab and point the browser at
+  # it, then ensure no stale popover lingers.
+  defp open_implementor_site(socket, site) do
+    class = Map.get(site, "class")
+    selector = Map.get(site, "method")
+    side = if Map.get(site, "class_side") == true, do: "class", else: "instance"
+
+    if is_binary(class) and is_binary(selector) do
+      socket
+      |> MethodEditor.open_method_tab(class, side, selector)
+      |> navigate_browser(class, side)
+      |> assign(nav_popover: nil)
+    else
+      goto_not_found(socket)
+    end
+  end
+
+  # The graceful unresolved no-op (BT-2666 AC): a brief flash, the editor and any
+  # open tab untouched. A transient info flash matches the cockpit's other
+  # lightweight status messages and self-dismisses.
+  defp goto_not_found(socket) do
+    put_flash(socket, :info, "No definition found.")
+  end
+
+  # ── System Browser view helpers (BT-2491) ───────────────────────────────────
+
+  # Category: `{category, [class_row]}` groups, each group's classes sorted by
+  # name, the groups themselves sorted by category. A class with no category falls
+  # into an "(uncategorized)" bucket rather than vanishing.
+  #
+  # BT-2557: TestCase subclasses (`is_test`) are pulled into a dedicated "Tests"
+  # bucket regardless of their package — the browser surfaces them as a category
+  # so a project's tests are one click away once loaded.
+  #
+  # Public: `WorkspaceLive`'s `system_browser_classes/1` render component calls
+  # it directly.
+  def category_groups(classes) do
+    classes
+    |> Enum.group_by(&class_category_bucket/1)
+    |> Enum.sort_by(fn {category, _} -> category end)
+    |> Enum.map(fn {category, rows} ->
+      {category, Enum.sort_by(rows, &Map.get(&1, "name"))}
+    end)
+  end
+
+  defp class_category_bucket(%{"is_test" => true}), do: "Tests"
+  # BT-2615: protocol class objects (ADR 0068) declare no package, so they would
+  # otherwise land in "(uncategorized)". Group them under a dedicated "Protocols"
+  # bucket — mirroring the "Tests" treatment — so a project's protocols are one
+  # click away and don't masquerade as uncategorized classes.
+  defp class_category_bucket(%{"is_protocol" => true}), do: "Protocols"
+  defp class_category_bucket(class), do: Map.get(class, "category") || "(uncategorized)"
+
+  # Narrow class rows by source origin (BT-2557). `source_origin` is the bare
+  # classification "project", "stdlib", or "dependency" (BT-2643 — the package
+  # name now lives in a separate `package` field). "all" is the identity filter;
+  # an unknown filter also passes everything through (fail-open so the tree is
+  # never silently blanked). Public: `WorkspaceLive`'s `system_browser_classes/1`
+  # render component calls it directly.
+  def filter_by_source(classes, "all"), do: classes
+
+  def filter_by_source(classes, "deps") do
+    Enum.filter(classes, &(Map.get(&1, "source_origin") == "dependency"))
+  end
+
+  def filter_by_source(classes, src) when src in ~w(project stdlib) do
+    Enum.filter(classes, &(Map.get(&1, "source_origin") == src))
+  end
+
+  def filter_by_source(classes, _src), do: classes
+
+  # True when no class is selected, or the selected class survives the current
+  # source filter (BT-2597). Used to decide whether switching filters should
+  # clear a now-hidden selection.
+  defp selected_class_visible?(%{assigns: %{selected_class: nil}}), do: true
+
+  defp selected_class_visible?(%{assigns: assigns}) do
+    assigns.browser_classes
+    |> filter_by_source(assigns.browser_source)
+    |> Enum.any?(&(Map.get(&1, "name") == assigns.selected_class))
+  end
+
+  # The flat method list for the current protocol filter: all selectors across the
+  # protocol tree (filter = nil → "all") or just the selected protocol's, each
+  # carrying its protocol name so the row badge / breadcrumb can show it. Sorted
+  # by selector for stable order. Public: `WorkspaceLive`'s
+  # `system_browser_methods/1` render component calls it directly.
+  def filtered_methods(protocols, filter) do
+    protocols
+    |> Enum.filter(fn p -> filter == nil or Map.get(p, "name") == filter end)
+    |> Enum.flat_map(fn p ->
+      name = Map.get(p, "name")
+      Enum.map(Map.get(p, "selectors", []), &Map.put(&1, "protocol", name))
+    end)
+    |> Enum.sort_by(&Map.get(&1, "selector"))
+  end
+
+  # Total selector count across the protocol tree (the "all" filter row's count).
+  # Public: `WorkspaceLive`'s `system_browser_methods/1` render component calls
+  # it directly.
+  def protocol_method_count(protocols) do
+    Enum.reduce(protocols, 0, fn p, acc -> acc + length(Map.get(p, "selectors", [])) end)
+  end
+
+  # A row is "runtime-only" (image-diverged, ADR 0096 / BT-2483) when its origin
+  # is `runtime` — in the live image with no static/disk source. The class tree
+  # and method list badge these so an observer sees what is not on disk. Public:
+  # `BtAttachWeb.Live.MethodEditor`'s `method_source_info/4` (BT-3296) and
+  # `WorkspaceLive`'s render template call it directly.
+  def runtime_only?(%{"origin" => "runtime"}), do: true
+  def runtime_only?(_), do: false
+
+  # A selector row is "derived" (BT-2714) when its xref `source_status` is
+  # `synthetic` — a compiler-synthesized method (Value accessors, `with<Field>:`
+  # setters, keyword constructors, actor `new`/`spawn`) with no hand-written
+  # source line. The method list badges these `derived` so the synthetic magic is
+  # visible rather than indistinguishable from real methods. Public:
+  # `WorkspaceLive`'s `system_browser_methods/1` render component calls it
+  # directly.
+  def synthetic?(%{"source_status" => "synthetic"}), do: true
+  def synthetic?(_), do: false
+
+  # BT-2735: the method-row hover (`title`). When the browse op enriched the row
+  # with a `signature` (and, for a compiler-derived method, a resolved `doc`,
+  # BT-2714) the hover reads VS Code-style — the rendered signature over the
+  # first line of the doc — so it conveys what the method is without a click.
+  # Rows the op left unenriched (hand-written selectors, kept off the browse hot
+  # path) fall back to the bare selector, the pre-BT-2735 behaviour. Public:
+  # `WorkspaceLive`'s `system_browser_methods/1` render component calls it
+  # directly.
+  def method_row_title(m) do
+    case {presence(m["signature"]), first_doc_line(m["doc"])} do
+      {nil, nil} -> presence(m["selector"])
+      {sig, nil} -> sig
+      {nil, doc} -> "#{m["selector"]}\n#{doc}"
+      {sig, doc} -> "#{sig}\n#{doc}"
+    end
+  end
+
+  # The first non-blank line of a method's `///` doc, or nil when the doc is
+  # absent/blank. Keeps the hover to a single descriptive line (the full doc is
+  # a click away in the read-only pane).
+  defp first_doc_line(doc) when is_binary(doc) do
+    doc
+    |> String.split("\n", parts: 2)
+    |> hd()
+    |> presence()
+  end
+
+  defp first_doc_line(_), do: nil
+
+  # A binary trimmed to nil when blank, itself otherwise — so an empty
+  # signature/doc string reads the same as an absent one.
+  defp presence(s) when is_binary(s) do
+    case String.trim(s) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp presence(_), do: nil
+
+  # Source origin badge helpers (BT-2552, BT-2643, BT-2641). Two orthogonal
+  # fields drive the badge: `source_origin` is the classification ("stdlib" |
+  # "dependency" | "project") and keys the css class + title; `package` is the
+  # package name and feeds the dependency badge label. The dependency badge reads
+  # as a "DEP" marker (parity with the generic "STDLIB" marker), suffixed with
+  # the package name when known ("DEP · HTTP") and bare ("DEP") otherwise.
+  # Public: `WorkspaceLive`'s render template calls these directly.
+  def source_origin_class(%{"source_origin" => "stdlib"}), do: "stdlib"
+  def source_origin_class(%{"source_origin" => "dependency"}), do: "dependency"
+  def source_origin_class(_), do: "project"
+
+  def source_origin_label(%{"source_origin" => "stdlib"}), do: "stdlib"
+
+  def source_origin_label(%{"source_origin" => "dependency"} = row),
+    do: dependency_badge_label(row)
+
+  def source_origin_label(_), do: ""
+
+  # Dependency badge text: "DEP · <pkg>" when the package is known, plain "DEP"
+  # when it is absent/unknown. This is the badge-specific label; `package_name/1`
+  # (which degrades to "unknown") still serves callers that need the raw package.
+  # Public: `BtAttachWeb.Live.MethodEditor`'s `header_package_label/1` (BT-3296)
+  # calls it directly for the editor-header badge.
+  def dependency_badge_label(row) do
+    case Map.get(row, "package") do
+      pkg when is_binary(pkg) and pkg != "" -> "DEP · #{pkg}"
+      _ -> "DEP"
+    end
+  end
+
+  def source_origin_title(%{"source_origin" => "stdlib"}), do: "Standard library"
+
+  def source_origin_title(%{"source_origin" => "dependency"} = row),
+    do: "Dependency: #{package_name(row)}"
+
+  def source_origin_title(_), do: "Project"
+
+  # The package name carried on a browse row's `package` field (BT-2643). Absent /
+  # null packages degrade to "unknown" so a dependency badge never renders blank.
+  # Public: `BtAttachWeb.Live.MethodEditor`'s `header_origin_title/1` (BT-3296)
+  # calls it directly for the editor-header badge.
+  def package_name(row) do
+    case Map.get(row, "package") do
+      pkg when is_binary(pkg) and pkg != "" -> pkg
+      _ -> "unknown"
+    end
+  end
+
+  # The method shown in the focused tab as a `%{class, side, selector}` ref (or nil
+  # for a class-definition tab), so the System Browser can highlight the matching
+  # method row. Takes bare `assigns` for the render template. An unsaved new-method
+  # tab has no real selector yet (`new: true`, `selector: ""`), so it highlights
+  # nothing — returning a `selector: ""` ref would never match a row anyway.
+  # Public: `WorkspaceLive`'s render template calls it directly.
+  def selected_method_ref(assigns) do
+    case MethodEditor.active_tab(assigns) do
+      %{new: true} ->
+        nil
+
+      %{kind: :method, class: class, side: side, selector: selector} ->
+        %{class: class, side: side, selector: selector}
+
+      _ ->
+        nil
+    end
+  end
+
+  # The class whose definition tab is focused, so the System Browser's "class
+  # definition" entry can track the editor (mirrors `selected_method_ref/1` for
+  # method tabs). nil when the active tab is a method or there is no def tab.
+  # Public: `WorkspaceLive`'s render template calls it directly.
+  def selected_def_ref(assigns) do
+    case MethodEditor.active_tab(assigns) do
+      %{kind: :def, class: class} -> class
+      _ -> nil
+    end
+  end
+end

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -243,11 +243,13 @@ defmodule BtAttachWeb.WorkspaceLive do
   alias BtAttach.Facade
   alias BtAttach.SessionRegistry
   alias BtAttach.Workspace
+  alias BtAttachWeb.ClassTree
   alias BtAttachWeb.Live.Dock
   alias BtAttachWeb.Live.FacadeError
   alias BtAttachWeb.Live.Inspector
   alias BtAttachWeb.Live.MethodEditor
   alias BtAttachWeb.Live.RequestContext
+  alias BtAttachWeb.Live.SystemBrowser
 
   # All RBAC-relevant workspace ops go through the curated facade (ADR 0091
   # Decision 3) — never a raw Workspace/:rpc call from an event handler. Pure
@@ -537,7 +539,7 @@ defmodule BtAttachWeb.WorkspaceLive do
       # the section currently being renamed/added (`nil` | a section name
       # binary | the sentinel `:new`); `section_form_error` surfaces a failed
       # save inline.
-      |> assign(:browser_categories, default_categories())
+      |> assign(:browser_categories, SystemBrowser.default_categories())
       |> assign(:browser_group_mode, "protocol")
       |> assign(:editing_section, nil)
       |> assign(:section_form_error, nil)
@@ -655,8 +657,8 @@ defmodule BtAttachWeb.WorkspaceLive do
       # `restore_doc/3`, so an expanded block stays expanded across a socket drop,
       # redeploy, or laptop wake (BT-2570).
       |> assign(:doc_expanded, false)
-      |> assign_browser_native_modules()
-      |> assign_browser_type_aliases()
+      |> SystemBrowser.assign_browser_native_modules()
+      |> SystemBrowser.assign_browser_type_aliases()
       # BT-2636: the set of expanded Changes-pane rows (keyed by the row's
       # `{class, selector, side}` — BT-3195 added `side` so a same-selector
       # instance-side and class-side entry, both now possible simultaneously
@@ -802,95 +804,6 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   defp force_close(_token, _pid), do: :ok
 
-  # Backend-driven autocomplete (BT-2544): the CodeMirror editors' autocomplete
-  # CompletionSource round-trips the current line up to the caret; we answer with
-  # ranked candidates from the live session via the `complete` op (receiver-aware:
-  # class names, selectors for a known receiver, session bindings, pseudo-vars).
-  # `:read` capability — completion runs no user code — so the Observer role
-  # completes too. We `{:reply, …}` on the same event so CodeMirror resolves its
-  # async source; an unreachable workspace, a denied op, or a missing session all
-  # degrade to an empty list (autocomplete simply shows nothing).
-  @impl true
-  def handle_event("complete", %{"code" => code}, %{assigns: %{session_pid: pid}} = socket)
-      when is_pid(pid) and is_binary(code) do
-    completions =
-      case Facade.dispatch(:complete, %{session_pid: pid, code: code}, ctx(socket)) do
-        {:ok, list} when is_list(list) -> list
-        _ -> []
-      end
-
-    {:reply, %{"completions" => completions}, socket}
-  end
-
-  def handle_event("complete", _params, socket) do
-    {:reply, %{"completions" => []}, socket}
-  end
-
-  # Live-image hover (BT-2555): the CodeMirror editors' `hoverTooltip` source
-  # round-trips the editor line up to the hovered token; we answer with
-  # signature + doc-comment markdown from the live session via the `hover` op
-  # (a class name → its docs; a `Receiver selector` pair → that method's docs).
-  # `:read` capability — hover runs no user code — so the Observer role hovers
-  # too. We `{:reply, …}` on the same event so CodeMirror resolves its async
-  # tooltip source; an unreachable workspace, a denied op, a missing session, or
-  # nothing-to-show all degrade to an empty string (no tooltip is shown).
-  @impl true
-  def handle_event("hover", %{"code" => code}, %{assigns: %{session_pid: pid}} = socket)
-      when is_pid(pid) and is_binary(code) do
-    hover =
-      case Facade.dispatch(:hover, %{session_pid: pid, code: code}, ctx(socket)) do
-        {:ok, docs} when is_binary(docs) -> docs
-        _ -> ""
-      end
-
-    {:reply, %{"hover" => hover}, socket}
-  end
-
-  def handle_event("hover", _params, socket) do
-    {:reply, %{"hover" => ""}, socket}
-  end
-
-  # Live parse-only diagnostics (BT-2556): the CodeMirror editors'
-  # `@codemirror/lint` source round-trips the FULL buffer; we answer with
-  # error/warning ranges from the compiler's side-effect-free `diagnostics` path
-  # (parse + semantic check, NO codegen / install / eval / ChangeLog), so it is
-  # safe to fire as the buffer changes and is a `:read` op — the Observer role
-  # sees diagnostics too. We `{:reply, …}` on the same event so CodeMirror
-  # resolves its async lint source; an unreachable workspace, a denied op, or a
-  # bad shape all degrade to an empty list (no squiggles shown). Diagnostics do
-  # not need a session pid — they analyse the buffer in isolation — so unlike
-  # `complete`/`hover` there is no `session_pid` guard.
-  #
-  # Debounce lives on the CLIENT: the `@codemirror/lint` `linter(…, {delay})`
-  # only invokes this source after the editor has been idle, so rapid keystrokes
-  # never flood the workspace (the same pattern the LSP uses to debounce
-  # `didChange`). A server-side *drop* debounce would break the request/reply
-  # contract — a coalesced request's reply would never arrive — so the throttle
-  # is deliberately upstream of the round-trip, not in this handler.
-  @impl true
-  def handle_event("diagnostics", %{"code" => code} = params, socket) when is_binary(code) do
-    # `mode` (BT-2569) selects the parse grammar. The method-editor CmEditor sends
-    # "method" (a bare method body — `=>` is not a valid top-level token, so the
-    # default script grammar would false-positive); the Workspace + REPL editors
-    # send nothing. Forward the raw client value — the facade normalises it to a
-    # known binary ("method" | "expression"), the single boundary for every caller.
-    diagnostics =
-      case Facade.dispatch(
-             :diagnostics,
-             %{code: code, mode: Map.get(params, "mode")},
-             ctx(socket)
-           ) do
-        {:ok, list} when is_list(list) -> list
-        _ -> []
-      end
-
-    {:reply, %{"diagnostics" => diagnostics}, socket}
-  end
-
-  def handle_event("diagnostics", _params, socket) do
-    {:reply, %{"diagnostics" => []}, socket}
-  end
-
   # ── Test-runner pane (BT-2557) ───────────────────────────────────────────────
   #
   # The GUI equivalent of a Smalltalk Test Runner: a dock tab that lists the live
@@ -1003,6 +916,23 @@ defmodule BtAttachWeb.WorkspaceLive do
     MethodEditor.handle_event(event, params, socket)
   end
 
+  # System Browser events (BT-3297, epic BT-3290): the class tree, instance/
+  # class side toggle, protocol + method list, method source opening, and the
+  # source-navigation affordances (hover/goto-definition/senders/implementors)
+  # all delegate to `BtAttachWeb.Live.SystemBrowser`, extracted out of this
+  # module so its `handle_event/3` clauses are directly unit-testable. See
+  # that module's docs for the full per-event behaviour (each clause used to
+  # run here). Reads its event list from `__system_browser_events__/0` —
+  # mirroring the BT-3301 fix that keeps this list from becoming a second,
+  # hand-maintained copy of the event names (unlike `@dock_events`/
+  # `@method_editor_events` above).
+  @system_browser_events SystemBrowser.__system_browser_events__()
+
+  @impl true
+  def handle_event(event, params, socket) when event in @system_browser_events do
+    SystemBrowser.handle_event(event, params, socket)
+  end
+
   # Open / close the top-bar appearance (Tweaks) dropdown. Pure view state — the
   # panel itself stays mounted (see `:show_settings` in `mount/3`); this only
   # flips the dropdown's visibility. `close_settings` is the click-away / Escape
@@ -1016,20 +946,15 @@ defmodule BtAttachWeb.WorkspaceLive do
   end
 
   # Panel visibility toggles (BT-2559): close/toggle side panels and dock.
-  def handle_event("toggle_browser", _params, socket) do
-    {:noreply, assign(socket, show_browser: !socket.assigns.show_browser)}
-  end
-
+  # `toggle_browser`/`close_browser` (the System Browser panel) delegate to
+  # `BtAttachWeb.Live.SystemBrowser` via the `@system_browser_events` guard
+  # clause above.
   def handle_event("toggle_inspector", _params, socket) do
     {:noreply, assign(socket, show_inspector: !socket.assigns.show_inspector)}
   end
 
   def handle_event("toggle_dock", _params, socket) do
     {:noreply, assign(socket, show_dock: !socket.assigns.show_dock)}
-  end
-
-  def handle_event("close_browser", _params, socket) do
-    {:noreply, assign(socket, show_browser: false)}
   end
 
   # ── method editor (Wave 3, write-surface ADR 0082) ──────────────────────────
@@ -1123,83 +1048,12 @@ defmodule BtAttachWeb.WorkspaceLive do
   # `save_method`/`native_source`/`native_save`/`dismiss_native_error`/
   # `dismiss_native_module_error`/`toggle_doc`/`select_source` all delegate to
   # `BtAttachWeb.Live.MethodEditor` (BT-3296, epic BT-3290) — see the
-  # `@method_editor_events` guard clause below.
-
-  # Open the *selected* class's definition tab from the System Browser's "class
-  # definition" entry (BT-2491). The class rides the click; a malformed payload
-  # is ignored rather than crashing the LiveView.
-  def handle_event("browser_open_definition", %{"class" => class}, socket)
-      when is_binary(class) and class != "" do
-    {:noreply, MethodEditor.open_definition(socket, class)}
-  end
-
-  def handle_event("browser_open_definition", _params, socket), do: {:noreply, socket}
-
-  # BT-2578: toggle the read-only native backing-source pane on a class-definition
-  # tab. A native: class (ADR 0056) only has `self delegate` facade methods — the
-  # real logic lives in the backing gen_server module's `handle_call` clauses — so
-  # this surfaces that module's `.erl` read-only. The backing source is lazily
-  # fetched on first open (a `:read` op, safe for the Observer) and cached on
-  # `native_view`; a second click collapses it.
-  def handle_event("browser_open_native", %{"class" => class}, socket)
-      when is_binary(class) and class != "" do
-    if native_shown?(socket.assigns, class) do
-      {:noreply, assign(socket, native_view: nil)}
-    else
-      {:noreply, assign(socket, native_view: load_native_view(socket, class))}
-    end
-  end
-
-  def handle_event("browser_open_native", _params, socket), do: {:noreply, socket}
-
-  # BT-2656: switch the left browser column between the class tree (`classes`) and
-  # the separate Native browser (`native`) via the panel-head `Classes | Native`
-  # toggle. Switching into Native mode re-fetches the module list so a dependency
-  # loaded mid-session is discoverable; an unknown mode is ignored rather than
-  # blanking the panel.
-  def handle_event("browser_mode", %{"mode" => "native"}, socket) do
-    {:noreply, assign(assign_browser_native_modules(socket), browser_mode: :native)}
-  end
-
-  def handle_event("browser_mode", %{"mode" => "classes"}, socket) do
-    {:noreply, assign(socket, browser_mode: :classes)}
-  end
-
-  # BT-2903: switch into the "Type Aliases" panel, re-fetching so an alias
-  # declared mid-session is discoverable — mirroring the Native mode switch.
-  def handle_event("browser_mode", %{"mode" => "aliases"}, socket) do
-    {:noreply, assign(assign_browser_type_aliases(socket), browser_mode: :aliases)}
-  end
-
-  def handle_event("browser_mode", _params, socket), do: {:noreply, socket}
-
-  # BT-2667: open a standalone native module's `.erl` as a first-class read-only
-  # editor TAB (a `:native` tab kind) rather than the old single-slot overlay
-  # assign. The module source now coexists with class/method tabs, switches and
-  # closes like any tab, and scrolls inside the editor pane. A module already open
-  # is re-focused (keyed by `native:<module>`) rather than duplicated. A module
-  # with no readable source still opens — the tab body shows the honest "Erlang
-  # source not available" empty state (BT-2648/BT-2668).
-  def handle_event("browser_open_native_module", %{"module" => module}, socket)
-      when is_binary(module) and module != "" do
-    {:noreply, open_native_module_tab(socket, module)}
-  end
-
-  def handle_event("browser_open_native_module", _params, socket), do: {:noreply, socket}
-
-  # BT-2578: jump from a `self delegate` method to its Erlang implementation.
-  # Opens (or focuses) the class-definition tab and expands the native pane with
-  # the method's selector resolved to its matching `handle_call` clause (which the
-  # pane highlights). The selector→clause mapping is best-effort: a delegate that
-  # completes in `handle_info` resolves to no clause, and the pane says so rather
-  # than pretending.
-  def handle_event("browser_jump_native", %{"class" => class, "selector" => selector}, socket)
-      when is_binary(class) and class != "" and is_binary(selector) do
-    socket = MethodEditor.open_definition(socket, class)
-    {:noreply, assign(socket, native_view: load_native_view(socket, class, selector))}
-  end
-
-  def handle_event("browser_jump_native", _params, socket), do: {:noreply, socket}
+  # `@method_editor_events` guard clause above.
+  #
+  # `browser_open_definition`/`browser_open_native`/`browser_mode`/
+  # `browser_open_native_module`/`browser_jump_native` all delegate to
+  # `BtAttachWeb.Live.SystemBrowser` (BT-3297, epic BT-3290) — see the
+  # `@system_browser_events` guard clause above.
 
   # Open a blank "new method" tab for the *selected* class (the System Browser's
   # "new method" entry). A new-method tab is a `:method` tab with no selector yet —
@@ -1268,180 +1122,6 @@ defmodule BtAttachWeb.WorkspaceLive do
     {:noreply, assign(socket, new_class_error: "Invalid new-class form payload.")}
   end
 
-  # ── System Browser (BT-2491, epic BT-2482 Phase 2) ──────────────────────────
-
-  # Toggle the class tree between Hierarchy (indented by superclass) and Category
-  # (grouped by annotation). Pure view state over the already-loaded class rows —
-  # no workspace round-trip; an unknown view is ignored rather than blanking the
-  # tree.
-  def handle_event("browser_view", %{"view" => view}, socket)
-      when view in ~w(hierarchy category) do
-    {:noreply, assign(socket, browser_view: view)}
-  end
-
-  def handle_event("browser_view", _params, socket), do: {:noreply, socket}
-
-  # Narrow the class tree by source origin (project / deps / stdlib / all). Pure
-  # view state over the already-loaded rows — no workspace round-trip; an unknown
-  # value is ignored rather than blanking the tree (BT-2557).
-  #
-  # BT-2597: if the new filter hides the currently-selected class, clear the
-  # selection (and its protocol/method pane) so the right pane can't show a
-  # "ghost" selection for a class no longer visible in the tree.
-  def handle_event("browser_source", %{"src" => src}, socket)
-      when src in ~w(all project deps stdlib) do
-    # BT-2661: a deliberate pick marks the filter "chosen" so the BT-2661 initial
-    # default (applied once the async class load lands) can never override it.
-    socket = assign(socket, browser_source: src, browser_source_chosen: true)
-
-    socket =
-      if selected_class_visible?(socket) do
-        socket
-      else
-        assign(socket,
-          selected_class: nil,
-          selected_protocol: nil,
-          browser_protocols: [],
-          browser_categories: default_categories(),
-          browser_group_mode: "protocol",
-          editing_section: nil,
-          section_form_error: nil
-        )
-      end
-
-    {:noreply, socket}
-  end
-
-  def handle_event("browser_source", _params, socket), do: {:noreply, socket}
-
-  # Toggle the instance/class side. The protocol/method list is class-side
-  # specific (a class's instance methods differ from its class methods), so
-  # flipping the side re-fetches the selected class's protocols for the new side
-  # and clears the protocol filter. Pure toggle when no class is selected yet.
-  def handle_event("browser_side", %{"side" => side}, socket)
-      when side in ~w(instance class) do
-    socket = assign(socket, browser_side: side, selected_protocol: nil)
-
-    case socket.assigns.selected_class do
-      nil -> {:noreply, assign(socket, browser_protocols: [])}
-      class -> {:noreply, load_protocols(socket, class, side)}
-    end
-  end
-
-  def handle_event("browser_side", _params, socket), do: {:noreply, socket}
-
-  # Select a class in the tree: fetch its protocols (for the current side) and
-  # reset the protocol filter. A non-binary / absent class name is ignored rather
-  # than crashing the LiveView.
-  def handle_event("browser_select_class", %{"class" => class}, socket)
-      when is_binary(class) do
-    socket =
-      assign(socket, selected_class: class, selected_protocol: nil)
-      |> load_protocols(class, socket.assigns.browser_side)
-      |> load_categories(class)
-
-    {:noreply, socket}
-  end
-
-  def handle_event("browser_select_class", _params, socket), do: {:noreply, socket}
-
-  # Set the protocol filter (the method list shows only that protocol's
-  # selectors). An empty value clears the filter back to "all" — the spike's ∗
-  # row. Pure view state over the already-loaded protocol tree.
-  def handle_event("browser_select_protocol", %{"protocol" => protocol}, socket)
-      when is_binary(protocol) do
-    filter = if protocol == "", do: nil, else: protocol
-    {:noreply, assign(socket, selected_protocol: filter)}
-  end
-
-  def handle_event("browser_select_protocol", _params, socket), do: {:noreply, socket}
-
-  # Select a method: open (or focus) it as a tab in the method editor, seeded with
-  # its image-accurate source. Browsing *is* editing — the Smalltalk idiom — so a
-  # browser click feeds the same write-surface the omni search and Senders /
-  # Implementors navigation already do (`open_method_tab`), rather than a separate
-  # read-only panel. The class/side/selector ride the click; a malformed payload is
-  # ignored.
-  def handle_event(
-        "browser_select_method",
-        %{"class" => class, "side" => side, "selector" => selector},
-        socket
-      )
-      when is_binary(class) and is_binary(side) and is_binary(selector) do
-    {:noreply, MethodEditor.open_method_tab(socket, class, side, selector)}
-  end
-
-  def handle_event("browser_select_method", _params, socket), do: {:noreply, socket}
-
-  # ── grouped method view: `// === Name ===` section dividers (BT-3238) ──────
-
-  # Toggle the method list between the existing per-protocol grouping and the
-  # divider-category grouping. The UI only renders this toggle when
-  # `browser_categories["has_dividers"]` is true (a divider-free class never
-  # shows it, so its method list renders exactly as before), but the handler
-  # itself just no-ops on an unrecognised mode rather than trusting that gate.
-  def handle_event("browser_group_mode", %{"mode" => mode}, socket)
-      when mode in ~w(protocol section) do
-    {:noreply,
-     assign(socket, browser_group_mode: mode, editing_section: nil, section_form_error: nil)}
-  end
-
-  def handle_event("browser_group_mode", _params, socket), do: {:noreply, socket}
-
-  # Open the inline section form: renaming an existing section (`name` is
-  # that section's current divider text) or adding a new one (`name` is
-  # empty, the `:new` sentinel). Owner-only, matching `new_method`'s gate —
-  # authoring is Owner-only, so the entry is rendered only for `:owner` and a
-  # crafted event from a read-only role is a no-op.
-  def handle_event(
-        "browser_edit_section",
-        %{"name" => name},
-        %{assigns: %{role: :owner}} = socket
-      )
-      when is_binary(name) do
-    target = if name == "", do: :new, else: name
-    {:noreply, assign(socket, editing_section: target, section_form_error: nil)}
-  end
-
-  def handle_event("browser_edit_section", _params, socket), do: {:noreply, socket}
-
-  # Close the inline section form without saving.
-  def handle_event("browser_cancel_section", _params, socket) do
-    {:noreply, assign(socket, editing_section: nil, section_form_error: nil)}
-  end
-
-  # Rename an existing section: `old_name` identifies the divider being
-  # edited, `new_name` is the submitted form text.
-  def handle_event(
-        "browser_rename_section",
-        %{"old_name" => old_name, "new_name" => new_name},
-        %{assigns: %{role: :owner, selected_class: class}} = socket
-      )
-      when is_binary(old_name) and is_binary(new_name) and is_binary(class) do
-    {:noreply, submit_section(socket, class, new_name, old_name: old_name)}
-  end
-
-  def handle_event("browser_rename_section", _params, socket), do: {:noreply, socket}
-
-  # Add a brand-new section directly above `before_selector` (the method
-  # picked in the inline "add section" form's dropdown).
-  def handle_event(
-        "browser_add_section",
-        %{"new_name" => new_name, "before_selector" => before_selector} = params,
-        %{assigns: %{role: :owner, selected_class: class, browser_side: side}} = socket
-      )
-      when is_binary(new_name) and is_binary(before_selector) and is_binary(class) do
-    before_side = Map.get(params, "before_side", side)
-
-    {:noreply,
-     submit_section(socket, class, new_name,
-       before_selector: before_selector,
-       before_side: before_side
-     )}
-  end
-
-  def handle_event("browser_add_section", _params, socket), do: {:noreply, socket}
-
   # ── omni search (BT-2495, epic BT-2482 Phase 3) ─────────────────────────────
 
   # Filter the workspace symbol index (classes + selectors) against the live
@@ -1474,7 +1154,7 @@ defmodule BtAttachWeb.WorkspaceLive do
         socket
       )
       when is_binary(class) do
-    {:noreply, socket |> open_class(class) |> close_omni()}
+    {:noreply, socket |> SystemBrowser.open_class(class) |> close_omni()}
   end
 
   def handle_event(
@@ -1492,130 +1172,12 @@ defmodule BtAttachWeb.WorkspaceLive do
   # opening anything.
   def handle_event("omni_close", _params, socket), do: {:noreply, close_omni(socket)}
 
-  # ── senders / implementors popovers (BT-2495) ───────────────────────────────
-
-  # The method editor's Senders / Implementors buttons: query the navigation
-  # channel for the active tab's selector and open the result popover. Both ride
-  # the same `nav-query` read (kinds `senders` / `implementors`); a missing
-  # selector (e.g. a class-definition tab) is ignored so the buttons no-op
-  # gracefully rather than querying an empty selector.
-  def handle_event("senders", _params, socket) do
-    {:noreply, run_nav_query(socket, :senders)}
-  end
-
-  def handle_event("implementors", _params, socket) do
-    {:noreply, run_nav_query(socket, :implementors)}
-  end
-
-  # ── native-module callers popover (BT-2669) ─────────────────────────────────
-  #
-  # The native-module viewer's Callers button: query the navigation channel for
-  # the Beamtalk methods that call into the focused `:native` tab's module via
-  # `(Erlang <module>) …` (the reverse of "go to native source") and open the
-  # same result popover the Senders/Implementors buttons use. A non-native tab is
-  # a graceful no-op so the button (only rendered on native tabs) never queries.
-  def handle_event("native_callers", _params, socket) do
-    {:noreply, run_native_callers_query(socket)}
-  end
-
-  # ── protocol actions (BT-2639) ──────────────────────────────────────────────
-  #
-  # The protocol equivalent of Senders/Implementors: on a class-definition tab
-  # whose class is a Protocol, query its required methods / conforming classes and
-  # open the same result popover. Both ride the `nav-query` channel (kinds
-  # `required_methods` / `conforming_classes`); a non-protocol def tab is a
-  # graceful no-op so the buttons (only rendered for protocols) never query a
-  # plain class.
-  def handle_event("required_methods", _params, socket) do
-    {:noreply, run_protocol_nav_query(socket, :required_methods)}
-  end
-
-  def handle_event("conforming_classes", _params, socket) do
-    {:noreply, run_protocol_nav_query(socket, :conforming_classes)}
-  end
-
-  # Open a conforming-class row (BT-2639): clicking a class in the Conforming
-  # classes popover opens that class's definition pane and points the System
-  # Browser tree at it, then closes the popover. Reuses the existing open-class
-  # definition path (`open_definition/2`).
-  def handle_event("nav_open_class", %{"class" => class}, socket) when is_binary(class) do
-    socket =
-      socket
-      |> MethodEditor.open_definition(class)
-      |> assign(nav_popover: nil)
-
-    {:noreply, socket}
-  end
-
-  def handle_event("nav_open_class", _params, socket),
-    do: {:noreply, assign(socket, nav_popover: nil)}
-
-  # Open the Implementors of a required-method selector (BT-2639): clicking a row
-  # in the Required methods popover re-runs the `nav-query` `implementors` kind for
-  # that selector (reusing the BT-2495 nav path), replacing the popover contents
-  # with the implementing classes.
-  def handle_event("nav_required_open", %{"selector" => selector}, socket)
-      when is_binary(selector) and selector != "" do
-    {:noreply, run_nav_query_for(socket, :implementors, selector)}
-  end
-
-  def handle_event("nav_required_open", _params, socket),
-    do: {:noreply, assign(socket, nav_popover: nil)}
-
-  # Open a site from the Senders/Implementors popover in the method-editor tab
-  # strip (its class + selector + side) and point the System Browser at that
-  # class/side too, so a jump to another class navigates the tree alongside the
-  # editor, then close the popover.
-  def handle_event(
-        "nav_open",
-        %{"class" => class, "side" => side, "selector" => selector},
-        socket
-      )
-      when is_binary(class) and is_binary(side) and is_binary(selector) do
-    socket =
-      socket
-      |> MethodEditor.open_method_tab(class, side, selector)
-      |> navigate_browser(class, side)
-      |> assign(nav_popover: nil)
-
-    {:noreply, socket}
-  end
-
-  def handle_event("nav_open", _params, socket), do: {:noreply, assign(socket, nav_popover: nil)}
-
-  # Dismiss the Senders/Implementors popover.
-  def handle_event("nav_close", _params, socket), do: {:noreply, assign(socket, nav_popover: nil)}
-
-  # ── Ctrl/Cmd-click go-to-definition (BT-2666) ───────────────────────────────
-  #
-  # The CodeMirror editors' `cm_goto.js` extension fires this when the user
-  # modifier-clicks a symbol. `token` is the bare identifier under the pointer;
-  # `code` is the editor line up to (and including) that token (the same
-  # `Receiver selector` line-prefix the `hover` op consumes). We resolve the
-  # clicked symbol to a definition target against the LIVE image, mirroring the
-  # LSP `definition_provider.rs` resolution order (class def, then selector send;
-  # locals/params are a future client-side resolve), and open it by REUSING the
-  # existing nav plumbing:
-  #
-  #   * a known CLASS name → open its `:def` definition tab (`open_definition/2`)
-  #     and point the System Browser at it, exactly as `nav_open_class` does.
-  #   * otherwise treat it as a SELECTOR send → run the BT-2495 `implementors`
-  #     `nav-query`. One implementor → open that method tab directly
-  #     (`open_method_tab/4` + `navigate_browser/3`, the `nav_open` path); several
-  #     → open the shared Senders/Implementors popover so the user picks; none →
-  #     a brief flash (the unresolved no-op), leaving the editor untouched.
-  #
-  # A class name takes priority over a same-named selector, matching the LSP
-  # (class declaration before selector). Unresolvable input (empty token, an
-  # unknown symbol with no implementors) flashes "No definition found" rather
-  # than crashing or silently doing nothing — the graceful no-op the AC asks for.
-  def handle_event("goto_definition", %{"token" => token} = params, socket)
-      when is_binary(token) do
-    code = Map.get(params, "code", "")
-    {:noreply, run_goto_definition(socket, token, code)}
-  end
-
-  def handle_event("goto_definition", _params, socket), do: {:noreply, socket}
+  # `senders`/`implementors`/`native_callers`/`required_methods`/
+  # `conforming_classes`/`nav_open_class`/`nav_required_open`/`nav_open`/
+  # `nav_close`/`goto_definition` (the Senders/Implementors/protocol-action
+  # popover + Ctrl/Cmd-click go-to-definition, BT-2495/BT-2639/BT-2666/BT-2669)
+  # all delegate to `BtAttachWeb.Live.SystemBrowser` (BT-3297, epic BT-3290) —
+  # see the `@system_browser_events` guard clause above.
 
   # ── dismissable status notices (BT-2612) ────────────────────────────────────
   #
@@ -1633,15 +1195,9 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   def handle_event("dismiss_notice", _params, socket), do: {:noreply, socket}
 
-  # Dismiss the error inside the Senders/Implementors popover without closing the
-  # whole popover (which `nav_close` does). `@nav_popover` is a map; clear only
-  # its `:error` field.
-  def handle_event("dismiss_nav_error", _params, socket) do
-    case socket.assigns[:nav_popover] do
-      %{} = nav -> {:noreply, assign(socket, nav_popover: Map.put(nav, :error, nil))}
-      _ -> {:noreply, socket}
-    end
-  end
+  # `dismiss_nav_error` (dismiss the error inside the Senders/Implementors
+  # popover without closing it) delegates to `BtAttachWeb.Live.SystemBrowser`
+  # via the `@system_browser_events` guard clause above.
 
   # Cap on the Transcript pane depth: the client keeps the most recent N lines
   # (via `stream_insert(:transcript, …, limit: -N)`), bounding the DOM in step
@@ -1832,7 +1388,11 @@ defmodule BtAttachWeb.WorkspaceLive do
   def handle_async(:mount_load, {:ok, result}, socket) do
     socket =
       socket
-      |> fold_mount_read(:source_loaded, result.browser_classes, &apply_browser_classes/2)
+      |> fold_mount_read(
+        :source_loaded,
+        result.browser_classes,
+        &SystemBrowser.apply_browser_classes/2
+      )
       |> fold_mount_read(:bindings_loaded, result.bindings, &apply_bindings/2)
       |> fold_mount_read(:source_loaded, result.changes, &apply_changes/2)
       |> assign(source_loaded: true, bindings_loaded: true)
@@ -2536,7 +2096,7 @@ defmodule BtAttachWeb.WorkspaceLive do
         # assigned AFTER it opens the renamed class's definition tab.
         socket
         |> close_tabs_for_class(old_name)
-        |> assign_browser_classes()
+        |> SystemBrowser.assign_browser_classes()
         |> assign_changes()
         |> MethodEditor.open_definition(new_name)
         |> reselect_renamed_class(old_name, new_name)
@@ -2697,7 +2257,7 @@ defmodule BtAttachWeb.WorkspaceLive do
     case Facade.dispatch(:new_class, %{source: source, path: path}, ctx(socket)) do
       {:ok, created_path} ->
         socket
-        |> assign_browser_classes()
+        |> SystemBrowser.assign_browser_classes()
         |> assign_changes()
         # Open + select the NEW class (`name`), not the superclass: the def tab
         # focuses it and the tree highlights it (BT-2645). `open_definition`
@@ -3259,255 +2819,11 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp test_status_class(status) when status in ~w(pass fail skip), do: "st-" <> status
   defp test_status_class(_other), do: "st-skip"
 
-  # ── System Browser data source (BT-2491, browse ops ADR 0096) ───────────────
+  # ── navigation aids: omni search (BT-2495) ──────────────────────────────────
   #
-  # The four browse ops return a `{:value, json_value}` live term verbatim
-  # (wire-shaped maps/lists of binaries — JSON only at the WebSocket edge, never
-  # here) or `{:error, reason}`. Each `assign_*`/`load_*` helper unwraps that and
-  # holds the rows in browser assigns the render walks; a dispatch failure or an
-  # RBAC denial renders a `browser_error` rather than crashing the pane.
-
-  # Load every class in scope for the class tree (op 1, `browse-classes`). Sorted
-  # workspace-side; the rows carry `superclass`/`category`/`origin` so the
-  # Hierarchy and Category views and the runtime badge render off one fetch.
-  #
-  # Split into the off-socket read + pure fold (BT-2591) so the mount-load async
-  # task and the post-action refresh callers share one fold. Public:
-  # `BtAttachWeb.Live.MethodEditor`'s `refresh_after_source_change/1` (BT-3296)
-  # calls it directly.
-  def assign_browser_classes(socket),
-    do: apply_browser_classes(socket, read_browser_classes(socket))
-
-  defp read_browser_classes(socket), do: Facade.dispatch(:browse_classes, %{}, ctx(socket))
-
-  defp apply_browser_classes(socket, {:value, rows}) when is_list(rows) do
-    socket
-    |> assign(browser_classes: rows, browser_error: nil)
-    |> apply_default_browser_source(rows)
-  end
-
-  defp apply_browser_classes(socket, {:error, reason}),
-    do: assign(socket, browser_classes: [], browser_error: facade_error(reason))
-
-  # Defensive catch-all (BT-2591): this fold runs in `handle_async(:mount_load,
-  # …)` AND on the sync `assign_browser_classes/1` refresh path. An unexpected
-  # dispatch shape (a facade evolution, a bare atom) would otherwise crash the
-  # LiveView — on the async path *after* the empty page rendered, harder to spot
-  # than the old mount-time crash. Degrade to an empty tree with an error instead.
-  defp apply_browser_classes(socket, unexpected) do
-    Logger.warning("unexpected browse_classes result: #{inspect(unexpected)}",
-      domain: [:beamtalk, :liveview]
-    )
-
-    assign(socket, browser_classes: [], browser_error: facade_error(:unexpected_response))
-  end
-
-  # BT-2661: apply the one-shot initial origin-filter default once the class rows
-  # arrive. The tree opens scoped to the project's own classes ("show me my code")
-  # — but only on the FIRST successful load (`:browser_source_chosen` still false)
-  # and only when there is at least one project-origin class to show; a bare /
-  # stdlib-only workspace falls back to "all" so the tree isn't empty on open. The
-  # flag flips `true` here (and in the `browser_source` handler when the user picks
-  # a filter), so a later async refresh / live push never resets a deliberate
-  # choice — the chosen value always wins over the default.
-  defp apply_default_browser_source(%{assigns: %{browser_source_chosen: true}} = socket, _rows),
-    do: socket
-
-  defp apply_default_browser_source(socket, rows) do
-    assign(socket,
-      browser_source: default_browser_source(rows),
-      browser_source_chosen: true
-    )
-  end
-
-  # "project" when the workspace has any project-origin class, else "all" (the
-  # empty-project fallback). The `source_origin` field is the bare classification
-  # (BT-2643); project rows carry "project" (the `source_origin_class/1` default
-  # bucket), so an explicit equality match is enough.
-  defp default_browser_source(rows) do
-    if Enum.any?(rows, &(Map.get(&1, "source_origin") == "project")),
-      do: "project",
-      else: "all"
-  end
-
-  # BT-2648/BT-2656: load the loaded packages' hand-written native Erlang modules
-  # for the separate Native browser. Each row carries `module`, `source_file`,
-  # `package`, `source_origin`, and `openable`. A dispatch failure / RBAC denial
-  # yields an empty list rather than crashing the browser — the class tree (the
-  # primary navigator) must still render.
-  defp assign_browser_native_modules(socket) do
-    rows =
-      case Facade.dispatch(:browse_native_modules, %{}, ctx(socket)) do
-        {:value, rows} when is_list(rows) -> rows
-        _ -> []
-      end
-
-    socket
-    |> assign(browser_native_modules: rows)
-    |> apply_default_native_source(rows)
-  end
-
-  # BT-2903 (ADR 0108 Phase 8): load every loaded package's declared `type`
-  # aliases for the "Type Aliases" panel. Each row carries `name`,
-  # `expansion`, `doc`, `source_file`, `internal`, `package`, and
-  # `source_origin`. A dispatch failure / RBAC denial yields an empty list
-  # rather than crashing the browser — the class tree (the primary
-  # navigator) must still render. No client-side origin filter: unlike
-  # native modules, a dependency's `internal` alias is already excluded
-  # server-side at the seeding boundary, so there is nothing left to filter.
-  defp assign_browser_type_aliases(socket) do
-    rows =
-      case Facade.dispatch(:browse_type_aliases, %{}, ctx(socket)) do
-        {:value, rows} when is_list(rows) -> rows
-        _ -> []
-      end
-
-    assign(socket, browser_type_aliases: rows)
-  end
-
-  # BT-2656/BT-2661: apply the one-shot Project-origin default to the Native browser
-  # once the module rows arrive, mirroring `apply_default_browser_source/2` for the
-  # class tree. Only on the FIRST load (`:native_source_chosen` still false) and only
-  # when there is at least one project-origin native module to show; otherwise it
-  # falls back to "all" so the list isn't empty on open. A deliberate pick flips the
-  # flag in the `native_source` handler so a later refresh never resets it.
-  defp apply_default_native_source(%{assigns: %{native_source_chosen: true}} = socket, _rows),
-    do: socket
-
-  defp apply_default_native_source(socket, rows) do
-    assign(socket,
-      native_source: default_browser_source(rows),
-      native_source_chosen: true
-    )
-  end
-
-  # Load `class`/`side`'s selectors grouped by protocol (op 2, `browse-protocols`)
-  # for the protocol filter row + method list. The `protocols` list each carry a
-  # `name` and `selectors`; an unknown class / bad side comes back as a structured
-  # error we surface without blanking the rest of the pane.
-  defp load_protocols(socket, class, side) do
-    case Facade.dispatch(:browse_protocols, %{class: class, side: side}, ctx(socket)) do
-      {:value, %{"protocols" => protocols}} when is_list(protocols) ->
-        assign(socket, browser_protocols: protocols, browser_error: nil)
-
-      {:value, _other} ->
-        assign(socket, browser_protocols: [], browser_error: nil)
-
-      {:error, reason} ->
-        assign(socket, browser_protocols: [], browser_error: facade_error(reason))
-    end
-  end
-
-  # Load `class`'s methods grouped by `// === Name ===` section-divider
-  # category (op `browse-categories`, BT-3238) for the grouped method view.
-  # Class-wide (not per-side, unlike protocols) — a category can hold both
-  # instance- and class-side methods. Resets the group-mode toggle back to
-  # "protocol" and clears any in-progress section edit whenever the class
-  # changes, so switching classes never leaves a stale rename form open. A
-  # dispatch failure degrades to the default "unaffected" shape (`browser_categories`
-  # is a rendering aid, not something worth surfacing its own error banner for
-  # — the protocol/method list is still fully usable).
-  defp load_categories(socket, class) do
-    socket
-    |> refresh_categories(class)
-    |> assign(browser_group_mode: "protocol", editing_section: nil, section_form_error: nil)
-  end
-
-  # BT-3238: re-fetch `browse-categories` WITHOUT resetting `browser_group_mode`
-  # / `editing_section` — the post-save refresh path (`submit_section/4`) uses
-  # this alone, not `load_categories/2`, so a successful rename/add doesn't
-  # kick the viewer back to Protocol mode right after they used Sections mode
-  # to get there (review finding: `load_categories/2` used to reset the mode
-  # unconditionally on every call, including this one).
-  defp refresh_categories(socket, class) do
-    view =
-      case Facade.dispatch(:browse_categories, %{class: class}, ctx(socket)) do
-        {:value, %{"has_dividers" => _, "categories" => _} = view} -> view
-        _ -> default_categories()
-      end
-
-    assign(socket, browser_categories: view)
-  end
-
-  defp default_categories, do: %{"has_dividers" => false, "categories" => []}
-
-  # BT-3238: flattens `browse-categories`' category list into one ordered
-  # list of `side`-only method rows, in source order across every category —
-  # the section-mode method list renders from this (filtered per-category at
-  # render time), and the "has any methods at all" empty-state check uses it
-  # unfiltered.
-  defp category_methods_for_side(categories, side) when is_list(categories) do
-    Enum.flat_map(categories, fn category ->
-      Enum.filter(category["methods"] || [], &(&1["side"] == side))
-    end)
-  end
-
-  defp category_methods_for_side(_categories, _side), do: []
-
-  # BT-3238: the "add a new section" form's before-selector dropdown draws
-  # from this, NOT the full `category_methods_for_side/2` list — it excludes
-  # each named category's own first method. Inserting a new divider directly
-  # above a method that already starts a category would write two dividers
-  # back-to-back with nothing between them; `find_divider_span`'s own doc
-  # (`method_category.rs`) says only the nearer one survives, so the
-  # existing category's divider would be silently orphaned (its methods
-  # merging into whatever category preceded it) rather than cleanly split.
-  # Every method in the implicit (unnamed) leading group stays a valid
-  # insertion point — there is no divider there yet to collide with — and so
-  # does every method after a category's first, since a new divider there
-  # cleanly splits that category into two.
-  defp insertable_methods_for_side(categories, side) when is_list(categories) do
-    Enum.flat_map(categories, fn category ->
-      same_side = Enum.filter(category["methods"] || [], &(&1["side"] == side))
-
-      case category["name"] do
-        nil ->
-          same_side
-
-        _named ->
-          # A category's "first method" is its first method OVERALL (any
-          # side), matching the server-side collision guard
-          # (`starts_named_category/3`, `beamtalk_repl_ops_load.erl`) — not
-          # the first *same-side* method. A category can legitimately open
-          # with a class-side method and continue with instance-side ones;
-          # filtering by side before dropping "the first" would wrongly
-          # treat that instance-side method as the category's start and
-          # exclude it, when the server would happily accept it.
-          case category["methods"] || [] do
-            [first_overall | _] -> Enum.reject(same_side, &(&1 == first_overall))
-            [] -> []
-          end
-      end
-    end)
-  end
-
-  defp insertable_methods_for_side(_categories, _side), do: []
-
-  # BT-3238: dispatch `save-section` (rename via `old_name:`, or insert via
-  # `before_selector:`/`before_side:` — the caller passes exactly one shape
-  # via `opts`) and, on success, close the inline form and refresh the
-  # grouped view so the new/renamed divider shows up immediately. A failure
-  # surfaces inline on the form (`section_form_error`) rather than the
-  # page-wide `@save_error` notice, since it's scoped to the small form, not
-  # the whole editor.
-  defp submit_section(socket, class, new_name, opts) do
-    params = Map.merge(%{class: class, new_name: new_name}, Map.new(opts))
-
-    case Facade.dispatch(:save_section, params, ctx(socket)) do
-      {:value, %{"ok" => true}} ->
-        socket
-        |> assign(editing_section: nil, section_form_error: nil)
-        |> refresh_categories(class)
-
-      {:error, reason} ->
-        assign(socket, section_form_error: facade_error(reason))
-
-      _other ->
-        assign(socket, section_form_error: "Could not save the section.")
-    end
-  end
-
-  # ── navigation aids: omni search + senders/implementors (BT-2495) ───────────
+  # The System Browser data source, protocol/category loaders, and the
+  # senders/implementors/go-to-definition navigation aids below all now live
+  # in `BtAttachWeb.Live.SystemBrowser` (BT-3297, epic BT-3290).
 
   # Filter the workspace symbol index (`nav-symbols`) against the live query and
   # open the results popover. The index — every loaded class plus its locally
@@ -3595,725 +2911,13 @@ defmodule BtAttachWeb.WorkspaceLive do
   # Close the omni-search popover and clear its results.
   defp close_omni(socket), do: assign(socket, omni_open: false, omni_results: [])
 
-  # Open a class in the System Browser (the omni-search "class" result): select it
-  # in the tree and load its protocols for the current side, exactly as a click in
-  # the class tree would. Public: `BtAttachWeb.Live.Dock`'s REPL `:help` /
-  # `Beamtalk help:` follow-up (BT-3295) calls it directly (System Browser not
-  # yet extracted, BT-3297).
-  def open_class(socket, class) do
-    socket
-    |> assign(selected_class: class, selected_protocol: nil)
-    |> load_protocols(class, socket.assigns.browser_side)
-    |> load_categories(class)
-  end
-
-  # Point the System Browser at a class/side — select it in the tree, flip the
-  # instance/class toggle to match, clear the protocol filter, and load its
-  # protocols. Used when a method is opened from *outside* the browser (a
-  # Senders/Implementors jump to another class) so the pane tracks the focused
-  # tab, per the "browser highlights whatever the focused tab shows" design.
-  defp navigate_browser(socket, class, side)
-       when is_binary(class) and is_binary(side) do
-    socket
-    |> assign(selected_class: class, browser_side: side, selected_protocol: nil)
-    |> load_protocols(class, side)
-    |> load_categories(class)
-  end
-
-  # BT-2578: fetch a native class's backing Erlang source for the read-only pane.
-  # `content: nil` is the honest "source not available" empty state (a `.beam`-only
-  # build that shipped no `.erl`); a non-native class / dispatch failure carries an
-  # `error` string instead.
-  defp load_native_view(socket, class, selector \\ nil) do
-    base = %{
-      class: class,
-      backing_module: nil,
-      source_file: nil,
-      source_origin: nil,
-      editable: false,
-      content: nil,
-      clauses: [],
-      # The selector a method→clause jump asked for, and the matching clause the
-      # backend resolved (or nil — a delegate may complete in `handle_info`).
-      requested_selector: selector,
-      selected_clause: nil,
-      error: nil
-    }
-
-    params = if selector, do: %{class: class, selector: selector}, else: %{class: class}
-
-    case Facade.dispatch(:browse_native_source, params, ctx(socket)) do
-      {:value, %{} = r} ->
-        %{
-          base
-          | backing_module: Map.get(r, "backing_module"),
-            # The Erlang op returns the atom `null` for absent values, which
-            # arrives over distribution as the Elixir atom `:null` (NOT `nil`).
-            # Normalise so template `is_nil/1` guards and `:if` truthiness behave
-            # (a raw `:null` is truthy and `is_nil(:null)` is false) — otherwise
-            # the "no matching handle_call clause" explanation never renders and a
-            # stripped-source path would interpolate as ":null" (BT-2578).
-            # BT-2668: clean the path to project-relative — never the absolute host
-            # path.
-            source_file: clean_native_path(Map.get(r, "source_file")),
-            source_origin: Map.get(r, "source_origin"),
-            editable: Map.get(r, "editable") == true,
-            content: nonempty_string(Map.get(r, "content")),
-            clauses: Map.get(r, "clauses", []),
-            selected_clause: map_or_nil(Map.get(r, "selected_clause"))
-        }
-
-      {:error, reason} ->
-        %{base | error: facade_error(reason)}
-
-      _ ->
-        %{base | error: "Could not load Erlang source."}
-    end
-  end
-
-  # True when a clause row is the one a jump selected (selector + line match).
-  defp clause_active?(%{"selector" => s, "line" => l}, %{"selector" => s, "line" => l}), do: true
-  defp clause_active?(_clause, _selected), do: false
-
-  defp nonempty_string(s) when is_binary(s) and s != "", do: s
-  defp nonempty_string(_), do: nil
-
-  # Normalise the Erlang `null` atom (delivered as `:null` over distribution) and
-  # any non-conforming value to a clean Elixir `nil` / typed value, so template
-  # guards (`is_nil/1`, `:if`) and interpolation behave (BT-2578).
-  defp map_or_nil(m) when is_map(m), do: m
-  defp map_or_nil(_), do: nil
-
-  # True when the native pane is currently showing `class`'s backing source.
-  defp native_shown?(%{native_view: %{class: shown}}, class), do: shown == class
-  defp native_shown?(_assigns, _class), do: false
-
-  # BT-2648: fetch a standalone native module's source for the read-only pane,
-  # keyed by `module` (not class). Same normalisation as `load_native_view/3`
-  # (the Erlang `null` atom arrives as `:null` over distribution); `content: nil`
-  # is the honest "source not available" empty state.
-  defp load_native_module_view(socket, module) do
-    base = %{
-      module: module,
-      backing_module: nil,
-      source_file: nil,
-      source_origin: nil,
-      editable: false,
-      content: nil,
-      clauses: [],
-      requested_selector: nil,
-      selected_clause: nil,
-      error: nil
-    }
-
-    case Facade.dispatch(:browse_native_module_source, %{module: module}, ctx(socket)) do
-      {:value, %{} = r} ->
-        %{
-          base
-          | backing_module: Map.get(r, "backing_module"),
-            # BT-2668: clean the path to project-relative — never the absolute host
-            # path (the workspace may be remote / another user's machine).
-            source_file: clean_native_path(Map.get(r, "source_file")),
-            source_origin: Map.get(r, "source_origin"),
-            editable: Map.get(r, "editable") == true,
-            content: nonempty_string(Map.get(r, "content")),
-            clauses: Map.get(r, "clauses", []),
-            selected_clause: map_or_nil(Map.get(r, "selected_clause"))
-        }
-
-      {:error, reason} ->
-        %{base | error: facade_error(reason)}
-
-      _ ->
-        %{base | error: "Could not load Erlang source."}
-    end
-  end
-
-  # BT-2667: open (or re-focus) a standalone native module's `.erl` as a read-only
-  # `:native` editor tab. The tab is keyed by `native:<module>` so re-opening the
-  # same module focuses the existing tab rather than stacking a duplicate, and a
-  # native tab coexists with class/method tabs in the strip. The source is fetched
-  # once at open and cached on the tab's `native_view`; a `:beam`-only module still
-  # opens (its body shows the "source not available" empty state).
-  defp open_native_module_tab(socket, module) do
-    id = "native:" <> module
-
-    case MethodEditor.find_tab(socket, id) do
-      %{} -> MethodEditor.activate_tab(socket, id)
-      nil -> add_native_module_tab(socket, id, module)
-    end
-  end
-
-  # Builds the 4th tab kind (`:native`) sharing `BtAttachWeb.Live.MethodEditor`'s
-  # `:tabs` list/shape (see that module's "tabbed method editor data model"
-  # comment) — this constructor stays here because the standalone Native
-  # module browser (BT-2667/BT-2670) is still `WorkspaceLive`-owned (BT-3297
-  # lands the rest of it later in the BT-3290 epic). A field added/renamed on
-  # the MethodEditor side must be mirrored here too until that extraction
-  # lands.
-  defp add_native_module_tab(socket, id, module) do
-    view = load_native_module_view(socket, module)
-    # BT-2670: a project-owned native (`view.editable == true`) opens as an
-    # EDITABLE tab — seed the write-surface `source`/`base` from the fetched
-    # `.erl` content so the CodeMirror editor shows it and dirty-tracking works
-    # (mirroring a method/class tab). Deps/stdlib natives keep `source: ""` and
-    # the read-only render branch.
-    initial_source = if view.editable, do: view.content || "", else: ""
-
-    tab = %{
-      id: id,
-      kind: :native,
-      class: module,
-      side: nil,
-      selector: nil,
-      # The fetched native Erlang source view (content/clauses/error/clean
-      # source_file/editable). For a project-owned native the tab is editable
-      # (compile + reload + write-back via `native_save`); deps/stdlib stay
-      # read-only and the editor render takes the read-only :native branch.
-      native_view: view,
-      source: initial_source,
-      base: initial_source,
-      dirty: false,
-      disk_differs: false,
-      runtime_only: false,
-      disk_source: nil,
-      doc: nil,
-      signature: nil,
-      is_protocol: false,
-      # No Beamtalk-class modifier/origin badges on a raw `.erl` tab; the source
-      # origin shows in the native pane header instead. Keys present so the shared
-      # tab helpers' dot-access never crashes.
-      native_module: nil,
-      native_delegate: false,
-      class_modifiers: nil,
-      class_native: false,
-      source_origin: nil,
-      package: nil,
-      new: false
-    }
-
-    socket
-    |> assign(:tabs, socket.assigns.tabs ++ [tab])
-    |> assign(:active_tab, id)
-    |> MethodEditor.sync_active(tab)
-  end
-
-  # BT-2667: the module name of the focused `:native` tab (or nil) — drives the
-  # "sel" highlight on the System Browser's Native modules list so it tracks the
-  # native tab the editor is showing, mirroring how the class tree tracks the
-  # active class/def tab.
-  defp active_native_module(assigns) do
-    case MethodEditor.active_tab(assigns) do
-      %{kind: :native, class: module} -> module
-      _ -> nil
-    end
-  end
-
-  # BT-2668: turn an absolute on-disk `.erl` path into a clean, project-relative
-  # one for display — never leak the host filesystem layout (the workspace may be
-  # remote / another user's machine). Strips the build/project prefix up to a
-  # recognisable source root (`apps/`, `deps/`, `src/`, `native/`, `lib/`) so a
-  # path like `/home/james/src/proj/deps/http/native/x.erl` shows as
-  # `deps/http/native/x.erl`. A path that is already relative is returned as-is; an
-  # absolute path with no recognisable root falls back to its basename so only the
-  # file name (not the directory tree) is shown. `nil`/`:null`/empty → nil (the
-  # honest "no path" state — the viewer then omits the path line).
-  @native_path_roots ~w(apps deps src native lib)
-  def clean_native_path(path) when is_binary(path) and path != "" do
-    if String.starts_with?(path, "/") do
-      segments = String.split(path, "/", trim: true)
-
-      case Enum.find_index(segments, &(&1 in @native_path_roots)) do
-        nil -> List.last(segments)
-        idx -> segments |> Enum.drop(idx) |> Enum.join("/")
-      end
-    else
-      # Already relative (no leading "/"): trust it as the project-relative form.
-      path
-    end
-  end
-
-  def clean_native_path(_), do: nil
-
-  # Query senders/implementors of the active method's selector (`nav-query`) and
-  # open the result popover. A tab with no selector (a class-definition tab) is a
-  # graceful no-op — there is nothing to query. `kind` is `:senders` |
-  # `:implementors`; the facade op name matches.
-  defp run_nav_query(socket, kind) do
-    selector =
-      case MethodEditor.active_tab(socket.assigns) do
-        %{selector: sel} -> sel
-        nil -> nil
-      end
-
-    run_nav_query_for(socket, kind, selector)
-  end
-
-  # Run a senders/implementors `nav-query` for an explicit selector (BT-2639
-  # reuses this for the Required-methods → Implementors jump; BT-2495's
-  # active-tab path delegates here). A nil/empty selector is a graceful no-op.
-  defp run_nav_query_for(socket, kind, selector) do
-    if is_binary(selector) and selector != "" do
-      case Facade.dispatch(kind, %{selector: selector}, ctx(socket)) do
-        {:value, %{"sites" => sites}} when is_list(sites) ->
-          assign(socket, nav_popover: %{kind: kind, selector: selector, sites: sites})
-
-        {:value, _other} ->
-          assign(socket, nav_popover: %{kind: kind, selector: selector, sites: []})
-
-        {:error, reason} ->
-          assign(socket,
-            nav_popover: %{kind: kind, selector: selector, sites: [], error: facade_error(reason)}
-          )
-
-        # Any other shape (version skew, an unexpected reply) degrades to an empty
-        # popover with a generic message rather than crashing the LiveView.
-        _other ->
-          assign(socket,
-            nav_popover: %{
-              kind: kind,
-              selector: selector,
-              sites: [],
-              error: "Navigation unavailable."
-            }
-          )
-      end
-    else
-      socket
-    end
-  end
-
-  # Query a protocol's required methods / conforming classes (`nav-query`
-  # `required_methods` / `conforming_classes`) and open the result popover
-  # (BT-2639). The protocol equivalent of `run_nav_query/2`; the active tab must
-  # be a class-definition tab for a Protocol — otherwise a graceful no-op (the
-  # buttons only render for protocols). The popover's `selector` slot carries the
-  # protocol name (the popover head shows it next to the kind label, mirroring the
-  # method-selector display for senders/implementors). `kind` is
-  # `:required_methods` | `:conforming_classes`; the facade op name matches.
-  defp run_protocol_nav_query(socket, kind) do
-    protocol =
-      case MethodEditor.active_tab(socket.assigns) do
-        %{kind: :def, class: class, is_protocol: true} -> class
-        _ -> nil
-      end
-
-    if is_binary(protocol) and protocol != "" do
-      case Facade.dispatch(kind, %{protocol: protocol}, ctx(socket)) do
-        {:value, %{"sites" => sites}} when is_list(sites) ->
-          assign(socket, nav_popover: %{kind: kind, selector: protocol, sites: sites})
-
-        {:value, _other} ->
-          assign(socket, nav_popover: %{kind: kind, selector: protocol, sites: []})
-
-        {:error, reason} ->
-          assign(socket,
-            nav_popover: %{kind: kind, selector: protocol, sites: [], error: facade_error(reason)}
-          )
-
-        _other ->
-          assign(socket,
-            nav_popover: %{
-              kind: kind,
-              selector: protocol,
-              sites: [],
-              error: "Navigation unavailable."
-            }
-          )
-      end
-    else
-      socket
-    end
-  end
-
-  # Query the Beamtalk callers of the focused native tab's module (`nav-query`
-  # `callers_of_native_module`, BT-2669) and open the result popover. The active
-  # tab must be a `:native` tab — otherwise a graceful no-op (the Callers button
-  # only renders on native tabs). The popover's `selector` slot carries the
-  # module name (shown next to the "Callers" head, mirroring the selector display
-  # for senders/implementors); each row opens the calling method via `nav_open`.
-  defp run_native_callers_query(socket) do
-    module =
-      case MethodEditor.active_tab(socket.assigns) do
-        %{kind: :native, class: class} -> class
-        _ -> nil
-      end
-
-    if is_binary(module) and module != "" do
-      kind = :callers_of_native_module
-
-      case Facade.dispatch(kind, %{module: module}, ctx(socket)) do
-        {:value, %{"sites" => sites}} when is_list(sites) ->
-          assign(socket, nav_popover: %{kind: kind, selector: module, sites: sites})
-
-        {:value, _other} ->
-          assign(socket, nav_popover: %{kind: kind, selector: module, sites: []})
-
-        {:error, reason} ->
-          assign(socket,
-            nav_popover: %{kind: kind, selector: module, sites: [], error: facade_error(reason)}
-          )
-
-        _other ->
-          assign(socket,
-            nav_popover: %{
-              kind: kind,
-              selector: module,
-              sites: [],
-              error: "Navigation unavailable."
-            }
-          )
-      end
-    else
-      socket
-    end
-  end
-
-  # ── go-to-definition resolution (BT-2666) ───────────────────────────────────
-  #
-  # Resolve a modifier-clicked symbol to a definition target and open it. The
-  # class-then-selector order mirrors the LSP `definition_provider.rs`: a name
-  # that is a loaded class is a class reference (→ its definition tab); anything
-  # else is treated as a message send (→ its implementor(s)).
-  defp run_goto_definition(socket, token, code) do
-    cond do
-      # An empty/blank token is a bare no-op (the JS never sends one — it only
-      # fires on an identifier — but guard it without even a flash).
-      String.trim(token) == "" ->
-        socket
-
-      known_class?(socket, token) ->
-        socket
-        |> MethodEditor.open_definition(token)
-        |> navigate_browser(token, "instance")
-        # Clear any open Implementors popover so it doesn't linger behind the
-        # newly-opened class tab (parity with nav_open_class/open_implementor_site).
-        |> assign(nav_popover: nil)
-
-      true ->
-        case goto_selector(token, code) do
-          nil -> goto_not_found(socket)
-          selector -> open_implementor(socket, selector)
-        end
-    end
-  end
-
-  # A loaded class name (matches the System Browser tree the editor already
-  # holds). Class lookup is case-sensitive and exact — Beamtalk class names are
-  # capitalised identifiers, so a clicked lowercase token never matches here and
-  # falls through to the selector path.
-  defp known_class?(socket, token) do
-    socket.assigns
-    |> Map.get(:browser_classes, [])
-    |> Enum.any?(fn row -> Map.get(row, "name") == token end)
-  end
-
-  # The message selector the clicked token denotes, derived from the `code`
-  # line-prefix (the line up to and including the token):
-  #
-  #   * a KEYWORD send — the prefix ends in `…word:` (optionally with a trailing
-  #     argument the click landed before) — resolves to the maximal trailing run
-  #     of `word:` parts, so clicking any part of `dict at: k put: v` resolves the
-  #     whole `at:put:` selector.
-  #   * otherwise the bare token is a UNARY selector (e.g. `factorial`).
-  #
-  # An empty/whitespace token yields nil (no selector to resolve). The result is
-  # only ever fed to the `implementors` nav-query, whose `binary_to_existing_atom`
-  # guard turns an unknown selector into an empty result set — so a wrong guess is
-  # a graceful "no definition", never a crash.
-  defp goto_selector(token, code) when is_binary(code) do
-    case keyword_selector(code) do
-      nil -> if token == "", do: nil, else: token
-      selector -> selector
-    end
-  end
-
-  defp goto_selector(token, _code), do: if(token == "", do: nil, else: token)
-
-  # Extract the trailing keyword selector (`word:word:…`) from a line prefix, or
-  # nil when it is not a keyword send. The clicked keyword belongs to the send
-  # that ends the prefix, so we first trim to the trailing segment — everything
-  # after the last statement/grouping breaker (`.`, `;`, brackets, `^`, `|`) —
-  # then join that segment's contiguous `word:` parts. This keeps unrelated sends
-  # earlier on the line out of the selector (e.g. `coll at: i. obj foo: x bar: y`
-  # clicked near `y` resolves to `foo:bar:`, not `at:foo:bar:`).
-  defp keyword_selector(code) do
-    segment = code |> String.split(~r/[.;()\[\]{}^|]/) |> List.last()
-    parts = Regex.scan(~r/([A-Za-z_][A-Za-z0-9_]*):/, segment) |> Enum.map(&Enum.at(&1, 1))
-
-    case parts do
-      [] -> nil
-      _ -> parts |> Enum.map(&(&1 <> ":")) |> Enum.join()
-    end
-  end
-
-  # Resolve a selector to its implementor(s) via the BT-2495 `implementors`
-  # nav-query and open the result. The single-hit case opens the method tab
-  # directly (the whole point of go-to-definition — no extra click); several hits
-  # fall back to the Senders/Implementors popover so the user disambiguates; none
-  # is the graceful unresolved no-op. Mirrors `run_nav_query_for/3` but acts on
-  # the result rather than always opening a popover.
-  defp open_implementor(socket, selector) do
-    case Facade.dispatch(:implementors, %{selector: selector}, ctx(socket)) do
-      {:value, %{"sites" => [site]}} when is_map(site) ->
-        open_implementor_site(socket, site)
-
-      {:value, %{"sites" => sites}} when is_list(sites) and sites != [] ->
-        # Ambiguous — reuse the BT-2495 popover so the user picks the implementor.
-        assign(socket, nav_popover: %{kind: :implementors, selector: selector, sites: sites})
-
-      _ ->
-        goto_not_found(socket)
-    end
-  end
-
-  # Open a single implementor site (a `{class, side, selector}` row) the same way
-  # the `nav_open` popover row does: open the method tab and point the browser at
-  # it, then ensure no stale popover lingers.
-  defp open_implementor_site(socket, site) do
-    class = Map.get(site, "class")
-    selector = Map.get(site, "method")
-    side = if Map.get(site, "class_side") == true, do: "class", else: "instance"
-
-    if is_binary(class) and is_binary(selector) do
-      socket
-      |> MethodEditor.open_method_tab(class, side, selector)
-      |> navigate_browser(class, side)
-      |> assign(nav_popover: nil)
-    else
-      goto_not_found(socket)
-    end
-  end
-
-  # The graceful unresolved no-op (BT-2666 AC): a brief flash, the editor and any
-  # open tab untouched. A transient info flash matches the cockpit's other
-  # lightweight status messages and self-dismisses.
-  defp goto_not_found(socket) do
-    put_flash(socket, :info, "No definition found.")
-  end
-
-  # ── System Browser view helpers (BT-2491) ───────────────────────────────────
-
-  # The class rows in display order for the active view. Hierarchy walks
-  # roots→children indenting by the *true* superclass depth (BT-2637: no cap — the
-  # real kernel chain is ProtoObject→Object→Value→Number→…, far deeper than the
-  # spike's two levels, so a cap collapsed everything onto one indent and read as
-  # flat). `class_rows/1` scales the visible indent from this depth.
-  # Category groups by the class annotation, each group a `{category, rows}` pair.
-  # Both feed `class_rows/1` `{row, indent, context?}` tuples so the template
-  # renders one branch — Category rows are always `context? = false`; only the
-  # filtered Hierarchy view (BT-2649) emits dimmed `context? = true` ancestor rows.
-
-  # Hierarchy under an active source filter (BT-2649). Builds the tree from the
-  # *full* class set so the transitive superclass ancestors connecting each
-  # matching class to a root are kept as dimmed, non-interactive "context" rows —
-  # otherwise the filtered set flattens (every match at indent 0). Returns
-  # `{class_row, indent, context?}`; a context row's name is not in `visible_names`.
-  # For the `all` filter every class is visible, so this emits zero context rows —
-  # identical shape to `hierarchy_rows/1` plus a `false` context flag.
-  defp hierarchy_rows_with_context(all_classes, visible_names),
-    do: BtAttachWeb.ClassTree.hierarchy_rows_with_context(all_classes, visible_names)
-
-  # Category: `{category, [class_row]}` groups, each group's classes sorted by
-  # name, the groups themselves sorted by category. A class with no category falls
-  # into an "(uncategorized)" bucket rather than vanishing.
-  #
-  # BT-2557: TestCase subclasses (`is_test`) are pulled into a dedicated "Tests"
-  # bucket regardless of their package — the browser surfaces them as a category
-  # so a project's tests are one click away once loaded.
-  defp category_groups(classes) do
-    classes
-    |> Enum.group_by(&class_category_bucket/1)
-    |> Enum.sort_by(fn {category, _} -> category end)
-    |> Enum.map(fn {category, rows} ->
-      {category, Enum.sort_by(rows, &Map.get(&1, "name"))}
-    end)
-  end
-
-  defp class_category_bucket(%{"is_test" => true}), do: "Tests"
-  # BT-2615: protocol class objects (ADR 0068) declare no package, so they would
-  # otherwise land in "(uncategorized)". Group them under a dedicated "Protocols"
-  # bucket — mirroring the "Tests" treatment — so a project's protocols are one
-  # click away and don't masquerade as uncategorized classes.
-  defp class_category_bucket(%{"is_protocol" => true}), do: "Protocols"
-  defp class_category_bucket(class), do: Map.get(class, "category") || "(uncategorized)"
-
-  # Narrow class rows by source origin (BT-2557). `source_origin` is the bare
-  # classification "project", "stdlib", or "dependency" (BT-2643 — the package
-  # name now lives in a separate `package` field). "all" is the identity filter;
-  # an unknown filter also passes everything through (fail-open so the tree is
-  # never silently blanked).
-  defp filter_by_source(classes, "all"), do: classes
-
-  defp filter_by_source(classes, "deps") do
-    Enum.filter(classes, &(Map.get(&1, "source_origin") == "dependency"))
-  end
-
-  defp filter_by_source(classes, src) when src in ~w(project stdlib) do
-    Enum.filter(classes, &(Map.get(&1, "source_origin") == src))
-  end
-
-  defp filter_by_source(classes, _src), do: classes
-
-  # True when no class is selected, or the selected class survives the current
-  # source filter (BT-2597). Used to decide whether switching filters should
-  # clear a now-hidden selection.
-  defp selected_class_visible?(%{assigns: %{selected_class: nil}}), do: true
-
-  defp selected_class_visible?(%{assigns: assigns}) do
-    assigns.browser_classes
-    |> filter_by_source(assigns.browser_source)
-    |> Enum.any?(&(Map.get(&1, "name") == assigns.selected_class))
-  end
-
-  # The flat method list for the current protocol filter: all selectors across the
-  # protocol tree (filter = nil → "all") or just the selected protocol's, each
-  # carrying its protocol name so the row badge / breadcrumb can show it. Sorted
-  # by selector for stable order.
-  defp filtered_methods(protocols, filter) do
-    protocols
-    |> Enum.filter(fn p -> filter == nil or Map.get(p, "name") == filter end)
-    |> Enum.flat_map(fn p ->
-      name = Map.get(p, "name")
-      Enum.map(Map.get(p, "selectors", []), &Map.put(&1, "protocol", name))
-    end)
-    |> Enum.sort_by(&Map.get(&1, "selector"))
-  end
-
-  # Total selector count across the protocol tree (the "all" filter row's count).
-  defp protocol_method_count(protocols) do
-    Enum.reduce(protocols, 0, fn p, acc -> acc + length(Map.get(p, "selectors", [])) end)
-  end
-
-  # A row is "runtime-only" (image-diverged, ADR 0096 / BT-2483) when its origin
-  # is `runtime` — in the live image with no static/disk source. The class tree
-  # and method list badge these so an observer sees what is not on disk. Public:
-  # `BtAttachWeb.Live.MethodEditor`'s `method_source_info/4` (BT-3296) calls it
-  # directly.
-  def runtime_only?(%{"origin" => "runtime"}), do: true
-  def runtime_only?(_), do: false
-
-  # A selector row is "derived" (BT-2714) when its xref `source_status` is
-  # `synthetic` — a compiler-synthesized method (Value accessors, `with<Field>:`
-  # setters, keyword constructors, actor `new`/`spawn`) with no hand-written
-  # source line. The method list badges these `derived` so the synthetic magic is
-  # visible rather than indistinguishable from real methods.
-  defp synthetic?(%{"source_status" => "synthetic"}), do: true
-  defp synthetic?(_), do: false
-
-  # BT-2735: the method-row hover (`title`). When the browse op enriched the row
-  # with a `signature` (and, for a compiler-derived method, a resolved `doc`,
-  # BT-2714) the hover reads VS Code-style — the rendered signature over the
-  # first line of the doc — so it conveys what the method is without a click.
-  # Rows the op left unenriched (hand-written selectors, kept off the browse hot
-  # path) fall back to the bare selector, the pre-BT-2735 behaviour.
-  defp method_row_title(m) do
-    case {presence(m["signature"]), first_doc_line(m["doc"])} do
-      {nil, nil} -> presence(m["selector"])
-      {sig, nil} -> sig
-      {nil, doc} -> "#{m["selector"]}\n#{doc}"
-      {sig, doc} -> "#{sig}\n#{doc}"
-    end
-  end
-
-  # The first non-blank line of a method's `///` doc, or nil when the doc is
-  # absent/blank. Keeps the hover to a single descriptive line (the full doc is
-  # a click away in the read-only pane).
-  defp first_doc_line(doc) when is_binary(doc) do
-    doc
-    |> String.split("\n", parts: 2)
-    |> hd()
-    |> presence()
-  end
-
-  defp first_doc_line(_), do: nil
-
-  # A binary trimmed to nil when blank, itself otherwise — so an empty
-  # signature/doc string reads the same as an absent one.
-  defp presence(s) when is_binary(s) do
-    case String.trim(s) do
-      "" -> nil
-      trimmed -> trimmed
-    end
-  end
-
-  defp presence(_), do: nil
-
-  # Source origin badge helpers (BT-2552, BT-2643, BT-2641). Two orthogonal
-  # fields drive the badge: `source_origin` is the classification ("stdlib" |
-  # "dependency" | "project") and keys the css class + title; `package` is the
-  # package name and feeds the dependency badge label. The dependency badge reads
-  # as a "DEP" marker (parity with the generic "STDLIB" marker), suffixed with
-  # the package name when known ("DEP · HTTP") and bare ("DEP") otherwise.
-  defp source_origin_class(%{"source_origin" => "stdlib"}), do: "stdlib"
-  defp source_origin_class(%{"source_origin" => "dependency"}), do: "dependency"
-  defp source_origin_class(_), do: "project"
-
-  defp source_origin_label(%{"source_origin" => "stdlib"}), do: "stdlib"
-
-  defp source_origin_label(%{"source_origin" => "dependency"} = row),
-    do: dependency_badge_label(row)
-
-  defp source_origin_label(_), do: ""
-
-  # Dependency badge text: "DEP · <pkg>" when the package is known, plain "DEP"
-  # when it is absent/unknown. This is the badge-specific label; `package_name/1`
-  # (which degrades to "unknown") still serves callers that need the raw package.
-  # Public: `BtAttachWeb.Live.MethodEditor`'s `header_package_label/1` (BT-3296)
-  # calls it directly for the editor-header badge.
-  def dependency_badge_label(row) do
-    case Map.get(row, "package") do
-      pkg when is_binary(pkg) and pkg != "" -> "DEP · #{pkg}"
-      _ -> "DEP"
-    end
-  end
-
-  defp source_origin_title(%{"source_origin" => "stdlib"}), do: "Standard library"
-
-  defp source_origin_title(%{"source_origin" => "dependency"} = row),
-    do: "Dependency: #{package_name(row)}"
-
-  defp source_origin_title(_), do: "Project"
-
-  # The package name carried on a browse row's `package` field (BT-2643). Absent /
-  # null packages degrade to "unknown" so a dependency badge never renders blank.
-  # Public: `BtAttachWeb.Live.MethodEditor`'s `header_origin_title/1` (BT-3296)
-  # calls it directly for the editor-header badge.
-  def package_name(row) do
-    case Map.get(row, "package") do
-      pkg when is_binary(pkg) and pkg != "" -> pkg
-      _ -> "unknown"
-    end
-  end
-
-  # The method shown in the focused tab as a `%{class, side, selector}` ref (or nil
-  # for a class-definition tab), so the System Browser can highlight the matching
-  # method row. Takes bare `assigns` for the render template. An unsaved new-method
-  # tab has no real selector yet (`new: true`, `selector: ""`), so it highlights
-  # nothing — returning a `selector: ""` ref would never match a row anyway.
-  defp selected_method_ref(assigns) do
-    case MethodEditor.active_tab(assigns) do
-      %{new: true} ->
-        nil
-
-      %{kind: :method, class: class, side: side, selector: selector} ->
-        %{class: class, side: side, selector: selector}
-
-      _ ->
-        nil
-    end
-  end
-
-  # The class whose definition tab is focused, so the System Browser's "class
-  # definition" entry can track the editor (mirrors `selected_method_ref/1` for
-  # method tabs). nil when the active tab is a method or there is no def tab.
-  defp selected_def_ref(assigns) do
-    case MethodEditor.active_tab(assigns) do
-      %{kind: :def, class: class} -> class
-      _ -> nil
-    end
-  end
-
+  # The System Browser class/protocol/category data source, the native-source
+  # panes, the senders/implementors/go-to-definition navigation aids, and the
+  # class-tree/method-list view helpers all now live in
+  # `BtAttachWeb.Live.SystemBrowser` (BT-3297, epic BT-3290); `open_class/2`
+  # there is the "point the System Browser at this class" primitive this
+  # module's `omni_open` handler and `BtAttachWeb.Live.Dock`'s REPL `:help`
+  # cross-call.
   # ── bindings + inspector helpers ────────────────────────────────────────────
 
   # Read the session's live bindings through the read-surface and assign display
@@ -4539,11 +3143,11 @@ defmodule BtAttachWeb.WorkspaceLive do
       assigns
       |> assign(
         :visible_classes,
-        filter_by_source(assigns.browser_classes, assigns.browser_source)
+        SystemBrowser.filter_by_source(assigns.browser_classes, assigns.browser_source)
       )
       |> assign(
         :visible_modules,
-        filter_by_source(assigns.browser_native_modules, assigns.native_source)
+        SystemBrowser.filter_by_source(assigns.browser_native_modules, assigns.native_source)
       )
 
     ~H"""
@@ -4793,7 +3397,10 @@ defmodule BtAttachWeb.WorkspaceLive do
           <% true -> %>
             <div class="tree">
               <%= if @browser_view == "category" do %>
-                <div :for={{category, rows} <- category_groups(@visible_classes)} class="cat-group">
+                <div
+                  :for={{category, rows} <- SystemBrowser.category_groups(@visible_classes)}
+                  class="cat-group"
+                >
                   <div class="cat-row">{category}</div>
                   <.class_rows
                     rows={Enum.map(rows, &{&1, 1, false})}
@@ -4808,7 +3415,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                      `all`, every class is visible, so no context rows are emitted. --%>
                 <.class_rows
                   rows={
-                    hierarchy_rows_with_context(
+                    ClassTree.hierarchy_rows_with_context(
                       @browser_classes,
                       MapSet.new(@visible_classes, &Map.get(&1, "name"))
                     )
@@ -4846,10 +3453,10 @@ defmodule BtAttachWeb.WorkspaceLive do
                 <span class="cls mono">{mod["module"]}</span>
                 <span
                   :if={mod["source_origin"] && mod["source_origin"] != "project"}
-                  class={"source-origin-tag #{source_origin_class(mod)}"}
-                  title={source_origin_title(mod)}
+                  class={"source-origin-tag #{SystemBrowser.source_origin_class(mod)}"}
+                  title={SystemBrowser.source_origin_title(mod)}
                 >
-                  {source_origin_label(mod)}
+                  {SystemBrowser.source_origin_label(mod)}
                 </span>
                 <span
                   :if={mod["openable"] == false}
@@ -4880,10 +3487,10 @@ defmodule BtAttachWeb.WorkspaceLive do
                 <span class="alias-expansion mono">= {alias_row["expansion"]}</span>
                 <span
                   :if={alias_row["source_origin"] && alias_row["source_origin"] != "project"}
-                  class={"source-origin-tag #{source_origin_class(alias_row)}"}
-                  title={source_origin_title(alias_row)}
+                  class={"source-origin-tag #{SystemBrowser.source_origin_class(alias_row)}"}
+                  title={SystemBrowser.source_origin_title(alias_row)}
                 >
-                  {source_origin_label(alias_row)}
+                  {SystemBrowser.source_origin_label(alias_row)}
                 </span>
                 <span :if={alias_row["internal"] == true} class="runtime-tag" title="internal alias">
                   internal
@@ -4964,13 +3571,13 @@ defmodule BtAttachWeb.WorkspaceLive do
       <span class="cls">{class["name"]}</span>
       <span
         :if={not context? && class["source_origin"] && class["source_origin"] != "project"}
-        class={"source-origin-tag #{source_origin_class(class)}"}
-        title={source_origin_title(class)}
+        class={"source-origin-tag #{SystemBrowser.source_origin_class(class)}"}
+        title={SystemBrowser.source_origin_title(class)}
       >
-        {source_origin_label(class)}
+        {SystemBrowser.source_origin_label(class)}
       </span>
       <span
-        :if={not context? && runtime_only?(class)}
+        :if={not context? && SystemBrowser.runtime_only?(class)}
         class="runtime-tag"
         title="runtime-only (not on disk)"
       >
@@ -5029,12 +3636,12 @@ defmodule BtAttachWeb.WorkspaceLive do
           :for={c <- @view.clauses}
           class={
             "mono" <>
-              if(clause_active?(c, @view.selected_clause),
+              if(SystemBrowser.clause_active?(c, @view.selected_clause),
                 do: " native-clause-active",
                 else: ""
               )
           }
-          aria-current={clause_active?(c, @view.selected_clause) && "true"}
+          aria-current={SystemBrowser.clause_active?(c, @view.selected_clause) && "true"}
         >
           {c["selector"]}<span class="muted-note"> · line {c["line"]}</span>
         </li>
@@ -5087,16 +3694,22 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp system_browser_methods(assigns) do
     assigns =
       assigns
-      |> assign(:methods, filtered_methods(assigns.browser_protocols, assigns.selected_protocol))
-      |> assign(:total_methods, protocol_method_count(assigns.browser_protocols))
+      |> assign(
+        :methods,
+        SystemBrowser.filtered_methods(assigns.browser_protocols, assigns.selected_protocol)
+      )
+      |> assign(:total_methods, SystemBrowser.protocol_method_count(assigns.browser_protocols))
       |> assign(:has_dividers, assigns.browser_categories["has_dividers"] || false)
       |> assign(
         :section_methods,
-        category_methods_for_side(assigns.browser_categories["categories"], assigns.browser_side)
+        SystemBrowser.category_methods_for_side(
+          assigns.browser_categories["categories"],
+          assigns.browser_side
+        )
       )
       |> assign(
         :insertable_methods,
-        insertable_methods_for_side(
+        SystemBrowser.insertable_methods_for_side(
           assigns.browser_categories["categories"],
           assigns.browser_side
         )
@@ -5339,20 +3952,22 @@ defmodule BtAttachWeb.WorkspaceLive do
                 phx-value-class={@selected_class}
                 phx-value-side={@browser_side}
                 phx-value-selector={m["selector"]}
-                title={method_row_title(m)}
+                title={SystemBrowser.method_row_title(m)}
               >
                 <span class="twig" style="color: var(--accent);">m</span>
                 <span class="mname mono">{m["selector"]}</span>
                 <span
                   :if={m["source_origin"] && m["source_origin"] != "project"}
-                  class={"source-origin-tag #{source_origin_class(m)}"}
-                  title={source_origin_title(m)}
+                  class={"source-origin-tag #{SystemBrowser.source_origin_class(m)}"}
+                  title={SystemBrowser.source_origin_title(m)}
                 >
-                  {source_origin_label(m)}
+                  {SystemBrowser.source_origin_label(m)}
                 </span>
-                <span :if={runtime_only?(m)} class="runtime-tag" title="runtime-only">⚡</span>
+                <span :if={SystemBrowser.runtime_only?(m)} class="runtime-tag" title="runtime-only">
+                  ⚡
+                </span>
                 <span
-                  :if={synthetic?(m)}
+                  :if={SystemBrowser.synthetic?(m)}
                   class="derived-tag"
                   title="compiler-derived (auto-generated synthetic method)"
                 >
@@ -5690,7 +4305,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                   browser_mode={@browser_mode}
                   browser_native_modules={@browser_native_modules}
                   native_source={@native_source}
-                  native_module_shown={active_native_module(assigns)}
+                  native_module_shown={SystemBrowser.active_native_module(assigns)}
                   browser_type_aliases={@browser_type_aliases}
                 />
                 <%!-- Draggable divider (BT-2576): rebalances the class tree vs.
@@ -5733,8 +4348,8 @@ defmodule BtAttachWeb.WorkspaceLive do
                   selected_protocol={@selected_protocol}
                   selected_class={@selected_class}
                   browser_side={@browser_side}
-                  active_method={selected_method_ref(assigns)}
-                  active_def={selected_def_ref(assigns)}
+                  active_method={SystemBrowser.selected_method_ref(assigns)}
+                  active_def={SystemBrowser.selected_def_ref(assigns)}
                   role={@role}
                   browser_categories={@browser_categories}
                   browser_group_mode={@browser_group_mode}
@@ -7021,9 +5636,11 @@ defmodule BtAttachWeb.WorkspaceLive do
                             class="native-toggle"
                             phx-click="browser_open_native"
                             phx-value-class={doc_tab.class}
-                            aria-expanded={to_string(native_shown?(assigns, doc_tab.class))}
+                            aria-expanded={
+                              to_string(SystemBrowser.native_shown?(assigns, doc_tab.class))
+                            }
                           >
-                            {if native_shown?(assigns, doc_tab.class),
+                            {if SystemBrowser.native_shown?(assigns, doc_tab.class),
                               do: "Hide Erlang source",
                               else: "View Erlang source"}
                           </button>
@@ -7043,7 +5660,10 @@ defmodule BtAttachWeb.WorkspaceLive do
                             Open native source →
                           </button>
                         </div>
-                        <div :if={native_shown?(assigns, doc_tab.class)} class="native-body">
+                        <div
+                          :if={SystemBrowser.native_shown?(assigns, doc_tab.class)}
+                          class="native-body"
+                        >
                           <.native_source_body
                             view={@native_view}
                             fallback_module={doc_tab.native_module}
@@ -7764,4 +6384,11 @@ defmodule BtAttachWeb.WorkspaceLive do
   # so a test can assert the two stay literally identical, guarding against a
   # future edit that reintroduces a second hardcoded list here.
   def inspector_events, do: @inspector_events
+
+  @doc false
+  # Mirrors `inspector_events/0`: `@system_browser_events` IS
+  # `SystemBrowser.__system_browser_events__/0` (BT-3297, following the
+  # BT-3301 fix), never a second hand-maintained copy. This accessor exists
+  # only so a test can assert the two stay literally identical.
+  def system_browser_events, do: @system_browser_events
 end

--- a/editors/liveview/test/bt_attach_web/method_editor_test.exs
+++ b/editors/liveview/test/bt_attach_web/method_editor_test.exs
@@ -139,10 +139,10 @@ defmodule BtAttachWeb.Live.MethodEditorTest do
     }
   end
 
-  # Mirrors `WorkspaceLive.add_native_module_tab/3`'s shape (BT-2667/BT-2670)
-  # — the 4th tab kind, still constructed on the `WorkspaceLive` side (BT-3297
-  # territory) but sharing this module's `:tabs` list, so `compile_clean/3`'s
-  # update-syntax writes need every key present.
+  # Mirrors `BtAttachWeb.Live.SystemBrowser`'s private `add_native_module_tab/3`
+  # shape (BT-2667/BT-2670, BT-3297) — the 4th tab kind, constructed on the
+  # `SystemBrowser` side but sharing this module's `:tabs` list, so
+  # `compile_clean/3`'s update-syntax writes need every key present.
   defp native_tab(id, module, opts \\ []) do
     editable = Keyword.get(opts, :editable, true)
     content = Keyword.get(opts, :content, "-module(#{module}).")

--- a/editors/liveview/test/bt_attach_web/system_browser_test.exs
+++ b/editors/liveview/test/bt_attach_web/system_browser_test.exs
@@ -1,0 +1,548 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.Live.SystemBrowserTest do
+  @moduledoc """
+  Direct unit tests for `BtAttachWeb.Live.SystemBrowser` (BT-3297), driving
+  its `handle_event/3` clauses and the browse/navigation data model against a
+  hand-built `%Phoenix.LiveView.Socket{}` and the fully-stubbed workspace
+  client (`BtAttachWeb.StubWorkspaceClient`, BT-2554) — no full LiveView
+  mount, no real workspace node. Mirrors `BtAttachWeb.Live.MethodEditorTest`
+  (BT-3296), `BtAttachWeb.Live.DockTest` (BT-3295), and
+  `BtAttachWeb.Live.InspectorTest` (BT-3291), the precedent this extraction
+  follows.
+
+  Covers the branches BT-3297's acceptance criteria calls out specifically:
+  hierarchy vs category view (`hierarchy_rows/1` — already covered by
+  `BtAttachWeb.ClassTreeTest`, reused directly here — and `category_groups/1`),
+  instance/class side toggle refetch, the protocol filter
+  (`filtered_methods/2`), runtime-badge origin marking, and the
+  source-navigation events (hover, goto-definition, senders, implementors).
+  """
+  use ExUnit.Case, async: false
+
+  alias BtAttachWeb.Live.SystemBrowser
+  alias BtAttachWeb.StubWorkspaceClient
+  alias BtAttachWeb.WorkspaceLive
+
+  @system_browser_source Path.expand("../../lib/bt_attach_web/live/system_browser.ex", __DIR__)
+
+  setup do
+    Application.put_env(:bt_attach, :workspace_client, StubWorkspaceClient)
+    {:ok, _} = StubWorkspaceClient.start_state()
+
+    on_exit(fn ->
+      Application.delete_env(:bt_attach, :workspace_client)
+      StubWorkspaceClient.stop_state(2_000)
+    end)
+
+    :ok
+  end
+
+  # A bare, disconnected socket carrying exactly the assigns SystemBrowser's
+  # functions read — the subset of `WorkspaceLive.bind_session/3`'s init
+  # relevant to the System Browser pane, plus the handful of tab-related keys
+  # `BtAttachWeb.Live.MethodEditor` owns that this module cross-calls
+  # (`:tabs`/`:active_tab`). `role: :owner` by default (most tests aren't
+  # about RBAC); override per test.
+  defp base_socket(overrides \\ %{}) do
+    assigns =
+      %{
+        __changed__: %{},
+        flash: %{},
+        current_user: nil,
+        role: :owner,
+        session_id: "sess-1",
+        session_pid: self(),
+        connected: true,
+        browser_view: "hierarchy",
+        browser_source: "all",
+        browser_source_chosen: true,
+        browser_side: "instance",
+        selected_class: nil,
+        selected_protocol: nil,
+        browser_protocols: [],
+        browser_classes: [],
+        browser_error: nil,
+        browser_categories: %{"has_dividers" => false, "categories" => []},
+        browser_group_mode: "protocol",
+        editing_section: nil,
+        section_form_error: nil,
+        native_view: nil,
+        browser_mode: :classes,
+        browser_native_modules: [],
+        browser_type_aliases: [],
+        native_source: "all",
+        native_source_chosen: true,
+        nav_popover: nil,
+        show_browser: true,
+        tabs: [],
+        active_tab: nil
+      }
+      |> Map.merge(overrides)
+
+    %Phoenix.LiveView.Socket{assigns: assigns}
+  end
+
+  defp def_tab(id, class, opts \\ []) do
+    %{
+      id: id,
+      kind: :def,
+      class: class,
+      side: nil,
+      selector: nil,
+      source: "Object subclass: #{class}",
+      base: "Object subclass: #{class}",
+      dirty: false,
+      disk_differs: false,
+      runtime_only: false,
+      disk_source: nil,
+      doc: nil,
+      signature: nil,
+      is_protocol: Keyword.get(opts, :is_protocol, false),
+      native_module: nil,
+      class_modifiers: [],
+      class_native: false,
+      source_origin: nil,
+      package: nil,
+      new: false
+    }
+  end
+
+  defp method_tab(id, class, selector, opts \\ []) do
+    %{
+      id: id,
+      kind: :method,
+      class: class,
+      side: Keyword.get(opts, :side, "instance"),
+      selector: selector,
+      source: "#{selector} => self",
+      base: "#{selector} => self",
+      dirty: false,
+      disk_differs: false,
+      runtime_only: false,
+      synthetic: false,
+      disk_source: nil,
+      doc: nil,
+      signature: nil,
+      native_module: nil,
+      native_delegate: false,
+      class_modifiers: [],
+      class_native: false,
+      source_origin: nil,
+      package: nil,
+      new: false
+    }
+  end
+
+  defp native_tab(id, module, opts \\ []) do
+    %{
+      id: id,
+      kind: :native,
+      class: module,
+      side: nil,
+      selector: nil,
+      native_view: %{editable: Keyword.get(opts, :editable, false), content: "", error: nil},
+      source: "",
+      base: "",
+      dirty: false,
+      disk_differs: false,
+      runtime_only: false,
+      disk_source: nil,
+      doc: nil,
+      signature: nil,
+      is_protocol: false,
+      native_module: nil,
+      native_delegate: false,
+      class_modifiers: nil,
+      class_native: false,
+      source_origin: nil,
+      package: nil,
+      new: false
+    }
+  end
+
+  describe "@system_browser_events coverage (BT-3301 pattern)" do
+    test "WorkspaceLive's @system_browser_events IS SystemBrowser's canonical list, not a copy" do
+      assert WorkspaceLive.system_browser_events() == SystemBrowser.__system_browser_events__()
+    end
+
+    test "every event WorkspaceLive delegates to SystemBrowser resolves to an implemented clause" do
+      tabs = [
+        method_tab("method:Counter:instance:increment", "Counter", "increment"),
+        def_tab("def:Printable", "Printable", is_protocol: true),
+        native_tab("native:beamtalk_subprocess", "beamtalk_subprocess")
+      ]
+
+      socket =
+        base_socket(%{
+          tabs: tabs,
+          active_tab: "method:Counter:instance:increment",
+          browser_classes: [%{"name" => "Counter"}]
+        })
+
+      params_by_event = %{
+        "complete" => %{"code" => "Int"},
+        "hover" => %{"code" => "Counter"},
+        "diagnostics" => %{"code" => "3 + 4"},
+        "close_browser" => %{},
+        "toggle_browser" => %{},
+        "browser_open_definition" => %{"class" => "Counter"},
+        "browser_open_native" => %{"class" => "Subprocess"},
+        "browser_mode" => %{"mode" => "classes"},
+        "browser_open_native_module" => %{"module" => "beamtalk_http_client"},
+        "browser_jump_native" => %{"class" => "Subprocess", "selector" => "readLine"},
+        "browser_view" => %{"view" => "hierarchy"},
+        "browser_source" => %{"src" => "all"},
+        "browser_side" => %{"side" => "instance"},
+        "browser_select_class" => %{"class" => "Counter"},
+        "browser_select_protocol" => %{"protocol" => ""},
+        "browser_select_method" => %{
+          "class" => "Counter",
+          "side" => "instance",
+          "selector" => "increment"
+        },
+        "browser_group_mode" => %{"mode" => "protocol"},
+        "browser_edit_section" => %{"name" => ""},
+        "browser_cancel_section" => %{},
+        "browser_rename_section" => %{"old_name" => "Old", "new_name" => "New"},
+        "browser_add_section" => %{"new_name" => "New", "before_selector" => "increment"},
+        "senders" => %{},
+        "implementors" => %{},
+        "native_callers" => %{},
+        "required_methods" => %{},
+        "conforming_classes" => %{},
+        "nav_open_class" => %{"class" => "Counter"},
+        "nav_required_open" => %{"selector" => "printOn:"},
+        "nav_open" => %{"class" => "Counter", "side" => "instance", "selector" => "increment"},
+        "nav_close" => %{},
+        "goto_definition" => %{"token" => "Counter"},
+        "dismiss_nav_error" => %{}
+      }
+
+      # `selected_class` must be set for `browser_rename_section`/
+      # `browser_add_section` (both require it in the socket, not the params).
+      socket = %{
+        socket
+        | assigns: Map.merge(socket.assigns, %{selected_class: "Counter"})
+      }
+
+      # A hardcoded event-name list here would itself be an unenforced
+      # "keep in sync" copy of `@system_browser_events` — read it from
+      # `SystemBrowser` instead, so adding/renaming/removing a name fails
+      # here rather than only at runtime in the browser.
+      for event <- SystemBrowser.__system_browser_events__() do
+        params = Map.fetch!(params_by_event, event)
+        result = SystemBrowser.handle_event(event, params, socket)
+
+        assert match?({:noreply, %Phoenix.LiveView.Socket{}}, result) or
+                 match?({:reply, %{}, %Phoenix.LiveView.Socket{}}, result),
+               "SystemBrowser.handle_event/3 has no clause for #{inspect(event)} (or it crashed)"
+      end
+    end
+
+    test "no handle_event/3 clause head names an event missing from the canonical list" do
+      # The test above only catches a name in the canonical list with no
+      # matching clause (a rename/removal that leaves the list stale). It
+      # can't catch the OTHER direction: a brand-new
+      # `SystemBrowser.handle_event("some_new_event", ...)` clause added
+      # without adding "some_new_event" to `__system_browser_events__/0` is
+      # unreachable dead code (`WorkspaceLive`'s `when event in
+      # @system_browser_events` guard never lets it through) rather than a
+      # crash, so nothing above would fail. Elixir doesn't expose clause-head
+      # literals through module reflection, so this scans the module's own
+      # source text for `handle_event("...", ...)` clause heads instead and
+      # asserts the literal name set matches the canonical list exactly.
+      source = File.read!(@system_browser_source)
+
+      clause_names =
+        ~r/def handle_event\("([a-z0-9_]+)"/
+        |> Regex.scan(source)
+        |> Enum.map(fn [_, name] -> name end)
+        |> MapSet.new()
+
+      assert clause_names == MapSet.new(SystemBrowser.__system_browser_events__())
+    end
+  end
+
+  describe "class tree view helpers" do
+    test "category_groups/1 buckets by category, with dedicated Tests/Protocols buckets" do
+      classes = [
+        %{"name" => "Counter", "category" => "Numbers"},
+        %{"name" => "Ledger", "category" => "Numbers"},
+        %{"name" => "CounterTest", "is_test" => true},
+        %{"name" => "Printable", "is_protocol" => true},
+        %{"name" => "Orphan"}
+      ]
+
+      groups = SystemBrowser.category_groups(classes)
+      bucket_names = Enum.map(groups, fn {category, _rows} -> category end)
+
+      assert Enum.sort(bucket_names) == ["(uncategorized)", "Numbers", "Protocols", "Tests"]
+
+      assert {_, [%{"name" => "Orphan"}]} = Enum.find(groups, &(elem(&1, 0) == "(uncategorized)"))
+      assert {_, [%{"name" => "Printable"}]} = Enum.find(groups, &(elem(&1, 0) == "Protocols"))
+      assert {_, [%{"name" => "CounterTest"}]} = Enum.find(groups, &(elem(&1, 0) == "Tests"))
+
+      assert {_, [%{"name" => "Counter"}, %{"name" => "Ledger"}]} =
+               Enum.find(groups, &(elem(&1, 0) == "Numbers"))
+    end
+
+    test "filter_by_source/2 narrows by source_origin, \"all\" and unknown filters pass through" do
+      classes = [
+        %{"name" => "Counter", "source_origin" => "project"},
+        %{"name" => "Object", "source_origin" => "stdlib"},
+        %{"name" => "HttpClient", "source_origin" => "dependency"}
+      ]
+
+      assert SystemBrowser.filter_by_source(classes, "all") == classes
+
+      assert SystemBrowser.filter_by_source(classes, "project") == [
+               %{"name" => "Counter", "source_origin" => "project"}
+             ]
+
+      assert SystemBrowser.filter_by_source(classes, "deps") == [
+               %{"name" => "HttpClient", "source_origin" => "dependency"}
+             ]
+
+      assert SystemBrowser.filter_by_source(classes, "bogus") == classes
+    end
+  end
+
+  describe "protocol filter + method list" do
+    @protocols [
+      %{"name" => "all", "selectors" => [%{"selector" => "increment"}]},
+      %{
+        "name" => "printing",
+        "selectors" => [%{"selector" => "printOn:"}, %{"selector" => "displayString"}]
+      }
+    ]
+
+    test "filtered_methods/2 with a nil filter flattens every protocol's selectors" do
+      selectors =
+        SystemBrowser.filtered_methods(@protocols, nil) |> Enum.map(&Map.get(&1, "selector"))
+
+      assert Enum.sort(selectors) == ["displayString", "increment", "printOn:"]
+    end
+
+    test "filtered_methods/2 with a protocol name narrows to just that protocol" do
+      selectors =
+        SystemBrowser.filtered_methods(@protocols, "printing")
+        |> Enum.map(&Map.get(&1, "selector"))
+
+      assert Enum.sort(selectors) == ["displayString", "printOn:"]
+    end
+
+    test "protocol_method_count/1 totals selectors across every protocol" do
+      assert SystemBrowser.protocol_method_count(@protocols) == 3
+    end
+  end
+
+  describe "runtime-badge origin marking" do
+    test "runtime_only?/1 is true only for a runtime-origin row" do
+      assert SystemBrowser.runtime_only?(%{"origin" => "runtime"})
+      refute SystemBrowser.runtime_only?(%{"origin" => "both"})
+      refute SystemBrowser.runtime_only?(%{})
+    end
+
+    test "synthetic?/1 is true only for a synthetic-source-status row" do
+      assert SystemBrowser.synthetic?(%{"source_status" => "synthetic"})
+      refute SystemBrowser.synthetic?(%{"source_status" => "indexed"})
+    end
+
+    test "source_origin_label/1 badges a dependency row with its package, stdlib bare" do
+      assert SystemBrowser.source_origin_label(%{
+               "source_origin" => "dependency",
+               "package" => "http"
+             }) == "DEP · http"
+
+      assert SystemBrowser.source_origin_label(%{"source_origin" => "stdlib"}) == "stdlib"
+      assert SystemBrowser.source_origin_label(%{"source_origin" => "project"}) == ""
+    end
+  end
+
+  describe "browser_select_class / browser_side (instance/class toggle refetch)" do
+    test "selecting a class fetches its protocols for the current side" do
+      socket = base_socket()
+
+      {:noreply, socket} =
+        SystemBrowser.handle_event("browser_select_class", %{"class" => "Counter"}, socket)
+
+      assert socket.assigns.selected_class == "Counter"
+      assert [%{"selectors" => selectors}] = socket.assigns.browser_protocols
+      assert Enum.any?(selectors, &(&1["selector"] == "increment"))
+    end
+
+    test "flipping the instance/class side re-fetches protocols for the new side" do
+      socket = base_socket(%{selected_class: "Counter", browser_side: "instance"})
+
+      {:noreply, socket} =
+        SystemBrowser.handle_event("browser_side", %{"side" => "class"}, socket)
+
+      assert socket.assigns.browser_side == "class"
+      # `Counter` has no class-side stub methods, so the class-side fetch
+      # comes back empty — proving the side toggle actually re-fetched
+      # (rather than keeping the instance-side result).
+      assert [%{"selectors" => []}] = socket.assigns.browser_protocols
+    end
+
+    test "an unrecognised side is ignored (pure no-op)" do
+      socket = base_socket(%{browser_side: "instance"})
+
+      {:noreply, unchanged} =
+        SystemBrowser.handle_event("browser_side", %{"side" => "bogus"}, socket)
+
+      assert unchanged == socket
+    end
+  end
+
+  describe "source-navigation: hover / diagnostics / complete" do
+    test "hover replies with the live docs for a known class" do
+      socket = base_socket()
+
+      assert {:reply, %{"hover" => hover}, ^socket} =
+               SystemBrowser.handle_event("hover", %{"code" => "Counter"}, socket)
+
+      assert hover =~ "Counter"
+    end
+
+    test "hover with no session_pid replies with an empty string" do
+      socket = base_socket(%{session_pid: nil})
+
+      assert {:reply, %{"hover" => ""}, ^socket} =
+               SystemBrowser.handle_event("hover", %{"code" => "Counter"}, socket)
+    end
+
+    test "complete replies with the stub's completion list" do
+      socket = base_socket()
+
+      assert {:reply, %{"completions" => []}, ^socket} =
+               SystemBrowser.handle_event("complete", %{"code" => "Int"}, socket)
+    end
+
+    test "diagnostics replies with the stub's diagnostic list, no session_pid needed" do
+      socket = base_socket(%{session_pid: nil})
+
+      assert {:reply, %{"diagnostics" => []}, ^socket} =
+               SystemBrowser.handle_event("diagnostics", %{"code" => "3 + 4"}, socket)
+    end
+  end
+
+  describe "source-navigation: senders / implementors" do
+    test "implementors opens the popover with the active method tab's selector" do
+      StubWorkspaceClient.set_implementors("increment", [
+        %{"class" => "Counter", "class_side" => false, "method" => "increment"}
+      ])
+
+      socket =
+        base_socket(%{
+          tabs: [method_tab("method:Counter:instance:increment", "Counter", "increment")],
+          active_tab: "method:Counter:instance:increment"
+        })
+
+      {:noreply, socket} = SystemBrowser.handle_event("implementors", %{}, socket)
+
+      assert %{kind: :implementors, selector: "increment", sites: [_site]} =
+               socket.assigns.nav_popover
+    end
+
+    test "senders/implementors on a class-definition tab (no selector) is a graceful no-op" do
+      socket =
+        base_socket(%{
+          tabs: [def_tab("def:Counter", "Counter")],
+          active_tab: "def:Counter"
+        })
+
+      {:noreply, socket} = SystemBrowser.handle_event("senders", %{}, socket)
+      assert socket.assigns.nav_popover == nil
+    end
+
+    test "nav_open opens the method tab and points the browser at its class/side" do
+      socket =
+        base_socket(%{nav_popover: %{kind: :implementors, selector: "increment", sites: []}})
+
+      {:noreply, socket} =
+        SystemBrowser.handle_event(
+          "nav_open",
+          %{"class" => "Counter", "side" => "instance", "selector" => "increment"},
+          socket
+        )
+
+      assert socket.assigns.nav_popover == nil
+      assert socket.assigns.selected_class == "Counter"
+      assert socket.assigns.active_tab == "method:Counter:instance:increment"
+    end
+  end
+
+  describe "source-navigation: goto_definition (BT-2666)" do
+    test "a known class name opens its definition tab and navigates the browser" do
+      socket = base_socket(%{browser_classes: [%{"name" => "Counter"}]})
+
+      {:noreply, socket} =
+        SystemBrowser.handle_event("goto_definition", %{"token" => "Counter"}, socket)
+
+      assert socket.assigns.active_tab == "def:Counter"
+      assert socket.assigns.selected_class == "Counter"
+    end
+
+    test "an unknown selector with no implementors flashes \"No definition found\"" do
+      socket = base_socket(%{browser_classes: []})
+
+      {:noreply, socket} =
+        SystemBrowser.handle_event("goto_definition", %{"token" => "nonesuch"}, socket)
+
+      assert Phoenix.Flash.get(socket.assigns.flash, :info) == "No definition found."
+    end
+
+    test "a single implementor opens that method tab directly" do
+      StubWorkspaceClient.set_implementors("increment", [
+        %{"class" => "Counter", "class_side" => false, "method" => "increment"}
+      ])
+
+      socket = base_socket(%{browser_classes: []})
+
+      {:noreply, socket} =
+        SystemBrowser.handle_event(
+          "goto_definition",
+          %{"token" => "increment", "code" => "self increment"},
+          socket
+        )
+
+      assert socket.assigns.active_tab == "method:Counter:instance:increment"
+      assert socket.assigns.nav_popover == nil
+    end
+
+    test "several implementors open the shared Senders/Implementors popover" do
+      StubWorkspaceClient.set_implementors("increment", [
+        %{"class" => "Counter", "class_side" => false, "method" => "increment"},
+        %{"class" => "Ledger", "class_side" => false, "method" => "increment"}
+      ])
+
+      socket = base_socket(%{browser_classes: []})
+
+      {:noreply, socket} =
+        SystemBrowser.handle_event(
+          "goto_definition",
+          %{"token" => "increment", "code" => "self increment"},
+          socket
+        )
+
+      assert %{kind: :implementors, sites: [_, _]} = socket.assigns.nav_popover
+    end
+  end
+
+  describe "panel visibility" do
+    test "toggle_browser flips show_browser, close_browser always closes it" do
+      socket = base_socket(%{show_browser: true})
+
+      {:noreply, socket} = SystemBrowser.handle_event("toggle_browser", %{}, socket)
+      assert socket.assigns.show_browser == false
+
+      {:noreply, socket} = SystemBrowser.handle_event("toggle_browser", %{}, socket)
+      assert socket.assigns.show_browser == true
+
+      {:noreply, socket} = SystemBrowser.handle_event("close_browser", %{}, socket)
+      assert socket.assigns.show_browser == false
+    end
+  end
+end

--- a/editors/liveview/test/bt_attach_web/workspace_native_modules_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_native_modules_test.exs
@@ -474,30 +474,30 @@ defmodule BtAttachWeb.WorkspaceNativeModulesTest do
   # test of the relativiser directly (it runs on whatever path the runtime op
   # returns), independent of the rendered viewer above.
   describe "clean_native_path/1 (BT-2668)" do
-    alias BtAttachWeb.WorkspaceLive
+    alias BtAttachWeb.Live.SystemBrowser
 
     test "relativises an absolute build path to a recognisable source root" do
-      assert WorkspaceLive.clean_native_path(
+      assert SystemBrowser.clean_native_path(
                "/home/james/source/proj/_build/default/deps/http/native/x.erl"
              ) == "deps/http/native/x.erl"
 
-      assert WorkspaceLive.clean_native_path("/opt/app/apps/beamtalk_stdlib/src/y.erl") ==
+      assert SystemBrowser.clean_native_path("/opt/app/apps/beamtalk_stdlib/src/y.erl") ==
                "apps/beamtalk_stdlib/src/y.erl"
     end
 
     test "leaves an already-relative path untouched" do
-      assert WorkspaceLive.clean_native_path("deps/http/native/x.erl") ==
+      assert SystemBrowser.clean_native_path("deps/http/native/x.erl") ==
                "deps/http/native/x.erl"
     end
 
     test "falls back to the basename for an absolute path with no known source root" do
-      assert WorkspaceLive.clean_native_path("/home/james/scratch/foo.erl") == "foo.erl"
+      assert SystemBrowser.clean_native_path("/home/james/scratch/foo.erl") == "foo.erl"
     end
 
     test "returns nil for the absent-path sentinels (no path leak)" do
-      assert WorkspaceLive.clean_native_path(:null) == nil
-      assert WorkspaceLive.clean_native_path(nil) == nil
-      assert WorkspaceLive.clean_native_path("") == nil
+      assert SystemBrowser.clean_native_path(:null) == nil
+      assert SystemBrowser.clean_native_path(nil) == nil
+      assert SystemBrowser.clean_native_path("") == nil
     end
   end
 

--- a/editors/liveview/test/support/stub_workspace_client.ex
+++ b/editors/liveview/test/support/stub_workspace_client.ex
@@ -1294,6 +1294,15 @@ defmodule BtAttachWeb.StubWorkspaceClient do
       else: {:ok, ""}
   end
 
+  # BT-2556/BT-3297: live parse-only diagnostics for the CodeMirror editors'
+  # lint source. The stub reports no diagnostics for any buffer (the "clean
+  # parse" default); a test driving the squiggle path itself lives in the
+  # `:playwright` browser suite (`workspace_browser_test.exs`), which exercises
+  # the real compiler — this stub only needs to answer the shape so
+  # `BtAttachWeb.Live.SystemBrowser`'s `diagnostics` event has something to
+  # dispatch to without a real workspace node.
+  def diagnostics(_code, _mode), do: {:ok, []}
+
   # ── Supervision tree ─────────────────────────────────────────────────────
 
   def supervision_tree(_pid, _scope), do: {:ok, []}


### PR DESCRIPTION
## Summary

Fourth extraction from `workspace_live.ex` (epic BT-3290), covering the System Browser pane: class tree (hierarchy/category), instance/class side toggle, protocol + method list, method source opening, and the source-navigation affordances (hover, goto-definition, senders/implementors, protocol actions, native-module callers).

Linear: https://linear.app/beamtalk/issue/BT-3297/extract-system-browser-pane-out-of-workspacelive

## Key changes

- New `BtAttachWeb.Live.SystemBrowser` module owns all `browser_*` events, `nav_*`, `goto_definition`, `hover`, `complete`, `diagnostics`, `senders`, `implementors`, `conforming_classes`, `required_methods`, `native_callers`, `close_browser`, and `toggle_browser` — delegated from `WorkspaceLive.handle_event/3` via a `__system_browser_events__/0` canonical list (the BT-3301 pattern), not a second hand-maintained event list.
- Reuses `BtAttachWeb.ClassTree` directly for the Hierarchy walk — no reimplementation. Delegates to `BtAttach.Workspace`'s existing `browse_classes`/`browse_protocols`/`browse_method_source` read-surface ops (ADR 0096).
- Updates `MethodEditor`'s and `Dock`'s cross-calls (`runtime_only?`, `dependency_badge_label`, `package_name`, `open_class`, `assign_browser_classes`) to point at `SystemBrowser` now that it owns them.
- Adds direct unit tests (`system_browser_test.exs`) for hierarchy/category view helpers, the instance/class side toggle refetch, the protocol filter, runtime-badge origin marking, and the source-navigation events — plus BT-3301-style event-coverage tests.
- Adds a `diagnostics/2` stub to `StubWorkspaceClient` (previously only reachable through the real-workspace e2e suite).
- Preserves Observer-role read-only access (no write ops moved or added).

`workspace_live.ex` shrinks from 7767 to 6394 lines; the new module has 79% direct test coverage.

## Test plan

- [x] `mix test` (867 passed, 0 regressions, 26 new)
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] Full pre-push CI (Rust build/clippy/fmt, Erlang dialyzer/fmt, JS lint/fmt, Beamtalk fmt, Elixir fmt) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4sgH136eGzDughfRsVbAG

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4sgH136eGzDughfRsVbAG)_