### PR TITLE
Exclude BtAttachWeb.StubWorkspaceClient from mix.exs coverage accounting (BT-3312)

### DIFF
--- a/editors/liveview/mix.exs
+++ b/editors/liveview/mix.exs
@@ -23,7 +23,13 @@ defmodule BtAttach.MixProject do
       test_coverage: [
         ignore_modules: [
           # Pure Phoenix boilerplate: `embed_templates` only, no logic to exercise.
-          BtAttachWeb.Layouts
+          BtAttachWeb.Layouts,
+          # Test-support fake of the backend workspace client (BT-2554); exists to
+          # simulate failure/crash branches, not production code (BT-3312).
+          BtAttachWeb.StubWorkspaceClient,
+          # ignore_modules matches by exact module name, not prefix — list its
+          # per-test Agent struct module separately.
+          BtAttachWeb.StubWorkspaceClient.State
         ],
         # :threshold only takes effect nested under :summary — Mix.Tasks.Test.Coverage
         # reads it from the :summary opts, not the top-level test_coverage opts.


### PR DESCRIPTION
## Decision
Excluding `BtAttachWeb.StubWorkspaceClient` (and its `.State` companion) from coverage accounting. It's test-support scaffolding (`test/support/`, excluded from `:dev`/`:prod` builds by `elixirc_paths`), not production code — much of its surface exists specifically to simulate failure/crash branches other tests trigger. Same rationale as the existing `BtAttachWeb.Layouts` exclusion.

## Change
Adds `BtAttachWeb.StubWorkspaceClient` and `BtAttachWeb.StubWorkspaceClient.State` to `mix.exs`'s `test_coverage.ignore_modules`, with a comment matching the `Layouts` entry's style. `ignore_modules` matches by exact module name (not prefix), so `.State` needs its own line — verified against Mix's `test.coverage.ex`.

## Effect
Total coverage rises from 95.84% → **96.26%** on this branch (measured locally as 96.28%, small variance from ExUnit run-to-run). The CI threshold (78, untouched — that's BT-3313's job) is unaffected either way.

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix test --cover` — total rises as expected, no coverage regression elsewhere
- [x] Confirmed the 2-4 test failures seen across repeated runs are the same pre-existing async-mount race already tracked in BT-3315 (non-deterministic count on an identical seed, in already-flagged files) — unrelated to this `mix.exs`-only change

Part of Epic BT-3304 ("Close editors/liveview Elixir coverage gap to 90%, stretch 95%").

---
_Generated by [Claude Code](https://claude.ai/code/session_017EEfqFa7rmuhhXqXyZg7nn)_