### PR TITLE
fix: avoid filename:join drive-letter lowercasing in class-rename flush

### DIFF
--- a/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
+++ b/runtime/apps/beamtalk_workspace/src/beamtalk_workspace_flush.erl
@@ -1522,7 +1522,18 @@ derive_new_path(OldPath, OldClassBin, NewClassBin) ->
             true -> binary_to_list(NewClassBin);
             false -> beamtalk_repl_loader:to_snake_case(binary_to_list(NewClassBin))
         end,
-    list_to_binary(filename:join(Dir, NewStem ++ ".bt")).
+    % NOTE: deliberately not filename:join/2 — on win32 it lower-cases a
+    % leading drive letter (e.g. "C:" -> "c:") while filename:dirname/1
+    % above does not, so the two would disagree on the drive-letter case
+    % and desync from the un-normalized paths used elsewhere (the original
+    % `beamtalk_source` attribute, and ChangeLog `old_path`/`new_path`
+    % strings), breaking `sourceFile` equality checks on Windows.
+    NewPath =
+        case Dir of
+            "." -> NewStem ++ ".bt";
+            _ -> Dir ++ "/" ++ NewStem ++ ".bt"
+        end,
+    list_to_binary(NewPath).
 
 -doc """
 Per-entry expected file set: every file that must appear in a Phase B


### PR DESCRIPTION
## Summary

Nightly Windows CI has failed on every run since 2026-08-27 in `rename_class_flush_sequential_rename.btscript:112`:

```
(Bt3526SeqRenameBar sourceFile) =:= _barPath
// => true
```

Reproduced consistently on `windows` in the `Test REPL protocol` job (runs `33098310240`, `33198699029`, `33252533123`), while `linux`/`macos`/`macos-x86_64` always pass.

**Root cause:** `derive_new_path/3` in `beamtalk_workspace_flush.erl` built the renamed class's new file path with `filename:join(Dir, NewStem ++ ".bt")`. On win32, OTP's `filename:join/2` lower-cases a leading drive letter (`"C:"` → `"c:"`), while the `filename:dirname/1` call just above it does not touch case. So the class's refreshed `sourceFile`/`beamtalk_source` attribute ended up with a different drive-letter case than the un-normalized path strings used elsewhere (the original attribute set at `Workspace load:`, and the test's own `_barPath`, built via plain string concatenation) — causing the `=:=` comparison to fail only on Windows, where drive letters exist.

## Changes

- `derive_new_path/3`: replaced `filename:join/2` with direct string concatenation (`Dir ++ "/" ++ NewStem ++ ".bt"`, with a `"."` guard for the same-directory case), matching how paths are handled everywhere else in this flow.

## Test plan

- [x] `rebar3 compile` — clean
- [x] `just fmt-check` / erlfmt — passes
- [x] `beamtalk_workspace_flush_tests` — 402 tests, 0 failures
- [x] `just test-repl-protocol` — all 2483 e2e tests pass locally (macOS), including the previously-failing case
- [x] `just test` (full suite) — 0 failures
- [x] Pre-push hook (full local CI) — passed
- [ ] Confirm next Windows nightly run goes green (can't run Windows CI locally)