### PR TITLE
Remove redundant facade_error/1 and ctx/1 wrapper delegates (BT-3317)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/class_modals.ex
+++ b/editors/liveview/lib/bt_attach_web/live/class_modals.ex
@@ -81,9 +81,6 @@ defmodule BtAttachWeb.Live.ClassModals do
   alias BtAttachWeb.Live.SystemBrowser
   alias BtAttachWeb.WorkspaceLive
 
-  defp ctx(socket), do: RequestContext.build(socket)
-  defp facade_error(reason), do: FacadeError.render(reason)
-
   # ── handle_event dispatch ────────────────────────────────────────────────
   #
   # `WorkspaceLive.handle_event/3` forwards every event whose name is in
@@ -298,7 +295,7 @@ defmodule BtAttachWeb.Live.ClassModals do
   end
 
   defp remove_method_eval(socket, tab, receiver, selector, expr, pid) do
-    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, RequestContext.build(socket)) do
       {:ok, _term, _output, _warnings} ->
         # `close_tab/2` wipes `save_result`/`save_error` whenever the closed
         # tab was the active one — via `clear_active/1` if it was the last
@@ -320,7 +317,7 @@ defmodule BtAttachWeb.Live.ClassModals do
         WorkspaceLive.status_error(socket, Workspace.render_error(reason))
 
       {:error, reason} ->
-        WorkspaceLive.status_error(socket, facade_error(reason))
+        WorkspaceLive.status_error(socket, FacadeError.render(reason))
     end
   end
 
@@ -361,7 +358,7 @@ defmodule BtAttachWeb.Live.ClassModals do
   end
 
   defp remove_class_eval(socket, tab, class, expr, pid) do
-    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, RequestContext.build(socket)) do
       {:ok, _term, _output, _warnings} ->
         # `close_tab/2` wipes `save_result`/`save_error` whenever the closed
         # tab was the active one — mirrors `remove_method_eval/6`'s success
@@ -384,7 +381,7 @@ defmodule BtAttachWeb.Live.ClassModals do
         WorkspaceLive.status_error(socket, Workspace.render_error(reason))
 
       {:error, reason} ->
-        WorkspaceLive.status_error(socket, facade_error(reason))
+        WorkspaceLive.status_error(socket, FacadeError.render(reason))
     end
   end
 
@@ -538,7 +535,7 @@ defmodule BtAttachWeb.Live.ClassModals do
   end
 
   defp rename_class_eval(socket, old_name, new_name, expr, pid) do
-    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, RequestContext.build(socket)) do
       {:ok, _term, _output, _warnings} ->
         # The class's identity changed, so every tab keyed on the old name
         # (its own `:def` tab plus any open `:method` tabs) is stale — close
@@ -575,7 +572,7 @@ defmodule BtAttachWeb.Live.ClassModals do
         assign(socket,
           rename_open: true,
           rename_new_name: new_name,
-          rename_error: facade_error(reason)
+          rename_error: FacadeError.render(reason)
         )
     end
   end
@@ -650,7 +647,7 @@ defmodule BtAttachWeb.Live.ClassModals do
   end
 
   defp rename_method_eval(socket, class, receiver, old_selector, new_selector, expr, pid) do
-    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, RequestContext.build(socket)) do
       {:ok, _term, _output, _warnings} ->
         # The selector changed, so the active method tab (keyed on the old
         # selector) is stale — close it, mirroring `remove_method_eval/6`'s
@@ -681,7 +678,7 @@ defmodule BtAttachWeb.Live.ClassModals do
         assign(socket,
           rename_open: true,
           rename_new_name: new_selector,
-          rename_error: facade_error(reason)
+          rename_error: FacadeError.render(reason)
         )
     end
   end
@@ -802,7 +799,7 @@ defmodule BtAttachWeb.Live.ClassModals do
   end
 
   defp dispatch_new_class(socket, name, superclass, source, path) do
-    case Facade.dispatch(:new_class, %{source: source, path: path}, ctx(socket)) do
+    case Facade.dispatch(:new_class, %{source: source, path: path}, RequestContext.build(socket)) do
       {:ok, created_path} ->
         socket
         |> SystemBrowser.assign_browser_classes()
@@ -838,7 +835,7 @@ defmodule BtAttachWeb.Live.ClassModals do
           new_class_open: true,
           new_class_name: name,
           new_class_super: superclass,
-          new_class_error: facade_error(reason)
+          new_class_error: FacadeError.render(reason)
         )
     end
   end

--- a/editors/liveview/lib/bt_attach_web/live/dock.ex
+++ b/editors/liveview/lib/bt_attach_web/live/dock.ex
@@ -86,9 +86,6 @@ defmodule BtAttachWeb.Live.Dock do
   alias BtAttachWeb.Live.TestRunner
   alias BtAttachWeb.WorkspaceLive
 
-  defp ctx(socket), do: RequestContext.build(socket)
-  defp facade_error(reason), do: FacadeError.render(reason)
-
   # ── handle_event dispatch ────────────────────────────────────────────────
   #
   # `WorkspaceLive.handle_event/3` forwards every event whose name is in
@@ -116,7 +113,7 @@ defmodule BtAttachWeb.Live.Dock do
     action = eval_action(params)
     target = eval_target(expr, socket)
 
-    case Facade.dispatch(:eval, %{session_pid: pid, code: target}, ctx(socket)) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: target}, RequestContext.build(socket)) do
       {:ok, term, output, _warnings} ->
         # eval returns the live term; rendering is display-only and reuses the
         # workspace's own formatter for surface-consistency with the browser.
@@ -138,7 +135,7 @@ defmodule BtAttachWeb.Live.Dock do
       # message rather than crashing the LiveView on an unmatched case clause.
       {:error, reason} ->
         {:noreply,
-         assign(socket, result: nil, output: nil, error: facade_error(reason), expr: expr)}
+         assign(socket, result: nil, output: nil, error: FacadeError.render(reason), expr: expr)}
     end
   end
 
@@ -199,12 +196,12 @@ defmodule BtAttachWeb.Live.Dock do
     if socket.assigns.git_diff_path == path do
       {:noreply, assign(socket, git_diff_path: nil, git_diff: nil)}
     else
-      case Facade.dispatch(:git_diff, %{path: path}, ctx(socket)) do
+      case Facade.dispatch(:git_diff, %{path: path}, RequestContext.build(socket)) do
         {:ok, diff} when is_map(diff) ->
           {:noreply, assign(socket, git_diff_path: path, git_diff: diff, git_error: nil)}
 
         {:error, reason} ->
-          {:noreply, assign(socket, git_error: facade_error(reason))}
+          {:noreply, assign(socket, git_error: FacadeError.render(reason))}
       end
     end
   end
@@ -290,7 +287,11 @@ defmodule BtAttachWeb.Live.Dock do
 
       true ->
         socket =
-          case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
+          case Facade.dispatch(
+                 :eval,
+                 %{session_pid: pid, code: expr},
+                 RequestContext.build(socket)
+               ) do
             {:ok, term, _output, _warnings} ->
               socket |> repl_append_ok(expr, term) |> repl_help_followup(expr)
 
@@ -301,7 +302,7 @@ defmodule BtAttachWeb.Live.Dock do
             # 2-tuple the eval contract never produces; render it as the
             # entry's response rather than crashing the LiveView.
             {:error, reason} ->
-              repl_append_error(socket, expr, facade_error(reason))
+              repl_append_error(socket, expr, FacadeError.render(reason))
           end
 
         {:noreply, socket |> repl_record_history(expr) |> repl_clear_input()}
@@ -1113,9 +1114,9 @@ defmodule BtAttachWeb.Live.Dock do
   # the user is editing), so they keep the original behaviour: dispatch and
   # refresh the git panel only.
   defp git_mutate_event(socket, op, params) do
-    case Facade.dispatch(op, params, ctx(socket)) do
+    case Facade.dispatch(op, params, RequestContext.build(socket)) do
       {:ok, _} -> assign_git(socket)
-      {:error, reason} -> assign(socket, git_error: facade_error(reason))
+      {:error, reason} -> assign(socket, git_error: FacadeError.render(reason))
     end
   end
 
@@ -1126,7 +1127,7 @@ defmodule BtAttachWeb.Live.Dock do
   # sessions; reloading + refreshing here makes the acting session update
   # synchronously rather than waiting on its own push.
   defp git_revert_event(socket, %{path: path} = params) do
-    case Facade.dispatch(:git_revert_file, params, ctx(socket)) do
+    case Facade.dispatch(:git_revert_file, params, RequestContext.build(socket)) do
       {:ok, _} ->
         {reloaded, reload_note} = reload_reverted_path(socket, path)
 
@@ -1161,7 +1162,7 @@ defmodule BtAttachWeb.Live.Dock do
         |> maybe_status_error(reload_note)
 
       {:error, reason} ->
-        assign(socket, git_error: facade_error(reason))
+        assign(socket, git_error: FacadeError.render(reason))
     end
   end
 
@@ -1176,12 +1177,12 @@ defmodule BtAttachWeb.Live.Dock do
   # tree was still reverted, and the subsequent refresh re-reads what the
   # image can serve; the note is surfaced afterwards.
   defp reload_reverted_path(socket, path) do
-    case Facade.dispatch(:reload, %{path: path}, ctx(socket)) do
+    case Facade.dispatch(:reload, %{path: path}, RequestContext.build(socket)) do
       {:ok, class_names} when is_list(class_names) ->
         {reloaded_tab_keys(socket.assigns.tabs, class_names), nil}
 
       {:error, reason} ->
-        {MapSet.new(), "Reverted #{path}, but reload failed: #{facade_error(reason)}"}
+        {MapSet.new(), "Reverted #{path}, but reload failed: #{FacadeError.render(reason)}"}
     end
   end
 
@@ -1262,7 +1263,7 @@ defmodule BtAttachWeb.Live.Dock do
   # the loading state on each refresh. Public: `WorkspaceLive.maybe_refresh_git/1`
   # (used by the not-yet-extracted save/flush paths) calls it directly.
   def assign_git(socket) do
-    ctx = ctx(socket)
+    ctx = RequestContext.build(socket)
 
     socket
     |> assign(git_diff_path: nil, git_diff: nil, git_status: nil, git_log: [], git_error: nil)
@@ -1284,20 +1285,20 @@ defmodule BtAttachWeb.Live.Dock do
     do: assign(socket, git_status: status, git_error: nil)
 
   defp apply_git_status(socket, {:error, reason}),
-    do: assign(socket, git_status: nil, git_error: facade_error(reason))
+    do: assign(socket, git_status: nil, git_error: FacadeError.render(reason))
 
   defp apply_git_status(socket, _other),
-    do: assign(socket, git_status: nil, git_error: facade_error(:unexpected_git_status))
+    do: assign(socket, git_status: nil, git_error: FacadeError.render(:unexpected_git_status))
 
   # Apply a completed git log read.
   defp apply_git_log(socket, {:ok, commits}) when is_list(commits),
     do: assign(socket, git_log: commits)
 
   defp apply_git_log(socket, {:error, reason}),
-    do: log_failed(socket, facade_error(reason))
+    do: log_failed(socket, FacadeError.render(reason))
 
   defp apply_git_log(socket, _other),
-    do: log_failed(socket, facade_error(:unexpected_git_log))
+    do: log_failed(socket, FacadeError.render(:unexpected_git_log))
 
   # A git-log read failed. Clear the list, and surface the error only if the
   # status read hasn't already reported one — when both fail together the
@@ -1327,7 +1328,11 @@ defmodule BtAttachWeb.Live.Dock do
   # structured error the workspace returns. `side` (ADR 0112, BT-3187)
   # disambiguates a same-selector instance-side entry from a class-side one.
   defp revert_change(socket, class, selector, side) do
-    case Facade.dispatch(:revert, %{class: class, selector: selector, side: side}, ctx(socket)) do
+    case Facade.dispatch(
+           :revert,
+           %{class: class, selector: selector, side: side},
+           RequestContext.build(socket)
+         ) do
       {:ok, reverted_class} ->
         socket
         |> assign(
@@ -1339,7 +1344,7 @@ defmodule BtAttachWeb.Live.Dock do
         |> WorkspaceLive.assign_changes()
 
       {:error, reason} ->
-        WorkspaceLive.status_error(socket, facade_error(reason))
+        WorkspaceLive.status_error(socket, FacadeError.render(reason))
     end
   end
 
@@ -1357,7 +1362,7 @@ defmodule BtAttachWeb.Live.Dock do
   defp flush_changes(socket) do
     was_pending = WorkspaceLive.pending_method_keys(socket.assigns.changes)
 
-    case Facade.dispatch(:flush, %{}, ctx(socket)) do
+    case Facade.dispatch(:flush, %{}, RequestContext.build(socket)) do
       {:ok, summary} ->
         socket
         |> assign(flush_result: Workspace.format_flush_summary(summary), flush_error: nil)
@@ -1369,7 +1374,7 @@ defmodule BtAttachWeb.Live.Dock do
         |> WorkspaceLive.maybe_refresh_git()
 
       {:error, reason} ->
-        assign(socket, flush_result: nil, flush_error: facade_error(reason))
+        assign(socket, flush_result: nil, flush_error: FacadeError.render(reason))
     end
   end
 
@@ -1426,7 +1431,7 @@ defmodule BtAttachWeb.Live.Dock do
   defp rename_flush_message(_kind, class), do: "Flushed the pending removal for #{class}"
 
   defp flush_destructive_eval(socket, class, kind, expr, pid) do
-    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, ctx(socket)) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: expr}, RequestContext.build(socket)) do
       {:ok, _term, _output, _warnings} ->
         socket
         |> assign(
@@ -1445,7 +1450,7 @@ defmodule BtAttachWeb.Live.Dock do
         WorkspaceLive.status_error(socket, Workspace.render_error(reason))
 
       {:error, reason} ->
-        WorkspaceLive.status_error(socket, facade_error(reason))
+        WorkspaceLive.status_error(socket, FacadeError.render(reason))
     end
   end
 

--- a/editors/liveview/lib/bt_attach_web/live/inspector.ex
+++ b/editors/liveview/lib/bt_attach_web/live/inspector.ex
@@ -53,8 +53,6 @@ defmodule BtAttachWeb.Live.Inspector do
   alias BtAttachWeb.Live.FacadeError
   alias BtAttachWeb.Live.RequestContext
 
-  defp ctx(socket), do: RequestContext.build(socket)
-
   # ── canonical event list (BT-3301) ───────────────────────────────────────
   #
   # The single source of truth for which event names `handle_event/3` below
@@ -463,7 +461,7 @@ defmodule BtAttachWeb.Live.Inspector do
   # are not inspectable, so we say so rather than guess.
   def inspect_term(socket, label, term, crumbs) do
     if Workspace.inspectable?(term) do
-      case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
+      case Facade.dispatch(:inspect, %{term: term}, RequestContext.build(socket)) do
         # BT-2634: a supervisor's content is its CHILDREN / supervision tree,
         # not actor instance vars. Each child row carries a live
         # `{:beamtalk_supervisor, …}` / `{:beamtalk_object, …}` handle, so the
@@ -539,7 +537,7 @@ defmodule BtAttachWeb.Live.Inspector do
   # current binding list, then inspect that term. The term — not a string —
   # drives the op.
   defp inspect_binding(socket, pid, name) do
-    case Facade.dispatch(:bindings, %{session_pid: pid}, ctx(socket)) do
+    case Facade.dispatch(:bindings, %{session_pid: pid}, RequestContext.build(socket)) do
       pairs when is_list(pairs) ->
         case List.keyfind(pairs, name, 0) do
           # Inspecting a binding starts a fresh drill breadcrumb at this
@@ -590,7 +588,11 @@ defmodule BtAttachWeb.Live.Inspector do
         # unsubscribe).
         assign(socket, inspect_watch: nil)
       else
-        case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
+        case Facade.dispatch(
+               :subscribe_object,
+               %{term: term, pid: self()},
+               RequestContext.build(socket)
+             ) do
           :ok -> assign(socket, inspect_watch: term)
           # A non-:ok (term not watchable, dist hiccup) leaves the pane
           # un-watched rather than claiming a live subscription that isn't
@@ -625,7 +627,11 @@ defmodule BtAttachWeb.Live.Inspector do
   defp unwatch(%{assigns: %{inspect_watch: term}} = socket)
        when not is_nil(term) do
     unless docked_pid_watched_by_window?(socket, term) do
-      Facade.dispatch(:unsubscribe_object, %{term: term, pid: self()}, ctx(socket))
+      Facade.dispatch(
+        :unsubscribe_object,
+        %{term: term, pid: self()},
+        RequestContext.build(socket)
+      )
     end
 
     assign(socket, inspect_watch: nil)
@@ -649,7 +655,7 @@ defmodule BtAttachWeb.Live.Inspector do
   # still drives the field flash, so the pane stays useful even when stats
   # are momentarily unavailable.
   defp refresh_stats(socket, term) do
-    case Facade.dispatch(:pid_stats, %{term: term}, ctx(socket)) do
+    case Facade.dispatch(:pid_stats, %{term: term}, RequestContext.build(socket)) do
       {:ok, stats} when is_map(stats) -> assign(socket, inspect_stats: stats)
       _ -> assign(socket, inspect_stats: nil)
     end
@@ -666,7 +672,7 @@ defmodule BtAttachWeb.Live.Inspector do
        when is_pid(pid) do
     label = current_inspect_label(socket)
 
-    case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
+    case Facade.dispatch(:inspect, %{term: term}, RequestContext.build(socket)) do
       {:ok, fields} when is_map(fields) ->
         socket
         |> assign(
@@ -734,7 +740,7 @@ defmodule BtAttachWeb.Live.Inspector do
   # window on it. A binding that no longer resolves opens a window showing
   # the error rather than silently doing nothing.
   defp open_window(socket, pid, name) do
-    case Facade.dispatch(:bindings, %{session_pid: pid}, ctx(socket)) do
+    case Facade.dispatch(:bindings, %{session_pid: pid}, RequestContext.build(socket)) do
       pairs when is_list(pairs) ->
         case List.keyfind(pairs, name, 0) do
           {^name, term} -> open_window_for_term(socket, to_string(name), term)
@@ -910,7 +916,7 @@ defmodule BtAttachWeb.Live.Inspector do
   # windows on the same actor doesn't silence the other).
   defp inspect_window(socket, w, label, term, crumbs) do
     if Workspace.inspectable?(term) do
-      case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
+      case Facade.dispatch(:inspect, %{term: term}, RequestContext.build(socket)) do
         # BT-2634: a supervisor renders its children / supervision tree
         # (drillable child handles), not actor instance vars — the
         # float-window twin of the docked supervisor case. `track_window/3`
@@ -989,7 +995,11 @@ defmodule BtAttachWeb.Live.Inspector do
       if w.frozen do
         %{w | watch: nil}
       else
-        case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
+        case Facade.dispatch(
+               :subscribe_object,
+               %{term: term, pid: self()},
+               RequestContext.build(socket)
+             ) do
           :ok -> %{w | watch: term}
           _ -> %{w | watch: nil}
         end
@@ -1013,7 +1023,11 @@ defmodule BtAttachWeb.Live.Inspector do
 
   defp unwatch_window(%{watch: term} = w, socket) do
     unless pid_watched_elsewhere?(socket, term, w.id) do
-      Facade.dispatch(:unsubscribe_object, %{term: term, pid: self()}, ctx(socket))
+      Facade.dispatch(
+        :unsubscribe_object,
+        %{term: term, pid: self()},
+        RequestContext.build(socket)
+      )
     end
 
     %{w | watch: nil}
@@ -1042,7 +1056,7 @@ defmodule BtAttachWeb.Live.Inspector do
   # failure clears the chips rather than rendering stale numbers (same
   # contract as the docked `refresh_stats/2`).
   defp refresh_window_stats(w, socket, term) do
-    case Facade.dispatch(:pid_stats, %{term: term}, ctx(socket)) do
+    case Facade.dispatch(:pid_stats, %{term: term}, RequestContext.build(socket)) do
       {:ok, stats} when is_map(stats) -> %{w | stats: stats}
       _ -> %{w | stats: nil}
     end
@@ -1055,7 +1069,7 @@ defmodule BtAttachWeb.Live.Inspector do
   defp refresh_window(w, socket, {:beamtalk_object, _c, _m, pid} = term) when is_pid(pid) do
     label = window_label(w)
 
-    case Facade.dispatch(:inspect, %{term: term}, ctx(socket)) do
+    case Facade.dispatch(:inspect, %{term: term}, RequestContext.build(socket)) do
       {:ok, fields} when is_map(fields) ->
         %{
           w
@@ -1110,7 +1124,11 @@ defmodule BtAttachWeb.Live.Inspector do
   end
 
   defp rearm_window_watch(w, socket, term) do
-    case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
+    case Facade.dispatch(
+           :subscribe_object,
+           %{term: term, pid: self()},
+           RequestContext.build(socket)
+         ) do
       :ok -> %{w | watch: term}
       _ -> %{w | watch: nil}
     end
@@ -1157,7 +1175,7 @@ defmodule BtAttachWeb.Live.Inspector do
   defp send_window_poke(socket, w, pid, label, message) do
     code = "#{label} #{message}"
 
-    case Facade.dispatch(:eval, %{session_pid: pid, code: code}, ctx(socket)) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: code}, RequestContext.build(socket)) do
       {:ok, term, _output, _warnings} ->
         w = %{w | poke_result: "→ #{Workspace.render_term(term)}", poke_error: nil}
 
@@ -1179,7 +1197,7 @@ defmodule BtAttachWeb.Live.Inspector do
         %{w | poke_result: nil, poke_error: Workspace.render_error(reason)}
 
       {:error, reason} ->
-        %{w | poke_result: nil, poke_error: facade_error(reason)}
+        %{w | poke_result: nil, poke_error: FacadeError.render(reason)}
     end
   end
 
@@ -1333,7 +1351,11 @@ defmodule BtAttachWeb.Live.Inspector do
   # rows (used by unfreeze, which re-reads separately). A non-:ok result
   # leaves the watch nil rather than claiming a live subscription.
   defp rearm_watch(socket, term) do
-    case Facade.dispatch(:subscribe_object, %{term: term, pid: self()}, ctx(socket)) do
+    case Facade.dispatch(
+           :subscribe_object,
+           %{term: term, pid: self()},
+           RequestContext.build(socket)
+         ) do
       :ok -> assign(socket, inspect_watch: term)
       _ -> assign(socket, inspect_watch: nil)
     end
@@ -1381,7 +1403,7 @@ defmodule BtAttachWeb.Live.Inspector do
   defp send_poke(socket, pid, label, message) do
     code = "#{label} #{message}"
 
-    case Facade.dispatch(:eval, %{session_pid: pid, code: code}, ctx(socket)) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: code}, RequestContext.build(socket)) do
       {:ok, term, _output, _warnings} ->
         socket
         |> assign(poke_result: "→ #{Workspace.render_term(term)}", poke_error: nil)
@@ -1397,7 +1419,7 @@ defmodule BtAttachWeb.Live.Inspector do
         assign(socket, poke_result: nil, poke_error: Workspace.render_error(reason))
 
       {:error, reason} ->
-        assign(socket, poke_result: nil, poke_error: facade_error(reason))
+        assign(socket, poke_result: nil, poke_error: FacadeError.render(reason))
     end
   end
 
@@ -1639,11 +1661,6 @@ defmodule BtAttachWeb.Live.Inspector do
     |> Enum.map_join(",", &Enum.join/1)
     |> String.reverse()
   end
-
-  # `BtAttachWeb.Live.FacadeError` (shared with `WorkspaceLive` and its other
-  # extracted panes) renders a facade short-circuit (RBAC denial /
-  # off-vocabulary op) as a clear, user-facing message.
-  defp facade_error(reason), do: FacadeError.render(reason)
 
   # True when `watch` is a pid-backed term watching `pid` — the shared
   # predicate every docked/window change-push router (`handle_info`) and

--- a/editors/liveview/lib/bt_attach_web/live/method_editor.ex
+++ b/editors/liveview/lib/bt_attach_web/live/method_editor.ex
@@ -85,9 +85,6 @@ defmodule BtAttachWeb.Live.MethodEditor do
   alias BtAttachWeb.Live.SystemBrowser
   alias BtAttachWeb.WorkspaceLive
 
-  defp ctx(socket), do: RequestContext.build(socket)
-  defp facade_error(reason), do: FacadeError.render(reason)
-
   # ── handle_event dispatch ────────────────────────────────────────────────
   #
   # `WorkspaceLive.handle_event/3` forwards every event whose name is in
@@ -354,7 +351,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
         case Facade.dispatch(
                :save,
                %{class: class, selector: selector, source: source},
-               ctx(socket)
+               RequestContext.build(socket)
              ) do
           {:ok, saved_class} ->
             # The patch is live + logged; refresh the change-history pane so
@@ -376,7 +373,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
             # `reason` may be a facade RBAC denial (`:unauthorized`) for a
             # crafted event from a read-only role, or a workspace
             # #beamtalk_error{}.
-            assign(socket, save_result: nil, save_error: facade_error(reason))
+            assign(socket, save_result: nil, save_error: FacadeError.render(reason))
         end
     end
   end
@@ -404,7 +401,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
   end
 
   defp save_definition_eval(socket, tab, source, pid) do
-    case Facade.dispatch(:eval, %{session_pid: pid, code: source}, ctx(socket)) do
+    case Facade.dispatch(:eval, %{session_pid: pid, code: source}, RequestContext.build(socket)) do
       {:ok, _term, _output, _warnings} ->
         socket
         |> assign(
@@ -426,7 +423,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
         assign(socket, save_result: nil, save_error: Workspace.render_error(reason))
 
       {:error, reason} ->
-        assign(socket, save_result: nil, save_error: facade_error(reason))
+        assign(socket, save_result: nil, save_error: FacadeError.render(reason))
     end
   end
 
@@ -444,7 +441,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
         case Facade.dispatch(
                :save_native_source,
                %{module: module, source: source},
-               ctx(socket)
+               RequestContext.build(socket)
              ) do
           {:value, %{"ok" => true}} ->
             # Compiled, reloaded, and written to disk. Clear the dirty dot,
@@ -464,7 +461,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
             assign(socket, save_result: nil, save_error: native_compile_error(errors))
 
           {:error, reason} ->
-            assign(socket, save_result: nil, save_error: facade_error(reason))
+            assign(socket, save_result: nil, save_error: FacadeError.render(reason))
 
           _other ->
             assign(socket, save_result: nil, save_error: "Could not save native source.")
@@ -517,7 +514,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
     case Facade.dispatch(
            :browse_method_source,
            %{class: class, side: side, selector: selector},
-           ctx(socket)
+           RequestContext.build(socket)
          ) do
       {:value, result} when is_map(result) ->
         %{
@@ -661,7 +658,7 @@ defmodule BtAttachWeb.Live.MethodEditor do
   # class' docs). `{"", nil, nil, nil, false}` if the browse fails — the tab
   # then opens empty rather than erroring.
   defp class_definition_info(socket, class) do
-    case Facade.dispatch(:browse_class_definition, %{class: class}, ctx(socket)) do
+    case Facade.dispatch(:browse_class_definition, %{class: class}, RequestContext.build(socket)) do
       {:value, %{} = result} ->
         definition =
           case Map.get(result, "definition") do

--- a/editors/liveview/lib/bt_attach_web/live/system_browser.ex
+++ b/editors/liveview/lib/bt_attach_web/live/system_browser.ex
@@ -95,9 +95,6 @@ defmodule BtAttachWeb.Live.SystemBrowser do
   alias BtAttachWeb.Live.MethodEditor
   alias BtAttachWeb.Live.RequestContext
 
-  defp ctx(socket), do: RequestContext.build(socket)
-  defp facade_error(reason), do: FacadeError.render(reason)
-
   # ── handle_event dispatch ────────────────────────────────────────────────
   #
   # `WorkspaceLive.handle_event/3` forwards every event whose name is in
@@ -133,7 +130,11 @@ defmodule BtAttachWeb.Live.SystemBrowser do
   def handle_event("complete", %{"code" => code}, %{assigns: %{session_pid: pid}} = socket)
       when is_pid(pid) and is_binary(code) do
     completions =
-      case Facade.dispatch(:complete, %{session_pid: pid, code: code}, ctx(socket)) do
+      case Facade.dispatch(
+             :complete,
+             %{session_pid: pid, code: code},
+             RequestContext.build(socket)
+           ) do
         {:ok, list} when is_list(list) -> list
         _ -> []
       end
@@ -156,7 +157,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
   def handle_event("hover", %{"code" => code}, %{assigns: %{session_pid: pid}} = socket)
       when is_pid(pid) and is_binary(code) do
     hover =
-      case Facade.dispatch(:hover, %{session_pid: pid, code: code}, ctx(socket)) do
+      case Facade.dispatch(:hover, %{session_pid: pid, code: code}, RequestContext.build(socket)) do
         {:ok, docs} when is_binary(docs) -> docs
         _ -> ""
       end
@@ -195,7 +196,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
       case Facade.dispatch(
              :diagnostics,
              %{code: code, mode: Map.get(params, "mode")},
-             ctx(socket)
+             RequestContext.build(socket)
            ) do
         {:ok, list} when is_list(list) -> list
         _ -> []
@@ -648,7 +649,8 @@ defmodule BtAttachWeb.Live.SystemBrowser do
   def assign_browser_classes(socket),
     do: apply_browser_classes(socket, read_browser_classes(socket))
 
-  defp read_browser_classes(socket), do: Facade.dispatch(:browse_classes, %{}, ctx(socket))
+  defp read_browser_classes(socket),
+    do: Facade.dispatch(:browse_classes, %{}, RequestContext.build(socket))
 
   # Public: `WorkspaceLive.handle_async(:mount_load, …)` folds the off-socket
   # mount read through this directly (`&SystemBrowser.apply_browser_classes/2`).
@@ -659,7 +661,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
   end
 
   def apply_browser_classes(socket, {:error, reason}),
-    do: assign(socket, browser_classes: [], browser_error: facade_error(reason))
+    do: assign(socket, browser_classes: [], browser_error: FacadeError.render(reason))
 
   # Defensive catch-all (BT-2591): this fold runs in `handle_async(:mount_load,
   # …)` AND on the sync `assign_browser_classes/1` refresh path. An unexpected
@@ -671,7 +673,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
       domain: [:beamtalk, :liveview]
     )
 
-    assign(socket, browser_classes: [], browser_error: facade_error(:unexpected_response))
+    assign(socket, browser_classes: [], browser_error: FacadeError.render(:unexpected_response))
   end
 
   # BT-2661: apply the one-shot initial origin-filter default once the class rows
@@ -710,7 +712,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
   # calls it directly at mount.
   def assign_browser_native_modules(socket) do
     rows =
-      case Facade.dispatch(:browse_native_modules, %{}, ctx(socket)) do
+      case Facade.dispatch(:browse_native_modules, %{}, RequestContext.build(socket)) do
         {:value, rows} when is_list(rows) -> rows
         _ -> []
       end
@@ -731,7 +733,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
   # Public: `WorkspaceLive.bind_session/3` calls it directly at mount.
   def assign_browser_type_aliases(socket) do
     rows =
-      case Facade.dispatch(:browse_type_aliases, %{}, ctx(socket)) do
+      case Facade.dispatch(:browse_type_aliases, %{}, RequestContext.build(socket)) do
         {:value, rows} when is_list(rows) -> rows
         _ -> []
       end
@@ -760,7 +762,11 @@ defmodule BtAttachWeb.Live.SystemBrowser do
   # `name` and `selectors`; an unknown class / bad side comes back as a structured
   # error we surface without blanking the rest of the pane.
   defp load_protocols(socket, class, side) do
-    case Facade.dispatch(:browse_protocols, %{class: class, side: side}, ctx(socket)) do
+    case Facade.dispatch(
+           :browse_protocols,
+           %{class: class, side: side},
+           RequestContext.build(socket)
+         ) do
       {:value, %{"protocols" => protocols}} when is_list(protocols) ->
         assign(socket, browser_protocols: protocols, browser_error: nil)
 
@@ -768,7 +774,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
         assign(socket, browser_protocols: [], browser_error: nil)
 
       {:error, reason} ->
-        assign(socket, browser_protocols: [], browser_error: facade_error(reason))
+        assign(socket, browser_protocols: [], browser_error: FacadeError.render(reason))
     end
   end
 
@@ -795,7 +801,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
   # unconditionally on every call, including this one).
   defp refresh_categories(socket, class) do
     view =
-      case Facade.dispatch(:browse_categories, %{class: class}, ctx(socket)) do
+      case Facade.dispatch(:browse_categories, %{class: class}, RequestContext.build(socket)) do
         {:value, %{"has_dividers" => _, "categories" => _} = view} -> view
         _ -> default_categories()
       end
@@ -870,14 +876,14 @@ defmodule BtAttachWeb.Live.SystemBrowser do
   defp submit_section(socket, class, new_name, opts) do
     params = Map.merge(%{class: class, new_name: new_name}, Map.new(opts))
 
-    case Facade.dispatch(:save_section, params, ctx(socket)) do
+    case Facade.dispatch(:save_section, params, RequestContext.build(socket)) do
       {:value, %{"ok" => true}} ->
         socket
         |> assign(editing_section: nil, section_form_error: nil)
         |> refresh_categories(class)
 
       {:error, reason} ->
-        assign(socket, section_form_error: facade_error(reason))
+        assign(socket, section_form_error: FacadeError.render(reason))
 
       _other ->
         assign(socket, section_form_error: "Could not save the section.")
@@ -932,7 +938,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
 
     params = if selector, do: %{class: class, selector: selector}, else: %{class: class}
 
-    case Facade.dispatch(:browse_native_source, params, ctx(socket)) do
+    case Facade.dispatch(:browse_native_source, params, RequestContext.build(socket)) do
       {:value, %{} = r} ->
         %{
           base
@@ -954,7 +960,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
         }
 
       {:error, reason} ->
-        %{base | error: facade_error(reason)}
+        %{base | error: FacadeError.render(reason)}
 
       _ ->
         %{base | error: "Could not load Erlang source."}
@@ -1007,7 +1013,11 @@ defmodule BtAttachWeb.Live.SystemBrowser do
       error: nil
     }
 
-    case Facade.dispatch(:browse_alias_source, %{name: name, package: package}, ctx(socket)) do
+    case Facade.dispatch(
+           :browse_alias_source,
+           %{name: name, package: package},
+           RequestContext.build(socket)
+         ) do
       {:value, %{} = r} ->
         %{
           base
@@ -1017,7 +1027,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
         }
 
       {:error, reason} ->
-        %{base | error: facade_error(reason)}
+        %{base | error: FacadeError.render(reason)}
 
       _ ->
         %{base | error: "Could not load type alias source."}
@@ -1064,7 +1074,11 @@ defmodule BtAttachWeb.Live.SystemBrowser do
       error: nil
     }
 
-    case Facade.dispatch(:browse_native_module_source, %{module: module}, ctx(socket)) do
+    case Facade.dispatch(
+           :browse_native_module_source,
+           %{module: module},
+           RequestContext.build(socket)
+         ) do
       {:value, %{} = r} ->
         %{
           base
@@ -1080,7 +1094,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
         }
 
       {:error, reason} ->
-        %{base | error: facade_error(reason)}
+        %{base | error: FacadeError.render(reason)}
 
       _ ->
         %{base | error: "Could not load Erlang source."}
@@ -1210,7 +1224,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
   # active-tab path delegates here). A nil/empty selector is a graceful no-op.
   defp run_nav_query_for(socket, kind, selector) do
     if is_binary(selector) and selector != "" do
-      case Facade.dispatch(kind, %{selector: selector}, ctx(socket)) do
+      case Facade.dispatch(kind, %{selector: selector}, RequestContext.build(socket)) do
         {:value, %{"sites" => sites}} when is_list(sites) ->
           assign(socket, nav_popover: %{kind: kind, selector: selector, sites: sites})
 
@@ -1219,7 +1233,12 @@ defmodule BtAttachWeb.Live.SystemBrowser do
 
         {:error, reason} ->
           assign(socket,
-            nav_popover: %{kind: kind, selector: selector, sites: [], error: facade_error(reason)}
+            nav_popover: %{
+              kind: kind,
+              selector: selector,
+              sites: [],
+              error: FacadeError.render(reason)
+            }
           )
 
         # Any other shape (version skew, an unexpected reply) degrades to an empty
@@ -1255,7 +1274,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
       end
 
     if is_binary(protocol) and protocol != "" do
-      case Facade.dispatch(kind, %{protocol: protocol}, ctx(socket)) do
+      case Facade.dispatch(kind, %{protocol: protocol}, RequestContext.build(socket)) do
         {:value, %{"sites" => sites}} when is_list(sites) ->
           assign(socket, nav_popover: %{kind: kind, selector: protocol, sites: sites})
 
@@ -1264,7 +1283,12 @@ defmodule BtAttachWeb.Live.SystemBrowser do
 
         {:error, reason} ->
           assign(socket,
-            nav_popover: %{kind: kind, selector: protocol, sites: [], error: facade_error(reason)}
+            nav_popover: %{
+              kind: kind,
+              selector: protocol,
+              sites: [],
+              error: FacadeError.render(reason)
+            }
           )
 
         _other ->
@@ -1298,7 +1322,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
     if is_binary(module) and module != "" do
       kind = :callers_of_native_module
 
-      case Facade.dispatch(kind, %{module: module}, ctx(socket)) do
+      case Facade.dispatch(kind, %{module: module}, RequestContext.build(socket)) do
         {:value, %{"sites" => sites}} when is_list(sites) ->
           assign(socket, nav_popover: %{kind: kind, selector: module, sites: sites})
 
@@ -1307,7 +1331,12 @@ defmodule BtAttachWeb.Live.SystemBrowser do
 
         {:error, reason} ->
           assign(socket,
-            nav_popover: %{kind: kind, selector: module, sites: [], error: facade_error(reason)}
+            nav_popover: %{
+              kind: kind,
+              selector: module,
+              sites: [],
+              error: FacadeError.render(reason)
+            }
           )
 
         _other ->
@@ -1410,7 +1439,7 @@ defmodule BtAttachWeb.Live.SystemBrowser do
   # is the graceful unresolved no-op. Mirrors `run_nav_query_for/3` but acts on
   # the result rather than always opening a popover.
   defp open_implementor(socket, selector) do
-    case Facade.dispatch(:implementors, %{selector: selector}, ctx(socket)) do
+    case Facade.dispatch(:implementors, %{selector: selector}, RequestContext.build(socket)) do
       {:value, %{"sites" => [site]}} when is_map(site) ->
         open_implementor_site(socket, site)
 

--- a/editors/liveview/lib/bt_attach_web/live/test_runner.ex
+++ b/editors/liveview/lib/bt_attach_web/live/test_runner.ex
@@ -78,9 +78,6 @@ defmodule BtAttachWeb.Live.TestRunner do
   alias BtAttachWeb.Live.MethodEditor
   alias BtAttachWeb.Live.RequestContext
 
-  defp ctx(socket), do: RequestContext.build(socket)
-  defp facade_error(reason), do: FacadeError.render(reason)
-
   # ── handle_event dispatch ────────────────────────────────────────────────
   #
   # `WorkspaceLive.handle_event/3` forwards every event whose name is in
@@ -277,7 +274,7 @@ defmodule BtAttachWeb.Live.TestRunner do
   # Public: `BtAttachWeb.Live.Dock`'s `ensure_test_classes/1` (BT-3295, the
   # `dock_tab`/`:test` meta-command lazy-load) calls it directly.
   def discover_test_classes(socket, keep_error? \\ false) do
-    ctx = ctx(socket)
+    ctx = RequestContext.build(socket)
 
     socket
     |> assign(:tests_discover_keep_error, keep_error?)
@@ -306,10 +303,11 @@ defmodule BtAttachWeb.Live.TestRunner do
     # Leave the catalogue as the nil sentinel (not []) so the pane shows only the
     # error — not the misleading "No TestCase subclasses" empty-state — and so
     # re-opening the tab retries discovery (a transient failure heals).
-    do: assign(socket, test_classes: nil, tests_error: facade_error(reason))
+    do: assign(socket, test_classes: nil, tests_error: FacadeError.render(reason))
 
   defp apply_test_classes(socket, _other, _keep_error?),
-    do: assign(socket, test_classes: nil, tests_error: facade_error(:unexpected_test_result))
+    do:
+      assign(socket, test_classes: nil, tests_error: FacadeError.render(:unexpected_test_result))
 
   # Run all tests (`class` = nil) or a single class (`run_tests`, `:execute`).
   #
@@ -320,7 +318,7 @@ defmodule BtAttachWeb.Live.TestRunner do
   # the in-flight op so only the latest result wins. The result lands in
   # `handle_async(:test_op, …)`; `tests_running` disables the controls meanwhile.
   defp run_tests(socket, class) do
-    ctx = ctx(socket)
+    ctx = RequestContext.build(socket)
 
     socket
     |> assign(tests_running: true, tests_error: nil)
@@ -337,7 +335,7 @@ defmodule BtAttachWeb.Live.TestRunner do
   # BT-2597: like `run_tests/2`, the load compiles user code, so it runs in the
   # off-socket `:test_op` task; the result lands in `handle_async(:test_op, …)`.
   defp load_tests(socket) do
-    ctx = ctx(socket)
+    ctx = RequestContext.build(socket)
 
     socket
     |> assign(tests_running: true, tests_error: nil)
@@ -355,10 +353,11 @@ defmodule BtAttachWeb.Live.TestRunner do
     do: assign(socket, test_results: result, tests_error: nil)
 
   defp apply_test_result(socket, {:error, reason}),
-    do: assign(socket, test_results: nil, tests_error: facade_error(reason))
+    do: assign(socket, test_results: nil, tests_error: FacadeError.render(reason))
 
   defp apply_test_result(socket, _other),
-    do: assign(socket, test_results: nil, tests_error: facade_error(:unexpected_test_result))
+    do:
+      assign(socket, test_results: nil, tests_error: FacadeError.render(:unexpected_test_result))
 
   # Apply a completed `load_tests` dispatch: refresh the catalogue to show
   # whatever loaded, surfacing partial compile errors as `tests_error`. The
@@ -383,10 +382,10 @@ defmodule BtAttachWeb.Live.TestRunner do
     do: socket |> assign(test_classes: nil) |> discover_test_classes()
 
   defp apply_test_load(socket, {:error, reason}),
-    do: assign(socket, tests_error: facade_error(reason))
+    do: assign(socket, tests_error: FacadeError.render(reason))
 
   defp apply_test_load(socket, _other),
-    do: assign(socket, tests_error: facade_error(:unexpected_test_result))
+    do: assign(socket, tests_error: FacadeError.render(:unexpected_test_result))
 
   # Summarise compile errors from a partial test load into one line. Each error
   # is a `%{"path" => ..., "message" => ...}` map (the load-project error shape).

--- a/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
+++ b/editors/liveview/lib/bt_attach_web/live/workspace_live.ex
@@ -256,9 +256,8 @@ defmodule BtAttachWeb.WorkspaceLive do
   # Decision 3) — never a raw Workspace/:rpc call from an event handler. Pure
   # transport/display/lifecycle helpers (connect, render_term, session start)
   # go through the injectable workspace client so the mount and session-start
-  # paths are testable without a live node (BT-2554). `ctx/1` carries the
-  # request identity the facade audits / RBAC gates on (BT-2421).
-  defp ctx(socket), do: RequestContext.build(socket)
+  # paths are testable without a live node (BT-2554). `RequestContext.build/1`
+  # carries the request identity the facade audits / RBAC gates on (BT-2421).
 
   defp ws_client, do: Application.get_env(:bt_attach, :workspace_client, Workspace)
 
@@ -390,8 +389,9 @@ defmodule BtAttachWeb.WorkspaceLive do
   # (the old pid's subscriptions died with it), so the resumed tab gets its
   # Transcript and bindings flowing again with its accumulated state intact.
   defp bind_session(socket, session_id, pid) do
-    with :ok <- Facade.dispatch(:subscribe_transcript, %{pid: self()}, ctx(socket)),
-         :ok <- Facade.dispatch(:subscribe_bindings, %{pid: self()}, ctx(socket)) do
+    with :ok <-
+           Facade.dispatch(:subscribe_transcript, %{pid: self()}, RequestContext.build(socket)),
+         :ok <- Facade.dispatch(:subscribe_bindings, %{pid: self()}, RequestContext.build(socket)) do
       # BT-2598: subscribe to the class-lifecycle push stream so any source change
       # — a git revert's disk→image reload, another session's flush, an external
       # edit reloaded into the image — pushes a `ClassLoaded`/`ClassRemoved`
@@ -752,7 +752,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   # does not fail the mount — the cockpit degrades to the clean-tab re-read on
   # re-activation rather than a live push, and re-subscribes on the next remount.
   defp subscribe_classes_best_effort(socket) do
-    case Facade.dispatch(:subscribe_classes, %{pid: self()}, ctx(socket)) do
+    case Facade.dispatch(:subscribe_classes, %{pid: self()}, RequestContext.build(socket)) do
       :ok ->
         :ok
 
@@ -771,7 +771,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   # reload-findings panel to whatever `initial_reload_findings/1` read at
   # mount (stale until next remount) rather than failing the whole session.
   defp subscribe_reload_check_best_effort(socket) do
-    case Facade.dispatch(:subscribe_reload_check, %{pid: self()}, ctx(socket)) do
+    case Facade.dispatch(:subscribe_reload_check, %{pid: self()}, RequestContext.build(socket)) do
       :ok ->
         :ok
 
@@ -790,7 +790,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   # an empty panel (consistent with `changes`/`browser_classes`'s
   # graceful-degradation default) rather than failing the mount.
   defp initial_reload_findings(socket) do
-    case Facade.dispatch(:reload_findings, %{}, ctx(socket)) do
+    case Facade.dispatch(:reload_findings, %{}, RequestContext.build(socket)) do
       {:ok, findings} when is_list(findings) -> findings
       _other -> []
     end
@@ -1618,7 +1618,7 @@ defmodule BtAttachWeb.WorkspaceLive do
 
   # The raw `:changes` dispatch result — runs off the LiveView process in the
   # mount-load task, so it captures only `ctx`, never `socket`.
-  defp read_changes(socket), do: Facade.dispatch(:changes, %{}, ctx(socket))
+  defp read_changes(socket), do: Facade.dispatch(:changes, %{}, RequestContext.build(socket))
 
   # Fold a completed `:changes` read into the socket. Pure (no dispatch); shared by
   # `handle_async(:mount_load, …)` and the sync refresh path.
@@ -1735,7 +1735,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   # The task captures only `ctx` + `pid` (never `socket`) and returns the four
   # raw `Facade.dispatch` outcomes in a map so the fold applies them atomically.
   defp start_mount_load(socket, pid) do
-    ctx = ctx(socket)
+    ctx = RequestContext.build(socket)
 
     start_async(socket, :mount_load, fn ->
       # Runs in a Task off the LiveView process — never touch `socket` here.
@@ -1817,7 +1817,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   # calls it directly — the System Browser hasn't been extracted out of this
   # module yet (BT-3297).
   def symbol_rows(socket) do
-    case Facade.dispatch(:symbols, %{scope: "all"}, ctx(socket)) do
+    case Facade.dispatch(:symbols, %{scope: "all"}, RequestContext.build(socket)) do
       {:value, %{"classes" => classes}} when is_list(classes) ->
         Enum.flat_map(classes, &class_symbol_rows/1)
 
@@ -1896,7 +1896,7 @@ defmodule BtAttachWeb.WorkspaceLive do
   defp assign_bindings(socket, pid), do: apply_bindings(socket, read_bindings(socket, pid))
 
   defp read_bindings(socket, pid),
-    do: Facade.dispatch(:bindings, %{session_pid: pid}, ctx(socket))
+    do: Facade.dispatch(:bindings, %{session_pid: pid}, RequestContext.build(socket))
 
   defp apply_bindings(socket, {:error, reason}),
     do: assign(socket, bindings: [], bindings_error: Workspace.render_error(reason))


### PR DESCRIPTION
## Summary
- Deletes 13 one-line private wrapper functions copy-pasted across every extracted Live pane module: 6× `defp facade_error(reason), do: FacadeError.render(reason)` and 7× `defp ctx(socket), do: RequestContext.build(socket)`.
- Updates all call sites to call the shared modules directly: `facade_error(x)` → `FacadeError.render(x)` (39 sites, including 6 atom-literal call sites a naive text search would've missed), `ctx(socket)` → `RequestContext.build(socket)` (64 sites). All 7 files already had the needed `alias`.
- Cleaned up two stale comments left behind referencing the deleted wrappers (`workspace_live.ex`, `inspector.ex`).
- Files: `workspace_live.ex`, `dock.ex`, `inspector.ex`, `system_browser.ex`, `method_editor.ex`, `class_modals.ex`, `test_runner.ex`.

## Why
`FacadeError.render/1` and `RequestContext.build/1` are themselves shared leaf modules extracted specifically to avoid this duplication (BT-3291) — `workspace_live.ex` had a comment saying exactly that — yet every extracted pane re-added a local one-line copy anyway. Exactly the "no duplicate implementations" anti-pattern CLAUDE.md calls out.

## Verification
No behavior change — purely mechanical (same function, called directly instead of through a wrapper). Verified with per-module **hit/miss line counts** (not just displayed percentages, since deleting two always-covered wrapper lines shrinks some denominators):

| Module | Baseline hits/misses | After | Verdict |
|---|---|---|---|
| WorkspaceLive | 872/24 | 872/23 | improved |
| ClassModals | 129/17 | 128/16 | improved |
| TestRunner, Dock, Inspector, SystemBrowser, MethodEditor | — | — | same miss count |

Every module's absolute uncovered-line count is unchanged or better, never worse.

- [x] `mix format --check-formatted`
- [x] `mix test --cover` — 1127/1127 (matches main's test count exactly)
- [x] Verified pre-existing test flakiness (5 files, non-deterministic across seeds) reproduces identically on the pre-refactor parent commit — confirmed unrelated to this change, already tracked in BT-3315

Part of Epic BT-3304 ("Close editors/liveview Elixir coverage gap to 90%, stretch 95%").

---
_Generated by [Claude Code](https://claude.ai/code/session_017EEfqFa7rmuhhXqXyZg7nn)_