### PR TITLE
Cover BtAttachWeb.WorkspaceLive session lifecycle branches (80% → 97.43%) (BT-3306)

### DIFF
--- a/editors/liveview/test/bt_attach_web/workspace_live_lifecycle_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_lifecycle_test.exs
@@ -1,0 +1,314 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.WorkspaceLiveLifecycleTest do
+  @moduledoc """
+  The cockpit's session attach/resume lifecycle (BT-3306), driven through the
+  full LiveView stack against the stubbed workspace client — no `:workspace`
+  tag, so this runs in the bare `mix test` lane.
+
+  `BtAttachWeb.WorkspaceLive.mount/3`'s connected path is a small state machine
+  with several failure exits that nothing else in the suite reaches:
+
+    * the per-tab `workspace_token` connect param (minted in
+      `assets/js/app.js`) is read off `get_connect_params/1` and drives resume;
+    * a registry hit is only *trusted* when the remote session pid is still
+      alive (`Workspace.session_alive?/1`) — a stale entry left by a restarted
+      workspace is discarded and a fresh session started instead;
+    * `connect/0` failing, `start_session/2` failing, and either subscribe
+      failing each leave the socket `connected: false` with its own error
+      (and, for the subscribe case, must not leak the half-started session);
+    * the session metadata a fresh session carries picks the authenticated
+      user out of three claim shapes (a bare binary, `%{username:}`, `%{id:}`).
+
+  `Workspace.session_alive?/1` runs `is_process_alive/1` **on the workspace
+  node** (`:rpc.call(node_name(), …)`), so the alive/dead axis is driven by
+  pointing `BT_WORKSPACE_NODE` at either this node (the call runs locally and
+  answers truthfully) or an unreachable node (`{:badrpc, :nodedown}` → false,
+  exactly the restarted-workspace case) — no live workspace required either
+  way.
+  """
+  # Mutates global app env / env vars and the (global) session registry.
+  use BtAttachWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias BtAttach.SessionRegistry
+  alias BtAttachWeb.SessionProbe
+  alias BtAttachWeb.StubWorkspaceClient
+
+  # ── test workspace clients ──────────────────────────────────────────────────
+  #
+  # Each overrides exactly the callback whose failure it drives; everything else
+  # delegates to the shared `StubWorkspaceClient` (see
+  # `BtAttachWeb.StubClientOverrides`).
+
+  defmodule UnreachableClient do
+    @moduledoc false
+    use BtAttachWeb.StubClientOverrides
+
+    def connect, do: {:error, {:connect_failed, :beamtalk_workspace_gone@localhost, false}}
+  end
+
+  defmodule NoSessionClient do
+    @moduledoc false
+    use BtAttachWeb.StubClientOverrides
+
+    def start_session(_session_id, _meta), do: {:error, {:unreachable, :nodedown}}
+  end
+
+  defmodule NoTranscriptClient do
+    @moduledoc false
+    use BtAttachWeb.StubClientOverrides
+
+    def start_session(session_id, meta), do: SessionProbe.record(session_id, meta)
+
+    def subscribe_transcript(_pid), do: {:badrpc, :nodedown}
+  end
+
+  defmodule NoBindingsStreamClient do
+    @moduledoc false
+    use BtAttachWeb.StubClientOverrides
+
+    def start_session(session_id, meta), do: SessionProbe.record(session_id, meta)
+
+    def subscribe_bindings(_pid), do: {:badrpc, :nodedown}
+  end
+
+  defmodule DegradedPushClient do
+    @moduledoc false
+    use BtAttachWeb.StubClientOverrides
+
+    def start_session(session_id, meta), do: SessionProbe.record(session_id, meta)
+
+    # Both best-effort push streams and the initial reload-findings snapshot are
+    # unavailable (an older workspace, or a transient dist hiccup).
+    def subscribe_classes(_pid), do: {:badrpc, :nodedown}
+    def subscribe_reload_check(_pid), do: {:badrpc, :nodedown}
+    def reload_findings, do: {:error, :nodedown}
+  end
+
+  setup do
+    {:ok, _} = SessionProbe.start_link()
+    {:ok, _} = StubWorkspaceClient.start_state()
+    Application.put_env(:bt_attach, :workspace_client, SessionProbe.Client)
+
+    on_exit(fn ->
+      Application.delete_env(:bt_attach, :workspace_client)
+      StubWorkspaceClient.stop_state(2_000)
+    end)
+
+    :ok
+  end
+
+  defp sessions, do: SessionProbe.sessions()
+
+  defp unique_token, do: "tok-#{System.unique_integer([:positive])}"
+
+  defp put_workspace_node(name) do
+    previous = System.get_env("BT_WORKSPACE_NODE")
+    System.put_env("BT_WORKSPACE_NODE", name)
+
+    on_exit(fn ->
+      if previous,
+        do: System.put_env("BT_WORKSPACE_NODE", previous),
+        else: System.delete_env("BT_WORKSPACE_NODE")
+    end)
+  end
+
+  defp connect_with(conn, token),
+    do: put_connect_params(conn, %{"workspace_token" => token})
+
+  # `bt_user` is assigned verbatim as `:current_user` when no auth gate is
+  # configured (`BtAttachWeb.Auth.on_mount/4`'s `not auth_required?()` arm), so
+  # a test can hand the LiveView any of the claim shapes `session_meta/1`
+  # pattern-matches on.
+  defp user_conn(conn, user) do
+    Plug.Test.init_test_session(conn, %{
+      "bt_user" => user,
+      "bt_logged_in_at" => System.system_time(:second)
+    })
+  end
+
+  # ── token extraction + resume ───────────────────────────────────────────────
+
+  describe "per-tab resume token" do
+    test "a `workspace_token` connect param registers a resumable session", %{conn: conn} do
+      token = unique_token()
+
+      {:ok, _view, html} = conn |> connect_with(token) |> live("/")
+
+      assert html =~ "Beamtalk Workspace"
+      assert [%{session_id: session_id, pid: pid}] = sessions()
+
+      # The token was read off the connect params (a nil token skips
+      # registration entirely), so the registry now owns this tab's session.
+      assert {:resumed, ^session_id, ^pid} = SessionRegistry.checkout(token)
+    end
+
+    test "a connect param that is not a `workspace_token` binary disables resume", %{conn: conn} do
+      params = %{"workspace_token" => 42}
+
+      {:ok, _first, _html} = conn |> put_connect_params(params) |> live("/")
+      {:ok, _second, _html} = build_conn() |> put_connect_params(params) |> live("/")
+
+      # A non-binary token collapses to nil rather than crashing the mount, and
+      # a nil token registers nothing — so each connect gets its own,
+      # non-resumable session.
+      assert [%{session_id: first}, %{session_id: second}] = sessions()
+      assert first != second
+    end
+
+    test "a reconnect resumes the live session instead of starting a second one", %{conn: conn} do
+      # `session_alive?/1` runs on the workspace node — point it at this node so
+      # the probe answers truthfully for the still-running fake session pid.
+      put_workspace_node(to_string(node()))
+      token = unique_token()
+
+      {:ok, _first, _html} = conn |> connect_with(token) |> live("/")
+      assert [%{session_id: session_id}] = sessions()
+
+      {:ok, _second, html} = build_conn() |> connect_with(token) |> live("/")
+
+      assert html =~ "Beamtalk Workspace"
+      # Resumed: the reconnect re-bound the SAME session rather than starting a
+      # fresh one, so `start_session/2` was never called a second time.
+      assert [%{session_id: ^session_id}] = sessions()
+    end
+
+    test "a stale token whose remote session is gone is discarded and restarted", %{conn: conn} do
+      # The workspace restarted between the disconnect and this reconnect: the
+      # registry entry survives (the local fake pid is alive) but the *remote*
+      # liveness probe cannot reach it, so resume must not claim success.
+      put_workspace_node("beamtalk_workspace_gone@localhost")
+      token = unique_token()
+
+      {:ok, _first, _html} = conn |> connect_with(token) |> live("/")
+      assert [%{session_id: first_id}] = sessions()
+
+      {:ok, _second, html} = build_conn() |> connect_with(token) |> live("/")
+
+      assert html =~ "Beamtalk Workspace"
+      assert [%{session_id: ^first_id}, %{session_id: second_id}] = sessions()
+      assert second_id != first_id
+      # The stale entry was discarded and replaced by the fresh session.
+      assert {:resumed, ^second_id, _pid} = SessionRegistry.checkout(token)
+    end
+
+    test "closing a tokened tab stashes its desk and defers teardown", %{conn: conn} do
+      token = unique_token()
+
+      {:ok, view, _html} = conn |> connect_with(token) |> live("/")
+      assert [%{session_id: session_id, pid: session_pid}] = sessions()
+
+      # A LiveView `terminate/2` fires on a real tab close AND a transient
+      # socket drop, so it must hand the session to the registry's grace
+      # window (stashing the desk) rather than closing it outright.
+      Process.flag(:trap_exit, true)
+      ref = Process.monitor(view.pid)
+      GenServer.stop(view.pid, :shutdown)
+      assert_receive {:DOWN, ^ref, :process, _pid, _reason}, 2_000
+
+      assert {:resumed, ^session_id, ^session_pid} = SessionRegistry.checkout(token)
+    end
+  end
+
+  # ── attach failures ─────────────────────────────────────────────────────────
+
+  describe "attach failures leave a diagnosable, disconnected socket" do
+    test "a workspace that will not accept a connection renders the attach error", %{conn: conn} do
+      Application.put_env(:bt_attach, :workspace_client, UnreachableClient)
+
+      {:ok, _view, html} = live(conn, "/")
+
+      assert html =~ "Not attached."
+      assert html =~ "attach failed:"
+      assert html =~ "connect_failed"
+      # No session was ever requested — the failure is upstream of session start.
+      assert sessions() == []
+    end
+
+    test "a workspace that cannot start a session renders the session-start error", %{conn: conn} do
+      Application.put_env(:bt_attach, :workspace_client, NoSessionClient)
+
+      {:ok, _view, html} = live(conn, "/")
+
+      assert html =~ "Not attached."
+      assert html =~ "session start failed:"
+      assert html =~ "unreachable"
+    end
+
+    test "a failed Transcript subscribe tears the session down (untokened tab)", %{conn: conn} do
+      Application.put_env(:bt_attach, :workspace_client, NoTranscriptClient)
+
+      {:ok, _view, html} = live(conn, "/")
+
+      assert html =~ "Not attached."
+      assert html =~ "subscribe failed:"
+      # A session WAS started before the subscribe failed, and an untokened one
+      # is not registry-owned — so the failure path closes it directly rather
+      # than leaving an orphan behind (the close itself is a workspace-side
+      # `stop_session` RPC, so only the started-then-abandoned session is
+      # observable from here).
+      assert [%{}] = sessions()
+    end
+
+    test "a failed bindings subscribe discards the tokened session", %{conn: conn} do
+      Application.put_env(:bt_attach, :workspace_client, NoBindingsStreamClient)
+      token = unique_token()
+
+      {:ok, _view, html} = conn |> connect_with(token) |> live("/")
+
+      assert html =~ "Not attached."
+      assert html =~ "subscribe failed:"
+      # A tokened session IS registry-owned, so the failure path discards the
+      # entry (which closes it) rather than leaving it to the grace timer.
+      assert :miss = SessionRegistry.checkout(token)
+    end
+
+    test "the best-effort push streams and the findings snapshot degrade, not fail", %{conn: conn} do
+      Application.put_env(:bt_attach, :workspace_client, DegradedPushClient)
+
+      {:ok, view, html} = live(conn, "/")
+
+      # Neither the class-lifecycle nor the reload-check subscribe is load
+      # bearing, and an unreadable findings snapshot degrades to an empty panel:
+      # the cockpit still mounts connected.
+      refute html =~ "Not attached."
+      assert html =~ ~s(id="system-browser")
+      assert render(view) =~ "No reload-induced findings."
+    end
+  end
+
+  # ── session metadata ────────────────────────────────────────────────────────
+
+  describe "session metadata carries the authenticated user" do
+    test "a bare binary claim is used verbatim", %{conn: conn} do
+      {:ok, _view, _html} = conn |> user_conn("alice") |> live("/")
+
+      assert [%{meta: meta}] = sessions()
+      assert meta.user == "alice"
+      assert meta.kind == "liveview"
+      assert meta.node == node()
+    end
+
+    test "a claims map with a username uses it", %{conn: conn} do
+      {:ok, _view, _html} = conn |> user_conn(%{username: "bob"}) |> live("/")
+
+      assert [%{meta: %{user: "bob"}}] = sessions()
+    end
+
+    test "a claims map with only an id stringifies it", %{conn: conn} do
+      {:ok, _view, _html} = conn |> user_conn(%{id: 42}) |> live("/")
+
+      assert [%{meta: %{user: "42"}}] = sessions()
+    end
+
+    test "an unauthenticated mount carries no user", %{conn: conn} do
+      {:ok, _view, _html} = live(conn, "/")
+
+      assert [%{meta: meta}] = sessions()
+      refute Map.has_key?(meta, :user)
+    end
+  end
+end

--- a/editors/liveview/test/bt_attach_web/workspace_live_panes_test.exs
+++ b/editors/liveview/test/bt_attach_web/workspace_live_panes_test.exs
@@ -1,0 +1,622 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.WorkspaceLivePanesTest do
+  @moduledoc """
+  The cockpit branches `BtAttachWeb.WorkspaceLive` still owns after the BT-3290
+  pane extraction (BT-3306), driven through the full LiveView stack against the
+  stubbed workspace client — no `:workspace` tag, so this runs in the bare
+  `mix test` lane.
+
+  What lives here (everything the extracted `Dock`/`Inspector`/`MethodEditor`/
+  `SystemBrowser`/`TestRunner` modules do NOT own):
+
+    * the omni-search palette — the symbol-index flattening, ranked filtering,
+      and the class / selector / unrecognised open paths;
+    * the panel-visibility toggles and the pass-through `handle_info`/
+      `handle_async` clauses (unknown message, per-session `BindingChanged`
+      filtering, the coalesced class-lifecycle refresh, a crashed mount load);
+    * the degraded read folds — an unreachable or nonsense `changes`/
+      `bindings`/`autoflush`/`browse_classes` reply must render an error pane,
+      never crash the socket;
+    * render-only helpers reached solely through the template: the git
+      porcelain state labels, the ChangeLog Kind/Side labels and their
+      destructive-tier confirm prompts, the structured unified-diff line
+      classes, and the reload-findings rows.
+  """
+  # Mutates global app env, so not async.
+  use BtAttachWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias BtAttachWeb.SessionProbe
+  alias BtAttachWeb.StubWorkspaceClient
+  alias BtAttachWeb.WorkspaceLive
+
+  # ── test workspace clients ──────────────────────────────────────────────────
+
+  defmodule SymbolClient do
+    @moduledoc false
+    use BtAttachWeb.StubClientOverrides
+
+    def start_session(session_id, meta), do: SessionProbe.record(session_id, meta)
+
+    # The `nav-symbols` outline: two classes with locally-defined selectors
+    # (instance- and class-side), plus a malformed row the flattener must drop
+    # rather than crash on.
+    def symbol_index(_scope) do
+      {:value,
+       %{
+         "classes" => [
+           %{
+             "name" => "Counter",
+             "methods" => [
+               %{"selector" => "increment"},
+               %{"selector" => "startingAt:", "class_side" => true},
+               # No selector: skipped by the comprehension's `is_binary` filter.
+               %{"class_side" => false}
+             ]
+           },
+           %{"name" => "CounterView", "methods" => []},
+           %{"no_name" => true}
+         ]
+       }}
+    end
+  end
+
+  defmodule DegradedReadsClient do
+    @moduledoc false
+    use BtAttachWeb.StubClientOverrides
+
+    def start_session(session_id, meta), do: SessionProbe.record(session_id, meta)
+
+    def browse_classes, do: {:error, :nodedown}
+    def change_history, do: {:error, :nodedown}
+  end
+
+  defmodule NonsenseReadsClient do
+    @moduledoc false
+    use BtAttachWeb.StubClientOverrides
+
+    def start_session(session_id, meta), do: SessionProbe.record(session_id, meta)
+
+    # Shapes no contract allows — an old workspace, a half-decoded reply. Each
+    # must degrade to an empty pane with an error, never crash the LiveView.
+    def change_history, do: :not_a_list
+    def list_bindings(_pid), do: :not_a_list
+    def autoflush, do: :not_a_boolean
+  end
+
+  defmodule ReplClient do
+    @moduledoc false
+    use BtAttachWeb.StubClientOverrides
+
+    def start_session(session_id, meta), do: SessionProbe.record(session_id, meta)
+
+    # One canned answer per REPL entry shape the scrollback renders.
+    def eval(_pid, code) do
+      if String.contains?(code, "boom"),
+        do: {:error, :not_understood, "", []},
+        else: {:ok, "stub-result", "", []}
+    end
+  end
+
+  defmodule CrashingMountClient do
+    @moduledoc false
+    use BtAttachWeb.StubClientOverrides
+
+    def start_session(session_id, meta), do: SessionProbe.record(session_id, meta)
+
+    def browse_classes, do: raise("simulated browse_classes crash")
+  end
+
+  setup do
+    {:ok, _} = SessionProbe.start_link()
+    {:ok, _} = StubWorkspaceClient.start_state()
+    Application.put_env(:bt_attach, :workspace_client, SessionProbe.Client)
+
+    on_exit(fn ->
+      Application.delete_env(:bt_attach, :workspace_client)
+      StubWorkspaceClient.stop_state(2_000)
+    end)
+
+    :ok
+  end
+
+  defp mount_cockpit(conn) do
+    {:ok, view, _html} = live(conn, "/")
+    # The mount-time reads run off-socket (BT-2591) — settle them so the panes
+    # hold real data before a test drives them.
+    render_async(view, 5_000)
+    view
+  end
+
+  # ── omni search (BT-2495) ───────────────────────────────────────────────────
+
+  describe "omni search" do
+    setup do
+      Application.put_env(:bt_attach, :workspace_client, SymbolClient)
+      :ok
+    end
+
+    test "a query ranks matching class and selector rows into the popover", %{conn: conn} do
+      view = mount_cockpit(conn)
+
+      html = render_hook(view, "omni_search", %{"value" => "counter"})
+
+      # Prefix matches rank ahead of substring matches, and a class-side
+      # selector row is tagged as such.
+      assert html =~ ~s(class="omni-results")
+      assert html =~ "Counter » increment"
+      assert html =~ "Counter » startingAt: (class)"
+      assert html =~ "CounterView"
+    end
+
+    test "an unchanged query is a no-op, and a blank query closes the popover", %{conn: conn} do
+      view = mount_cockpit(conn)
+
+      opened = render_hook(view, "omni_search", %{"value" => "counter"})
+      assert opened =~ ~s(class="omni-results")
+
+      # `phx-keyup` fires on every key release (arrows/enter included): an
+      # identical query must not re-render the list out from under the hook's
+      # client-side highlight.
+      assert render_hook(view, "omni_search", %{"value" => "counter"}) == opened
+
+      # Whitespace-only is an empty query: the popover closes.
+      refute render_hook(view, "omni_search", %{"value" => "   "}) =~ ~s(class="omni-results")
+
+      # A payload with no value at all is ignored outright.
+      refute render_hook(view, "omni_search", %{}) =~ ~s(class="omni-results")
+    end
+
+    test "opening a class row points the System Browser at it", %{conn: conn} do
+      view = mount_cockpit(conn)
+      render_hook(view, "omni_search", %{"value" => "counter"})
+
+      html = render_hook(view, "omni_open", %{"kind" => "class", "class" => "Counter"})
+
+      refute html =~ ~s(class="omni-results")
+      assert html =~ "Counter"
+      assert Process.alive?(view.pid)
+    end
+
+    test "opening a selector row opens its method tab", %{conn: conn} do
+      view = mount_cockpit(conn)
+      render_hook(view, "omni_search", %{"value" => "increment"})
+
+      html =
+        render_hook(view, "omni_open", %{
+          "kind" => "selector",
+          "class" => "Counter",
+          "side" => "instance",
+          "selector" => "increment"
+        })
+
+      refute html =~ ~s(class="omni-results")
+      assert html =~ "increment"
+      assert Process.alive?(view.pid)
+    end
+
+    test "an unrecognised open payload and an explicit close both just dismiss", %{conn: conn} do
+      view = mount_cockpit(conn)
+
+      render_hook(view, "omni_search", %{"value" => "counter"})
+      refute render_hook(view, "omni_open", %{"kind" => "mystery"}) =~ ~s(class="omni-results")
+
+      render_hook(view, "omni_search", %{"value" => "counter"})
+      refute render_hook(view, "omni_close", %{}) =~ ~s(class="omni-results")
+      assert Process.alive?(view.pid)
+    end
+  end
+
+  # ── panel visibility ────────────────────────────────────────────────────────
+
+  describe "panel visibility toggles" do
+    test "the Inspector and dock panels toggle independently", %{conn: conn} do
+      view = mount_cockpit(conn)
+
+      hidden_inspector = render_click(view, "toggle_inspector", %{})
+      assert render_click(view, "toggle_inspector", %{}) != hidden_inspector
+
+      hidden_dock = render_click(view, "toggle_dock", %{})
+      assert render_click(view, "toggle_dock", %{}) != hidden_dock
+      assert Process.alive?(view.pid)
+    end
+  end
+
+  # ── push streams + async plumbing ───────────────────────────────────────────
+
+  describe "push handling" do
+    test "a bindings push refreshes only this session's pane", %{conn: conn} do
+      StubWorkspaceClient.put_bindings([{"x", 41}])
+      view = mount_cockpit(conn)
+      session_id = SessionProbe.session_id()
+
+      # Another session's eval must not force this pane to re-read.
+      StubWorkspaceClient.put_bindings([{"x", 42}])
+      send(view.pid, binding_changed(%{sessionId: "phoenix-someone-else"}))
+      assert render(view) =~ "41"
+
+      # This session's own change does.
+      send(view.pid, binding_changed(%{sessionId: session_id}))
+      assert render(view) =~ "42"
+    end
+
+    test "an unrecognised message is ignored", %{conn: conn} do
+      view = mount_cockpit(conn)
+
+      send(view.pid, :something_no_clause_matches)
+
+      assert render(view) =~ ~s(id="system-browser")
+      assert Process.alive?(view.pid)
+    end
+
+    test "inspector pushes are forwarded without a docked watch", %{conn: conn} do
+      view = mount_cockpit(conn)
+
+      # Nothing is being inspected, so each push is a no-op forward to the
+      # Inspector pane rather than a crash on an absent watch.
+      send(view.pid, {:object_changed, self(), %{}})
+      send(view.pid, :do_object_refresh)
+      send(view.pid, {:do_window_refresh, self()})
+
+      assert render(view) =~ ~s(id="system-browser")
+      assert Process.alive?(view.pid)
+    end
+
+    test "a class-lifecycle burst coalesces into a single source refresh", %{conn: conn} do
+      view = mount_cockpit(conn)
+
+      # The first push arms the deferred refresh; the second collapses into it.
+      send(view.pid, class_loaded())
+      send(view.pid, class_loaded())
+      assert render(view) =~ ~s(id="system-browser")
+
+      # Let the coalescing window elapse so the single refresh actually runs.
+      Process.sleep(150)
+      assert render(view) =~ ~s(id="system-browser")
+      assert Process.alive?(view.pid)
+    end
+
+    test "a crashed mount load leaves the panes in their empty state", %{conn: conn} do
+      Application.put_env(:bt_attach, :workspace_client, CrashingMountClient)
+
+      {:ok, view, _html} = live(conn, "/")
+      render_async(view, 5_000)
+
+      assert render(view) =~ "No classes in the image yet."
+      assert Process.alive?(view.pid)
+    end
+
+    test "a cancelled mount load is a no-op" do
+      socket = %Phoenix.LiveView.Socket{}
+
+      assert {:noreply, ^socket} =
+               WorkspaceLive.handle_async(:mount_load, {:exit, :cancelled}, socket)
+    end
+  end
+
+  # ── degraded reads ──────────────────────────────────────────────────────────
+
+  describe "degraded workspace reads" do
+    test "unreachable class/changes reads render errors, not a crash", %{conn: conn} do
+      Application.put_env(:bt_attach, :workspace_client, DegradedReadsClient)
+
+      view = mount_cockpit(conn)
+      html = render_hook(view, "dock_tab", %{"tab" => "changes"})
+
+      # The class tree shows its error rather than an empty-image claim, and the
+      # Changes pane carries the rendered reason.
+      assert html =~ ~s(id="system-browser")
+      assert html =~ ":nodedown"
+
+      # A later class-lifecycle push must not mark the errored surfaces loaded.
+      send(view.pid, class_loaded())
+      Process.sleep(150)
+      assert Process.alive?(view.pid)
+    end
+
+    test "nonsense reply shapes degrade each pane to an error", %{conn: conn} do
+      Application.put_env(:bt_attach, :workspace_client, NonsenseReadsClient)
+
+      view = mount_cockpit(conn)
+      html = render_hook(view, "dock_tab", %{"tab" => "changes"})
+
+      assert html =~ "No pending changes."
+      assert html =~ ":unexpected_response"
+      assert Process.alive?(view.pid)
+    end
+  end
+
+  # ── render-only helpers ─────────────────────────────────────────────────────
+
+  describe "git pane" do
+    test "every porcelain state, the upstream counts, diffs and log render", %{conn: conn} do
+      StubWorkspaceClient.set_git_status(
+        {:ok,
+         %{
+           branch: "main",
+           upstream: "origin/main",
+           ahead: 2,
+           behind: 1,
+           files: [
+             %{path: "src/a.bt", index: :added, worktree: :deleted},
+             %{path: "src/b.bt", index: :renamed, worktree: :copied},
+             %{path: "src/c.bt", index: :unmerged, worktree: :untracked},
+             %{path: "src/d.bt", index: :ignored, worktree: :type_changed},
+             %{path: "src/e.bt", index: :some_future_state, worktree: :modified}
+           ]
+         }}
+      )
+
+      StubWorkspaceClient.set_git_log(
+        {:ok, [%{short_sha: "abc1234", subject: "Add Counter", author: "alice"}]}
+      )
+
+      StubWorkspaceClient.set_git_diff(
+        {:ok,
+         %{
+           staged: "diff --git a/src/a.bt b/src/a.bt\n@@ -1 +1 @@\n-old\n+new\n context\n",
+           worktree: ""
+         }}
+      )
+
+      view = mount_cockpit(conn)
+      render_hook(view, "dock_tab", %{"tab" => "git"})
+      html = render_async(view, 5_000)
+
+      assert html =~ "↑2 ↓1"
+
+      # One Staged/Working cell per porcelain state `beamtalk_git` classifies.
+      for label <- ~w(added deleted renamed copied unmerged untracked ignored type-changed) do
+        assert html =~ "<td>#{label}</td>"
+      end
+
+      # An unrecognised future state falls back to its raw name.
+      assert html =~ "<td>some_future_state</td>"
+      assert html =~ "abc1234"
+      assert html =~ "Add Counter"
+
+      # The structured diff classifies hunk headers and file metadata lines
+      # distinctly from the +/- body.
+      diffed = render_click(view, "git_diff", %{"path" => "src/a.bt"})
+      assert diffed =~ "diff-hunk"
+      assert diffed =~ "diff-meta"
+      assert diffed =~ "diff-add"
+    end
+  end
+
+  describe "changes pane" do
+    test "each ChangeLog kind gets its own label and destructive affordance", %{conn: conn} do
+      for row <- [
+            change_row(%{class: "Counter", selector: nil, kind: "class-def"}),
+            change_row(%{class: "Ledger", selector: nil, kind: "remove-class"}),
+            change_row(%{class: "Ledger", selector: nil, kind: "rename-class"}),
+            change_row(%{
+              class: "Counter",
+              selector: "bump",
+              kind: "rename-method",
+              side: "class"
+            }),
+            change_row(%{class: "Counter", selector: "tick", kind: "rename-method", side: nil}),
+            change_row(%{class: "Counter", selector: "sum", kind: "some-future-kind"})
+          ] do
+        StubWorkspaceClient.seed_change_row(row)
+      end
+
+      view = mount_cockpit(conn)
+      html = render_hook(view, "dock_tab", %{"tab" => "changes"})
+
+      assert html =~ "class definition"
+      assert html =~ "remove class"
+      assert html =~ "rename class"
+      assert html =~ "rename (class)"
+      assert html =~ "rename (?)"
+      assert html =~ "some-future-kind"
+
+      # The Tier-2 rows carry their own independently-confirmed gestures.
+      assert html =~ "delete file"
+      assert html =~ "apply rename"
+      assert html =~ "Rename to Ledger on disk?"
+      assert html =~ "Rename bump on Counter class on disk?"
+    end
+
+    test "a row's net-vs-disk diff expands into structured lines", %{conn: conn} do
+      StubWorkspaceClient.seed_change_row(
+        change_row(%{
+          class: "Counter",
+          selector: "increment",
+          kind: "instance",
+          side: "instance",
+          diff: "--- a/src/counter.bt\n+++ b/src/counter.bt\n@@ -1 +1 @@\n-old\n+new\n same\n"
+        })
+      )
+
+      view = mount_cockpit(conn)
+      render_hook(view, "dock_tab", %{"tab" => "changes"})
+
+      expanded =
+        render_click(view, "toggle_change_diff", %{
+          "class" => "Counter",
+          "selector" => "increment",
+          "entry-side" => "instance"
+        })
+
+      assert expanded =~ "diff-meta"
+      assert expanded =~ "diff-hunk"
+      assert expanded =~ "diff-ctx"
+    end
+
+    test "a finding with no recorded call sites still renders a row", %{conn: conn} do
+      StubWorkspaceClient.put_reload_findings([
+        %{
+          owner: "Ledger",
+          changed_class: "Counter",
+          selector: "increment",
+          classification: :signature_change,
+          severity: "warning",
+          category: "reload",
+          message: "Counter>>increment changed arity",
+          note: "re-check after fixing the caller",
+          sites: []
+        },
+        %{
+          owner: "Report",
+          changed_class: "Counter",
+          selector: "increment",
+          classification: :signature_change,
+          severity: "error",
+          category: "reload",
+          message: "Counter>>increment is gone",
+          note: nil,
+          sites: [%{method: "render", line: 12}]
+        }
+      ])
+
+      view = mount_cockpit(conn)
+      html = render_hook(view, "dock_tab", %{"tab" => "changes"})
+
+      assert html =~ "Counter&gt;&gt;increment changed arity"
+      assert html =~ "re-check after fixing the caller"
+      assert html =~ "Report&gt;&gt;render (line 12)"
+    end
+  end
+
+  describe "rename modal" do
+    test "a definition tab renames its class, a method tab its selector", %{conn: conn} do
+      view = mount_cockpit(conn)
+
+      # A method tab: the modal is worded for a selector rename and pre-fills
+      # the current selector.
+      render_click(view, "browser_select_class", %{"class" => "Counter"})
+
+      render_click(view, "browser_select_method", %{
+        "class" => "Counter",
+        "side" => "instance",
+        "selector" => "increment"
+      })
+
+      method_modal = render_click(view, "open_rename", %{})
+      assert method_modal =~ ~s(id="rename-modal")
+      assert method_modal =~ "Rename Method"
+      assert method_modal =~ "New selector for Counter increment"
+      assert method_modal =~ ~s(placeholder="incrementBy")
+      assert method_modal =~ ~s(aria-invalid="false")
+
+      render_click(view, "close_rename", %{})
+
+      # A definition tab: same modal, class wording, pre-filled with the class.
+      render_click(view, "browser_open_definition", %{"class" => "Counter"})
+      class_modal = render_click(view, "open_rename", %{})
+
+      assert class_modal =~ "Rename Class"
+      assert class_modal =~ "New name for Counter"
+      assert class_modal =~ ~s(placeholder="Accumulator")
+    end
+
+    test "a rejected new name keeps the modal open with an inline error", %{conn: conn} do
+      view = mount_cockpit(conn)
+      render_click(view, "browser_open_definition", %{"class" => "Counter"})
+      render_click(view, "open_rename", %{})
+
+      html =
+        view
+        |> form("#rename-form", %{"new_name" => "not a class name"})
+        |> render_submit()
+
+      assert html =~ ~s(id="rename-error")
+      assert html =~ ~s(aria-invalid="true")
+      assert html =~ ~s(id="rename-modal")
+    end
+  end
+
+  describe "REPL scrollback" do
+    setup do
+      Application.put_env(:bt_attach, :workspace_client, ReplClient)
+      :ok
+    end
+
+    test "ok, error and info entries each render their own row shape", %{conn: conn} do
+      view = mount_cockpit(conn)
+
+      ok = render_hook(view, "repl_eval", %{"expr" => "3 + 4"})
+      assert ok =~ ~s(class="repl-expr")
+      # An ok entry stashes its term, so it offers the Inspect affordance.
+      assert ok =~ ~s(phx-click="repl_inspect")
+
+      errored = render_hook(view, "repl_eval", %{"expr" => "boom"})
+      assert errored =~ "repl-entry err"
+
+      # A `:`-prefixed meta-command never reaches eval: it appends an info
+      # entry, and the (multi-line) help text collapses behind a summary.
+      helped = render_hook(view, "repl_eval", %{"expr" => ":help"})
+      assert helped =~ "repl-entry meta"
+      assert helped =~ ~s(class="repl-collapse")
+      assert helped =~ ~s(class="repl-summary")
+    end
+  end
+
+  describe "docked inspector" do
+    test "inspecting a live object renders its pid-stat chips", %{conn: conn} do
+      StubWorkspaceClient.put_bindings([
+        {"counter", {:beamtalk_object, :Counter, :"Elixir.Counter", self()}}
+      ])
+
+      StubWorkspaceClient.seed_pid_stats("Counter", %{
+        "status" => "waiting",
+        "queue_depth" => 0,
+        "reductions" => 1_234_567
+      })
+
+      view = mount_cockpit(conn)
+      html = render_click(view, "inspect", %{"name" => "counter"})
+
+      assert html =~ "waiting"
+      # A drained mailbox (0) is the most reassuring reading and must still show.
+      assert html =~ "mailbox <b>0</b>"
+      assert html =~ "1,234,567"
+    end
+  end
+
+  describe "navigation popover" do
+    test "the Senders query renders its own heading", %{conn: conn} do
+      view = mount_cockpit(conn)
+      render_click(view, "browser_select_class", %{"class" => "Counter"})
+
+      render_click(view, "browser_select_method", %{
+        "class" => "Counter",
+        "side" => "instance",
+        "selector" => "increment"
+      })
+
+      assert render_click(view, "senders", %{}) =~ "Senders"
+    end
+  end
+
+  # ── helpers ─────────────────────────────────────────────────────────────────
+
+  defp binding_changed(event),
+    do: {:beamtalk_announcement, make_ref(), :BindingChanged, :handler, event}
+
+  defp class_loaded,
+    do: {:beamtalk_announcement, make_ref(), :ClassLoaded, :handler, %{}}
+
+  # One ChangeLog row in the shape `entry_to_row/1` produces for a real
+  # workspace (see `StubWorkspaceClient.seed_change_row/1`).
+  defp change_row(overrides) do
+    Map.merge(
+      %{
+        class: "Counter",
+        selector: "increment",
+        kind: "instance",
+        intent: "durable",
+        flushable: true,
+        flushed: false,
+        author_kind: "liveview",
+        diff: nil
+      },
+      overrides
+    )
+  end
+end

--- a/editors/liveview/test/support/session_probe.ex
+++ b/editors/liveview/test/support/session_probe.ex
@@ -1,0 +1,75 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.SessionProbe do
+  @moduledoc """
+  A per-test log of the workspace sessions a LiveView mount asked for (BT-3306).
+
+  `BtAttachWeb.StubWorkspaceClient.start_session/2` answers with an
+  *immediately-exiting* process, which is fine for the untokened mounts most
+  tests drive but not for the resume lifecycle: a resumable (non-nil) token
+  registers a monitor on the session pid, so a dead pid is dropped from
+  `BtAttach.SessionRegistry` before a reconnect could ever reach the
+  `Workspace.session_alive?/1` probe. This probe answers with a pid that stays
+  alive for the whole test (it exits with the log Agent) and records what was
+  asked for, so a test can assert *whether* a second session was started
+  (resume vs. fresh) and what metadata a fresh one carried — and can read back
+  the session id the LiveView is bound to, which the `BindingChanged` push
+  stream is filtered on.
+
+  Start it in `setup` with `start_link/0` and point the app env at
+  `BtAttachWeb.SessionProbe.Client` (or at a test-local client that delegates
+  its `start_session/2` to `record/2`).
+  """
+
+  @log __MODULE__.Log
+
+  @doc "Start the per-test session log. Call in `setup`; it dies with the test."
+  def start_link, do: Agent.start_link(fn -> [] end, name: @log)
+
+  @doc """
+  Record one `start_session/2` request and answer with a fake session pid that
+  stays alive until the log Agent (and so the test) goes away.
+  """
+  def record(session_id, meta) do
+    pid = spawn_session()
+    Agent.update(@log, &(&1 ++ [%{session_id: session_id, meta: meta, pid: pid}]))
+    pid
+  end
+
+  @doc "Every recorded session, oldest first."
+  def sessions, do: Agent.get(@log, & &1)
+
+  @doc "The session id of the first (usually only) recorded session, or nil."
+  def session_id do
+    case sessions() do
+      [%{session_id: id} | _] -> id
+      [] -> nil
+    end
+  end
+
+  defp spawn_session do
+    owner = Process.whereis(@log)
+
+    spawn(fn ->
+      ref = Process.monitor(owner)
+
+      receive do
+        {:DOWN, ^ref, :process, _pid, _reason} -> :ok
+      after
+        60_000 -> :ok
+      end
+    end)
+  end
+
+  defmodule Client do
+    @moduledoc """
+    The shared stub workspace client with `start_session/2` routed through
+    `BtAttachWeb.SessionProbe` — the default client for tests that need a
+    long-lived, observable session.
+    """
+    use BtAttachWeb.StubClientOverrides
+
+    def start_session(session_id, meta), do: BtAttachWeb.SessionProbe.record(session_id, meta)
+  end
+end

--- a/editors/liveview/test/support/stub_client_overrides.ex
+++ b/editors/liveview/test/support/stub_client_overrides.ex
@@ -1,0 +1,52 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.StubClientOverrides do
+  @moduledoc """
+  Build a one-off workspace client that behaves exactly like
+  `BtAttachWeb.StubWorkspaceClient` apart from the handful of callbacks a test
+  overrides (BT-3306).
+
+      defmodule UnreachableClient do
+        use BtAttachWeb.StubClientOverrides
+
+        def connect, do: {:error, {:connect_failed, :ws@host, false}}
+      end
+
+      Application.put_env(:bt_attach, :workspace_client, UnreachableClient)
+
+  The workspace client is a plain module read out of app env
+  (`:bt_attach, :workspace_client` — see `BtAttach.Facade`'s `client/0` and
+  `BtAttachWeb.WorkspaceLive`'s `ws_client/0`), so driving a single degraded
+  callback (a failed `connect`, a `subscribe_transcript` that answers
+  `{:badrpc, _}`, a `browse_classes` that raises) otherwise means restating the
+  stub's whole ~100-function surface. `@before_compile` fills in a `defdelegate`
+  to `BtAttachWeb.StubWorkspaceClient` for every exported name/arity the using
+  module did NOT define itself, so the overrides ARE the whole test double —
+  and the shared stub stays the single implementation of the happy path
+  (CLAUDE.md no-duplicate-implementations) rather than each failure test
+  growing its own copy.
+
+  The using module keeps the stub's per-test `Agent` state, so the usual
+  `StubWorkspaceClient.start_state/0` + seeding helpers apply unchanged.
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      @before_compile BtAttachWeb.StubClientOverrides
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    overridden = Module.definitions_in(env.module, :def)
+
+    for {fun, arity} <- BtAttachWeb.StubWorkspaceClient.__info__(:functions),
+        {fun, arity} not in overridden do
+      args = Macro.generate_arguments(arity, env.module)
+
+      quote do
+        defdelegate unquote(fun)(unquote_splicing(args)), to: BtAttachWeb.StubWorkspaceClient
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds two new default-lane test files covering the previously-uncovered session-lifecycle branches in `BtAttachWeb.WorkspaceLive`:
  - `test/bt_attach_web/workspace_live_lifecycle_test.exs` (14 tests): `workspace_token` connect-param extraction, the `session_alive?` resume branch vs. fresh start, stale-token `discard`+`start_fresh` fallback, the attach-failure branch, all three `session_meta/1` user-shape matches, `bind_session`'s error exits, subscribe-failure logging (both `force_close` arms), and terminate-time stash/release.
  - `test/bt_attach_web/workspace_live_panes_test.exs` (23 tests): omni search, panel toggles, `handle_info`/`handle_async` pass-throughs, git porcelain/ChangeLog labels, unified-diff line classes, reload-findings rows, rename modal, REPL scrollback shapes, pid-stat chips.
- The issue named `test/bt_attach_web/workspace_live_test.exs`, but that file is `@moduletag :workspace` and excluded from the default `mix test` lane (needs a live workspace node), so tests there wouldn't move measured coverage — hence two new default-lane files instead.
- Two small test-support additions (`test/support/`, not `lib/`): `BtAttachWeb.StubClientOverrides` (delegates unoverridden callbacks to `StubWorkspaceClient` instead of restating its ~100-function surface) and `BtAttachWeb.SessionProbe` (a long-lived session stand-in — the shared stub's session pid exits immediately, which made the resume path untestable before).
- No production code changed — tests + test-support only.
- `BtAttachWeb.WorkspaceLive` module coverage: 79.91% → **97.43%**. Suite total: 82.64% → **87.52%**.

## Notes for follow-up (not fixed here, out of scope for a test-only PR)
1. **Pre-existing async-mount test flakiness**, unrelated to this change: `mix test --seed 0` against clean `main` intermittently fails `WorkspaceDiffViewTest`, `workspace_doc_block_test.exs`, `workspace_goto_definition_test.exs`, `workspace_flush_badge_test.exs`, `workspace_modifier_badge_test.exs`, and `workspace_git_revert_refresh_test.exs` — assertions made immediately after `render_async` race the mount-load settling, more visible under `--cover`/load. Filing a separate issue for this.
2. `StubWorkspaceClient.start_session/2` returns an immediately-exiting pid, silently reaping any tokened-mount test's `SessionRegistry` entry via the monitor's `:DOWN` — only documented in a comment. `SessionProbe` works around it in this PR; the stub itself could grow a long-lived variant.
3. Two lines in `WorkspaceLive` look genuinely unreachable rather than merely untested: `force_close/2`'s final catch-all, and `terminate/2`'s `_ -> :ok` for a non-pid `session_pid` on a connected socket. Candidates for deletion in a later cleanup, not covered here.

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix test --cover` — 983 passed, 0 failures, 133 excluded (`:playwright`/`:workspace`)
- [x] `mix test` at seeds 0/1/2 — all green
- [x] `BtAttachWeb.WorkspaceLive` ≥95% (97.43%)

Part of Epic BT-3304 ("Close editors/liveview Elixir coverage gap to 90%, stretch 95%").

---
_Generated by [Claude Code](https://claude.ai/code/session_017EEfqFa7rmuhhXqXyZg7nn)_