### PR TITLE
Extract Test Runner pane + New Class/Rename modals out of WorkspaceLive (BT-3298)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/class_modals.ex
+++ b/editors/liveview/lib/bt_attach_web/live/class_modals.ex
@@ -1,0 +1,895 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.Live.ClassModals do
+  @moduledoc """
+  The New Class / Rename modals, "Add a method…", and the Remove Method /
+  Remove Class editor actions (BT-2293/BT-2645, ADR 0112 Phase 4 BT-3189, ADR
+  0113 Phase 4 BT-3210, ADR 0114 Phase 5 BT-3277) — extracted out of
+  `BtAttachWeb.WorkspaceLive` (BT-3298, epic BT-3290, the fifth and final
+  sequential extraction) so its `handle_event/3` clauses and the
+  create/rename/remove data model they drive are directly unit-testable
+  instead of only reachable through a full-LiveView integration test.
+  Follows the same extraction shape `BtAttachWeb.Live.Inspector` (BT-3291),
+  `BtAttachWeb.Live.Dock` (BT-3295), `BtAttachWeb.Live.MethodEditor`
+  (BT-3296), and `BtAttachWeb.Live.SystemBrowser` (BT-3297) established.
+
+  This module owns:
+
+    * **New Class modal** (BT-2293, BT-2645) — `"toggle_new_class"` /
+      `"close_new_class"` open/close the modal; `"new_class"` validates the
+      submitted PascalCase name + superclass locally, synthesizes the
+      `<Superclass> subclass: <Name>` definition and its derived `src/`
+      path, and dispatches `Workspace newClass:at:` (ADR 0082 Phase 5).
+    * **"Add a method…"** — `"new_method"` opens a blank `:method` tab for
+      the selected class via `BtAttachWeb.Live.MethodEditor.open_new_method/3`
+      — this module never opens its own editor surface.
+    * **Remove Method / Remove Class** (ADR 0112 Phase 4 BT-3189, ADR 0113
+      Phase 4 BT-3210) — `"remove_method"` / `"remove_class"` read the
+      target from the active method-editor tab (never client-supplied
+      params) and submit `Class removeSelector: #sel` /
+      `Class removeFromSystem` through the existing `evaluate` op, exactly
+      like the REPL meta-commands and MCP tools.
+    * **Rename modal** (ADR 0114 Phase 5, BT-3277) — `"open_rename"` reads
+      the active tab (a `:def` tab renames its class via `renameTo:`, a
+      `:method` tab renames its selector via `renameSelector:to:`) and
+      captures the target at open time; `"rename_submit"` dispatches the
+      typed name through the matching primitive, and `"close_rename"`
+      dismisses the modal without renaming anything.
+
+  Every workspace read/write goes through `BtAttach.Facade.dispatch/3` (ADR
+  0091 Decision 3) with `BtAttachWeb.Live.RequestContext` — never a raw
+  `BtAttach.Workspace`/`:rpc` call — so this module never reimplements the
+  `new_class`/`evaluate` ops or the RBAC gates they ride (CLAUDE.md
+  no-duplicate-implementations). Every mutation is submitted through the same
+  generic `evaluate`/`new_class` ops the REPL meta-commands and MCP tools
+  use — there is no dedicated workspace-side "remove"/"rename" op to
+  duplicate (ADR 0112's/ADR 0113's/ADR 0114's "Surface" tables).
+
+  State (`:new_class_open`, `:new_class_error`, `:new_class_name`,
+  `:new_class_super`, `:rename_open`, `:rename_kind`, `:rename_class`,
+  `:rename_side`, `:rename_old_selector`, `:rename_new_name`,
+  `:rename_error`) stays on the LiveView's own socket — initialised in
+  `WorkspaceLive.bind_session/3` and mount, same as the
+  Dock/Inspector/MethodEditor/SystemBrowser/TestRunner assigns.
+  `WorkspaceLive` still owns `handle_event/3` (`Phoenix.LiveView` callback
+  contract) and `render/1` (the New Class/Rename modal markup is woven into
+  the System Browser panel and the tabbed method editor's action row, so it
+  does not split cleanly along this extraction's event boundary — see the
+  same call in `Dock`'s/`Inspector`'s/`MethodEditor`'s/`SystemBrowser`'s
+  moduledocs), but delegates every event this module owns to the functions
+  here by name — see the `@class_modals_events` guard clause in
+  `WorkspaceLive`, which reads its event list from
+  `__class_modals_events__/0` below (mirroring the BT-3301 fix that keeps
+  `WorkspaceLive` from hand-maintaining a second copy of the event names).
+
+  `valid_class_name?/1` is public: `BtAttachWeb.Live.Dock`'s
+  `flush_destructive/3` (BT-3295) validates a client-controlled `class`
+  value against this same bare-PascalCase-identifier rule before
+  interpolating it into a raw `evaluate` expression, so a crafted event
+  can't inject arbitrary source — reusing this module's rule rather than
+  duplicating it.
+  """
+
+  use BtAttachWeb, :html
+
+  alias BtAttach.Facade
+  alias BtAttach.Workspace
+  alias BtAttachWeb.Live.FacadeError
+  alias BtAttachWeb.Live.MethodEditor
+  alias BtAttachWeb.Live.RequestContext
+  alias BtAttachWeb.Live.SystemBrowser
+  alias BtAttachWeb.WorkspaceLive
+
+  defp ctx(socket), do: RequestContext.build(socket)
+  defp facade_error(reason), do: FacadeError.render(reason)
+
+  # ── handle_event dispatch ────────────────────────────────────────────────
+  #
+  # `WorkspaceLive.handle_event/3` forwards every event whose name is in
+  # `@class_modals_events` (read from `__class_modals_events__/0` below) here
+  # unchanged (same event name, params, socket), so each clause below is
+  # exactly the body the LiveView used to run directly.
+  @class_modals_events ~w(
+    remove_method remove_class open_rename close_rename rename_submit
+    new_method toggle_new_class close_new_class new_class
+  )
+
+  @doc false
+  def __class_modals_events__, do: @class_modals_events
+
+  # Bare PascalCase class-name identifier (BT-2645) — the shape the New Class
+  # modal and the Rename modal's class-rename path both enforce. Defined here
+  # (ahead of every clause below that reads it) rather than beside
+  # `validate_new_class_name/2` further down, since `rename_class/3` also
+  # needs it and module attributes must be set before their first use.
+  @new_class_name_re ~r/^[A-Z][A-Za-z0-9_]*$/
+
+  # ── method editor (Wave 3, write-surface ADR 0082) ──────────────────────────
+
+  # Remove the active method tab's method from its class (ADR 0112 Phase 4,
+  # BT-3189). Wired the same way Save is: an owner-only editor action that
+  # drives a write-surface primitive and refreshes the Changes pane. Unlike
+  # `save_method`, there is no dedicated workspace-side op — this just builds
+  # `Class removeSelector: #selector` (or `Class class removeSelector:
+  # #selector` for a class-side tab) and submits it through the existing
+  # `evaluate` op, exactly like the REPL `:remove-method` meta-command, the
+  # MCP `remove_method` tool, and the LSP `beamtalk.removeMethod` command
+  # (ADR 0112's "Beamtalk-level surface to add" — no new dispatcher op).
+  def handle_event("remove_method", _params, %{assigns: %{role: :owner}} = socket) do
+    {:noreply, remove_active_method(socket)}
+  end
+
+  # Non-owner (Observer) or a crafted event with no matching role: a no-op —
+  # the button is rendered only for `:owner`, mirroring `new_method` above.
+  def handle_event("remove_method", _params, socket), do: {:noreply, socket}
+
+  # Remove the active class-definition tab's class from the running system
+  # (ADR 0113 Phase 4, BT-3210). Wired the same way "Remove Method" is above
+  # (ADR 0112 Phase 4, BT-3189): an owner-only editor action, `data-confirm`
+  # -gated in the template, that drives a write-surface primitive and
+  # refreshes the Changes pane. There is no dedicated workspace-side op —
+  # this just builds `Class removeFromSystem` and submits it through the
+  # existing `evaluate` op, exactly like the REPL `:remove-class` meta-
+  # command and the MCP `remove_class` tool (ADR 0113's "Surface" table).
+  #
+  # This is the memory-mutating gesture only, matching `autoflush: true`'s
+  # existing "the memory step is not gated" behaviour for ordinary patches
+  # (ADR 0113 Surface, browser row) — the resulting `remove-class` entry
+  # does NOT get silently written to disk by autoflush; it renders in the
+  # Changes pane with a distinct destructive-dirty affordance requiring its
+  # own explicit "Delete file" click (`confirmDestructive: true`) to reach
+  # disk. Two gestures for two genuinely separate decisions, same shape as
+  # the REPL's two independently-confirmed `:remove-class` / `:flush-
+  # destructive` commands.
+  def handle_event("remove_class", _params, %{assigns: %{role: :owner}} = socket) do
+    {:noreply, remove_active_class(socket)}
+  end
+
+  # Non-owner (Observer) or a crafted event with no matching role: a no-op —
+  # the button is rendered only for `:owner`, mirroring `remove_method` above.
+  def handle_event("remove_class", _params, socket), do: {:noreply, socket}
+
+  # Open the Rename modal for the active tab (ADR 0114 Phase 5, BT-3277): a
+  # `:def` tab renames its class (`renameTo:`), an existing `:method` tab
+  # renames its selector (`renameSelector:to:`). Mirrors `remove_class`/
+  # `remove_method` above in reading the target from the active tab rather
+  # than trusting client-supplied params, but — unlike those, which act
+  # immediately — this only opens the modal; the actual rename waits for
+  # `rename_submit` once the owner has typed the new name.
+  def handle_event("open_rename", _params, %{assigns: %{role: :owner}} = socket) do
+    {:noreply, open_rename(socket)}
+  end
+
+  # Non-owner (Observer) or a crafted event with no matching role: a no-op —
+  # the buttons opening this modal are rendered only for `:owner`.
+  def handle_event("open_rename", _params, socket), do: {:noreply, socket}
+
+  # Dismiss the Rename modal without renaming anything — mirrors
+  # `close_new_class` (Escape / click-away / the modal's own × button all
+  # route here).
+  def handle_event("close_rename", _params, socket) do
+    {:noreply, assign(socket, rename_open: false, rename_error: nil)}
+  end
+
+  # Submit the Rename modal's new name (ADR 0114 Phase 5, BT-3277). Dispatches
+  # to `renameTo:` or `renameSelector:to:` depending on which kind of rename
+  # was opened; a rejected submit re-renders the modal with the in-flight
+  # value and an inline error, mirroring `new_class`'s validation-failure
+  # shape.
+  def handle_event(
+        "rename_submit",
+        %{"new_name" => new_name},
+        %{assigns: %{role: :owner}} = socket
+      )
+      when is_binary(new_name) do
+    {:noreply, submit_rename(socket, new_name)}
+  end
+
+  # Non-owner (Observer) or a crafted event with a missing/non-binary name: a
+  # no-op — the form is rendered only for `:owner` while the modal is open.
+  def handle_event("rename_submit", _params, socket), do: {:noreply, socket}
+
+  # Open a blank "new method" tab for the *selected* class (the System Browser's
+  # "new method" entry). A new-method tab is a `:method` tab with no selector yet —
+  # the only editor surface that still shows a selector input (the breadcrumb can't
+  # name a selector that doesn't exist), so the author types the selector + body.
+  # The starter tab used to fill this role on startup; it now opens on demand only.
+  def handle_event("new_method", %{"class" => class}, %{assigns: %{role: :owner}} = socket)
+      when is_binary(class) and class != "" do
+    # Author on whichever side the browser is showing (instance/class), so "new
+    # method" while viewing the class side opens a class-side tab.
+    {:noreply, MethodEditor.open_new_method(socket, class, socket.assigns.browser_side)}
+  end
+
+  # Non-owner (Observer) or malformed payload: a no-op. Authoring is owner-only —
+  # the entry is rendered only for `:owner`, and a crafted event from a read-only
+  # role must not even open a (non-savable) scratch tab in their strip.
+  def handle_event("new_method", _params, socket), do: {:noreply, socket}
+
+  # Toggle the System Browser's "New Class" modal open/closed (BT-2293, BT-2645).
+  # Closed by default; the ＋ button in the browser head flips it. Opening the
+  # modal resets the field values + clears any stale in-modal validation error
+  # from a prior attempt so the owner gets a clean slate (the superclass defaults
+  # back to `Object`).
+  def handle_event("toggle_new_class", _params, socket) do
+    opening? = !socket.assigns.new_class_open
+
+    socket =
+      if opening? do
+        assign(socket,
+          new_class_open: true,
+          new_class_error: nil,
+          new_class_name: "",
+          new_class_super: "Object"
+        )
+      else
+        assign(socket, new_class_open: false, new_class_error: nil)
+      end
+
+    {:noreply, socket}
+  end
+
+  # Close the New Class modal (Esc / close button / scrim click), discarding the
+  # in-flight fields without creating anything (BT-2645).
+  def handle_event("close_new_class", _params, socket) do
+    {:noreply, assign(socket, new_class_open: false, new_class_error: nil)}
+  end
+
+  # Create a brand-new class from the New Class modal's name + superclass fields
+  # (ADR 0082 Phase 5 `Workspace newClass:at:`, BT-2293, BT-2645). The owner types
+  # a plain PascalCase class name and picks a superclass (default `Object`); the
+  # `<Superclass> subclass: <Name>` definition is synthesized server-side — the
+  # user never types `subclass:`. The target `.bt` path is derived from the class
+  # name (`Greeter` → `src/Greeter.bt`); the user thinks in classes, not files. A
+  # successful create logs a durable `new-class` ChangeLog entry (written to disk
+  # later on flush), appears in the Changes pane, and opens + selects the new class.
+  def handle_event("new_class", %{"name" => name} = params, socket)
+      when is_binary(name) do
+    superclass = Map.get(params, "superclass", "Object")
+    superclass = if is_binary(superclass), do: superclass, else: "Object"
+    {:noreply, new_class(socket, name, superclass)}
+  end
+
+  # Malformed payload (missing key / non-binary value): surface an in-modal
+  # validation error rather than letting a crafted event crash the LiveView.
+  def handle_event("new_class", _params, socket) do
+    {:noreply, assign(socket, new_class_error: "Invalid new-class form payload.")}
+  end
+
+  # ── Remove Method (ADR 0112 Phase 4, BT-3189) ───────────────────────────────
+
+  defp remove_active_method(socket) do
+    case MethodEditor.active_tab(socket.assigns) do
+      %{kind: :method, new: true} ->
+        WorkspaceLive.status_error(
+          socket,
+          "This method hasn't been saved yet — nothing to remove."
+        )
+
+      %{kind: :method, class: class, side: side, selector: selector} = tab
+      when is_binary(selector) and selector != "" ->
+        remove_method(socket, tab, class, side, selector)
+
+      _ ->
+        WorkspaceLive.status_error(socket, "Open an existing method to remove it.")
+    end
+  end
+
+  # `Class removeSelector: #selector` (or `Class class removeSelector:
+  # #selector` for a class-side tab), submitted through the same generic
+  # `evaluate` op the REPL `:remove-method` meta-command, the MCP
+  # `remove_method` tool, and the LSP `beamtalk.removeMethod` command all use —
+  # no dedicated workspace-side op (ADR 0112's "Beamtalk-level surface to
+  # add"). On success the tab is closed (its method no longer exists) and the
+  # Changes pane refreshes, mirroring `save_method_body/5`'s success path; a
+  # raised `selector_not_found` (or any other structured error) renders inline
+  # via the shared status area.
+  defp remove_method(socket, tab, class, side, selector) do
+    receiver = if side == "class", do: "#{class} class", else: class
+    expr = "#{receiver} removeSelector: ##{selector}"
+    pid = socket.assigns[:session_pid]
+
+    if not is_pid(pid) do
+      WorkspaceLive.status_error(socket, "not attached to workspace")
+    else
+      remove_method_eval(socket, tab, receiver, selector, expr, pid)
+    end
+  end
+
+  defp remove_method_eval(socket, tab, receiver, selector, expr, pid) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
+      {:ok, _term, _output, _warnings} ->
+        # `close_tab/2` wipes `save_result`/`save_error` whenever the closed
+        # tab was the active one — via `clear_active/1` if it was the last
+        # open tab, or via `sync_active/2` when focus moves to the next
+        # remaining tab — so the success message must be assigned AFTER
+        # closing the tab, not before, or closing the active tab would
+        # silently swallow it.
+        socket
+        |> MethodEditor.close_tab(tab.id)
+        |> assign(
+          save_result: "Removed #{selector} from #{receiver}",
+          save_error: nil,
+          flush_result: nil,
+          flush_error: nil
+        )
+        |> WorkspaceLive.assign_changes()
+
+      {:error, reason, _output, _warnings} ->
+        WorkspaceLive.status_error(socket, Workspace.render_error(reason))
+
+      {:error, reason} ->
+        WorkspaceLive.status_error(socket, facade_error(reason))
+    end
+  end
+
+  # ── Remove Class (ADR 0113 Phase 4, BT-3210) ────────────────────────────────
+
+  # Remove the active class-definition tab's class from the system (ADR 0113
+  # Phase 4, BT-3210). A `:def` tab always names an already-existing class
+  # (unlike a `:method` tab, there is no "new, unsaved class" draft state —
+  # class creation is a separate System Browser form, see the "NEW CLASS"
+  # comment in the template below), so there is no `new: true` guard to
+  # mirror `remove_active_method/1`'s; a crafted event against a non-`:def`
+  # tab is still a graceful no-op, surfaced as a local validation error
+  # rather than evaluating a malformed expression.
+  defp remove_active_class(socket) do
+    case MethodEditor.active_tab(socket.assigns) do
+      %{kind: :def, class: class} = tab when is_binary(class) and class != "" ->
+        remove_class(socket, tab, class)
+
+      _ ->
+        WorkspaceLive.status_error(socket, "Open a class definition to remove it.")
+    end
+  end
+
+  # `Class removeFromSystem`, submitted through the same generic `evaluate`
+  # op the REPL `:remove-class` meta-command and the MCP `remove_class` tool
+  # use — no dedicated workspace-side op (ADR 0113's "Surface" table: "every
+  # surface constructs one of the Beamtalk expressions above and submits via
+  # the existing `evaluate` op"). Memory-mutating only: this never flushes.
+  defp remove_class(socket, tab, class) do
+    expr = "#{class} removeFromSystem"
+    pid = socket.assigns[:session_pid]
+
+    if not is_pid(pid) do
+      WorkspaceLive.status_error(socket, "not attached to workspace")
+    else
+      remove_class_eval(socket, tab, class, expr, pid)
+    end
+  end
+
+  defp remove_class_eval(socket, tab, class, expr, pid) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
+      {:ok, _term, _output, _warnings} ->
+        # `close_tab/2` wipes `save_result`/`save_error` whenever the closed
+        # tab was the active one — mirrors `remove_method_eval/6`'s success
+        # path, so the confirmation message must be assigned AFTER closing
+        # the tab. The message names the still-open second step (ADR 0113's
+        # two-gesture flow) so the owner isn't surprised the file survives
+        # this click.
+        socket
+        |> MethodEditor.close_tab(tab.id)
+        |> assign(
+          save_result:
+            "Removed #{class} from memory — not yet flushed to disk. Delete its file from the Changes pane to finish.",
+          save_error: nil,
+          flush_result: nil,
+          flush_error: nil
+        )
+        |> WorkspaceLive.assign_changes()
+
+      {:error, reason, _output, _warnings} ->
+        WorkspaceLive.status_error(socket, Workspace.render_error(reason))
+
+      {:error, reason} ->
+        WorkspaceLive.status_error(socket, facade_error(reason))
+    end
+  end
+
+  # ── Rename modal (ADR 0114 Phase 5, BT-3277) ────────────────────────────────
+
+  # Deliberately NOT a selector grammar (unary/keyword/binary, whitespace
+  # rules, the lexer's exact binary-operator character set) — duplicating
+  # that here would be exactly the un-enforced "keep in sync" copy
+  # `docs/development/architecture-principles.md`'s Duplication section
+  # warns against, since nothing would catch this regex drifting from
+  # `crates/beamtalk-core/src/source_analysis/lexer.rs`'s
+  # `is_binary_selector_char/1` if the language ever adds an operator
+  # character. Instead this only guards the one property that actually
+  # matters here: the value is embedded as `##{new_name}` inside a
+  # textually-interpolated `evaluate` expression, so it must contain no
+  # character that could end the symbol literal early or splice in a second
+  # expression (whitespace, `#`, quotes, backslash). Anything that passes
+  # this narrow check but isn't actually a well-formed selector fails the
+  # same way any other malformed `evaluate` expression does — a normal
+  # compiler error surfaced via `rename_method_eval/6`'s `{:error, ...}`
+  # branch — so the compiler stays the sole source of truth for "is this a
+  # valid selector", never re-implemented here.
+  @selector_injection_re ~r/^[^[:space:]#"'\\]+$/
+
+  # Open the Rename modal against the active tab (ADR 0114 Phase 5, BT-3277):
+  # a `:def` tab renames its class, an existing (already-saved) `:method` tab
+  # renames its selector — mirroring `remove_active_class`/`remove_active_method`'s
+  # identical tab-kind dispatch, including `remove_active_method`'s `new: true`
+  # guard (a brand-new, not-yet-compiled method has no selector to rename).
+  # The target is captured into `rename_class`/`rename_side`/`rename_old_selector`
+  # now, at open time, rather than re-read from the active tab on submit — so
+  # switching tabs while the modal is open can't retarget the rename mid-flight.
+  defp open_rename(socket) do
+    case MethodEditor.active_tab(socket.assigns) do
+      %{kind: :def, class: class} when is_binary(class) and class != "" ->
+        assign(socket,
+          rename_open: true,
+          rename_kind: :class,
+          rename_class: class,
+          rename_side: nil,
+          rename_old_selector: nil,
+          rename_new_name: class,
+          rename_error: nil
+        )
+
+      %{kind: :method, new: true} ->
+        WorkspaceLive.status_error(
+          socket,
+          "This method hasn't been saved yet — nothing to rename."
+        )
+
+      %{kind: :method, class: class, side: side, selector: selector}
+      when is_binary(class) and class != "" and is_binary(selector) and selector != "" ->
+        assign(socket,
+          rename_open: true,
+          rename_kind: :method,
+          rename_class: class,
+          rename_side: side,
+          rename_old_selector: selector,
+          rename_new_name: selector,
+          rename_error: nil
+        )
+
+      _ ->
+        WorkspaceLive.status_error(
+          socket,
+          "Open a class definition or an existing method to rename it."
+        )
+    end
+  end
+
+  # Dispatch the Rename modal's submitted name to whichever primitive
+  # `rename_kind` selected. A rejected submit keeps the modal open with the
+  # in-flight value and an inline error (never the method editor's shared
+  # `save_error`), mirroring `new_class/3`'s validation-failure shape.
+  defp submit_rename(socket, new_name) do
+    new_name = String.trim(new_name)
+
+    case socket.assigns.rename_kind do
+      :class ->
+        rename_class(socket, socket.assigns.rename_class, new_name)
+
+      :method ->
+        rename_method(
+          socket,
+          socket.assigns.rename_class,
+          socket.assigns.rename_side,
+          socket.assigns.rename_old_selector,
+          new_name
+        )
+
+      _ ->
+        assign(socket, rename_open: false, rename_error: nil)
+    end
+  end
+
+  # `OldClass renameTo: #NewName` (ADR 0114 Phase 2, `Behaviour>>renameTo:`,
+  # BT-3278), submitted through the same generic `evaluate` op the REPL
+  # `:rename-class` meta-command and the MCP `rename_class` tool use — no
+  # dedicated workspace-side op (ADR 0114's "Surface" table, reusing ADR
+  # 0113's "every surface constructs one of the Beamtalk expressions above
+  # and submits via the existing `evaluate` op"). Memory-mutating only: this
+  # never flushes — the resulting `rename-class` entry needs its own
+  # confirmed "apply rename" click in the Changes pane to reach disk (ADR
+  # 0114's two-gesture flow, reusing ADR 0113's `confirmDestructive` tier).
+  #
+  # `new_name` is validated locally against the same bare-PascalCase-identifier
+  # shape the New Class modal enforces (`@new_class_name_re`) before it is
+  # textually interpolated into the `evaluate` expression — this field is
+  # owner-typed but still raw client input reaching a raw Beamtalk expression,
+  # exactly the injection concern `flush_destructive/2`'s class-name check
+  # guards against.
+  defp rename_class(socket, old_name, new_name) do
+    cond do
+      new_name == "" ->
+        assign(socket,
+          rename_open: true,
+          rename_new_name: new_name,
+          rename_error: "Enter a new class name."
+        )
+
+      not Regex.match?(@new_class_name_re, new_name) ->
+        assign(socket,
+          rename_open: true,
+          rename_new_name: new_name,
+          rename_error:
+            "Class name must be PascalCase — start with an uppercase letter, e.g. `Accumulator`."
+        )
+
+      class_name_taken?(socket, new_name) ->
+        assign(socket,
+          rename_open: true,
+          rename_new_name: new_name,
+          rename_error: "A class named #{new_name} already exists."
+        )
+
+      true ->
+        expr = "#{old_name} renameTo: ##{new_name}"
+        pid = socket.assigns[:session_pid]
+
+        if not is_pid(pid) do
+          assign(socket,
+            rename_open: true,
+            rename_new_name: new_name,
+            rename_error: "not attached to workspace"
+          )
+        else
+          rename_class_eval(socket, old_name, new_name, expr, pid)
+        end
+    end
+  end
+
+  defp rename_class_eval(socket, old_name, new_name, expr, pid) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
+      {:ok, _term, _output, _warnings} ->
+        # The class's identity changed, so every tab keyed on the old name
+        # (its own `:def` tab plus any open `:method` tabs) is stale — close
+        # them all, mirroring `remove_class_eval/4`'s tab-closing success
+        # path, then refresh the class tree (a new name to browse) and the
+        # Changes pane (the new `rename-class` entry). `open_definition/2`
+        # re-syncs the active-tab editor assigns (clearing `save_result`,
+        # same note as `dispatch_new_class/5` above), so the success status is
+        # assigned AFTER it opens the renamed class's definition tab.
+        socket
+        |> close_tabs_for_class(old_name)
+        |> SystemBrowser.assign_browser_classes()
+        |> WorkspaceLive.assign_changes()
+        |> MethodEditor.open_definition(new_name)
+        |> reselect_renamed_class(old_name, new_name)
+        |> assign(
+          rename_open: false,
+          rename_error: nil,
+          save_result:
+            "Renamed #{old_name} to #{new_name} — not yet flushed to disk. Apply the rename from the Changes pane to finish.",
+          save_error: nil,
+          flush_result: nil,
+          flush_error: nil
+        )
+
+      {:error, reason, _output, _warnings} ->
+        assign(socket,
+          rename_open: true,
+          rename_new_name: new_name,
+          rename_error: Workspace.render_error(reason)
+        )
+
+      {:error, reason} ->
+        assign(socket,
+          rename_open: true,
+          rename_new_name: new_name,
+          rename_error: facade_error(reason)
+        )
+    end
+  end
+
+  # Only follow the rename into `selected_class` when the System Browser
+  # tree's own current selection WAS the renamed class (or nothing was
+  # selected) — unlike `dispatch_new_class/5`'s unconditional select-the-
+  # new-class (there's no prior selection to conflict with when creating a
+  # class), a rename can be triggered from an open `:def` tab while the
+  # tree has a DIFFERENT, unrelated class selected. Reassigning
+  # unconditionally would move the tree highlight to the renamed class
+  # while leaving `browser_protocols`/`browser_categories` showing the
+  # untouched previously-selected class — the same "ghost selection"
+  # mismatch `selected_class_visible?/1` (BT-2597) exists to avoid for the
+  # browser-source-filter case. Leaving an unrelated selection alone is
+  # simpler and correct here; there's no stale-name problem to fix in that
+  # case, since the unrelated class's own identity didn't change.
+  defp reselect_renamed_class(socket, old_name, new_name) do
+    if socket.assigns.selected_class in [old_name, nil] do
+      assign(socket, selected_class: new_name, selected_protocol: nil)
+    else
+      socket
+    end
+  end
+
+  # `Class renameSelector: #old to: #new` (or `Class class renameSelector: #old
+  # to: #new` for a class-side tab) — `Behaviour>>renameSelector:to:` (ADR
+  # 0114 Phase 3, BT-3279), submitted through the same generic `evaluate` op
+  # the REPL `:rename-method` meta-command and the MCP `rename_method` tool
+  # use. Memory-mutating only, same two-gesture flow as `rename_class/3`
+  # above: reaching disk needs the Changes pane's "apply rename" click.
+  #
+  # `new_name` is only checked against `@selector_injection_re` (no
+  # whitespace/`#`/quotes/backslash) before interpolation — see that
+  # attribute's own comment for why this stops short of validating full
+  # selector syntax. A value that passes this check but isn't actually a
+  # well-formed selector, or collides with an already-defined local
+  # selector, is refused server-side by `renameSelector:to:` itself
+  # (mirroring `removeSelector:`'s existing error surface) and surfaces
+  # through `rename_method_eval/6`'s ordinary error branch.
+  defp rename_method(socket, class, side, old_selector, new_name) do
+    cond do
+      new_name == "" ->
+        assign(socket,
+          rename_open: true,
+          rename_new_name: new_name,
+          rename_error: "Enter a new selector."
+        )
+
+      not Regex.match?(@selector_injection_re, new_name) ->
+        assign(socket,
+          rename_open: true,
+          rename_new_name: new_name,
+          rename_error: "Selector cannot contain spaces, #, quotes, or backslashes."
+        )
+
+      true ->
+        receiver = if side == "class", do: "#{class} class", else: class
+        expr = "#{receiver} renameSelector: ##{old_selector} to: ##{new_name}"
+        pid = socket.assigns[:session_pid]
+
+        if not is_pid(pid) do
+          assign(socket,
+            rename_open: true,
+            rename_new_name: new_name,
+            rename_error: "not attached to workspace"
+          )
+        else
+          rename_method_eval(socket, class, receiver, old_selector, new_name, expr, pid)
+        end
+    end
+  end
+
+  defp rename_method_eval(socket, class, receiver, old_selector, new_selector, expr, pid) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
+      {:ok, _term, _output, _warnings} ->
+        # The selector changed, so the active method tab (keyed on the old
+        # selector) is stale — close it, mirroring `remove_method_eval/6`'s
+        # tab-closing success path.
+        socket
+        |> close_active_tab_if(
+          &match?(%{kind: :method, class: ^class, selector: ^old_selector}, &1)
+        )
+        |> assign(
+          rename_open: false,
+          rename_error: nil,
+          save_result:
+            "Renamed #{receiver} #{old_selector} to #{new_selector} — not yet flushed to disk. Apply the rename from the Changes pane to finish.",
+          save_error: nil,
+          flush_result: nil,
+          flush_error: nil
+        )
+        |> WorkspaceLive.assign_changes()
+
+      {:error, reason, _output, _warnings} ->
+        assign(socket,
+          rename_open: true,
+          rename_new_name: new_selector,
+          rename_error: Workspace.render_error(reason)
+        )
+
+      {:error, reason} ->
+        assign(socket,
+          rename_open: true,
+          rename_new_name: new_selector,
+          rename_error: facade_error(reason)
+        )
+    end
+  end
+
+  # Close every open tab (def or method) belonging to `class` — used after a
+  # successful class rename, since every one of them is keyed on the
+  # now-stale old name. Iterates `close_tab/2` (rather than a bulk filter)
+  # so each close runs its normal active-tab-reassignment bookkeeping.
+  defp close_tabs_for_class(socket, class) do
+    socket.assigns.tabs
+    |> Enum.filter(&(&1.kind in [:def, :method] and Map.get(&1, :class) == class))
+    |> Enum.reduce(socket, fn tab, acc -> MethodEditor.close_tab(acc, tab.id) end)
+  end
+
+  # Close the active tab only when `pred` matches it — used after a
+  # successful method rename so a rename triggered from a *different* tab
+  # (not reachable today, since `open_rename/1` only ever targets the active
+  # tab, but kept explicit rather than assumed) never closes the wrong one.
+  defp close_active_tab_if(socket, pred) do
+    case MethodEditor.active_tab(socket.assigns) do
+      %{} = tab -> if pred.(tab), do: MethodEditor.close_tab(socket, tab.id), else: socket
+      _ -> socket
+    end
+  end
+
+  # ── New Class modal (BT-2293, BT-2645) ──────────────────────────────────────
+
+  # Create a new class from the New Class modal's name + superclass (BT-2293,
+  # BT-2645). The owner supplies a plain PascalCase class name and a superclass
+  # (default `Object`); validation (PascalCase, non-empty, non-duplicate) runs
+  # locally — a rejected name surfaces an in-modal error and never round-trips.
+  # A valid name synthesizes the `<Superclass> subclass: <Name>` definition,
+  # derives the target `.bt` path from the name (so the user never types a file
+  # path), threads source + path to the workspace newClass chokepoint, refreshes
+  # the Changes pane (ChangeLog coherence), and opens + selects the new class.
+  defp new_class(socket, name, superclass) do
+    name = String.trim(name)
+    superclass = trim_superclass(superclass)
+
+    with :ok <- validate_new_class_name(socket, name),
+         :ok <- validate_superclass(superclass) do
+      source = superclass <> " subclass: " <> name
+      {:ok, path} = derive_class_path(name)
+      dispatch_new_class(socket, name, superclass, source, path)
+    else
+      {:error, message} ->
+        # Keep the in-flight field values so the re-rendered modal shows what the
+        # owner typed, and route the error to the modal-local assign (never the
+        # method-editor's shared `save_error` — BT-2645).
+        assign(socket,
+          new_class_open: true,
+          new_class_name: name,
+          new_class_super: superclass,
+          new_class_error: message
+        )
+    end
+  end
+
+  # An empty / blank superclass falls back to the default `Object` — the modal's
+  # select defaults to it, but a crafted payload or cleared typeahead must not
+  # synthesize a headerless `subclass: Name`.
+  defp trim_superclass(superclass) do
+    case String.trim(superclass) do
+      "" -> "Object"
+      trimmed -> trimmed
+    end
+  end
+
+  # Validate the superclass field the same way as the class name (BT-2645): a bare
+  # PascalCase identifier. The empty case is already normalised to `Object` by
+  # `trim_superclass/1`. This rejects a crafted payload (e.g. embedded newlines /
+  # syntax) locally, matching the name field rather than relying on the server
+  # parser to reject the synthesized source.
+  defp validate_superclass(superclass) do
+    if Regex.match?(~r/^[A-Z][A-Za-z0-9_]*$/, superclass),
+      do: :ok,
+      else:
+        {:error, "Superclass must be a class name starting with a capital letter, e.g. `Object`."}
+  end
+
+  # Validate a new class name locally (BT-2645): non-empty, PascalCase
+  # (`^[A-Z][A-Za-z0-9_]*$`, `@new_class_name_re` above), and not a duplicate
+  # of an existing class in the browse list. Returns `:ok` or `{:error,
+  # message}` for an in-modal error.
+
+  # Whether `name` is a bare PascalCase class-name identifier
+  # (`^[A-Z][A-Za-z0-9_]*$`) — the shape the New Class modal enforces. Public:
+  # `BtAttachWeb.Live.Dock`'s `flush_destructive/3` (BT-3295) validates a
+  # client-controlled `class` value against this same rule before
+  # interpolating it into a raw `evaluate` expression, so a crafted event
+  # can't inject arbitrary source.
+  def valid_class_name?(name), do: Regex.match?(@new_class_name_re, name)
+
+  defp validate_new_class_name(socket, name) do
+    cond do
+      name == "" ->
+        {:error, "Enter a class name to create a class."}
+
+      not valid_class_name?(name) ->
+        {:error,
+         "Class name must be PascalCase — start with an uppercase letter, e.g. `Greeter`."}
+
+      class_name_taken?(socket, name) ->
+        {:error, "A class named #{name} already exists."}
+
+      true ->
+        :ok
+    end
+  end
+
+  # Is `name` already a class in the loaded browse list? Compared against the
+  # `"name"` field of every browse row (the same list the tree renders), so a
+  # duplicate is caught before any round-trip.
+  defp class_name_taken?(socket, name) do
+    Enum.any?(socket.assigns[:browser_classes] || [], fn row ->
+      Map.get(row, "name") == name
+    end)
+  end
+
+  defp dispatch_new_class(socket, name, superclass, source, path) do
+    case Facade.dispatch(:new_class, %{source: source, path: path}, ctx(socket)) do
+      {:ok, created_path} ->
+        socket
+        |> SystemBrowser.assign_browser_classes()
+        |> WorkspaceLive.assign_changes()
+        # Open + select the NEW class (`name`), not the superclass: the def tab
+        # focuses it and the tree highlights it (BT-2645). `open_definition`
+        # re-syncs the active-tab editor assigns (clearing `save_result`), so the
+        # success status is assigned *after* it — otherwise the "Created …" banner
+        # would be wiped by the very tab it opens.
+        |> MethodEditor.open_definition(name)
+        |> assign(
+          selected_class: name,
+          selected_protocol: nil,
+          save_result: "Created new class — #{created_path}",
+          save_error: nil,
+          flush_result: nil,
+          flush_error: nil,
+          new_class_open: false,
+          new_class_error: nil
+        )
+        # BT-2586/BT-2590: a new class only writes its `.bt` file to disk when
+        # autoflush is on (it is otherwise a durable in-memory ChangeLog entry,
+        # written at the next flush — `maybe_autoflush(durable)` in
+        # beamtalk_repl_loader). So reflect it in the git panel only when autoflush
+        # is on, matching the save path; with autoflush off the working tree is
+        # unchanged and the shell-out is skipped.
+        |> WorkspaceLive.maybe_refresh_git_after_save()
+
+      {:error, reason} ->
+        # Route a failed create to the in-modal error (keep fields + modal open),
+        # never the method-editor's `save_error` (BT-2645).
+        assign(socket,
+          new_class_open: true,
+          new_class_name: name,
+          new_class_super: superclass,
+          new_class_error: facade_error(reason)
+        )
+    end
+  end
+
+  # Derive the in-project `.bt` path for a new class from its name (BT-2293,
+  # BT-2646): `Greeter` → `src/greeter.bt`, `EventStore` → `src/event_store.bt`.
+  # The basename is snake_cased to match the project convention (every file in a
+  # package `src/` is snake_case). The runtime's `newClass:at:` validation
+  # snake_case-normalises both the declared class name and the path basename
+  # (`beamtalk_repl_loader:validate_new_class/3` via `to_snake_case/1`), so a
+  # snake_case file maps cleanly to the PascalCase class. The name is already
+  # PascalCase-validated by the caller, so this always succeeds; it returns
+  # `{:ok, path}` to keep the call-site explicit.
+  #
+  # The `src/` prefix is assumed — it's the canonical package source dir the
+  # runtime resolves (`resolve_package_module` tries `src/` then `test/`). A
+  # project with a different layout would get a `target_outside_project` error at
+  # creation time (not silently on flush). If per-project source dirs ever land,
+  # this is the spot to read the configured dir instead of hardcoding `src/`.
+  defp derive_class_path(name) do
+    {:ok, "src/" <> to_snake_case(name) <> ".bt"}
+  end
+
+  # Snake-case a PascalCase class name, mirroring the runtime's
+  # `beamtalk_repl_loader:to_snake_case/1` EXACTLY so the IDE-derived filename and
+  # the loader's basename normalisation agree (BT-2646). The rule: the first
+  # character is lowercased unconditionally; thereafter an uppercase letter gets a
+  # leading `_` ONLY when the previous character was a lowercase letter. This
+  # collapses acronyms (`HTTPServer` → `httpserver`) rather than splitting every
+  # capital — diverging from the runtime here would make the loader reject or
+  # mis-locate the created file. Digits and other characters pass through verbatim
+  # and do not count as "lowercase" for the boundary test.
+  defp to_snake_case(name) do
+    name
+    |> String.to_charlist()
+    |> snake_chars(false, [])
+  end
+
+  defp snake_chars([], _prev_was_lower?, acc), do: acc |> Enum.reverse() |> List.to_string()
+
+  defp snake_chars([c | rest], prev_was_lower?, acc) when c >= ?A and c <= ?Z do
+    lowered = c + 32
+
+    if prev_was_lower? do
+      snake_chars(rest, false, [lowered, ?_ | acc])
+    else
+      snake_chars(rest, false, [lowered | acc])
+    end
+  end
+
+  defp snake_chars([c | rest], _prev_was_lower?, acc) do
+    snake_chars(rest, c >= ?a and c <= ?z, [c | acc])
+  end
+end

--- a/editors/liveview/lib/bt_attach_web/live/dock.ex
+++ b/editors/liveview/lib/bt_attach_web/live/dock.ex
@@ -53,11 +53,14 @@ defmodule BtAttachWeb.Live.Dock do
   calls `BtAttachWeb.Live.MethodEditor`'s tab-refresh helpers (extracted
   BT-3296) directly, `BtAttachWeb.Live.SystemBrowser`'s `open_class/2`
   (extracted BT-3297) focuses the System Browser on a class from the REPL
-  `:help` meta-command, and the top-bar omni search's `symbol_rows/1` and the
-  Tests pane's `discover_test_classes/1` are still `WorkspaceLive`-owned —
-  this module calls those public functions rather than duplicating their
-  logic, exactly the temporary cross-call shape a sequential decomposition
-  produces.
+  `:help` meta-command, the Tests pane's `discover_test_classes/1` (extracted
+  BT-3298, `BtAttachWeb.Live.TestRunner`) backs the `dock_tab`/`:test` lazy
+  first-open, and `flush_destructive/3`'s class-name check reuses
+  `BtAttachWeb.Live.ClassModals.valid_class_name?/1` (also BT-3298) — this
+  module calls those public functions rather than duplicating their logic,
+  exactly the temporary cross-call shape a sequential decomposition
+  produces. The top-bar omni search's `symbol_rows/1` is still
+  `WorkspaceLive`-owned.
   """
 
   use BtAttachWeb, :html
@@ -74,11 +77,13 @@ defmodule BtAttachWeb.Live.Dock do
 
   alias BtAttach.Facade
   alias BtAttach.Workspace
+  alias BtAttachWeb.Live.ClassModals
   alias BtAttachWeb.Live.FacadeError
   alias BtAttachWeb.Live.Inspector
   alias BtAttachWeb.Live.MethodEditor
   alias BtAttachWeb.Live.RequestContext
   alias BtAttachWeb.Live.SystemBrowser
+  alias BtAttachWeb.Live.TestRunner
   alias BtAttachWeb.WorkspaceLive
 
   defp ctx(socket), do: RequestContext.build(socket)
@@ -1069,16 +1074,16 @@ defmodule BtAttachWeb.Live.Dock do
   # load the test catalogue on first open — the Tests pane's own events
   # (`tests_refresh`/`run_tests`/`load_tests`/`run_test_class`/
   # `open_test_method`) are NOT part of this extraction (BT-3295's "Events to
-  # move" list) and stay on `WorkspaceLive`, so the actual discovery RPC
-  # (`WorkspaceLive.discover_test_classes/1`) stays there too — this is a
-  # thin call-through, not a reimplementation.
+  # move" list); they belong to `BtAttachWeb.Live.TestRunner` (extracted
+  # BT-3298), so the actual discovery RPC (`TestRunner.discover_test_classes/1`)
+  # lives there too — this is a thin call-through, not a reimplementation.
 
   # Load the test catalogue once (lazy first open of the Tests tab).
   # Re-opening the tab keeps the already-loaded list — use `tests_refresh` to
   # re-discover.
   defp ensure_test_classes(socket) do
     if is_nil(socket.assigns.test_classes),
-      do: WorkspaceLive.discover_test_classes(socket),
+      do: TestRunner.discover_test_classes(socket),
       else: socket
   end
 
@@ -1392,11 +1397,11 @@ defmodule BtAttachWeb.Live.Dock do
   # `class` rides a `phx-value-*` attribute, so — unlike `remove_class`'s
   # `class` (read from server-tracked active-tab state) — it is
   # client-controlled input reaching a raw, textually-interpolated Beamtalk
-  # expression: validated against `WorkspaceLive.valid_class_name?/1`, the
+  # expression: validated against `ClassModals.valid_class_name?/1`, the
   # same bare-PascalCase-identifier shape the New Class modal enforces, so a
   # crafted event cannot inject arbitrary source into the `evaluate` call.
   defp flush_destructive(socket, class, kind) do
-    if WorkspaceLive.valid_class_name?(class) do
+    if ClassModals.valid_class_name?(class) do
       expr = "Workspace flush: ##{class} confirmDestructive: true"
       pid = socket.assigns[:session_pid]
 

--- a/editors/liveview/lib/bt_attach_web/live/test_runner.ex
+++ b/editors/liveview/lib/bt_attach_web/live/test_runner.ex
@@ -1,0 +1,451 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.Live.TestRunner do
+  @moduledoc """
+  The cockpit Test Runner pane (BT-2557, epic BT-2482 Phase 1/3) — test
+  catalogue discovery, running all-or-one `TestCase` subclass, loading a
+  project's `test/` files, and the cross-pane dismissable-notice utility —
+  extracted out of `BtAttachWeb.WorkspaceLive` (BT-3298, epic BT-3290, the
+  fifth and final sequential extraction) so its `handle_event/3` /
+  `handle_async/3` clauses and the discovery/run data model they drive are
+  directly unit-testable instead of only reachable through a full-LiveView
+  integration test. Follows the same extraction shape
+  `BtAttachWeb.Live.Inspector` (BT-3291), `BtAttachWeb.Live.Dock` (BT-3295),
+  `BtAttachWeb.Live.MethodEditor` (BT-3296), and
+  `BtAttachWeb.Live.SystemBrowser` (BT-3297) established.
+
+  This module owns:
+
+    * **Test discovery** (BT-2599) — `"tests_refresh"` re-discovers the live
+      image's `TestCase` subclasses + selectors via the `list_tests` `:read`
+      op. Although a `:read` reflection is usually fast, it is still a
+      blocking workspace RPC, so it runs off-socket in a `:test_discover`
+      `start_async` task rather than stalling the LiveView process; the
+      result folds in through `handle_async/3`. `discover_test_classes/2` is
+      public — `BtAttachWeb.Live.Dock`'s `dock_tab`/`:test` meta-command
+      lazy first-open calls it directly (a thin call-through, not a
+      reimplementation).
+    * **Running tests** (BT-2597) — `"run_tests"` (every loaded class) and
+      `"run_test_class"` (one class, `class` rides the click) both run the
+      `run_tests` `:execute` op off-socket via a `:test_op` `start_async`
+      task; `"load_tests"` loads the project's `test/` files (`:execute`)
+      then re-discovers the catalogue so newly-loaded classes appear
+      immediately. `"open_test_method"` opens a (failing) test method in the
+      method editor, reusing `BtAttachWeb.Live.MethodEditor.open_method_tab/4`
+      — test selectors are always instance-side.
+    * **Dismissable status notices** (BT-2612) — `"dismiss_notice"`, the
+      generic dismiss for every pane's inline `.notice` banner. The key
+      arrives from the client and is never turned into an atom — it is
+      mapped through a fixed whitelist (`dismiss_key_to_assign/1`) covering
+      assigns owned by several different panes (`tests_error` here,
+      `browser_error`/`save_error`/`git_error`/… elsewhere). This is a
+      cross-pane utility with no single natural owner among the five
+      sequential extractions; it lands here, the last one, rather than
+      staying behind in `WorkspaceLive` — which after this extraction holds
+      only mount/socket wiring and the top-level `render/1` shell.
+
+  Every workspace read/write goes through `BtAttach.Facade.dispatch/3` (ADR
+  0091 Decision 3) with `BtAttachWeb.Live.RequestContext` — never a raw
+  `BtAttach.Workspace`/`:rpc` call — so this module never reimplements the
+  `list_tests`/`run_tests`/`load_tests` ops or the RBAC gates they ride
+  (CLAUDE.md no-duplicate-implementations).
+
+  State (`:test_classes`, `:test_results`, `:tests_error`, `:tests_running`,
+  `:tests_discover_keep_error`) stays on the LiveView's own socket —
+  initialised in `WorkspaceLive.bind_session/3` and mount, same as the
+  Dock/Inspector/MethodEditor/SystemBrowser assigns. `WorkspaceLive` still
+  owns `handle_event/3` / `handle_async/3` (`Phoenix.LiveView` callback
+  contracts) and `render/1` (the Tests pane markup is woven into the dock's
+  Workspace/REPL/Transcript/Changes/Git tab strip, so it does not split
+  cleanly along this extraction's event boundary — see the same call in
+  `Dock`'s/`Inspector`'s/`MethodEditor`'s/`SystemBrowser`'s moduledocs), but
+  delegates every Test Runner event to the functions here by name — see the
+  `@test_runner_events` guard clause in `WorkspaceLive`, which reads its
+  event list from `__test_runner_events__/0` below (mirroring the BT-3301
+  fix that keeps `WorkspaceLive` from hand-maintaining a second copy of the
+  event names).
+  """
+
+  use BtAttachWeb, :html
+
+  import Phoenix.LiveView, only: [start_async: 3, cancel_async: 3]
+
+  require Logger
+
+  alias BtAttach.Facade
+  alias BtAttachWeb.Live.FacadeError
+  alias BtAttachWeb.Live.MethodEditor
+  alias BtAttachWeb.Live.RequestContext
+
+  defp ctx(socket), do: RequestContext.build(socket)
+  defp facade_error(reason), do: FacadeError.render(reason)
+
+  # ── handle_event dispatch ────────────────────────────────────────────────
+  #
+  # `WorkspaceLive.handle_event/3` forwards every event whose name is in
+  # `@test_runner_events` (read from `__test_runner_events__/0` below) here
+  # unchanged (same event name, params, socket), so each clause below is
+  # exactly the body the LiveView used to run directly.
+  @test_runner_events ~w(
+    tests_refresh run_tests load_tests run_test_class open_test_method
+    dismiss_notice
+  )
+
+  @doc false
+  def __test_runner_events__, do: @test_runner_events
+
+  # ── Test-runner pane (BT-2557) ───────────────────────────────────────────────
+  #
+  # The GUI equivalent of a Smalltalk Test Runner: a dock tab that lists the live
+  # image's `TestCase` subclasses, runs all or a selected class through the
+  # attached session (never a shelled-out `beamtalk test`), and shows per-case
+  # pass/fail with failure detail — with an affordance to open a failing method
+  # in the method editor. Discovery is a `:read` op (the Observer may browse the
+  # catalogue); running tests is `:execute` (Owner-only, it evaluates code), so
+  # the run controls are owner-gated in the template, mirroring the eval form.
+
+  # Re-discover the test catalogue (the "refresh" affordance). The discovery is a
+  # `:read` reflection op, but it is still a blocking workspace RPC — so it runs
+  # off-socket via `discover_test_classes/1` (`:test_discover` `start_async`,
+  # BT-2599) rather than stalling the LiveView process against a slow node. We
+  # reset `test_classes` to the nil sentinel so the pane shows its "discovering"
+  # state (not the misleading "No TestCase subclasses" empty-state) until the
+  # `handle_async(:test_discover, …)` fold resolves.
+  def handle_event("tests_refresh", _params, socket) do
+    {:noreply, socket |> assign(:test_classes, nil) |> discover_test_classes()}
+  end
+
+  # Run every loaded TestCase subclass (`test-all`).
+  def handle_event("run_tests", _params, socket) do
+    {:noreply, run_tests(socket, nil)}
+  end
+
+  # Load the project's test/ files into the live image, then re-discover the
+  # catalogue (`load_tests`, `:execute` — Owner-only). A freshly-opened project
+  # holds only src/ classes, so without this the catalogue is empty (BT-2557).
+  def handle_event("load_tests", _params, socket) do
+    {:noreply, load_tests(socket)}
+  end
+
+  # Run a single selected test class (`test`, `class` = the row's class).
+  def handle_event("run_test_class", %{"class" => class}, socket) when is_binary(class) do
+    {:noreply, run_tests(socket, class)}
+  end
+
+  # Open a (failing) test method in the method editor. Test selectors are
+  # instance-side, so the side is always "instance"; reuses the System Browser's
+  # method-tab opener (BT-2491) so the test runner and browser share one editor.
+  def handle_event("open_test_method", %{"class" => class, "selector" => selector}, socket)
+      when is_binary(class) and is_binary(selector) do
+    {:noreply, MethodEditor.open_method_tab(socket, class, "instance", selector)}
+  end
+
+  # Fallback clauses for the guarded test handlers: a crafted WebSocket message
+  # with a missing / non-binary `class`/`selector` must be ignored, not crash the
+  # socket on a FunctionClauseError before RBAC is reached (matching `save_method`,
+  # `revert`, `browser_select_class`, etc.).
+  def handle_event("run_test_class", _params, socket), do: {:noreply, socket}
+  def handle_event("open_test_method", _params, socket), do: {:noreply, socket}
+
+  # ── dismissable status notices (BT-2612) ────────────────────────────────────
+  #
+  # Generic dismiss for top-level *scalar* status assigns. The key arrives from
+  # the client and is NEVER turned into an atom (`String.to_atom/1` on user input
+  # is a memory/atom-table attack vector) — instead it is mapped through a fixed
+  # whitelist to the assign we clear. Unknown keys are ignored (no-op), matching
+  # the existing "clear to nil" convention every backing handler uses.
+  def handle_event("dismiss_notice", %{"key" => key}, socket) do
+    case dismiss_key_to_assign(key) do
+      nil -> {:noreply, socket}
+      assign_key -> {:noreply, assign(socket, assign_key, nil)}
+    end
+  end
+
+  def handle_event("dismiss_notice", _params, socket), do: {:noreply, socket}
+
+  # The dismiss-key whitelist: every scalar status assign any pane's `.notice`
+  # can render, across all five extractions — `browser_error`/`native_view`'s
+  # implicit errors are handled inline elsewhere, but every OTHER pane's plain
+  # "here's an error string" banner dismisses through here.
+  defp dismiss_key_to_assign("browser_error"), do: :browser_error
+  defp dismiss_key_to_assign("output"), do: :output
+  defp dismiss_key_to_assign("changes_error"), do: :changes_error
+  defp dismiss_key_to_assign("git_error"), do: :git_error
+  defp dismiss_key_to_assign("tests_error"), do: :tests_error
+  defp dismiss_key_to_assign("save_result"), do: :save_result
+  defp dismiss_key_to_assign("save_error"), do: :save_error
+  defp dismiss_key_to_assign("flush_result"), do: :flush_result
+  defp dismiss_key_to_assign("flush_error"), do: :flush_error
+  defp dismiss_key_to_assign("bindings_error"), do: :bindings_error
+  defp dismiss_key_to_assign("inspect_error"), do: :inspect_error
+  defp dismiss_key_to_assign(_unknown), do: nil
+
+  # ── handle_async dispatch ────────────────────────────────────────────────
+  #
+  # `WorkspaceLive.handle_async/3` forwards `:test_discover`/`:test_op` results
+  # here unchanged, mirroring `handle_event/3`'s delegation above.
+
+  # BT-2599: the off-socket test-catalogue discovery (`discover_test_classes/1` →
+  # `list_tests`, `:read`) completed. We fold the raw dispatch outcome onto the
+  # socket through the pure `apply_test_classes/3` helper — the same path the
+  # load-tests re-discovery uses — so the async and sync callers agree. The
+  # `keep_error?` flag (set by the partial-load re-discovery) rides a transient
+  # assign so a *successful* re-discovery doesn't clear a partial-load banner.
+  def handle_async(:test_discover, {:ok, result}, socket) do
+    keep_error? = socket.assigns[:tests_discover_keep_error] || false
+
+    {:noreply,
+     socket
+     |> apply_test_classes(result, keep_error?)
+     |> assign(:tests_discover_keep_error, false)}
+  end
+
+  # A newer discovery (rapid double-refresh / open-then-refresh) `cancel_async`-ed
+  # this one — a no-op, mirroring the `:git_load` / `:test_op` cancellation. The
+  # replacement task already reset `test_classes` to the nil sentinel, so the
+  # pane stays in its "discovering" state until that newer result lands.
+  def handle_async(:test_discover, {:exit, :cancelled}, socket), do: {:noreply, socket}
+
+  # The discovery task crashed/exited. Degrade to a `tests_error` rather than
+  # taking down the socket (matching the `:git_load` / `:test_op` crash handlers).
+  # Leave `test_classes` at the nil sentinel so the pane shows only the error —
+  # not the misleading "No TestCase subclasses" empty-state — and retries on the
+  # next open/refresh.
+  def handle_async(:test_discover, {:exit, reason}, socket) do
+    Logger.error("test discovery crashed: #{inspect(reason)}", domain: [:beamtalk, :liveview])
+
+    {:noreply,
+     assign(socket,
+       test_classes: nil,
+       tests_error: "Couldn't discover tests — the discovery failed unexpectedly.",
+       tests_discover_keep_error: false
+     )}
+  end
+
+  # BT-2597: the off-socket test run/load (`run_tests/2` / `load_tests/1`)
+  # completed. The task tags its dispatch result `{:run, _}` or `{:load, _}` so
+  # the right result-application path runs; either way the op is no longer in
+  # flight, so the controls re-enable.
+  def handle_async(:test_op, {:ok, {:run, dispatch_result}}, socket) do
+    {:noreply, socket |> apply_test_result(dispatch_result) |> assign(tests_running: false)}
+  end
+
+  def handle_async(:test_op, {:ok, {:load, dispatch_result}}, socket) do
+    {:noreply, socket |> apply_test_load(dispatch_result) |> assign(tests_running: false)}
+  end
+
+  # A newer run/load `cancel_async`-ed this one. Safe as a no-op only because
+  # every `cancel_async(:test_op, …)` is immediately followed by a paired
+  # `start_async(:test_op, …)` (in `run_tests/2` / `load_tests/1`) that has
+  # already set `tests_running: true` — so the replacement task owns the running
+  # state. A future standalone `cancel_async(:test_op, …)` (e.g. a Cancel button)
+  # would need to reset `tests_running` itself. Mirrors the `:git_load` no-op.
+  def handle_async(:test_op, {:exit, :cancelled}, socket), do: {:noreply, socket}
+
+  def handle_async(:test_op, {:exit, reason}, socket) do
+    Logger.error("test run/load crashed: #{inspect(reason)}", domain: [:beamtalk, :liveview])
+
+    # Clear any prior run's results so a stale pass/fail table can't sit beside
+    # the crash banner (a torn read) — matching the `:git_load` crash handler and
+    # the `apply_test_result/2` dispatch-error path.
+    {:noreply,
+     assign(socket,
+       tests_running: false,
+       test_results: nil,
+       tests_error: "The test run failed unexpectedly."
+     )}
+  end
+
+  # ── Test-runner pane data source (BT-2557) ──────────────────────────────────
+
+  # Discover the live image's TestCase subclasses + selectors (`list_tests`,
+  # `:read`). Although `:read` reflection is usually fast, it is still a blocking
+  # workspace RPC: against a slow/unresponsive node the ~5s timeout would stall
+  # the LiveView process (first Tests-tab open / every manual Refresh). So it
+  # runs off-socket in a `:test_discover` `start_async` task, mirroring the test
+  # run/load `:test_op` (BT-2597) and the git panel's `:git_load` (BT-2590). A
+  # rapid double-refresh / open-then-refresh `cancel_async`-es the prior probe so
+  # only the latest result wins; the result lands in
+  # `handle_async(:test_discover, …)`. The `test_classes` nil sentinel is
+  # preserved meanwhile so the pane shows its "discovering" state rather than the
+  # misleading "No TestCase subclasses" empty-state.
+  # `keep_error?` is set by the load-tests re-discovery path: a partial load has
+  # already populated `tests_error` with its compile-error summary, and a
+  # *successful* discovery must NOT clear it (it would swallow the partial-load
+  # banner). The flag rides a transient assign that `handle_async/3` consumes.
+  # Public: `BtAttachWeb.Live.Dock`'s `ensure_test_classes/1` (BT-3295, the
+  # `dock_tab`/`:test` meta-command lazy-load) calls it directly.
+  def discover_test_classes(socket, keep_error? \\ false) do
+    ctx = ctx(socket)
+
+    socket
+    |> assign(:tests_discover_keep_error, keep_error?)
+    |> cancel_async(:test_discover, :cancelled)
+    |> start_async(:test_discover, fn ->
+      # Off the LiveView process — capture only `ctx`, never `socket`.
+      Facade.dispatch(:list_tests, %{}, ctx)
+    end)
+  end
+
+  # Apply a completed `list_tests` dispatch to the socket. Pure (no dispatch);
+  # shared by `handle_async(:test_discover, …)` so the async path and the
+  # load-tests re-discovery agree (mirrors `apply_test_result/2` and
+  # `apply_git_status/2`). A dispatch failure / RBAC denial renders a
+  # `tests_error` rather than crashing the pane, mirroring `apply_changes/2`.
+  #
+  # On success we normally clear `tests_error` (a stale failure heals), but when
+  # `keep_error?` is true (a partial load is showing its compile-error summary)
+  # we leave `tests_error` intact so the banner survives the re-discovery.
+  defp apply_test_classes(socket, {:ok, classes}, keep_error?) when is_list(classes) do
+    socket = assign(socket, :test_classes, classes)
+    if keep_error?, do: socket, else: assign(socket, :tests_error, nil)
+  end
+
+  defp apply_test_classes(socket, {:error, reason}, _keep_error?),
+    # Leave the catalogue as the nil sentinel (not []) so the pane shows only the
+    # error — not the misleading "No TestCase subclasses" empty-state — and so
+    # re-opening the tab retries discovery (a transient failure heals).
+    do: assign(socket, test_classes: nil, tests_error: facade_error(reason))
+
+  defp apply_test_classes(socket, _other, _keep_error?),
+    do: assign(socket, test_classes: nil, tests_error: facade_error(:unexpected_test_result))
+
+  # Run all tests (`class` = nil) or a single class (`run_tests`, `:execute`).
+  #
+  # BT-2597: the run compiles + evaluates user code on the workspace node, which
+  # can take seconds for a large suite — so it runs off-socket in a `:test_op`
+  # `start_async` task (mirroring the git panel's `:git_load`, BT-2590) rather
+  # than blocking the LiveView process. A rapid second action `cancel_async`-es
+  # the in-flight op so only the latest result wins. The result lands in
+  # `handle_async(:test_op, …)`; `tests_running` disables the controls meanwhile.
+  defp run_tests(socket, class) do
+    ctx = ctx(socket)
+
+    socket
+    |> assign(tests_running: true, tests_error: nil)
+    |> cancel_async(:test_op, :cancelled)
+    |> start_async(:test_op, fn ->
+      # Off the LiveView process — capture only `ctx`, never `socket`.
+      {:run, Facade.dispatch(:run_tests, %{class: class}, ctx)}
+    end)
+  end
+
+  # Load the project's test/ files (`load_tests`, `:execute`), then re-discover
+  # the catalogue so the newly-loaded TestCase subclasses appear immediately.
+  #
+  # BT-2597: like `run_tests/2`, the load compiles user code, so it runs in the
+  # off-socket `:test_op` task; the result lands in `handle_async(:test_op, …)`.
+  defp load_tests(socket) do
+    ctx = ctx(socket)
+
+    socket
+    |> assign(tests_running: true, tests_error: nil)
+    |> cancel_async(:test_op, :cancelled)
+    |> start_async(:test_op, fn ->
+      {:load, Facade.dispatch(:load_tests, %{}, ctx)}
+    end)
+  end
+
+  # Apply a completed `run_tests` dispatch to the socket. Pure (no dispatch);
+  # shared by `handle_async/3` so the async path and any future sync caller agree
+  # (mirrors `apply_git_status/2`). An error (incl. a non-Owner RBAC denial)
+  # surfaces as `tests_error` and clears any stale results.
+  defp apply_test_result(socket, {:ok, result}) when is_map(result),
+    do: assign(socket, test_results: result, tests_error: nil)
+
+  defp apply_test_result(socket, {:error, reason}),
+    do: assign(socket, test_results: nil, tests_error: facade_error(reason))
+
+  defp apply_test_result(socket, _other),
+    do: assign(socket, test_results: nil, tests_error: facade_error(:unexpected_test_result))
+
+  # Apply a completed `load_tests` dispatch: refresh the catalogue to show
+  # whatever loaded, surfacing partial compile errors as `tests_error`. The
+  # re-discovery is kicked off via the off-socket `:test_discover` task
+  # (`discover_test_classes/2`) so the fold never blocks the LiveView process.
+  #
+  # We reset `test_classes` to the nil sentinel so the catalogue shows its
+  # "discovering" state until the off-socket re-discovery resolves with the
+  # freshly-loaded classes, and pass `keep_error?: true` so the later
+  # `handle_async(:test_discover, …)` fold doesn't clear this partial-load
+  # banner on a successful re-discovery.
+  defp apply_test_load(socket, {:ok, %{"errors" => [_ | _] = errors}}),
+    do:
+      socket
+      |> assign(test_classes: nil, tests_error: load_tests_error(errors))
+      |> discover_test_classes(true)
+
+  # A clean load simply re-discovers the catalogue off-socket; the
+  # `handle_async(:test_discover, …)` fold clears any stale `tests_error` on
+  # success (via `apply_test_classes/3`) and sets it on failure.
+  defp apply_test_load(socket, {:ok, _result}),
+    do: socket |> assign(test_classes: nil) |> discover_test_classes()
+
+  defp apply_test_load(socket, {:error, reason}),
+    do: assign(socket, tests_error: facade_error(reason))
+
+  defp apply_test_load(socket, _other),
+    do: assign(socket, tests_error: facade_error(:unexpected_test_result))
+
+  # Summarise compile errors from a partial test load into one line. Each error
+  # is a `%{"path" => ..., "message" => ...}` map (the load-project error shape).
+  defp load_tests_error(errors) do
+    count = length(errors)
+    first = errors |> List.first() |> Map.get("message", "")
+    "#{count} test file(s) failed to load: #{first}"
+  end
+
+  # Render the aggregate run duration (seconds, from the runtime TestResult) in a
+  # human unit: sub-second runs in ms, longer runs in seconds. A non-number (an
+  # unexpected wire shape) renders nothing rather than crashing the summary.
+  # Public: `WorkspaceLive`'s render template calls it directly.
+  def format_test_duration(seconds) when is_number(seconds) and seconds < 1.0 do
+    "#{round(seconds * 1000)} ms"
+  end
+
+  def format_test_duration(seconds) when is_number(seconds) do
+    "#{:erlang.float_to_binary(seconds * 1.0, decimals: 2)} s"
+  end
+
+  def format_test_duration(_), do: ""
+
+  # Per-class pass/fail tally from the last run, keyed by class name, so the
+  # catalogue can show "2✓ 1✗" next to each class without re-running. Returns nil
+  # when there are no results yet or the class had no cases in the last run.
+  # Public: `WorkspaceLive`'s render template calls it directly.
+  def test_class_tally(nil, _class), do: nil
+
+  def test_class_tally(test_results, class) when is_map(test_results) do
+    cases = for t <- test_results["tests"] || [], t["class"] == class, do: t["status"]
+
+    case cases do
+      [] ->
+        nil
+
+      _ ->
+        %{
+          passed: Enum.count(cases, &(&1 == "pass")),
+          failed: Enum.count(cases, &(&1 == "fail")),
+          skipped: Enum.count(cases, &(&1 == "skip"))
+        }
+    end
+  end
+
+  # Short status glyph for a per-case result row. Public: `WorkspaceLive`'s
+  # render template calls it directly.
+  def test_status_label("pass"), do: "✓ pass"
+  def test_status_label("fail"), do: "✗ fail"
+  def test_status_label("skip"), do: "○ skip"
+  # An unanticipated status from the runner still gets a visible "?" label rather
+  # than rendering the raw atom text unadorned.
+  def test_status_label(other), do: "? " <> other
+
+  # CSS class suffix for a per-case status. Only the three known statuses carry a
+  # styled rule (`.st-pass` / `.st-fail` / `.st-skip`); an unknown status falls
+  # back to the neutral skip style so a row is never left unstyled with a raw
+  # `st-<atom>` class that has no matching rule. Public: `WorkspaceLive`'s render
+  # template calls it directly.
+  def test_status_class(status) when status in ~w(pass fail skip), do: "st-" <> status
+  def test_status_class(_other), do: "st-skip"
+end

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -244,12 +244,13 @@ defmodule BtAttachWeb.WorkspaceLive do
   alias BtAttach.SessionRegistry
   alias BtAttach.Workspace
   alias BtAttachWeb.ClassTree
+  alias BtAttachWeb.Live.ClassModals
   alias BtAttachWeb.Live.Dock
-  alias BtAttachWeb.Live.FacadeError
   alias BtAttachWeb.Live.Inspector
   alias BtAttachWeb.Live.MethodEditor
   alias BtAttachWeb.Live.RequestContext
   alias BtAttachWeb.Live.SystemBrowser
+  alias BtAttachWeb.Live.TestRunner
 
   # All RBAC-relevant workspace ops go through the curated facade (ADR 0091
   # Decision 3) — never a raw Workspace/:rpc call from an event handler. Pure
@@ -444,8 +445,9 @@ defmodule BtAttachWeb.WorkspaceLive do
       |> assign(:tests_running, false)
       # BT-2599: a transient flag for the off-socket `:test_discover` catalogue
       # discovery — true only while a partial-load re-discovery is in flight so
-      # `handle_async(:test_discover, …)` keeps the partial-load `tests_error`
-      # banner across a successful re-discovery (see `apply_test_classes/3`).
+      # `TestRunner.handle_async(:test_discover, …)` keeps the partial-load
+      # `tests_error` banner across a successful re-discovery (see
+      # `TestRunner`'s `apply_test_classes/3`).
       |> assign(:tests_discover_keep_error, false)
       # REPL tab (BT-2543): a classic TUI request→response scrollback with the
       # input pinned at the bottom. `:repl` is the scrollback stream (so long
@@ -804,59 +806,37 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   defp force_close(_token, _pid), do: :ok
 
-  # ── Test-runner pane (BT-2557) ───────────────────────────────────────────────
-  #
-  # The GUI equivalent of a Smalltalk Test Runner: a dock tab that lists the live
-  # image's `TestCase` subclasses, runs all or a selected class through the
-  # attached session (never a shelled-out `beamtalk test`), and shows per-case
-  # pass/fail with failure detail — with an affordance to open a failing method
-  # in the method editor. Discovery is a `:read` op (the Observer may browse the
-  # catalogue); running tests is `:execute` (Owner-only, it evaluates code), so
-  # the run controls are owner-gated in the template, mirroring the eval form.
+  # Test Runner pane events (BT-2557/BT-2597/BT-2599, epic BT-3290): test
+  # catalogue discovery, running all/one TestCase subclass, loading the
+  # project's test/ files, opening a failing test method, and the
+  # cross-pane `dismiss_notice` utility all delegate to
+  # `BtAttachWeb.Live.TestRunner`, extracted out of this module (BT-3298) so
+  # its `handle_event/3`/`handle_async/3` clauses are directly unit-testable.
+  # See that module's docs for the full per-event behaviour (each clause used
+  # to run here). Reads its event list from `__test_runner_events__/0` —
+  # mirroring the BT-3301 fix that keeps this list from becoming a second,
+  # hand-maintained copy of the event names.
+  @test_runner_events TestRunner.__test_runner_events__()
 
-  # Re-discover the test catalogue (the "refresh" affordance). The discovery is a
-  # `:read` reflection op, but it is still a blocking workspace RPC — so it runs
-  # off-socket via `discover_test_classes/1` (`:test_discover` `start_async`,
-  # BT-2599) rather than stalling the LiveView process against a slow node. We
-  # reset `test_classes` to the nil sentinel so the pane shows its "discovering"
-  # state (not the misleading "No TestCase subclasses" empty-state) until the
-  # `handle_async(:test_discover, …)` fold resolves.
   @impl true
-  def handle_event("tests_refresh", _params, socket) do
-    {:noreply, socket |> assign(:test_classes, nil) |> discover_test_classes()}
+  def handle_event(event, params, socket) when event in @test_runner_events do
+    TestRunner.handle_event(event, params, socket)
   end
 
-  # Run every loaded TestCase subclass (`test-all`).
-  def handle_event("run_tests", _params, socket) do
-    {:noreply, run_tests(socket, nil)}
-  end
+  # New Class / Rename modals + Remove Method / Remove Class (BT-2293/BT-2645,
+  # ADR 0112 Phase 4 BT-3189, ADR 0113 Phase 4 BT-3210, ADR 0114 Phase 5
+  # BT-3277) all delegate to `BtAttachWeb.Live.ClassModals`, extracted out of
+  # this module (BT-3298, epic BT-3290) so its `handle_event/3` clauses are
+  # directly unit-testable. See that module's docs for the full per-event
+  # behaviour (each clause used to run here). Reads its event list from
+  # `__class_modals_events__/0` — mirroring the BT-3301 fix that keeps this
+  # list from becoming a second, hand-maintained copy of the event names.
+  @class_modals_events ClassModals.__class_modals_events__()
 
-  # Load the project's test/ files into the live image, then re-discover the
-  # catalogue (`load_tests`, `:execute` — Owner-only). A freshly-opened project
-  # holds only src/ classes, so without this the catalogue is empty (BT-2557).
-  def handle_event("load_tests", _params, socket) do
-    {:noreply, load_tests(socket)}
+  @impl true
+  def handle_event(event, params, socket) when event in @class_modals_events do
+    ClassModals.handle_event(event, params, socket)
   end
-
-  # Run a single selected test class (`test`, `class` = the row's class).
-  def handle_event("run_test_class", %{"class" => class}, socket) when is_binary(class) do
-    {:noreply, run_tests(socket, class)}
-  end
-
-  # Open a (failing) test method in the method editor. Test selectors are
-  # instance-side, so the side is always "instance"; reuses the System Browser's
-  # method-tab opener (BT-2491) so the test runner and browser share one editor.
-  def handle_event("open_test_method", %{"class" => class, "selector" => selector}, socket)
-      when is_binary(class) and is_binary(selector) do
-    {:noreply, MethodEditor.open_method_tab(socket, class, "instance", selector)}
-  end
-
-  # Fallback clauses for the guarded test handlers: a crafted WebSocket message
-  # with a missing / non-binary `class`/`selector` must be ignored, not crash the
-  # socket on a FunctionClauseError before RBAC is reached (matching `save_method`,
-  # `revert`, `browser_select_class`, etc.).
-  def handle_event("run_test_class", _params, socket), do: {:noreply, socket}
-  def handle_event("open_test_method", _params, socket), do: {:noreply, socket}
 
   # Workspace dock events (BT-3295, epic BT-3290): the eval/Workspace tab,
   # REPL tab, Transcript tab (push-only, no events), and Changes/Git tabs all
@@ -958,89 +938,11 @@ defmodule BtAttachWeb.WorkspaceLive do
   end
 
   # ── method editor (Wave 3, write-surface ADR 0082) ──────────────────────────
-
-  # Remove the active method tab's method from its class (ADR 0112 Phase 4,
-  # BT-3189). Wired the same way Save is: an owner-only editor action that
-  # drives a write-surface primitive and refreshes the Changes pane. Unlike
-  # `save_method`, there is no dedicated workspace-side op — this just builds
-  # `Class removeSelector: #selector` (or `Class class removeSelector:
-  # #selector` for a class-side tab) and submits it through the existing
-  # `evaluate` op, exactly like the REPL `:remove-method` meta-command, the
-  # MCP `remove_method` tool, and the LSP `beamtalk.removeMethod` command
-  # (ADR 0112's "Beamtalk-level surface to add" — no new dispatcher op).
-  def handle_event("remove_method", _params, %{assigns: %{role: :owner}} = socket) do
-    {:noreply, remove_active_method(socket)}
-  end
-
-  # Non-owner (Observer) or a crafted event with no matching role: a no-op —
-  # the button is rendered only for `:owner`, mirroring `new_method` above.
-  def handle_event("remove_method", _params, socket), do: {:noreply, socket}
-
-  # Remove the active class-definition tab's class from the running system
-  # (ADR 0113 Phase 4, BT-3210). Wired the same way "Remove Method" is above
-  # (ADR 0112 Phase 4, BT-3189): an owner-only editor action, `data-confirm`
-  # -gated in the template, that drives a write-surface primitive and
-  # refreshes the Changes pane. There is no dedicated workspace-side op —
-  # this just builds `Class removeFromSystem` and submits it through the
-  # existing `evaluate` op, exactly like the REPL `:remove-class` meta-
-  # command and the MCP `remove_class` tool (ADR 0113's "Surface" table).
   #
-  # This is the memory-mutating gesture only, matching `autoflush: true`'s
-  # existing "the memory step is not gated" behaviour for ordinary patches
-  # (ADR 0113 Surface, browser row) — the resulting `remove-class` entry
-  # does NOT get silently written to disk by autoflush; it renders in the
-  # Changes pane with a distinct destructive-dirty affordance requiring its
-  # own explicit "Delete file" click (`confirmDestructive: true`) to reach
-  # disk. Two gestures for two genuinely separate decisions, same shape as
-  # the REPL's two independently-confirmed `:remove-class` / `:flush-
-  # destructive` commands.
-  def handle_event("remove_class", _params, %{assigns: %{role: :owner}} = socket) do
-    {:noreply, remove_active_class(socket)}
-  end
-
-  # Non-owner (Observer) or a crafted event with no matching role: a no-op —
-  # the button is rendered only for `:owner`, mirroring `remove_method` above.
-  def handle_event("remove_class", _params, socket), do: {:noreply, socket}
-
-  # Open the Rename modal for the active tab (ADR 0114 Phase 5, BT-3277): a
-  # `:def` tab renames its class (`renameTo:`), an existing `:method` tab
-  # renames its selector (`renameSelector:to:`). Mirrors `remove_class`/
-  # `remove_method` above in reading the target from the active tab rather
-  # than trusting client-supplied params, but — unlike those, which act
-  # immediately — this only opens the modal; the actual rename waits for
-  # `rename_submit` once the owner has typed the new name.
-  def handle_event("open_rename", _params, %{assigns: %{role: :owner}} = socket) do
-    {:noreply, open_rename(socket)}
-  end
-
-  # Non-owner (Observer) or a crafted event with no matching role: a no-op —
-  # the buttons opening this modal are rendered only for `:owner`.
-  def handle_event("open_rename", _params, socket), do: {:noreply, socket}
-
-  # Dismiss the Rename modal without renaming anything — mirrors
-  # `close_new_class` (Escape / click-away / the modal's own × button all
-  # route here).
-  def handle_event("close_rename", _params, socket) do
-    {:noreply, assign(socket, rename_open: false, rename_error: nil)}
-  end
-
-  # Submit the Rename modal's new name (ADR 0114 Phase 5, BT-3277). Dispatches
-  # to `renameTo:` or `renameSelector:to:` depending on which kind of rename
-  # was opened; a rejected submit re-renders the modal with the in-flight
-  # value and an inline error, mirroring `new_class`'s validation-failure
-  # shape.
-  def handle_event(
-        "rename_submit",
-        %{"new_name" => new_name},
-        %{assigns: %{role: :owner}} = socket
-      )
-      when is_binary(new_name) do
-    {:noreply, submit_rename(socket, new_name)}
-  end
-
-  # Non-owner (Observer) or a crafted event with a missing/non-binary name: a
-  # no-op — the form is rendered only for `:owner` while the modal is open.
-  def handle_event("rename_submit", _params, socket), do: {:noreply, socket}
+  # `remove_method`/`remove_class`/`open_rename`/`close_rename`/`rename_submit`
+  # (ADR 0112 Phase 4 BT-3189, ADR 0113 Phase 4 BT-3210, ADR 0114 Phase 5
+  # BT-3277) all delegate to `BtAttachWeb.Live.ClassModals` (BT-3298, epic
+  # BT-3290) — see the `@class_modals_events` guard clause above.
 
   # ── tabbed method editor (BT-2494, epic BT-2482 Phase 2) ────────────────────
   #
@@ -1054,73 +956,10 @@ defmodule BtAttachWeb.WorkspaceLive do
   # `browser_open_native_module`/`browser_jump_native` all delegate to
   # `BtAttachWeb.Live.SystemBrowser` (BT-3297, epic BT-3290) — see the
   # `@system_browser_events` guard clause above.
-
-  # Open a blank "new method" tab for the *selected* class (the System Browser's
-  # "new method" entry). A new-method tab is a `:method` tab with no selector yet —
-  # the only editor surface that still shows a selector input (the breadcrumb can't
-  # name a selector that doesn't exist), so the author types the selector + body.
-  # The starter tab used to fill this role on startup; it now opens on demand only.
-  def handle_event("new_method", %{"class" => class}, %{assigns: %{role: :owner}} = socket)
-      when is_binary(class) and class != "" do
-    # Author on whichever side the browser is showing (instance/class), so "new
-    # method" while viewing the class side opens a class-side tab.
-    {:noreply, MethodEditor.open_new_method(socket, class, socket.assigns.browser_side)}
-  end
-
-  # Non-owner (Observer) or malformed payload: a no-op. Authoring is owner-only —
-  # the entry is rendered only for `:owner`, and a crafted event from a read-only
-  # role must not even open a (non-savable) scratch tab in their strip.
-  def handle_event("new_method", _params, socket), do: {:noreply, socket}
-
-  # Toggle the System Browser's "New Class" modal open/closed (BT-2293, BT-2645).
-  # Closed by default; the ＋ button in the browser head flips it. Opening the
-  # modal resets the field values + clears any stale in-modal validation error
-  # from a prior attempt so the owner gets a clean slate (the superclass defaults
-  # back to `Object`).
-  def handle_event("toggle_new_class", _params, socket) do
-    opening? = !socket.assigns.new_class_open
-
-    socket =
-      if opening? do
-        assign(socket,
-          new_class_open: true,
-          new_class_error: nil,
-          new_class_name: "",
-          new_class_super: "Object"
-        )
-      else
-        assign(socket, new_class_open: false, new_class_error: nil)
-      end
-
-    {:noreply, socket}
-  end
-
-  # Close the New Class modal (Esc / close button / scrim click), discarding the
-  # in-flight fields without creating anything (BT-2645).
-  def handle_event("close_new_class", _params, socket) do
-    {:noreply, assign(socket, new_class_open: false, new_class_error: nil)}
-  end
-
-  # Create a brand-new class from the New Class modal's name + superclass fields
-  # (ADR 0082 Phase 5 `Workspace newClass:at:`, BT-2293, BT-2645). The owner types
-  # a plain PascalCase class name and picks a superclass (default `Object`); the
-  # `<Superclass> subclass: <Name>` definition is synthesized server-side — the
-  # user never types `subclass:`. The target `.bt` path is derived from the class
-  # name (`Greeter` → `src/Greeter.bt`); the user thinks in classes, not files. A
-  # successful create logs a durable `new-class` ChangeLog entry (written to disk
-  # later on flush), appears in the Changes pane, and opens + selects the new class.
-  def handle_event("new_class", %{"name" => name} = params, socket)
-      when is_binary(name) do
-    superclass = Map.get(params, "superclass", "Object")
-    superclass = if is_binary(superclass), do: superclass, else: "Object"
-    {:noreply, new_class(socket, name, superclass)}
-  end
-
-  # Malformed payload (missing key / non-binary value): surface an in-modal
-  # validation error rather than letting a crafted event crash the LiveView.
-  def handle_event("new_class", _params, socket) do
-    {:noreply, assign(socket, new_class_error: "Invalid new-class form payload.")}
-  end
+  #
+  # `new_method`/`toggle_new_class`/`close_new_class`/`new_class` (BT-2293,
+  # BT-2645) all delegate to `BtAttachWeb.Live.ClassModals` (BT-3298, epic
+  # BT-3290) — see the `@class_modals_events` guard clause above.
 
   # ── omni search (BT-2495, epic BT-2482 Phase 3) ─────────────────────────────
 
@@ -1179,21 +1018,10 @@ defmodule BtAttachWeb.WorkspaceLive do
   # all delegate to `BtAttachWeb.Live.SystemBrowser` (BT-3297, epic BT-3290) —
   # see the `@system_browser_events` guard clause above.
 
-  # ── dismissable status notices (BT-2612) ────────────────────────────────────
-  #
-  # Generic dismiss for top-level *scalar* status assigns. The key arrives from
-  # the client and is NEVER turned into an atom (`String.to_atom/1` on user input
-  # is a memory/atom-table attack vector) — instead it is mapped through a fixed
-  # whitelist to the assign we clear. Unknown keys are ignored (no-op), matching
-  # the existing "clear to nil" convention every backing handler uses.
-  def handle_event("dismiss_notice", %{"key" => key}, socket) do
-    case dismiss_key_to_assign(key) do
-      nil -> {:noreply, socket}
-      assign_key -> {:noreply, assign(socket, assign_key, nil)}
-    end
-  end
-
-  def handle_event("dismiss_notice", _params, socket), do: {:noreply, socket}
+  # `dismiss_notice` (the generic dismiss for every pane's inline `.notice`
+  # status banner, BT-2612) delegates to `BtAttachWeb.Live.TestRunner`
+  # (BT-3298, epic BT-3290) — see the `@test_runner_events` guard clause
+  # above.
 
   # `dismiss_nav_error` (dismiss the error inside the Senders/Implementors
   # popover without closing it) delegates to `BtAttachWeb.Live.SystemBrowser`
@@ -1416,76 +1244,18 @@ defmodule BtAttachWeb.WorkspaceLive do
     {:noreply, socket}
   end
 
-  # BT-2597: the off-socket test run/load (`run_tests/2` / `load_tests/1`)
-  # completed. The task tags its dispatch result `{:run, _}` or `{:load, _}` so
-  # the right result-application path runs; either way the op is no longer in
-  # flight, so the controls re-enable.
-  def handle_async(:test_op, {:ok, {:run, dispatch_result}}, socket) do
-    {:noreply, socket |> apply_test_result(dispatch_result) |> assign(tests_running: false)}
-  end
+  # Test Runner async loads (BT-2597/BT-2599, extracted BT-3298): the
+  # off-socket `:test_op` (run/load) and `:test_discover` (catalogue
+  # discovery) `start_async` results forward to
+  # `BtAttachWeb.Live.TestRunner.handle_async/3` unchanged, mirroring the
+  # `:git_load` delegation above.
+  @impl true
+  def handle_async(:test_op, result, socket),
+    do: TestRunner.handle_async(:test_op, result, socket)
 
-  def handle_async(:test_op, {:ok, {:load, dispatch_result}}, socket) do
-    {:noreply, socket |> apply_test_load(dispatch_result) |> assign(tests_running: false)}
-  end
-
-  # A newer run/load `cancel_async`-ed this one. Safe as a no-op only because
-  # every `cancel_async(:test_op, …)` is immediately followed by a paired
-  # `start_async(:test_op, …)` (in `run_tests/2` / `load_tests/1`) that has
-  # already set `tests_running: true` — so the replacement task owns the running
-  # state. A future standalone `cancel_async(:test_op, …)` (e.g. a Cancel button)
-  # would need to reset `tests_running` itself. Mirrors the `:git_load` no-op.
-  def handle_async(:test_op, {:exit, :cancelled}, socket), do: {:noreply, socket}
-
-  def handle_async(:test_op, {:exit, reason}, socket) do
-    Logger.error("test run/load crashed: #{inspect(reason)}", domain: [:beamtalk, :liveview])
-
-    # Clear any prior run's results so a stale pass/fail table can't sit beside
-    # the crash banner (a torn read) — matching the `:git_load` crash handler and
-    # the `apply_test_result/2` dispatch-error path.
-    {:noreply,
-     assign(socket,
-       tests_running: false,
-       test_results: nil,
-       tests_error: "The test run failed unexpectedly."
-     )}
-  end
-
-  # BT-2599: the off-socket test-catalogue discovery (`discover_test_classes/1` →
-  # `list_tests`, `:read`) completed. We fold the raw dispatch outcome onto the
-  # socket through the pure `apply_test_classes/3` helper — the same path the
-  # load-tests re-discovery uses — so the async and sync callers agree. The
-  # `keep_error?` flag (set by the partial-load re-discovery) rides a transient
-  # assign so a *successful* re-discovery doesn't clear a partial-load banner.
-  def handle_async(:test_discover, {:ok, result}, socket) do
-    keep_error? = socket.assigns[:tests_discover_keep_error] || false
-
-    {:noreply,
-     socket
-     |> apply_test_classes(result, keep_error?)
-     |> assign(:tests_discover_keep_error, false)}
-  end
-
-  # A newer discovery (rapid double-refresh / open-then-refresh) `cancel_async`-ed
-  # this one — a no-op, mirroring the `:git_load` / `:test_op` cancellation. The
-  # replacement task already reset `test_classes` to the nil sentinel, so the
-  # pane stays in its "discovering" state until that newer result lands.
-  def handle_async(:test_discover, {:exit, :cancelled}, socket), do: {:noreply, socket}
-
-  # The discovery task crashed/exited. Degrade to a `tests_error` rather than
-  # taking down the socket (matching the `:git_load` / `:test_op` crash handlers).
-  # Leave `test_classes` at the nil sentinel so the pane shows only the error —
-  # not the misleading "No TestCase subclasses" empty-state — and retries on the
-  # next open/refresh.
-  def handle_async(:test_discover, {:exit, reason}, socket) do
-    Logger.error("test discovery crashed: #{inspect(reason)}", domain: [:beamtalk, :liveview])
-
-    {:noreply,
-     assign(socket,
-       test_classes: nil,
-       tests_error: "Couldn't discover tests — the discovery failed unexpectedly.",
-       tests_discover_keep_error: false
-     )}
-  end
+  @impl true
+  def handle_async(:test_discover, result, socket),
+    do: TestRunner.handle_async(:test_discover, result, socket)
 
   @impl true
   def terminate(_reason, socket) do
@@ -1552,27 +1322,15 @@ defmodule BtAttachWeb.WorkspaceLive do
     :ok
   end
 
-  # Whitelist mapping a client-supplied dismiss key → the scalar status assign to
-  # clear (BT-2612). This is the security boundary: only these exact strings
-  # resolve; everything else returns nil and is ignored by `dismiss_notice`.
-  # NEVER replace this with `String.to_atom/1` on the user-supplied key.
-  defp dismiss_key_to_assign("browser_error"), do: :browser_error
-  defp dismiss_key_to_assign("output"), do: :output
-  defp dismiss_key_to_assign("changes_error"), do: :changes_error
-  defp dismiss_key_to_assign("git_error"), do: :git_error
-  defp dismiss_key_to_assign("tests_error"), do: :tests_error
-  defp dismiss_key_to_assign("save_result"), do: :save_result
-  defp dismiss_key_to_assign("save_error"), do: :save_error
-  defp dismiss_key_to_assign("flush_result"), do: :flush_result
-  defp dismiss_key_to_assign("flush_error"), do: :flush_error
-  defp dismiss_key_to_assign("bindings_error"), do: :bindings_error
-  defp dismiss_key_to_assign("inspect_error"), do: :inspect_error
-  defp dismiss_key_to_assign(_unknown), do: nil
+  # The `dismiss_notice` key whitelist (BT-2612) moved to
+  # `BtAttachWeb.Live.TestRunner.dismiss_key_to_assign/1` (BT-3298) alongside
+  # the `handle_event("dismiss_notice", …)` clause it backs.
 
   # `facade_error/1` moved to `BtAttachWeb.Live.FacadeError` (BT-3291) so
   # extracted panes (e.g. `BtAttachWeb.Live.Inspector`) render the same
-  # facade-error copy instead of keeping their own.
-  defp facade_error(reason), do: FacadeError.render(reason)
+  # facade-error copy instead of keeping their own; `WorkspaceLive` itself has
+  # had no direct caller left since the New Class/Rename/Remove handlers
+  # moved to `BtAttachWeb.Live.ClassModals` (BT-3298).
 
   # Human label for a porcelain status atom (BT-2586). `beamtalk_git` classifies
   # each XY column into one of these; "—" marks the no-change column.
@@ -1722,628 +1480,10 @@ defmodule BtAttachWeb.WorkspaceLive do
     %{id: System.unique_integer([:positive]), text: to_string(text)}
   end
 
-  # Remove the active method tab's method from its class (ADR 0112 Phase 4,
-  # BT-3189). A new (unsaved) method tab has nothing to remove, and a crafted
-  # event against a non-method tab is a graceful no-op — surfaced as a local
-  # validation error rather than evaluating a malformed expression.
-  defp remove_active_method(socket) do
-    case MethodEditor.active_tab(socket.assigns) do
-      %{kind: :method, new: true} ->
-        status_error(socket, "This method hasn't been saved yet — nothing to remove.")
-
-      %{kind: :method, class: class, side: side, selector: selector} = tab
-      when is_binary(selector) and selector != "" ->
-        remove_method(socket, tab, class, side, selector)
-
-      _ ->
-        status_error(socket, "Open an existing method to remove it.")
-    end
-  end
-
-  # `Class removeSelector: #selector` (or `Class class removeSelector:
-  # #selector` for a class-side tab), submitted through the same generic
-  # `evaluate` op the REPL `:remove-method` meta-command, the MCP
-  # `remove_method` tool, and the LSP `beamtalk.removeMethod` command all use —
-  # no dedicated workspace-side op (ADR 0112's "Beamtalk-level surface to
-  # add"). On success the tab is closed (its method no longer exists) and the
-  # Changes pane refreshes, mirroring `save_method_body/5`'s success path; a
-  # raised `selector_not_found` (or any other structured error) renders inline
-  # via the shared status area.
-  defp remove_method(socket, tab, class, side, selector) do
-    receiver = if side == "class", do: "#{class} class", else: class
-    expr = "#{receiver} removeSelector: ##{selector}"
-    pid = socket.assigns[:session_pid]
-
-    if not is_pid(pid) do
-      status_error(socket, "not attached to workspace")
-    else
-      remove_method_eval(socket, tab, receiver, selector, expr, pid)
-    end
-  end
-
-  defp remove_method_eval(socket, tab, receiver, selector, expr, pid) do
-    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
-      {:ok, _term, _output, _warnings} ->
-        # `close_tab/2` wipes `save_result`/`save_error` whenever the closed
-        # tab was the active one — via `clear_active/1` if it was the last
-        # open tab, or via `sync_active/2` when focus moves to the next
-        # remaining tab — so the success message must be assigned AFTER
-        # closing the tab, not before, or closing the active tab would
-        # silently swallow it.
-        socket
-        |> MethodEditor.close_tab(tab.id)
-        |> assign(
-          save_result: "Removed #{selector} from #{receiver}",
-          save_error: nil,
-          flush_result: nil,
-          flush_error: nil
-        )
-        |> assign_changes()
-
-      {:error, reason, _output, _warnings} ->
-        status_error(socket, Workspace.render_error(reason))
-
-      {:error, reason} ->
-        status_error(socket, facade_error(reason))
-    end
-  end
-
-  # Remove the active class-definition tab's class from the system (ADR 0113
-  # Phase 4, BT-3210). A `:def` tab always names an already-existing class
-  # (unlike a `:method` tab, there is no "new, unsaved class" draft state —
-  # class creation is a separate System Browser form, see the "NEW CLASS"
-  # comment in the template below), so there is no `new: true` guard to
-  # mirror `remove_active_method/1`'s; a crafted event against a non-`:def`
-  # tab is still a graceful no-op, surfaced as a local validation error
-  # rather than evaluating a malformed expression.
-  defp remove_active_class(socket) do
-    case MethodEditor.active_tab(socket.assigns) do
-      %{kind: :def, class: class} = tab when is_binary(class) and class != "" ->
-        remove_class(socket, tab, class)
-
-      _ ->
-        status_error(socket, "Open a class definition to remove it.")
-    end
-  end
-
-  # `Class removeFromSystem`, submitted through the same generic `evaluate`
-  # op the REPL `:remove-class` meta-command and the MCP `remove_class` tool
-  # use — no dedicated workspace-side op (ADR 0113's "Surface" table: "every
-  # surface constructs one of the Beamtalk expressions above and submits via
-  # the existing `evaluate` op"). Memory-mutating only: this never flushes.
-  defp remove_class(socket, tab, class) do
-    expr = "#{class} removeFromSystem"
-    pid = socket.assigns[:session_pid]
-
-    if not is_pid(pid) do
-      status_error(socket, "not attached to workspace")
-    else
-      remove_class_eval(socket, tab, class, expr, pid)
-    end
-  end
-
-  defp remove_class_eval(socket, tab, class, expr, pid) do
-    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
-      {:ok, _term, _output, _warnings} ->
-        # `close_tab/2` wipes `save_result`/`save_error` whenever the closed
-        # tab was the active one — mirrors `remove_method_eval/6`'s success
-        # path, so the confirmation message must be assigned AFTER closing
-        # the tab. The message names the still-open second step (ADR 0113's
-        # two-gesture flow) so the owner isn't surprised the file survives
-        # this click.
-        socket
-        |> MethodEditor.close_tab(tab.id)
-        |> assign(
-          save_result:
-            "Removed #{class} from memory — not yet flushed to disk. Delete its file from the Changes pane to finish.",
-          save_error: nil,
-          flush_result: nil,
-          flush_error: nil
-        )
-        |> assign_changes()
-
-      {:error, reason, _output, _warnings} ->
-        status_error(socket, Workspace.render_error(reason))
-
-      {:error, reason} ->
-        status_error(socket, facade_error(reason))
-    end
-  end
-
-  # Create a new class from the New Class modal's name + superclass (BT-2293,
-  # BT-2645). The owner supplies a plain PascalCase class name and a superclass
-  # (default `Object`); validation (PascalCase, non-empty, non-duplicate) runs
-  # locally — a rejected name surfaces an in-modal error and never round-trips.
-  # A valid name synthesizes the `<Superclass> subclass: <Name>` definition,
-  # derives the target `.bt` path from the name (so the user never types a file
-  # path), threads source + path to the workspace newClass chokepoint, refreshes
-  # the Changes pane (ChangeLog coherence), and opens + selects the new class.
-  defp new_class(socket, name, superclass) do
-    name = String.trim(name)
-    superclass = trim_superclass(superclass)
-
-    with :ok <- validate_new_class_name(socket, name),
-         :ok <- validate_superclass(superclass) do
-      source = superclass <> " subclass: " <> name
-      {:ok, path} = derive_class_path(name)
-      dispatch_new_class(socket, name, superclass, source, path)
-    else
-      {:error, message} ->
-        # Keep the in-flight field values so the re-rendered modal shows what the
-        # owner typed, and route the error to the modal-local assign (never the
-        # method-editor's shared `save_error` — BT-2645).
-        assign(socket,
-          new_class_open: true,
-          new_class_name: name,
-          new_class_super: superclass,
-          new_class_error: message
-        )
-    end
-  end
-
-  # An empty / blank superclass falls back to the default `Object` — the modal's
-  # select defaults to it, but a crafted payload or cleared typeahead must not
-  # synthesize a headerless `subclass: Name`.
-  defp trim_superclass(superclass) do
-    case String.trim(superclass) do
-      "" -> "Object"
-      trimmed -> trimmed
-    end
-  end
-
-  # Validate the superclass field the same way as the class name (BT-2645): a bare
-  # PascalCase identifier. The empty case is already normalised to `Object` by
-  # `trim_superclass/1`. This rejects a crafted payload (e.g. embedded newlines /
-  # syntax) locally, matching the name field rather than relying on the server
-  # parser to reject the synthesized source.
-  defp validate_superclass(superclass) do
-    if Regex.match?(~r/^[A-Z][A-Za-z0-9_]*$/, superclass),
-      do: :ok,
-      else:
-        {:error, "Superclass must be a class name starting with a capital letter, e.g. `Object`."}
-  end
-
-  # Validate a new class name locally (BT-2645): non-empty, PascalCase
-  # (`^[A-Z][A-Za-z0-9_]*$`), and not a duplicate of an existing class in the
-  # browse list. Returns `:ok` or `{:error, message}` for an in-modal error.
-  @new_class_name_re ~r/^[A-Z][A-Za-z0-9_]*$/
-
-  # Whether `name` is a bare PascalCase class-name identifier
-  # (`^[A-Z][A-Za-z0-9_]*$`) — the shape the New Class modal enforces. Public:
-  # `BtAttachWeb.Live.Dock`'s `flush_destructive/3` (BT-3295) validates a
-  # client-controlled `class` value against this same rule before
-  # interpolating it into a raw `evaluate` expression, so a crafted event
-  # can't inject arbitrary source.
-  def valid_class_name?(name), do: Regex.match?(@new_class_name_re, name)
-
-  defp validate_new_class_name(socket, name) do
-    cond do
-      name == "" ->
-        {:error, "Enter a class name to create a class."}
-
-      not valid_class_name?(name) ->
-        {:error,
-         "Class name must be PascalCase — start with an uppercase letter, e.g. `Greeter`."}
-
-      class_name_taken?(socket, name) ->
-        {:error, "A class named #{name} already exists."}
-
-      true ->
-        :ok
-    end
-  end
-
-  # Is `name` already a class in the loaded browse list? Compared against the
-  # `"name"` field of every browse row (the same list the tree renders), so a
-  # duplicate is caught before any round-trip.
-  defp class_name_taken?(socket, name) do
-    Enum.any?(socket.assigns[:browser_classes] || [], fn row ->
-      Map.get(row, "name") == name
-    end)
-  end
-
-  # Deliberately NOT a selector grammar (unary/keyword/binary, whitespace
-  # rules, the lexer's exact binary-operator character set) — duplicating
-  # that here would be exactly the un-enforced "keep in sync" copy
-  # `docs/development/architecture-principles.md`'s Duplication section
-  # warns against, since nothing would catch this regex drifting from
-  # `crates/beamtalk-core/src/source_analysis/lexer.rs`'s
-  # `is_binary_selector_char/1` if the language ever adds an operator
-  # character. Instead this only guards the one property that actually
-  # matters here: the value is embedded as `##{new_name}` inside a
-  # textually-interpolated `evaluate` expression, so it must contain no
-  # character that could end the symbol literal early or splice in a second
-  # expression (whitespace, `#`, quotes, backslash). Anything that passes
-  # this narrow check but isn't actually a well-formed selector fails the
-  # same way any other malformed `evaluate` expression does — a normal
-  # compiler error surfaced via `rename_method_eval/6`'s `{:error, ...}`
-  # branch — so the compiler stays the sole source of truth for "is this a
-  # valid selector", never re-implemented here.
-  @selector_injection_re ~r/^[^[:space:]#"'\\]+$/
-
-  # Open the Rename modal against the active tab (ADR 0114 Phase 5, BT-3277):
-  # a `:def` tab renames its class, an existing (already-saved) `:method` tab
-  # renames its selector — mirroring `remove_active_class`/`remove_active_method`'s
-  # identical tab-kind dispatch, including `remove_active_method`'s `new: true`
-  # guard (a brand-new, not-yet-compiled method has no selector to rename).
-  # The target is captured into `rename_class`/`rename_side`/`rename_old_selector`
-  # now, at open time, rather than re-read from the active tab on submit — so
-  # switching tabs while the modal is open can't retarget the rename mid-flight.
-  defp open_rename(socket) do
-    case MethodEditor.active_tab(socket.assigns) do
-      %{kind: :def, class: class} when is_binary(class) and class != "" ->
-        assign(socket,
-          rename_open: true,
-          rename_kind: :class,
-          rename_class: class,
-          rename_side: nil,
-          rename_old_selector: nil,
-          rename_new_name: class,
-          rename_error: nil
-        )
-
-      %{kind: :method, new: true} ->
-        status_error(socket, "This method hasn't been saved yet — nothing to rename.")
-
-      %{kind: :method, class: class, side: side, selector: selector}
-      when is_binary(class) and class != "" and is_binary(selector) and selector != "" ->
-        assign(socket,
-          rename_open: true,
-          rename_kind: :method,
-          rename_class: class,
-          rename_side: side,
-          rename_old_selector: selector,
-          rename_new_name: selector,
-          rename_error: nil
-        )
-
-      _ ->
-        status_error(socket, "Open a class definition or an existing method to rename it.")
-    end
-  end
-
-  # Dispatch the Rename modal's submitted name to whichever primitive
-  # `rename_kind` selected. A rejected submit keeps the modal open with the
-  # in-flight value and an inline error (never the method editor's shared
-  # `save_error`), mirroring `new_class/3`'s validation-failure shape.
-  defp submit_rename(socket, new_name) do
-    new_name = String.trim(new_name)
-
-    case socket.assigns.rename_kind do
-      :class ->
-        rename_class(socket, socket.assigns.rename_class, new_name)
-
-      :method ->
-        rename_method(
-          socket,
-          socket.assigns.rename_class,
-          socket.assigns.rename_side,
-          socket.assigns.rename_old_selector,
-          new_name
-        )
-
-      _ ->
-        assign(socket, rename_open: false, rename_error: nil)
-    end
-  end
-
-  # `OldClass renameTo: #NewName` (ADR 0114 Phase 2, `Behaviour>>renameTo:`,
-  # BT-3278), submitted through the same generic `evaluate` op the REPL
-  # `:rename-class` meta-command and the MCP `rename_class` tool use — no
-  # dedicated workspace-side op (ADR 0114's "Surface" table, reusing ADR
-  # 0113's "every surface constructs one of the Beamtalk expressions above
-  # and submits via the existing `evaluate` op"). Memory-mutating only: this
-  # never flushes — the resulting `rename-class` entry needs its own
-  # confirmed "apply rename" click in the Changes pane to reach disk (ADR
-  # 0114's two-gesture flow, reusing ADR 0113's `confirmDestructive` tier).
-  #
-  # `new_name` is validated locally against the same bare-PascalCase-identifier
-  # shape the New Class modal enforces (`@new_class_name_re`) before it is
-  # textually interpolated into the `evaluate` expression — this field is
-  # owner-typed but still raw client input reaching a raw Beamtalk expression,
-  # exactly the injection concern `flush_destructive/2`'s class-name check
-  # guards against.
-  defp rename_class(socket, old_name, new_name) do
-    cond do
-      new_name == "" ->
-        assign(socket,
-          rename_open: true,
-          rename_new_name: new_name,
-          rename_error: "Enter a new class name."
-        )
-
-      not Regex.match?(@new_class_name_re, new_name) ->
-        assign(socket,
-          rename_open: true,
-          rename_new_name: new_name,
-          rename_error:
-            "Class name must be PascalCase — start with an uppercase letter, e.g. `Accumulator`."
-        )
-
-      class_name_taken?(socket, new_name) ->
-        assign(socket,
-          rename_open: true,
-          rename_new_name: new_name,
-          rename_error: "A class named #{new_name} already exists."
-        )
-
-      true ->
-        expr = "#{old_name} renameTo: ##{new_name}"
-        pid = socket.assigns[:session_pid]
-
-        if not is_pid(pid) do
-          assign(socket,
-            rename_open: true,
-            rename_new_name: new_name,
-            rename_error: "not attached to workspace"
-          )
-        else
-          rename_class_eval(socket, old_name, new_name, expr, pid)
-        end
-    end
-  end
-
-  defp rename_class_eval(socket, old_name, new_name, expr, pid) do
-    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
-      {:ok, _term, _output, _warnings} ->
-        # The class's identity changed, so every tab keyed on the old name
-        # (its own `:def` tab plus any open `:method` tabs) is stale — close
-        # them all, mirroring `remove_class_eval/4`'s tab-closing success
-        # path, then refresh the class tree (a new name to browse) and the
-        # Changes pane (the new `rename-class` entry). `open_definition/2`
-        # re-syncs the active-tab editor assigns (clearing `save_result`,
-        # same note as `dispatch_new_class/5` above), so the success status is
-        # assigned AFTER it opens the renamed class's definition tab.
-        socket
-        |> close_tabs_for_class(old_name)
-        |> SystemBrowser.assign_browser_classes()
-        |> assign_changes()
-        |> MethodEditor.open_definition(new_name)
-        |> reselect_renamed_class(old_name, new_name)
-        |> assign(
-          rename_open: false,
-          rename_error: nil,
-          save_result:
-            "Renamed #{old_name} to #{new_name} — not yet flushed to disk. Apply the rename from the Changes pane to finish.",
-          save_error: nil,
-          flush_result: nil,
-          flush_error: nil
-        )
-
-      {:error, reason, _output, _warnings} ->
-        assign(socket,
-          rename_open: true,
-          rename_new_name: new_name,
-          rename_error: Workspace.render_error(reason)
-        )
-
-      {:error, reason} ->
-        assign(socket,
-          rename_open: true,
-          rename_new_name: new_name,
-          rename_error: facade_error(reason)
-        )
-    end
-  end
-
-  # Only follow the rename into `selected_class` when the System Browser
-  # tree's own current selection WAS the renamed class (or nothing was
-  # selected) — unlike `dispatch_new_class/5`'s unconditional select-the-
-  # new-class (there's no prior selection to conflict with when creating a
-  # class), a rename can be triggered from an open `:def` tab while the
-  # tree has a DIFFERENT, unrelated class selected. Reassigning
-  # unconditionally would move the tree highlight to the renamed class
-  # while leaving `browser_protocols`/`browser_categories` showing the
-  # untouched previously-selected class — the same "ghost selection"
-  # mismatch `selected_class_visible?/1` (BT-2597) exists to avoid for the
-  # browser-source-filter case. Leaving an unrelated selection alone is
-  # simpler and correct here; there's no stale-name problem to fix in that
-  # case, since the unrelated class's own identity didn't change.
-  defp reselect_renamed_class(socket, old_name, new_name) do
-    if socket.assigns.selected_class in [old_name, nil] do
-      assign(socket, selected_class: new_name, selected_protocol: nil)
-    else
-      socket
-    end
-  end
-
-  # `Class renameSelector: #old to: #new` (or `Class class renameSelector: #old
-  # to: #new` for a class-side tab) — `Behaviour>>renameSelector:to:` (ADR
-  # 0114 Phase 3, BT-3279), submitted through the same generic `evaluate` op
-  # the REPL `:rename-method` meta-command and the MCP `rename_method` tool
-  # use. Memory-mutating only, same two-gesture flow as `rename_class/3`
-  # above: reaching disk needs the Changes pane's "apply rename" click.
-  #
-  # `new_name` is only checked against `@selector_injection_re` (no
-  # whitespace/`#`/quotes/backslash) before interpolation — see that
-  # attribute's own comment for why this stops short of validating full
-  # selector syntax. A value that passes this check but isn't actually a
-  # well-formed selector, or collides with an already-defined local
-  # selector, is refused server-side by `renameSelector:to:` itself
-  # (mirroring `removeSelector:`'s existing error surface) and surfaces
-  # through `rename_method_eval/6`'s ordinary error branch.
-  defp rename_method(socket, class, side, old_selector, new_name) do
-    cond do
-      new_name == "" ->
-        assign(socket,
-          rename_open: true,
-          rename_new_name: new_name,
-          rename_error: "Enter a new selector."
-        )
-
-      not Regex.match?(@selector_injection_re, new_name) ->
-        assign(socket,
-          rename_open: true,
-          rename_new_name: new_name,
-          rename_error: "Selector cannot contain spaces, #, quotes, or backslashes."
-        )
-
-      true ->
-        receiver = if side == "class", do: "#{class} class", else: class
-        expr = "#{receiver} renameSelector: ##{old_selector} to: ##{new_name}"
-        pid = socket.assigns[:session_pid]
-
-        if not is_pid(pid) do
-          assign(socket,
-            rename_open: true,
-            rename_new_name: new_name,
-            rename_error: "not attached to workspace"
-          )
-        else
-          rename_method_eval(socket, class, receiver, old_selector, new_name, expr, pid)
-        end
-    end
-  end
-
-  defp rename_method_eval(socket, class, receiver, old_selector, new_selector, expr, pid) do
-    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
-      {:ok, _term, _output, _warnings} ->
-        # The selector changed, so the active method tab (keyed on the old
-        # selector) is stale — close it, mirroring `remove_method_eval/6`'s
-        # tab-closing success path.
-        socket
-        |> close_active_tab_if(
-          &match?(%{kind: :method, class: ^class, selector: ^old_selector}, &1)
-        )
-        |> assign(
-          rename_open: false,
-          rename_error: nil,
-          save_result:
-            "Renamed #{receiver} #{old_selector} to #{new_selector} — not yet flushed to disk. Apply the rename from the Changes pane to finish.",
-          save_error: nil,
-          flush_result: nil,
-          flush_error: nil
-        )
-        |> assign_changes()
-
-      {:error, reason, _output, _warnings} ->
-        assign(socket,
-          rename_open: true,
-          rename_new_name: new_selector,
-          rename_error: Workspace.render_error(reason)
-        )
-
-      {:error, reason} ->
-        assign(socket,
-          rename_open: true,
-          rename_new_name: new_selector,
-          rename_error: facade_error(reason)
-        )
-    end
-  end
-
-  # Close every open tab (def or method) belonging to `class` — used after a
-  # successful class rename, since every one of them is keyed on the
-  # now-stale old name. Iterates `close_tab/2` (rather than a bulk filter)
-  # so each close runs its normal active-tab-reassignment bookkeeping.
-  defp close_tabs_for_class(socket, class) do
-    socket.assigns.tabs
-    |> Enum.filter(&(&1.kind in [:def, :method] and Map.get(&1, :class) == class))
-    |> Enum.reduce(socket, fn tab, acc -> MethodEditor.close_tab(acc, tab.id) end)
-  end
-
-  # Close the active tab only when `pred` matches it — used after a
-  # successful method rename so a rename triggered from a *different* tab
-  # (not reachable today, since `open_rename/1` only ever targets the active
-  # tab, but kept explicit rather than assumed) never closes the wrong one.
-  defp close_active_tab_if(socket, pred) do
-    case MethodEditor.active_tab(socket.assigns) do
-      %{} = tab -> if pred.(tab), do: MethodEditor.close_tab(socket, tab.id), else: socket
-      _ -> socket
-    end
-  end
-
-  defp dispatch_new_class(socket, name, superclass, source, path) do
-    case Facade.dispatch(:new_class, %{source: source, path: path}, ctx(socket)) do
-      {:ok, created_path} ->
-        socket
-        |> SystemBrowser.assign_browser_classes()
-        |> assign_changes()
-        # Open + select the NEW class (`name`), not the superclass: the def tab
-        # focuses it and the tree highlights it (BT-2645). `open_definition`
-        # re-syncs the active-tab editor assigns (clearing `save_result`), so the
-        # success status is assigned *after* it — otherwise the "Created …" banner
-        # would be wiped by the very tab it opens.
-        |> MethodEditor.open_definition(name)
-        |> assign(
-          selected_class: name,
-          selected_protocol: nil,
-          save_result: "Created new class — #{created_path}",
-          save_error: nil,
-          flush_result: nil,
-          flush_error: nil,
-          new_class_open: false,
-          new_class_error: nil
-        )
-        # BT-2586/BT-2590: a new class only writes its `.bt` file to disk when
-        # autoflush is on (it is otherwise a durable in-memory ChangeLog entry,
-        # written at the next flush — `maybe_autoflush(durable)` in
-        # beamtalk_repl_loader). So reflect it in the git panel only when autoflush
-        # is on, matching the save path; with autoflush off the working tree is
-        # unchanged and the shell-out is skipped.
-        |> maybe_refresh_git_after_save()
-
-      {:error, reason} ->
-        # Route a failed create to the in-modal error (keep fields + modal open),
-        # never the method-editor's `save_error` (BT-2645).
-        assign(socket,
-          new_class_open: true,
-          new_class_name: name,
-          new_class_super: superclass,
-          new_class_error: facade_error(reason)
-        )
-    end
-  end
-
-  # Derive the in-project `.bt` path for a new class from its name (BT-2293,
-  # BT-2646): `Greeter` → `src/greeter.bt`, `EventStore` → `src/event_store.bt`.
-  # The basename is snake_cased to match the project convention (every file in a
-  # package `src/` is snake_case). The runtime's `newClass:at:` validation
-  # snake_case-normalises both the declared class name and the path basename
-  # (`beamtalk_repl_loader:validate_new_class/3` via `to_snake_case/1`), so a
-  # snake_case file maps cleanly to the PascalCase class. The name is already
-  # PascalCase-validated by the caller, so this always succeeds; it returns
-  # `{:ok, path}` to keep the call-site explicit.
-  #
-  # The `src/` prefix is assumed — it's the canonical package source dir the
-  # runtime resolves (`resolve_package_module` tries `src/` then `test/`). A
-  # project with a different layout would get a `target_outside_project` error at
-  # creation time (not silently on flush). If per-project source dirs ever land,
-  # this is the spot to read the configured dir instead of hardcoding `src/`.
-  defp derive_class_path(name) do
-    {:ok, "src/" <> to_snake_case(name) <> ".bt"}
-  end
-
-  # Snake-case a PascalCase class name, mirroring the runtime's
-  # `beamtalk_repl_loader:to_snake_case/1` EXACTLY so the IDE-derived filename and
-  # the loader's basename normalisation agree (BT-2646). The rule: the first
-  # character is lowercased unconditionally; thereafter an uppercase letter gets a
-  # leading `_` ONLY when the previous character was a lowercase letter. This
-  # collapses acronyms (`HTTPServer` → `httpserver`) rather than splitting every
-  # capital — diverging from the runtime here would make the loader reject or
-  # mis-locate the created file. Digits and other characters pass through verbatim
-  # and do not count as "lowercase" for the boundary test.
-  defp to_snake_case(name) do
-    name
-    |> String.to_charlist()
-    |> snake_chars(false, [])
-  end
-
-  defp snake_chars([], _prev_was_lower?, acc), do: acc |> Enum.reverse() |> List.to_string()
-
-  defp snake_chars([c | rest], prev_was_lower?, acc) when c >= ?A and c <= ?Z do
-    lowered = c + 32
-
-    if prev_was_lower? do
-      snake_chars(rest, false, [lowered, ?_ | acc])
-    else
-      snake_chars(rest, false, [lowered | acc])
-    end
-  end
-
-  defp snake_chars([c | rest], _prev_was_lower?, acc) do
-    snake_chars(rest, c >= ?a and c <= ?z, [c | acc])
-  end
+  # Remove Method / Remove Class / Rename modal (ADR 0112 Phase 4 BT-3189, ADR
+  # 0113 Phase 4 BT-3210, ADR 0114 Phase 5 BT-3277) and the New Class modal
+  # (BT-2293, BT-2645) all moved to `BtAttachWeb.Live.ClassModals` (BT-3298)
+  # alongside the `handle_event/3` clauses they back.
 
   # Human-readable Kind/Side label for one Changes-pane row (BT-3195): before
   # this, the table had no column distinguishing an instance-side patch from a
@@ -2382,7 +1522,8 @@ defmodule BtAttachWeb.WorkspaceLive do
   # (BT-2293). Keeps the validation/error branches from leaving a stale flush
   # banner visible — the success branches already clear all four inline.
   # Public: shared with `BtAttachWeb.Live.Dock`'s revert/git-revert paths
-  # (BT-3295).
+  # (BT-3295) and `BtAttachWeb.Live.ClassModals`'s remove/rename paths
+  # (BT-3298).
   def status_error(socket, message) do
     assign(socket,
       save_result: nil,
@@ -2409,7 +1550,8 @@ defmodule BtAttachWeb.WorkspaceLive do
   # lazily on next open), so the common edit loop never pays for an extra git
   # shell-out it can't see. Used by the flush path, which always changes disk.
   # Public: shared with `BtAttachWeb.Live.Dock`'s flush paths (BT-3295) — the
-  # git panel's own `assign_git/1` now lives there.
+  # git panel's own `assign_git/1` now lives there — and
+  # `BtAttachWeb.Live.ClassModals`'s new-class create path (BT-3298).
   def maybe_refresh_git(socket) do
     if socket.assigns.dock_tab == "git", do: Dock.assign_git(socket), else: socket
   end
@@ -2420,7 +1562,8 @@ defmodule BtAttachWeb.WorkspaceLive do
   # result and is pure waste. When autoflush is on the save wrote through to disk,
   # so the panel must reflect it (gated, as ever, on the Git tab being active).
   # Public: `BtAttachWeb.Live.MethodEditor`'s save-definition path (BT-3296)
-  # calls it directly.
+  # and `BtAttachWeb.Live.ClassModals`'s new-class create path (BT-3298)
+  # call it directly.
   def maybe_refresh_git_after_save(socket) do
     if socket.assigns.autoflush, do: maybe_refresh_git(socket), else: socket
   end
@@ -2463,7 +1606,8 @@ defmodule BtAttachWeb.WorkspaceLive do
   # (`apply_changes/2`) so the mount-time async load (BT-2591) and the post-action
   # refresh callers share one fold. The sync helper keeps its old signature.
   # Public: shared with `BtAttachWeb.Live.Dock`'s eval/REPL/Changes/git paths
-  # (BT-3295).
+  # (BT-3295) and `BtAttachWeb.Live.ClassModals`'s remove/rename/new-class
+  # paths (BT-3298).
   def assign_changes(socket), do: apply_changes(socket, read_changes(socket))
 
   # The raw `:changes` dispatch result — runs off the LiveView process in the
@@ -2630,194 +1774,10 @@ defmodule BtAttachWeb.WorkspaceLive do
       else: socket
   end
 
-  # ── Test-runner pane data source (BT-2557) ──────────────────────────────────
-
-  # Discover the live image's TestCase subclasses + selectors (`list_tests`,
-  # `:read`). Although `:read` reflection is usually fast, it is still a blocking
-  # workspace RPC: against a slow/unresponsive node the ~5s timeout would stall
-  # the LiveView process (first Tests-tab open / every manual Refresh). So it
-  # runs off-socket in a `:test_discover` `start_async` task, mirroring the test
-  # run/load `:test_op` (BT-2597) and the git panel's `:git_load` (BT-2590). A
-  # rapid double-refresh / open-then-refresh `cancel_async`-es the prior probe so
-  # only the latest result wins; the result lands in
-  # `handle_async(:test_discover, …)`. The `test_classes` nil sentinel is
-  # preserved meanwhile so the pane shows its "discovering" state rather than the
-  # misleading "No TestCase subclasses" empty-state.
-  # `keep_error?` is set by the load-tests re-discovery path: a partial load has
-  # already populated `tests_error` with its compile-error summary, and a
-  # *successful* discovery must NOT clear it (it would swallow the partial-load
-  # banner). The flag rides a transient assign that `handle_async/3` consumes.
-  # Public: `BtAttachWeb.Live.Dock`'s `ensure_test_classes/1` (BT-3295, the
-  # `dock_tab`/`:test` meta-command lazy-load) calls it directly — the Tests
-  # pane's own events haven't been extracted out of this module yet.
-  def discover_test_classes(socket, keep_error? \\ false) do
-    ctx = ctx(socket)
-
-    socket
-    |> assign(:tests_discover_keep_error, keep_error?)
-    |> cancel_async(:test_discover, :cancelled)
-    |> start_async(:test_discover, fn ->
-      # Off the LiveView process — capture only `ctx`, never `socket`.
-      Facade.dispatch(:list_tests, %{}, ctx)
-    end)
-  end
-
-  # Apply a completed `list_tests` dispatch to the socket. Pure (no dispatch);
-  # shared by `handle_async(:test_discover, …)` so the async path and the
-  # load-tests re-discovery agree (mirrors `apply_test_result/2` and
-  # `apply_git_status/2`). A dispatch failure / RBAC denial renders a
-  # `tests_error` rather than crashing the pane, mirroring `apply_changes/2`.
-  #
-  # On success we normally clear `tests_error` (a stale failure heals), but when
-  # `keep_error?` is true (a partial load is showing its compile-error summary)
-  # we leave `tests_error` intact so the banner survives the re-discovery.
-  defp apply_test_classes(socket, {:ok, classes}, keep_error?) when is_list(classes) do
-    socket = assign(socket, :test_classes, classes)
-    if keep_error?, do: socket, else: assign(socket, :tests_error, nil)
-  end
-
-  defp apply_test_classes(socket, {:error, reason}, _keep_error?),
-    # Leave the catalogue as the nil sentinel (not []) so the pane shows only the
-    # error — not the misleading "No TestCase subclasses" empty-state — and so
-    # re-opening the tab retries discovery (a transient failure heals).
-    do: assign(socket, test_classes: nil, tests_error: facade_error(reason))
-
-  defp apply_test_classes(socket, _other, _keep_error?),
-    do: assign(socket, test_classes: nil, tests_error: facade_error(:unexpected_test_result))
-
-  # Run all tests (`class` = nil) or a single class (`run_tests`, `:execute`).
-  #
-  # BT-2597: the run compiles + evaluates user code on the workspace node, which
-  # can take seconds for a large suite — so it runs off-socket in a `:test_op`
-  # `start_async` task (mirroring the git panel's `:git_load`, BT-2590) rather
-  # than blocking the LiveView process. A rapid second action `cancel_async`-es
-  # the in-flight op so only the latest result wins. The result lands in
-  # `handle_async(:test_op, …)`; `tests_running` disables the controls meanwhile.
-  defp run_tests(socket, class) do
-    ctx = ctx(socket)
-
-    socket
-    |> assign(tests_running: true, tests_error: nil)
-    |> cancel_async(:test_op, :cancelled)
-    |> start_async(:test_op, fn ->
-      # Off the LiveView process — capture only `ctx`, never `socket`.
-      {:run, Facade.dispatch(:run_tests, %{class: class}, ctx)}
-    end)
-  end
-
-  # Load the project's test/ files (`load_tests`, `:execute`), then re-discover
-  # the catalogue so the newly-loaded TestCase subclasses appear immediately.
-  #
-  # BT-2597: like `run_tests/2`, the load compiles user code, so it runs in the
-  # off-socket `:test_op` task; the result lands in `handle_async(:test_op, …)`.
-  defp load_tests(socket) do
-    ctx = ctx(socket)
-
-    socket
-    |> assign(tests_running: true, tests_error: nil)
-    |> cancel_async(:test_op, :cancelled)
-    |> start_async(:test_op, fn ->
-      {:load, Facade.dispatch(:load_tests, %{}, ctx)}
-    end)
-  end
-
-  # Apply a completed `run_tests` dispatch to the socket. Pure (no dispatch);
-  # shared by `handle_async/3` so the async path and any future sync caller agree
-  # (mirrors `apply_git_status/2`). An error (incl. a non-Owner RBAC denial)
-  # surfaces as `tests_error` and clears any stale results.
-  defp apply_test_result(socket, {:ok, result}) when is_map(result),
-    do: assign(socket, test_results: result, tests_error: nil)
-
-  defp apply_test_result(socket, {:error, reason}),
-    do: assign(socket, test_results: nil, tests_error: facade_error(reason))
-
-  defp apply_test_result(socket, _other),
-    do: assign(socket, test_results: nil, tests_error: facade_error(:unexpected_test_result))
-
-  # Apply a completed `load_tests` dispatch: refresh the catalogue to show
-  # whatever loaded, surfacing partial compile errors as `tests_error`. The
-  # re-discovery is kicked off via the off-socket `:test_discover` task
-  # (`discover_test_classes/2`) so the fold never blocks the LiveView process.
-  #
-  # We reset `test_classes` to the nil sentinel so the catalogue shows its
-  # "discovering" state until the off-socket re-discovery resolves with the
-  # freshly-loaded classes, and pass `keep_error?: true` so the later
-  # `handle_async(:test_discover, …)` fold doesn't clear this partial-load
-  # banner on a successful re-discovery.
-  defp apply_test_load(socket, {:ok, %{"errors" => [_ | _] = errors}}),
-    do:
-      socket
-      |> assign(test_classes: nil, tests_error: load_tests_error(errors))
-      |> discover_test_classes(true)
-
-  # A clean load simply re-discovers the catalogue off-socket; the
-  # `handle_async(:test_discover, …)` fold clears any stale `tests_error` on
-  # success (via `apply_test_classes/3`) and sets it on failure.
-  defp apply_test_load(socket, {:ok, _result}),
-    do: socket |> assign(test_classes: nil) |> discover_test_classes()
-
-  defp apply_test_load(socket, {:error, reason}),
-    do: assign(socket, tests_error: facade_error(reason))
-
-  defp apply_test_load(socket, _other),
-    do: assign(socket, tests_error: facade_error(:unexpected_test_result))
-
-  # Summarise compile errors from a partial test load into one line. Each error
-  # is a `%{"path" => ..., "message" => ...}` map (the load-project error shape).
-  defp load_tests_error(errors) do
-    count = length(errors)
-    first = errors |> List.first() |> Map.get("message", "")
-    "#{count} test file(s) failed to load: #{first}"
-  end
-
-  # Render the aggregate run duration (seconds, from the runtime TestResult) in a
-  # human unit: sub-second runs in ms, longer runs in seconds. A non-number (an
-  # unexpected wire shape) renders nothing rather than crashing the summary.
-  defp format_test_duration(seconds) when is_number(seconds) and seconds < 1.0 do
-    "#{round(seconds * 1000)} ms"
-  end
-
-  defp format_test_duration(seconds) when is_number(seconds) do
-    "#{:erlang.float_to_binary(seconds * 1.0, decimals: 2)} s"
-  end
-
-  defp format_test_duration(_), do: ""
-
-  # Per-class pass/fail tally from the last run, keyed by class name, so the
-  # catalogue can show "2✓ 1✗" next to each class without re-running. Returns nil
-  # when there are no results yet or the class had no cases in the last run.
-  defp test_class_tally(nil, _class), do: nil
-
-  defp test_class_tally(test_results, class) when is_map(test_results) do
-    cases = for t <- test_results["tests"] || [], t["class"] == class, do: t["status"]
-
-    case cases do
-      [] ->
-        nil
-
-      _ ->
-        %{
-          passed: Enum.count(cases, &(&1 == "pass")),
-          failed: Enum.count(cases, &(&1 == "fail")),
-          skipped: Enum.count(cases, &(&1 == "skip"))
-        }
-    end
-  end
-
-  # Short status glyph for a per-case result row.
-  defp test_status_label("pass"), do: "✓ pass"
-  defp test_status_label("fail"), do: "✗ fail"
-  defp test_status_label("skip"), do: "○ skip"
-  # An unanticipated status from the runner still gets a visible "?" label rather
-  # than rendering the raw atom text unadorned.
-  defp test_status_label(other), do: "? " <> other
-
-  # CSS class suffix for a per-case status. Only the three known statuses carry a
-  # styled rule (`.st-pass` / `.st-fail` / `.st-skip`); an unknown status falls
-  # back to the neutral skip style so a row is never left unstyled with a raw
-  # `st-<atom>` class that has no matching rule.
-  defp test_status_class(status) when status in ~w(pass fail skip), do: "st-" <> status
-  defp test_status_class(_other), do: "st-skip"
+  # The Test-runner pane data source (BT-2557/BT-2597/BT-2599) — discovery,
+  # running, and the render-template status-glyph helpers — moved to
+  # `BtAttachWeb.Live.TestRunner` (BT-3298) alongside the `handle_event/3`/
+  # `handle_async/3` clauses they back.
 
   # ── navigation aids: omni search (BT-2495) ──────────────────────────────────
   #
@@ -5105,7 +4065,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                           , {@test_results["skipped"]} skipped
                         </span>
                         <span :if={@test_results["duration"]} class="test-duration">
-                          · {format_test_duration(@test_results["duration"])}
+                          · {TestRunner.format_test_duration(@test_results["duration"])}
                         </span>
                       </span>
                     </div>
@@ -5133,10 +4093,10 @@ defmodule BtAttachWeb.WorkspaceLive do
                       <tbody>
                         <tr
                           :for={t <- @test_results["tests"]}
-                          class={["test-row", test_status_class(t["status"])]}
+                          class={["test-row", TestRunner.test_status_class(t["status"])]}
                         >
-                          <td class={["test-status", test_status_class(t["status"])]}>
-                            {test_status_label(t["status"])}
+                          <td class={["test-status", TestRunner.test_status_class(t["status"])]}>
+                            {TestRunner.test_status_label(t["status"])}
                           </td>
                           <td class="k">{t["class"]}</td>
                           <td>
@@ -5184,7 +4144,7 @@ defmodule BtAttachWeb.WorkspaceLive do
                               <td class="k">{tc["class"]}</td>
                               <td>{length(tc["selectors"])}</td>
                               <td class="test-tally">
-                                <%= case test_class_tally(@test_results, tc["class"]) do %>
+                                <%= case TestRunner.test_class_tally(@test_results, tc["class"]) do %>
                                   <% nil -> %>
                                     <span class="muted-note">—</span>
                                   <% tally -> %>
@@ -6391,4 +5351,18 @@ defmodule BtAttachWeb.WorkspaceLive do
   # BT-3301 fix), never a second hand-maintained copy. This accessor exists
   # only so a test can assert the two stay literally identical.
   def system_browser_events, do: @system_browser_events
+
+  @doc false
+  # Mirrors `inspector_events/0`/`system_browser_events/0`: `@test_runner_events`
+  # IS `TestRunner.__test_runner_events__/0` (BT-3298, following the BT-3301
+  # fix), never a second hand-maintained copy. This accessor exists only so a
+  # test can assert the two stay literally identical.
+  def test_runner_events, do: @test_runner_events
+
+  @doc false
+  # Mirrors `test_runner_events/0`: `@class_modals_events` IS
+  # `ClassModals.__class_modals_events__/0` (BT-3298, following the BT-3301
+  # fix), never a second hand-maintained copy. This accessor exists only so a
+  # test can assert the two stay literally identical.
+  def class_modals_events, do: @class_modals_events
 end

--- a/editors/liveview/test/bt_attach_web/class_modals_test.exs
+++ b/editors/liveview/test/bt_attach_web/class_modals_test.exs
@@ -1,0 +1,616 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.Live.ClassModalsTest do
+  @moduledoc """
+  Direct unit tests for `BtAttachWeb.Live.ClassModals` (BT-3298), driving its
+  `handle_event/3` clauses and the create/rename/remove data model against a
+  hand-built `%Phoenix.LiveView.Socket{}` and the fully-stubbed workspace
+  client (`BtAttachWeb.StubWorkspaceClient`, BT-2554) — no full LiveView
+  mount, no real workspace node. Mirrors `BtAttachWeb.Live.MethodEditorTest`
+  (BT-3296) and `BtAttachWeb.Live.SystemBrowserTest` (BT-3297), the
+  precedent this extraction follows.
+
+  Covers the branches BT-3298's acceptance criteria calls out specifically:
+  new-class/new-method validation errors and rename submit validation.
+  """
+  use ExUnit.Case, async: false
+
+  alias BtAttachWeb.Live.ClassModals
+  alias BtAttachWeb.StubWorkspaceClient
+  alias BtAttachWeb.WorkspaceLive
+
+  setup do
+    Application.put_env(:bt_attach, :workspace_client, StubWorkspaceClient)
+    {:ok, _} = StubWorkspaceClient.start_state()
+
+    on_exit(fn ->
+      Application.delete_env(:bt_attach, :workspace_client)
+      StubWorkspaceClient.stop_state(2_000)
+    end)
+
+    :ok
+  end
+
+  # A bare, disconnected socket carrying exactly the assigns ClassModals'
+  # functions read — the subset of `WorkspaceLive.bind_session/3`'s init
+  # relevant to the New Class/Rename modals and the tabbed method editor's
+  # Remove/Rename actions (mirroring `MethodEditorTest.base_socket/1`, since
+  # this module cross-calls `BtAttachWeb.Live.MethodEditor` the same way).
+  # `role: :owner` by default (most tests aren't about RBAC); override per
+  # test.
+  defp base_socket(overrides \\ %{}) do
+    assigns =
+      %{
+        __changed__: %{},
+        current_user: nil,
+        role: :owner,
+        session_id: "sess-1",
+        session_pid: self(),
+        tabs: [],
+        active_tab: nil,
+        editor_rev: 0,
+        doc_expanded: false,
+        native_view: nil,
+        native_source: "all",
+        native_source_chosen: false,
+        edit_class: "",
+        edit_selector: "",
+        edit_source: "",
+        edit_selection: nil,
+        save_result: nil,
+        save_error: nil,
+        flush_result: nil,
+        flush_error: nil,
+        save_echo_pending: false,
+        source_refresh_pending: false,
+        browser_classes: [],
+        browser_source: "all",
+        browser_source_chosen: true,
+        browser_error: nil,
+        selected_class: nil,
+        selected_protocol: nil,
+        autoflush: false,
+        changes: [],
+        changes_error: nil,
+        expanded_changes: MapSet.new(),
+        dock_tab: "workspace",
+        git_status: nil,
+        git_log: [],
+        browser_side: "instance",
+        new_class_open: false,
+        new_class_error: nil,
+        new_class_name: "",
+        new_class_super: "Object",
+        rename_open: false,
+        rename_kind: nil,
+        rename_class: nil,
+        rename_side: nil,
+        rename_old_selector: nil,
+        rename_new_name: "",
+        rename_error: nil,
+        show_settings: false,
+        nav_popover: nil
+      }
+      |> Map.merge(overrides)
+
+    %Phoenix.LiveView.Socket{
+      assigns: assigns,
+      private: %{live_temp: %{}, lifecycle: %Phoenix.LiveView.Lifecycle{}}
+    }
+  end
+
+  defp method_tab(id, class, selector, opts \\ []) do
+    %{
+      id: id,
+      kind: :method,
+      class: class,
+      side: Keyword.get(opts, :side, "instance"),
+      selector: selector,
+      source: "#{selector} => self",
+      base: "#{selector} => self",
+      dirty: false,
+      disk_differs: false,
+      runtime_only: false,
+      synthetic: false,
+      disk_source: "#{selector} => self",
+      doc: nil,
+      signature: nil,
+      native_module: nil,
+      native_delegate: false,
+      class_modifiers: [],
+      class_native: false,
+      source_origin: nil,
+      package: nil,
+      new: Keyword.get(opts, :new, false)
+    }
+  end
+
+  defp def_tab(id, class) do
+    %{
+      id: id,
+      kind: :def,
+      class: class,
+      side: nil,
+      selector: nil,
+      source: "Object subclass: #{class}",
+      base: "Object subclass: #{class}",
+      dirty: false,
+      disk_differs: false,
+      runtime_only: false,
+      disk_source: nil,
+      doc: nil,
+      signature: nil,
+      is_protocol: false,
+      native_module: nil,
+      class_modifiers: [],
+      class_native: false,
+      source_origin: nil,
+      package: nil,
+      new: false
+    }
+  end
+
+  describe "@class_modals_events coverage (BT-3301 pattern)" do
+    test "WorkspaceLive's @class_modals_events IS ClassModals's canonical list, not a copy" do
+      assert WorkspaceLive.class_modals_events() == ClassModals.__class_modals_events__()
+    end
+
+    test "every event WorkspaceLive delegates to ClassModals resolves to an implemented clause" do
+      tabs = [
+        method_tab("method:Counter:instance:increment", "Counter", "increment"),
+        def_tab("def:Counter", "Counter")
+      ]
+
+      socket =
+        base_socket(%{
+          tabs: tabs,
+          active_tab: "method:Counter:instance:increment",
+          rename_open: true,
+          rename_kind: :class,
+          rename_class: "Counter"
+        })
+
+      params_by_event = %{
+        "remove_method" => %{},
+        "remove_class" => %{},
+        "open_rename" => %{},
+        "close_rename" => %{},
+        "rename_submit" => %{"new_name" => "Accumulator"},
+        "new_method" => %{"class" => "Counter"},
+        "toggle_new_class" => %{},
+        "close_new_class" => %{},
+        "new_class" => %{"name" => "Greeter", "superclass" => "Object"}
+      }
+
+      for event <- ClassModals.__class_modals_events__() do
+        params = Map.fetch!(params_by_event, event)
+        result = ClassModals.handle_event(event, params, socket)
+
+        assert match?({:noreply, %Phoenix.LiveView.Socket{}}, result),
+               "ClassModals.handle_event/3 has no clause for #{inspect(event)} (or it crashed)"
+      end
+    end
+
+    test "no handle_event/3 clause head names an event missing from the canonical list" do
+      source =
+        Path.expand("../../lib/bt_attach_web/live/class_modals.ex", __DIR__) |> File.read!()
+
+      clause_names =
+        ~r/def handle_event\("([a-z0-9_]+)"/
+        |> Regex.scan(source)
+        |> Enum.map(fn [_, name] -> name end)
+        |> MapSet.new()
+
+      assert clause_names == MapSet.new(ClassModals.__class_modals_events__())
+    end
+  end
+
+  describe "New Class modal validation (BT-2293, BT-2645)" do
+    test "toggle_new_class opens the modal with clean defaults" do
+      socket = base_socket(%{new_class_error: "stale"})
+
+      {:noreply, socket} = ClassModals.handle_event("toggle_new_class", %{}, socket)
+
+      assert socket.assigns.new_class_open == true
+      assert socket.assigns.new_class_error == nil
+      assert socket.assigns.new_class_name == ""
+      assert socket.assigns.new_class_super == "Object"
+    end
+
+    test "toggle_new_class closes an already-open modal" do
+      socket = base_socket(%{new_class_open: true})
+
+      {:noreply, socket} = ClassModals.handle_event("toggle_new_class", %{}, socket)
+
+      assert socket.assigns.new_class_open == false
+    end
+
+    test "close_new_class discards the in-flight fields" do
+      socket = base_socket(%{new_class_open: true, new_class_error: "boom"})
+
+      {:noreply, socket} = ClassModals.handle_event("close_new_class", %{}, socket)
+
+      assert socket.assigns.new_class_open == false
+      assert socket.assigns.new_class_error == nil
+    end
+
+    test "an empty class name is rejected with an in-modal error" do
+      {:noreply, socket} =
+        ClassModals.handle_event("new_class", %{"name" => ""}, base_socket())
+
+      assert socket.assigns.new_class_open == true
+      assert socket.assigns.new_class_error == "Enter a class name to create a class."
+    end
+
+    test "a non-PascalCase class name is rejected" do
+      {:noreply, socket} =
+        ClassModals.handle_event("new_class", %{"name" => "greeter"}, base_socket())
+
+      assert socket.assigns.new_class_error =~ "PascalCase"
+      # The in-flight value is preserved so the re-rendered modal shows it.
+      assert socket.assigns.new_class_name == "greeter"
+    end
+
+    test "a duplicate class name is rejected" do
+      socket = base_socket(%{browser_classes: [%{"name" => "Greeter"}]})
+
+      {:noreply, socket} =
+        ClassModals.handle_event("new_class", %{"name" => "Greeter"}, socket)
+
+      assert socket.assigns.new_class_error == "A class named Greeter already exists."
+    end
+
+    test "an invalid superclass is rejected even when the class name is valid" do
+      {:noreply, socket} =
+        ClassModals.handle_event(
+          "new_class",
+          %{"name" => "Greeter", "superclass" => "not valid!"},
+          base_socket()
+        )
+
+      assert socket.assigns.new_class_error =~ "Superclass must be a class name"
+    end
+
+    test "a valid submission creates the class, opens its definition tab, and closes the modal" do
+      socket = base_socket(%{new_class_open: true})
+
+      {:noreply, socket} =
+        ClassModals.handle_event("new_class", %{"name" => "Greeter"}, socket)
+
+      assert socket.assigns.new_class_open == false
+      assert socket.assigns.new_class_error == nil
+      assert socket.assigns.active_tab == "def:Greeter"
+      assert socket.assigns.selected_class == "Greeter"
+      assert socket.assigns.save_result =~ "Created new class"
+    end
+
+    test "a blank superclass falls back to Object" do
+      socket = base_socket()
+
+      {:noreply, socket} =
+        ClassModals.handle_event(
+          "new_class",
+          %{"name" => "Greeter", "superclass" => "  "},
+          socket
+        )
+
+      assert socket.assigns.new_class_error == nil
+      assert socket.assigns.active_tab == "def:Greeter"
+    end
+
+    test "a malformed payload (missing name) surfaces a validation error rather than crashing" do
+      {:noreply, socket} = ClassModals.handle_event("new_class", %{}, base_socket())
+
+      assert socket.assigns.new_class_error == "Invalid new-class form payload."
+    end
+  end
+
+  describe "new_method (\"Add a method…\")" do
+    test "opens a blank method tab for the given class on the current browser side" do
+      socket = base_socket(%{browser_side: "instance"})
+
+      {:noreply, socket} =
+        ClassModals.handle_event("new_method", %{"class" => "Counter"}, socket)
+
+      assert [%{kind: :method, class: "Counter", side: "instance", new: true}] =
+               socket.assigns.tabs
+    end
+
+    test "a non-owner (Observer) click is a no-op" do
+      socket = base_socket(%{role: :observer})
+
+      assert {:noreply, ^socket} =
+               ClassModals.handle_event("new_method", %{"class" => "Counter"}, socket)
+    end
+
+    test "a malformed payload (empty class) is a no-op" do
+      socket = base_socket()
+
+      assert {:noreply, ^socket} =
+               ClassModals.handle_event("new_method", %{"class" => ""}, socket)
+    end
+  end
+
+  describe "Remove Method (ADR 0112 Phase 4, BT-3189)" do
+    test "removes the active method's selector and closes its tab" do
+      tabs = [method_tab("method:Counter:instance:increment", "Counter", "increment")]
+      socket = base_socket(%{tabs: tabs, active_tab: "method:Counter:instance:increment"})
+
+      {:noreply, socket} = ClassModals.handle_event("remove_method", %{}, socket)
+
+      assert socket.assigns.tabs == []
+      assert socket.assigns.save_result =~ "Removed increment from Counter"
+    end
+
+    test "a brand-new (unsaved) method tab has nothing to remove" do
+      tabs = [method_tab("method:new:1", "Counter", nil, new: true)]
+      socket = base_socket(%{tabs: tabs, active_tab: "method:new:1"})
+
+      {:noreply, socket} = ClassModals.handle_event("remove_method", %{}, socket)
+
+      assert socket.assigns.save_error =~ "hasn't been saved yet"
+    end
+
+    test "a crafted event against a non-method tab is a graceful no-op" do
+      tabs = [def_tab("def:Counter", "Counter")]
+      socket = base_socket(%{tabs: tabs, active_tab: "def:Counter"})
+
+      {:noreply, socket} = ClassModals.handle_event("remove_method", %{}, socket)
+
+      assert socket.assigns.save_error == "Open an existing method to remove it."
+    end
+
+    test "a non-owner (Observer) click is a no-op" do
+      socket = base_socket(%{role: :observer})
+
+      assert {:noreply, ^socket} = ClassModals.handle_event("remove_method", %{}, socket)
+    end
+  end
+
+  describe "Remove Class (ADR 0113 Phase 4, BT-3210)" do
+    test "removes the active class-definition tab's class and closes it" do
+      tabs = [def_tab("def:Counter", "Counter")]
+      socket = base_socket(%{tabs: tabs, active_tab: "def:Counter"})
+
+      {:noreply, socket} = ClassModals.handle_event("remove_class", %{}, socket)
+
+      assert socket.assigns.tabs == []
+      assert socket.assigns.save_result =~ "Removed Counter from memory"
+    end
+
+    test "a crafted event against a non-def tab is a graceful no-op" do
+      tabs = [method_tab("method:Counter:instance:increment", "Counter", "increment")]
+      socket = base_socket(%{tabs: tabs, active_tab: "method:Counter:instance:increment"})
+
+      {:noreply, socket} = ClassModals.handle_event("remove_class", %{}, socket)
+
+      assert socket.assigns.save_error == "Open a class definition to remove it."
+    end
+
+    test "a non-owner (Observer) click is a no-op" do
+      socket = base_socket(%{role: :observer})
+
+      assert {:noreply, ^socket} = ClassModals.handle_event("remove_class", %{}, socket)
+    end
+  end
+
+  describe "Rename modal open/close (ADR 0114 Phase 5, BT-3277)" do
+    test "opening against a :def tab targets a class rename, pre-filled with the current name" do
+      tabs = [def_tab("def:Counter", "Counter")]
+      socket = base_socket(%{tabs: tabs, active_tab: "def:Counter"})
+
+      {:noreply, socket} = ClassModals.handle_event("open_rename", %{}, socket)
+
+      assert socket.assigns.rename_open == true
+      assert socket.assigns.rename_kind == :class
+      assert socket.assigns.rename_class == "Counter"
+      assert socket.assigns.rename_new_name == "Counter"
+    end
+
+    test "opening against an existing :method tab targets a selector rename" do
+      tabs = [method_tab("method:Counter:instance:increment", "Counter", "increment")]
+      socket = base_socket(%{tabs: tabs, active_tab: "method:Counter:instance:increment"})
+
+      {:noreply, socket} = ClassModals.handle_event("open_rename", %{}, socket)
+
+      assert socket.assigns.rename_kind == :method
+      assert socket.assigns.rename_class == "Counter"
+      assert socket.assigns.rename_old_selector == "increment"
+      assert socket.assigns.rename_new_name == "increment"
+    end
+
+    test "opening against a brand-new (unsaved) method tab reports nothing to rename" do
+      tabs = [method_tab("method:new:1", "Counter", nil, new: true)]
+      socket = base_socket(%{tabs: tabs, active_tab: "method:new:1"})
+
+      {:noreply, socket} = ClassModals.handle_event("open_rename", %{}, socket)
+
+      assert socket.assigns.rename_open == false
+      assert socket.assigns.save_error =~ "hasn't been saved yet"
+    end
+
+    test "opening with an empty tab strip reports nothing to rename" do
+      {:noreply, socket} = ClassModals.handle_event("open_rename", %{}, base_socket())
+
+      assert socket.assigns.save_error =~ "Open a class definition or an existing method"
+    end
+
+    test "a non-owner (Observer) open is a no-op" do
+      socket = base_socket(%{role: :observer})
+
+      assert {:noreply, ^socket} = ClassModals.handle_event("open_rename", %{}, socket)
+    end
+
+    test "close_rename dismisses without renaming anything" do
+      socket = base_socket(%{rename_open: true, rename_error: "stale"})
+
+      {:noreply, socket} = ClassModals.handle_event("close_rename", %{}, socket)
+
+      assert socket.assigns.rename_open == false
+      assert socket.assigns.rename_error == nil
+    end
+  end
+
+  describe "rename_submit validation (ADR 0114 Phase 5, BT-3277)" do
+    test "an empty new class name is rejected, keeping the modal open" do
+      socket =
+        base_socket(%{rename_open: true, rename_kind: :class, rename_class: "Counter"})
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => ""}, socket)
+
+      assert socket.assigns.rename_open == true
+      assert socket.assigns.rename_error == "Enter a new class name."
+    end
+
+    test "a non-PascalCase new class name is rejected" do
+      socket =
+        base_socket(%{rename_open: true, rename_kind: :class, rename_class: "Counter"})
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => "accumulator"}, socket)
+
+      assert socket.assigns.rename_error =~ "PascalCase"
+    end
+
+    test "a duplicate new class name is rejected" do
+      socket =
+        base_socket(%{
+          rename_open: true,
+          rename_kind: :class,
+          rename_class: "Counter",
+          browser_classes: [%{"name" => "Accumulator"}]
+        })
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => "Accumulator"}, socket)
+
+      assert socket.assigns.rename_error == "A class named Accumulator already exists."
+    end
+
+    test "a valid class rename closes the modal and reports success" do
+      tabs = [def_tab("def:Counter", "Counter")]
+
+      socket =
+        base_socket(%{
+          tabs: tabs,
+          active_tab: "def:Counter",
+          rename_open: true,
+          rename_kind: :class,
+          rename_class: "Counter",
+          selected_class: "Counter"
+        })
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => "Accumulator"}, socket)
+
+      assert socket.assigns.rename_open == false
+      assert socket.assigns.rename_error == nil
+      assert socket.assigns.save_result =~ "Renamed Counter to Accumulator"
+      # The stale-named tab was closed and the renamed class's definition
+      # tab opened in its place.
+      assert socket.assigns.active_tab == "def:Accumulator"
+      assert socket.assigns.selected_class == "Accumulator"
+    end
+
+    test "an empty new selector is rejected for a method rename" do
+      socket =
+        base_socket(%{
+          rename_open: true,
+          rename_kind: :method,
+          rename_class: "Counter",
+          rename_side: "instance",
+          rename_old_selector: "increment"
+        })
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => ""}, socket)
+
+      assert socket.assigns.rename_error == "Enter a new selector."
+    end
+
+    test "a new selector containing an injection-shaped character is rejected" do
+      socket =
+        base_socket(%{
+          rename_open: true,
+          rename_kind: :method,
+          rename_class: "Counter",
+          rename_side: "instance",
+          rename_old_selector: "increment"
+        })
+
+      {:noreply, socket} =
+        ClassModals.handle_event(
+          "rename_submit",
+          %{"new_name" => "increment to: #evil"},
+          socket
+        )
+
+      assert socket.assigns.rename_error =~ "cannot contain spaces"
+    end
+
+    test "a valid method rename closes the modal, closes the stale tab, and reports success" do
+      tabs = [method_tab("method:Counter:instance:increment", "Counter", "increment")]
+
+      socket =
+        base_socket(%{
+          tabs: tabs,
+          active_tab: "method:Counter:instance:increment",
+          rename_open: true,
+          rename_kind: :method,
+          rename_class: "Counter",
+          rename_side: "instance",
+          rename_old_selector: "increment"
+        })
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => "incrementBy"}, socket)
+
+      assert socket.assigns.rename_open == false
+      assert socket.assigns.save_result =~ "Renamed Counter increment to incrementBy"
+      assert socket.assigns.tabs == []
+    end
+
+    test "no session (attach failed) reports 'not attached' rather than crashing" do
+      socket =
+        base_socket(%{
+          session_pid: nil,
+          rename_open: true,
+          rename_kind: :class,
+          rename_class: "Counter"
+        })
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => "Accumulator"}, socket)
+
+      assert socket.assigns.rename_error == "not attached to workspace"
+    end
+
+    test "a non-owner (Observer) submit is a no-op" do
+      socket = base_socket(%{role: :observer, rename_open: true})
+
+      assert {:noreply, ^socket} =
+               ClassModals.handle_event("rename_submit", %{"new_name" => "X"}, socket)
+    end
+
+    test "a malformed payload (missing new_name) is a no-op" do
+      socket = base_socket(%{rename_open: true})
+
+      assert {:noreply, ^socket} = ClassModals.handle_event("rename_submit", %{}, socket)
+    end
+  end
+
+  describe "valid_class_name?/1 (shared with BtAttachWeb.Live.Dock's flush_destructive/3)" do
+    test "accepts a bare PascalCase identifier" do
+      assert ClassModals.valid_class_name?("Greeter")
+      assert ClassModals.valid_class_name?("HTTPServer")
+    end
+
+    test "rejects lowercase, empty, and injection-shaped input" do
+      refute ClassModals.valid_class_name?("greeter")
+      refute ClassModals.valid_class_name?("")
+      refute ClassModals.valid_class_name?("Foo. Session current clear")
+    end
+  end
+end

--- a/editors/liveview/test/bt_attach_web/test_runner_test.exs
+++ b/editors/liveview/test/bt_attach_web/test_runner_test.exs
@@ -1,0 +1,406 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.Live.TestRunnerTest do
+  @moduledoc """
+  Direct unit tests for `BtAttachWeb.Live.TestRunner` (BT-3298), driving its
+  `handle_event/3` / `handle_async/3` clauses and pure helpers against a
+  hand-built `%Phoenix.LiveView.Socket{}` and the fully-stubbed workspace
+  client (`BtAttachWeb.StubWorkspaceClient`, BT-2554) — no full LiveView
+  mount, no real workspace node. Mirrors `BtAttachWeb.Live.DockTest`
+  (BT-3295) and `BtAttachWeb.Live.SystemBrowserTest` (BT-3297), the
+  precedent this extraction follows.
+
+  Covers the branches BT-3298's acceptance criteria calls out specifically:
+  test discovery failure handling — including the simulated-crash path via
+  `StubWorkspaceClient.set_list_tests_raise/1` — and class-scoped vs full
+  test runs. The full off-socket `start_async`/`handle_async` round trip
+  (discovering/running through a real LiveView process) is already covered
+  end-to-end by `BtAttachWeb.WorkspaceTestsPaneTest`; these tests instead
+  drive `handle_async/3` directly (a disconnected socket's `start_async` is
+  a no-op per `Phoenix.LiveView.Async`, so the dispatch outcome is asserted
+  by calling the async callback with the outcome directly, exactly as
+  `BtAttachWeb.Live.DockTest` does for `:git_load`) so the fold logic is
+  unit-testable without a live process.
+  """
+  use ExUnit.Case, async: false
+
+  alias BtAttach.Facade
+  alias BtAttachWeb.Live.RequestContext
+  alias BtAttachWeb.Live.TestRunner
+  alias BtAttachWeb.StubWorkspaceClient
+  alias BtAttachWeb.WorkspaceLive
+
+  setup do
+    Application.put_env(:bt_attach, :workspace_client, StubWorkspaceClient)
+    {:ok, _} = StubWorkspaceClient.start_state()
+
+    on_exit(fn ->
+      Application.delete_env(:bt_attach, :workspace_client)
+      StubWorkspaceClient.stop_state(2_000)
+    end)
+
+    :ok
+  end
+
+  # A bare, disconnected socket carrying exactly the assigns TestRunner's
+  # functions read — the subset of `WorkspaceLive.bind_session/3`'s init
+  # relevant to the Test Runner pane. `role: :owner` by default (most tests
+  # aren't about RBAC); override per test. Disconnected
+  # (`Phoenix.LiveView.connected?/1` is false), so `start_async`/
+  # `cancel_async` are no-ops rather than spawning a linked Task — exactly
+  # the behaviour `Phoenix.LiveView.Async` documents for a disconnected
+  # socket. `handle_async/3` is exercised directly instead (see the
+  # `handle_async/3` describe block below).
+  defp base_socket(overrides \\ %{}) do
+    assigns =
+      %{
+        __changed__: %{},
+        current_user: nil,
+        role: :owner,
+        session_id: "sess-1",
+        session_pid: self(),
+        test_classes: nil,
+        test_results: nil,
+        tests_error: nil,
+        tests_running: false,
+        tests_discover_keep_error: false,
+        tabs: [],
+        active_tab: nil,
+        browser_error: nil,
+        output: nil,
+        changes_error: nil,
+        git_error: nil,
+        save_result: nil,
+        save_error: nil,
+        flush_result: nil,
+        flush_error: nil,
+        bindings_error: nil,
+        inspect_error: nil
+      }
+      |> Map.merge(overrides)
+
+    %Phoenix.LiveView.Socket{
+      assigns: assigns,
+      private: %{live_temp: %{}, lifecycle: %Phoenix.LiveView.Lifecycle{}}
+    }
+  end
+
+  defp method_tab(id, class, selector, opts \\ []) do
+    %{
+      id: id,
+      kind: :method,
+      class: class,
+      side: Keyword.get(opts, :side, "instance"),
+      selector: selector,
+      source: "#{selector} => self",
+      base: "#{selector} => self",
+      dirty: false,
+      disk_differs: false,
+      runtime_only: false,
+      synthetic: false,
+      disk_source: nil,
+      doc: nil,
+      signature: nil,
+      native_module: nil,
+      native_delegate: false,
+      class_modifiers: nil,
+      class_native: false,
+      source_origin: nil,
+      package: nil,
+      new: false
+    }
+  end
+
+  describe "@test_runner_events coverage (BT-3301 pattern)" do
+    test "WorkspaceLive's @test_runner_events IS TestRunner's canonical list, not a copy" do
+      assert WorkspaceLive.test_runner_events() == TestRunner.__test_runner_events__()
+    end
+
+    test "every event WorkspaceLive delegates to TestRunner resolves to an implemented clause" do
+      tabs = [method_tab("method:Counter:instance:increment", "Counter", "increment")]
+      socket = base_socket(%{tabs: tabs, active_tab: "method:Counter:instance:increment"})
+
+      params_by_event = %{
+        "tests_refresh" => %{},
+        "run_tests" => %{},
+        "load_tests" => %{},
+        "run_test_class" => %{"class" => "Counter"},
+        "open_test_method" => %{"class" => "Counter", "selector" => "increment"},
+        "dismiss_notice" => %{"key" => "tests_error"}
+      }
+
+      for event <- TestRunner.__test_runner_events__() do
+        params = Map.fetch!(params_by_event, event)
+        result = TestRunner.handle_event(event, params, socket)
+
+        assert match?({:noreply, %Phoenix.LiveView.Socket{}}, result),
+               "TestRunner.handle_event/3 has no clause for #{inspect(event)} (or it crashed)"
+      end
+    end
+
+    test "no handle_event/3 clause head names an event missing from the canonical list" do
+      source =
+        Path.expand("../../lib/bt_attach_web/live/test_runner.ex", __DIR__) |> File.read!()
+
+      clause_names =
+        ~r/def handle_event\("([a-z0-9_]+)"/
+        |> Regex.scan(source)
+        |> Enum.map(fn [_, name] -> name end)
+        |> MapSet.new()
+
+      assert clause_names == MapSet.new(TestRunner.__test_runner_events__())
+    end
+  end
+
+  describe "run_test_class / open_test_method malformed-payload fallbacks" do
+    test "run_test_class with a missing class is a no-op" do
+      socket = base_socket()
+      assert {:noreply, ^socket} = TestRunner.handle_event("run_test_class", %{}, socket)
+    end
+
+    test "open_test_method with a non-binary selector is a no-op" do
+      socket = base_socket()
+
+      assert {:noreply, ^socket} =
+               TestRunner.handle_event(
+                 "open_test_method",
+                 %{"class" => "Counter", "selector" => nil},
+                 socket
+               )
+    end
+  end
+
+  describe "dismiss_notice (BT-2612)" do
+    test "dismisses a known key by clearing its assign" do
+      socket = base_socket(%{tests_error: "boom"})
+
+      {:noreply, socket} =
+        TestRunner.handle_event("dismiss_notice", %{"key" => "tests_error"}, socket)
+
+      assert socket.assigns.tests_error == nil
+    end
+
+    test "an unknown key is a no-op, never String.to_atom/1 on client input" do
+      socket = base_socket(%{tests_error: "boom"})
+
+      assert {:noreply, ^socket} =
+               TestRunner.handle_event(
+                 "dismiss_notice",
+                 %{"key" => "not_a_real_assign_key"},
+                 socket
+               )
+    end
+
+    test "a crafted event with no key is a no-op" do
+      socket = base_socket()
+      assert {:noreply, ^socket} = TestRunner.handle_event("dismiss_notice", %{}, socket)
+    end
+  end
+
+  describe "handle_async(:test_discover, …) — test discovery failure handling (BT-2599)" do
+    test "a successful discovery clears any stale error and stores the catalogue" do
+      classes = [%{"class" => "FooTest", "selectors" => ["testOne"]}]
+      socket = base_socket(%{tests_error: "stale error"})
+
+      {:noreply, socket} = TestRunner.handle_async(:test_discover, {:ok, {:ok, classes}}, socket)
+
+      assert socket.assigns.test_classes == classes
+      assert socket.assigns.tests_error == nil
+    end
+
+    test "a dispatch error degrades to tests_error and keeps the nil sentinel (not [])" do
+      socket = base_socket(%{test_classes: [%{"class" => "Stale"}]})
+
+      {:noreply, socket} =
+        TestRunner.handle_async(:test_discover, {:ok, {:error, :workspace_unreachable}}, socket)
+
+      assert socket.assigns.test_classes == nil
+      assert socket.assigns.tests_error != nil
+    end
+
+    test "an unexpected reply shape degrades rather than crashing" do
+      socket = base_socket()
+
+      {:noreply, socket} = TestRunner.handle_async(:test_discover, {:ok, :bogus}, socket)
+
+      assert socket.assigns.test_classes == nil
+      assert socket.assigns.tests_error =~ "unexpected_test_result"
+    end
+
+    test "a successful re-discovery honours keep_error?: true (partial-load banner survives)" do
+      socket =
+        base_socket(%{
+          tests_error: "2 test file(s) failed to load: boom",
+          tests_discover_keep_error: true
+        })
+
+      {:noreply, socket} =
+        TestRunner.handle_async(:test_discover, {:ok, {:ok, []}}, socket)
+
+      assert socket.assigns.tests_error == "2 test file(s) failed to load: boom"
+      # The transient flag is always cleared after the fold, win or lose.
+      assert socket.assigns.tests_discover_keep_error == false
+    end
+
+    test "a cancelled discovery (rapid double-refresh) is a no-op" do
+      socket = base_socket(%{test_classes: nil})
+
+      assert {:noreply, ^socket} =
+               TestRunner.handle_async(:test_discover, {:exit, :cancelled}, socket)
+    end
+
+    test "the simulated list_tests crash actually raises through the same dispatch discover_test_classes/1 makes, and the resulting {:exit, …} degrades gracefully" do
+      # `StubWorkspaceClient.set_list_tests_raise/1` is the crash path
+      # `discover_test_classes/1`'s off-socket `fn -> Facade.dispatch(:list_tests,
+      # …) end` would hit inside its `:test_discover` `start_async` task. A
+      # disconnected socket's `start_async` never actually invokes that
+      # function (`Phoenix.LiveView.Async.run_async_task/5` no-ops when
+      # `connected?/1` is false), so exercising the raise itself — rather
+      # than only asserting the downstream `{:exit, …}` fold on a
+      # hand-constructed reason — means calling the SAME dispatch
+      # `discover_test_classes/1` builds directly. This is the direct-unit-test
+      # half of the coverage; `BtAttachWeb.WorkspaceTestsPaneTest`'s
+      # full-LiveView "a discovery crash degrades to tests_error" test
+      # exercises the real off-socket Task/handle_async round trip end-to-end.
+      StubWorkspaceClient.set_list_tests_raise(true)
+      socket = base_socket()
+      ctx = RequestContext.build(socket)
+
+      assert_raise RuntimeError, "simulated list_tests crash", fn ->
+        Facade.dispatch(:list_tests, %{}, ctx)
+      end
+
+      # The crash caught by `Phoenix.LiveView.Async`'s task wrapper reaches
+      # `handle_async(:test_discover, {:exit, reason}, socket)` as some
+      # `reason` term (the exact shape isn't this module's concern — see
+      # `Phoenix.LiveView.Async.to_exit/3` — only that ANY reason degrades
+      # to a `tests_error` rather than propagating).
+      {:noreply, socket} =
+        TestRunner.handle_async(:test_discover, {:exit, %RuntimeError{message: "boom"}}, socket)
+
+      assert socket.assigns.test_classes == nil
+      assert socket.assigns.tests_error =~ "discovery failed unexpectedly"
+      assert socket.assigns.tests_discover_keep_error == false
+    end
+  end
+
+  describe "handle_async(:test_op, …) — class-scoped vs full test runs (BT-2597)" do
+    test "a successful full run (class: nil) stores the results and clears tests_running" do
+      socket = base_socket(%{tests_running: true})
+      result = %{"passed" => 2, "failed" => 0, "total" => 2, "tests" => []}
+
+      {:noreply, socket} =
+        TestRunner.handle_async(:test_op, {:ok, {:run, {:ok, result}}}, socket)
+
+      assert socket.assigns.test_results == result
+      assert socket.assigns.tests_running == false
+      assert socket.assigns.tests_error == nil
+    end
+
+    test "a successful class-scoped run stores the results the same way as a full run" do
+      socket = base_socket(%{tests_running: true})
+      result = %{"passed" => 1, "failed" => 0, "total" => 1, "tests" => []}
+
+      {:noreply, socket} =
+        TestRunner.handle_async(:test_op, {:ok, {:run, {:ok, result}}}, socket)
+
+      assert socket.assigns.test_results == result
+      assert socket.assigns.tests_running == false
+    end
+
+    test "a run dispatch error surfaces as tests_error and clears stale results" do
+      socket = base_socket(%{tests_running: true, test_results: %{"passed" => 9}})
+
+      {:noreply, socket} =
+        TestRunner.handle_async(:test_op, {:ok, {:run, {:error, :unauthorized}}}, socket)
+
+      assert socket.assigns.test_results == nil
+      assert socket.assigns.tests_running == false
+      assert socket.assigns.tests_error != nil
+    end
+
+    test "a clean load re-discovers off-socket (a no-op start_async here) and clears tests_running" do
+      socket = base_socket(%{tests_running: true})
+
+      {:noreply, socket} =
+        TestRunner.handle_async(:test_op, {:ok, {:load, {:ok, %{}}}}, socket)
+
+      assert socket.assigns.tests_running == false
+      # `discover_test_classes/1` reset the catalogue to the loading sentinel;
+      # the disconnected socket's `start_async` never resolves it further here.
+      assert socket.assigns.test_classes == nil
+    end
+
+    test "a partial load surfaces the compile-error summary and keeps it across re-discovery" do
+      socket = base_socket(%{tests_running: true})
+
+      errors = [%{"path" => "test/foo.bt", "message" => "boom"}]
+
+      {:noreply, socket} =
+        TestRunner.handle_async(:test_op, {:ok, {:load, {:ok, %{"errors" => errors}}}}, socket)
+
+      assert socket.assigns.tests_error == "1 test file(s) failed to load: boom"
+      assert socket.assigns.tests_running == false
+      # The partial-load re-discovery passed keep_error?: true.
+      assert socket.assigns.tests_discover_keep_error == true
+    end
+
+    test "a cancelled run/load (rapid double-action) is a no-op" do
+      socket = base_socket(%{tests_running: true})
+
+      assert {:noreply, ^socket} = TestRunner.handle_async(:test_op, {:exit, :cancelled}, socket)
+    end
+
+    test "a crashed run/load degrades to tests_error and clears stale results" do
+      socket = base_socket(%{tests_running: true, test_results: %{"passed" => 1}})
+
+      {:noreply, socket} = TestRunner.handle_async(:test_op, {:exit, :boom}, socket)
+
+      assert socket.assigns.tests_running == false
+      assert socket.assigns.test_results == nil
+      assert socket.assigns.tests_error == "The test run failed unexpectedly."
+    end
+  end
+
+  describe "render-template helpers" do
+    test "format_test_duration/1 renders sub-second runs in ms" do
+      assert TestRunner.format_test_duration(0.123) == "123 ms"
+    end
+
+    test "format_test_duration/1 renders longer runs in seconds" do
+      assert TestRunner.format_test_duration(2.5) == "2.50 s"
+    end
+
+    test "format_test_duration/1 renders nothing for a non-number" do
+      assert TestRunner.format_test_duration(nil) == ""
+    end
+
+    test "test_class_tally/2 tallies pass/fail/skip for one class" do
+      results = %{
+        "tests" => [
+          %{"class" => "Counter", "status" => "pass"},
+          %{"class" => "Counter", "status" => "fail"},
+          %{"class" => "Other", "status" => "pass"}
+        ]
+      }
+
+      assert TestRunner.test_class_tally(results, "Counter") == %{
+               passed: 1,
+               failed: 1,
+               skipped: 0
+             }
+    end
+
+    test "test_class_tally/2 returns nil when there are no results yet" do
+      assert TestRunner.test_class_tally(nil, "Counter") == nil
+    end
+
+    test "test_status_label/1 and test_status_class/1 cover pass/fail/skip and an unknown status" do
+      assert TestRunner.test_status_label("pass") == "✓ pass"
+      assert TestRunner.test_status_class("pass") == "st-pass"
+      assert TestRunner.test_status_label("weird") == "? weird"
+      assert TestRunner.test_status_class("weird") == "st-skip"
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://linear.app/beamtalk/issue/BT-3298/extract-test-runner-pane-new-classrename-modals-out-of-workspacelive

Part of epic BT-3290. Fifth and **final** sequential extraction from `workspace_live.ex` (following Inspector BT-3291, Dock BT-3295, Method Editor BT-3296, System Browser BT-3297).

## What moved

**`BtAttachWeb.Live.TestRunner`** (`lib/bt_attach_web/live/test_runner.ex`):
- Test catalogue discovery (`tests_refresh`, off-socket `:test_discover` `start_async`)
- Running all/one `TestCase` subclass (`run_tests` / `run_test_class`, off-socket `:test_op`)
- Loading the project's `test/` files (`load_tests`)
- Opening a failing test method in the method editor (`open_test_method`)
- The generic cross-pane `dismiss_notice` status-banner dismiss utility (BT-2612) — has no single natural pane owner among the five extractions, so it lands here as the final one, per the moduledoc.

**`BtAttachWeb.Live.ClassModals`** (`lib/bt_attach_web/live/class_modals.ex`):
- New Class modal (`new_class` / `toggle_new_class` / `close_new_class`)
- "Add a method…" (`new_method`)
- Remove Method / Remove Class (ADR 0112 Phase 4, ADR 0113 Phase 4)
- Rename modal (`open_rename` / `close_rename` / `rename_submit`, ADR 0114 Phase 5)

Both modules delegate every write to `BtAttach.Workspace`'s existing test-discovery/run ops and class/method mutation ops via `BtAttach.Facade.dispatch/3` — no reimplementation. Event-name lists follow the BT-3301/BT-3297 canonical-list pattern: `WorkspaceLive`'s `@test_runner_events`/`@class_modals_events` guard-clause attributes read directly from each module's `__*_events__/0`, so there is no second hand-maintained copy of the event names.

Two small cross-module reference updates: `BtAttachWeb.Live.Dock`'s `dock_tab`/`:test` lazy-load now calls `TestRunner.discover_test_classes/1` (was `WorkspaceLive.discover_test_classes/1`), and `flush_destructive/3`'s class-name injection guard now calls `ClassModals.valid_class_name?/1` (was `WorkspaceLive.valid_class_name?/1`).

## Line-count / handle_event-clause reduction (acceptance criterion)

| | Lines | `handle_event` clauses |
|---|---|---|
| Original (pre-extraction) | 12,318 | 171 |
| Post-BT-3297 (main, before this PR) | 6,394 | 38 |
| **Post-BT-3298 (this PR)** | **5,368** | **16** |

After this lands, `workspace_live.ex` holds only mount/socket wiring, the top-level `render/1` shell, and the handful of small panel-visibility/omni-search/status-formatting bits that don't split cleanly along any single pane's boundary (documented case-by-case, matching the same call the four prior extractions made).

## Tests

- `test/bt_attach_web/test_runner_test.exs` — 27 direct unit tests (86.84% module coverage): `handle_event`/`handle_async` delegation coverage, `dismiss_notice`, and test-discovery failure handling — including a test that drives `Facade.dispatch(:list_tests, …)` through `StubWorkspaceClient.set_list_tests_raise(true)` directly (not just relying on the pre-existing full-LiveView crash test) before asserting the `handle_async(:test_discover, {:exit, …})` degrade.
- `test/bt_attach_web/class_modals_test.exs` — 41 direct unit tests (88.36% module coverage): new-class/new-method validation errors, rename-submit validation (both class- and method-rename paths), and Remove Method/Remove Class guards.
- `mix test`: 935 passed, 133 excluded (pre-existing `:workspace`/`:playwright`-tagged suites, unaffected — `workspace_live_test.exs`'s full-stack class-scoped-run test continues to exercise the same events, now delegated).
- `mix format --check-formatted` and `mix compile --warnings-as-errors`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4sgH136eGzDughfRsVbAG)_