### PR TITLE
DRY up InspectorFakeClient/DockFakeClient into a shared ForcedReplyClient macro (BT-3316)

### DIFF
--- a/editors/liveview/test/bt_attach_web/dock_test.exs
+++ b/editors/liveview/test/bt_attach_web/dock_test.exs
@@ -16,43 +16,17 @@ defmodule BtAttachWeb.Live.DockFakeClient do
   rather than widen it with failure knobs no other test needs, this module
   wraps it: every function delegates to the stub unless the test forced a
   reply for that op via `Application.put_env(:bt_attach, :dock_fake, %{op =>
-  reply})`. Mirrors `BtAttachWeb.Live.InspectorFakeClient` (BT-3305), the
-  precedent this follows.
+  reply})`. Shares its `forced/1` + per-op wrapping mechanics with
+  `BtAttachWeb.Live.InspectorFakeClient` (BT-3305) via the
+  `BtAttachWeb.ForcedReplyClient` macro (BT-3316).
   """
 
-  alias BtAttachWeb.StubWorkspaceClient
+  use BtAttachWeb.ForcedReplyClient, key: :dock_fake
 
-  # The reply this test forced for `key`, or `:error` when it forced none (in
-  # which case the caller falls through to the real stub).
-  defp forced(key), do: Map.fetch(Application.get_env(:bt_attach, :dock_fake, %{}), key)
-
-  def eval(pid, code) do
-    case forced(:eval) do
-      {:ok, reply} -> reply
-      :error -> StubWorkspaceClient.eval(pid, code)
-    end
-  end
-
-  def git_diff(path) do
-    case forced(:git_diff) do
-      {:ok, reply} -> reply
-      :error -> StubWorkspaceClient.git_diff(path)
-    end
-  end
-
-  def git_revert_file(path) do
-    case forced(:git_revert_file) do
-      {:ok, reply} -> reply
-      :error -> StubWorkspaceClient.git_revert_file(path)
-    end
-  end
-
-  def symbol_index(scope) do
-    case forced(:symbol_index) do
-      {:ok, reply} -> reply
-      :error -> StubWorkspaceClient.symbol_index(scope)
-    end
-  end
+  forceable(eval(pid, code))
+  forceable(git_diff(path))
+  forceable(git_revert_file(path))
+  forceable(symbol_index(scope))
 
   # `repl_focus_class/3`'s found branch drives the System Browser's
   # `open_class/2`, which immediately re-loads protocols + categories for the

--- a/editors/liveview/test/bt_attach_web/inspector_test.exs
+++ b/editors/liveview/test/bt_attach_web/inspector_test.exs
@@ -14,44 +14,18 @@ defmodule BtAttachWeb.Live.InspectorFakeClient do
   stub is shared by the whole suite and its per-class seeding helpers
   (`seed_inspect_value/2`, `seed_pid_stats/2`) are shaped for the success path,
   so rather than widen it with failure knobs no other test needs, this module
-  wraps it: every function delegates to the stub unless the test forced a reply
-  for that op via `Application.put_env(:bt_attach, :inspector_fake, %{op =>
-  reply})`.
+  wraps it — mechanics shared with `BtAttachWeb.Live.DockFakeClient` via the
+  `BtAttachWeb.ForcedReplyClient` macro (BT-3316) — every function delegates
+  to the stub unless the test forced a reply for that op via
+  `Application.put_env(:bt_attach, :inspector_fake, %{op => reply})`.
   """
 
-  alias BtAttachWeb.StubWorkspaceClient
+  use BtAttachWeb.ForcedReplyClient, key: :inspector_fake
 
-  # The reply this test forced for `key`, or `:error` when it forced none (in
-  # which case the caller falls through to the real stub).
-  defp forced(key), do: Map.fetch(Application.get_env(:bt_attach, :inspector_fake, %{}), key)
-
-  def inspect_value(term) do
-    case forced(:inspect_value) do
-      {:ok, reply} -> reply
-      :error -> StubWorkspaceClient.inspect_value(term)
-    end
-  end
-
-  def pid_stats(term) do
-    case forced(:pid_stats) do
-      {:ok, reply} -> reply
-      :error -> StubWorkspaceClient.pid_stats(term)
-    end
-  end
-
-  def eval(pid, code) do
-    case forced(:eval) do
-      {:ok, reply} -> reply
-      :error -> StubWorkspaceClient.eval(pid, code)
-    end
-  end
-
-  def subscribe_object_changes(term, pid) do
-    case forced(:subscribe_object_changes) do
-      {:ok, reply} -> reply
-      :error -> StubWorkspaceClient.subscribe_object_changes(term, pid)
-    end
-  end
+  forceable(inspect_value(term))
+  forceable(pid_stats(term))
+  forceable(eval(pid, code))
+  forceable(subscribe_object_changes(term, pid))
 
   defdelegate unsubscribe_object_changes(term, pid), to: StubWorkspaceClient
   defdelegate list_bindings(pid), to: StubWorkspaceClient

--- a/editors/liveview/test/support/forced_reply_client.ex
+++ b/editors/liveview/test/support/forced_reply_client.ex
@@ -1,0 +1,76 @@
+# Copyright 2026 James Casey
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BtAttachWeb.ForcedReplyClient do
+  @moduledoc """
+  Shared plumbing for a per-test-configurable veneer over
+  `BtAttachWeb.StubWorkspaceClient` (BT-3316).
+
+  `BtAttachWeb.Live.InspectorFakeClient` (BT-3305) and
+  `BtAttachWeb.Live.DockFakeClient` (BT-3308) each wrap the shared stub so a
+  test can force a reply for one op — a degrade-gracefully branch the stub's
+  success-shaped replies never reach — while every other op still delegates
+  straight through. Both wanted the identical mechanics: a `forced/1` helper
+  reading a module-specific `Application.get_env(:bt_attach, key, %{})`, and
+  a `case forced(op) do {:ok, reply} -> reply; :error -> Stub.op(args) end`
+  body per wrapped function. This module factors that mechanism out so each
+  fake client only states its own op list and *why* those particular ops need
+  a forced-reply knob (module-specific context that belongs in that module's
+  own `@moduledoc`, not here).
+
+      defmodule SomeFakeClient do
+        use BtAttachWeb.ForcedReplyClient, key: :some_fake
+
+        forceable(some_op(arg1, arg2))
+
+        defdelegate other_op(arg), to: StubWorkspaceClient
+      end
+
+      Application.put_env(:bt_attach, :some_fake, %{some_op: forced_reply})
+
+  `use BtAttachWeb.ForcedReplyClient, key: :some_fake` generates the
+  `forced/1` helper bound to `:some_fake` and aliases `StubWorkspaceClient`.
+  `forceable(name(args...))` then generates:
+
+      def name(args...) do
+        case forced(:name) do
+          {:ok, reply} -> reply
+          :error -> apply(StubWorkspaceClient, :name, [args...])
+        end
+      end
+
+  Ops that never need forcing stay plain `defdelegate` lines in the using
+  module — this macro only touches the ops that can be forced.
+  """
+
+  defmacro __using__(opts) do
+    key = Keyword.fetch!(opts, :key)
+
+    quote do
+      alias BtAttachWeb.StubWorkspaceClient
+      import BtAttachWeb.ForcedReplyClient, only: [forceable: 1]
+
+      # The reply this test forced for `op`, or `:error` when it forced none
+      # (in which case the caller falls through to the real stub).
+      defp forced(op), do: Map.fetch(Application.get_env(:bt_attach, unquote(key), %{}), op)
+    end
+  end
+
+  @doc """
+  Generates a function named/shaped after `call` (e.g. `some_op(a, b)`) that
+  returns the test-forced reply for that op, if any, falling back to
+  `StubWorkspaceClient.some_op(a, b)` otherwise. See the moduledoc.
+  """
+  defmacro forceable({name, _meta, args}) do
+    args = args || []
+
+    quote do
+      def unquote(name)(unquote_splicing(args)) do
+        case forced(unquote(name)) do
+          {:ok, reply} -> reply
+          :error -> apply(BtAttachWeb.StubWorkspaceClient, unquote(name), unquote(args))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Extracts `BtAttachWeb.ForcedReplyClient`, a shared macro (`test/support/forced_reply_client.ex`), from the near-identical `InspectorFakeClient` (BT-3305) and `DockFakeClient` (BT-3308) test veneers.
- `use BtAttachWeb.ForcedReplyClient, key: :some_key` generates the `forced/1` helper (reads `Application.get_env(:bt_attach, key, %{})`) and aliases `StubWorkspaceClient`; `forceable(name(args...))` generates the wrapped function that returns a forced reply or falls through to `StubWorkspaceClient` via `apply/3`.
- `InspectorFakeClient` and `DockFakeClient` rewritten to use the macro, replacing repeated `case forced(...) do ... end` bodies with one-liners. Each keeps its own `@moduledoc` explaining *why* its specific ops need forcing — only the mechanical plumbing moved into the shared macro. Fixed the stale "Mirrors InspectorFakeClient" comment in Dock's moduledoc to describe the real shared abstraction now in place.
- No production code touched, no test behavior change.

## Why
`DockFakeClient`'s own moduledoc said it "Mirrors `BtAttachWeb.Live.InspectorFakeClient`, the precedent this follows" — a copy with no test enforcing the invariant, exactly the anti-pattern CLAUDE.md's Duplication section calls out.

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix test test/bt_attach_web/inspector_test.exs test/bt_attach_web/dock_test.exs` — 162 passed, same tests/assertions as before
- [x] `mix test --cover` before/after comparison: both 1097 passed / 133 excluded, `Dock` 99.61% and `Inspector` 99.76% unchanged

Part of Epic BT-3304 ("Close editors/liveview Elixir coverage gap to 90%, stretch 95%").

---
_Generated by [Claude Code](https://claude.ai/code/session_017EEfqFa7rmuhhXqXyZg7nn)_