### PR TITLE
fix: disable active-line highlight in read-only CodeMirror panes

### DIFF
--- a/editors/liveview/assets/js/hooks/cm_editor.js
+++ b/editors/liveview/assets/js/hooks/cm_editor.js
@@ -96,7 +96,6 @@ export const CmEditor = {
     const extensions = [
       history(),
       drawSelection(),
-      highlightActiveLine(),
       indentUnit.of("  "),
       EditorState.tabSize.of(2),
       // ⌘D/⌘P/⌘I are NOT bound here: they're the Workspace's Do-it/Print-it/
@@ -110,6 +109,11 @@ export const CmEditor = {
       EditorState.readOnly.of(readOnly),
       EditorView.updateListener.of((u) => this.onUpdate(u)),
     ]
+    // Active-line highlighting tracks the editing cursor, so it only makes sense
+    // where there is one. A read-only pane (docs viewer, native viewer,
+    // class-definition source) mounts with its cursor defaulted to line 1, which
+    // would otherwise paint that line with a permanent, meaningless highlight.
+    if (!readOnly) extensions.push(highlightActiveLine())
     if (placeholderText) extensions.push(placeholderExt(placeholderText))
     if (this.inlineResults) extensions.push(inlineResultsField)
     // Backend-driven autocomplete (BT-2544): candidates come from the live image


### PR DESCRIPTION
## Summary
- Read-only CodeMirror panes (class-definition source, native `.erl` viewer) mount with the cursor defaulted to line 1, so `highlightActiveLine()` permanently tinted that line's background — visible as a stray two-tone "boxed" first line in the System Browser's class comment/source view.
- Gate `highlightActiveLine()` behind `!readOnly`: it only makes sense where there's a real editing cursor.

## Test plan
- [x] `just build && just clippy && just fmt-check`
- [x] `just test`
- [ ] Manual visual check of the class-comment/source pane in the LiveView IDE