### PR TITLE
Mop-up: cover remaining sub-90% small editors/liveview modules (BT-3311)

### DIFF
--- a/editors/liveview/test/bt_attach/ide_config_test.exs
+++ b/editors/liveview/test/bt_attach/ide_config_test.exs
@@ -8,7 +8,8 @@ defmodule BtAttach.IdeConfigTest do
   alias BtAttach.IdeConfig
 
   @oidc_env ~w(BT_OIDC_ISSUER BT_OIDC_CLIENT_ID BT_OIDC_REDIRECT_URI BT_OIDC_GROUPS_CLAIM
-               BT_OIDC_CLIENT_SECRET BT_OIDC_CLIENT_SECRET_ENV BT_IDE_CONFIG ACME_SECRET)
+               BT_OIDC_CLIENT_SECRET BT_OIDC_CLIENT_SECRET_ENV BT_IDE_CONFIG ACME_SECRET
+               BT_OIDC_ROLES_OWNER BT_OIDC_ROLES_OBSERVER)
 
   setup do
     saved = Map.new(@oidc_env, fn k -> {k, System.get_env(k)} end)
@@ -181,6 +182,147 @@ defmodule BtAttach.IdeConfigTest do
 
       assert {:error, message} = IdeConfig.load(path)
       assert message =~ "chmod 600"
+    end
+
+    test "an empty secret file (after trim) is rejected", %{tmp: tmp} do
+      secret_path = tmp <> ".secret"
+      File.write!(secret_path, "   \n")
+      File.chmod!(secret_path, 0o600)
+      on_exit(fn -> File.rm_rf(secret_path) end)
+
+      path =
+        write!(tmp, """
+        [oidc]
+        issuer = "https://idp"
+        client_id = "id"
+        redirect_uri = "https://ide/callback"
+        client_secret_file = "#{secret_path}"
+        """)
+
+      assert {:error, message} = IdeConfig.load(path)
+      assert message =~ "client_secret_file is empty"
+    end
+
+    test "a client_secret_file that does not exist is reported not found", %{tmp: tmp} do
+      missing_secret =
+        Path.join(System.tmp_dir!(), "missing-secret-#{System.unique_integer([:positive])}")
+
+      path =
+        write!(tmp, """
+        [oidc]
+        issuer = "https://idp"
+        client_id = "id"
+        redirect_uri = "https://ide/callback"
+        client_secret_file = "#{missing_secret}"
+        """)
+
+      assert {:error, message} = IdeConfig.load(path)
+      assert message =~ "client_secret_file not found"
+    end
+
+    test "a client_secret_file that is a directory yields an atom-reason read error", %{tmp: tmp} do
+      # `File.stat/1` succeeds on a directory (so `check_secret_perms/2` passes
+      # so long as it isn't group/other-writable), but `File.read/1` then
+      # fails with an atom reason (`:eisdir`) distinct from `:enoent` —
+      # `read_secret_file/1`'s `{:error, reason} when is_atom(reason)` branch.
+      secret_dir = tmp <> ".secretdir"
+      File.mkdir_p!(secret_dir)
+      File.chmod!(secret_dir, 0o700)
+      on_exit(fn -> File.rm_rf(secret_dir) end)
+
+      path =
+        write!(tmp, """
+        [oidc]
+        issuer = "https://idp"
+        client_id = "id"
+        redirect_uri = "https://ide/callback"
+        client_secret_file = "#{secret_dir}"
+        """)
+
+      assert {:error, message} = IdeConfig.load(path)
+      assert message =~ "cannot read client_secret_file"
+    end
+  end
+
+  describe "default_path/0 (BT-3311)" do
+    test "falls back to ~/.beamtalk/ide.toml when BT_IDE_CONFIG is unset" do
+      # setup/0 already deletes BT_IDE_CONFIG for every test in this module.
+      path = IdeConfig.default_path()
+
+      assert String.ends_with?(path, Path.join(".beamtalk", "ide.toml"))
+    end
+
+    test "load/0 (no path given) uses default_path/0 as the default argument" do
+      path = tmp_path()
+      System.put_env("BT_IDE_CONFIG", path)
+
+      # The file doesn't exist, so this is deterministically "OIDC not
+      # requested" regardless of what default_path/0 resolves to.
+      assert {:ok, nil} = IdeConfig.load()
+    end
+  end
+
+  describe "roles (BT-2421) further branches (BT-3311)" do
+    test "a non-list role entry in the file is dropped rather than crashing", %{tmp: tmp} do
+      path =
+        write!(tmp, """
+        [oidc]
+        issuer = "https://idp"
+        client_id = "id"
+        redirect_uri = "https://ide/callback"
+        client_secret_env = "ACME_SECRET"
+
+        [oidc.roles]
+        owner = "not-a-list"
+        observer = ["beamtalk-observers"]
+        """)
+
+      System.put_env("ACME_SECRET", "s3cret")
+
+      assert {:ok, config} = IdeConfig.load(path)
+      refute Map.has_key?(config.roles, "owner")
+      assert config.roles["observer"] == ["beamtalk-observers"]
+    end
+
+    test "BT_OIDC_ROLES_OWNER overrides the file's owner group list", %{tmp: tmp} do
+      path =
+        write!(tmp, """
+        [oidc]
+        issuer = "https://idp"
+        client_id = "id"
+        redirect_uri = "https://ide/callback"
+        client_secret_env = "ACME_SECRET"
+
+        [oidc.roles]
+        owner = ["file-owners"]
+        """)
+
+      System.put_env("ACME_SECRET", "s3cret")
+      System.put_env("BT_OIDC_ROLES_OWNER", "env-owners, platform admins")
+
+      assert {:ok, config} = IdeConfig.load(path)
+      assert config.roles["owner"] == ["env-owners", "platform", "admins"]
+    end
+  end
+
+  describe "read_file/1 further error branches (BT-3311)" do
+    test "an ide.toml parse error is reported with its line number", %{tmp: tmp} do
+      path = write!(tmp, "[oidc\nissuer = \"https://idp\"\n")
+
+      assert {:error, message} = IdeConfig.load(path)
+      assert message =~ "ide.toml parse error"
+      assert message =~ "line 1"
+    end
+
+    test "a non-enoent file read error is reported (path is a directory)", %{tmp: tmp} do
+      # `File.read/1` on a directory fails with an atom reason distinct from
+      # `:enoent` — `read_file/1`'s final `{:error, reason} -> {:error, "cannot
+      # read ..."}` branch.
+      File.mkdir_p!(tmp)
+      on_exit(fn -> File.rm_rf(tmp) end)
+
+      assert {:error, message} = IdeConfig.load(tmp)
+      assert message =~ "cannot read #{tmp}"
     end
   end
 end

--- a/editors/liveview/test/bt_attach/toml_test.exs
+++ b/editors/liveview/test/bt_attach/toml_test.exs
@@ -128,4 +128,41 @@ defmodule BtAttach.TomlTest do
       assert map["\"oidc\""]["issuer"] == "https://idp.example.com"
     end
   end
+
+  describe "further parse/1 error branches (BT-3311)" do
+    test "rejects a pair with an empty key" do
+      assert {:error, {:malformed, 2, _}} = Toml.parse("[oidc]\n= \"x\"\n")
+    end
+
+    test "rejects an array containing a non-string (bare) element" do
+      assert {:error, {:malformed, 2, _}} =
+               Toml.parse(~s([oidc.roles]\nowner = [invalid, "b"]\n))
+    end
+
+    test "an array element's escaped quote does not break comma-splitting" do
+      # Exercises `split_array_elements/5`'s backslash/quote-toggle clauses —
+      # distinct from `unquote_chars/2`'s own `\"` handling (already covered
+      # by the scalar-string escape test above), since arrays track quote
+      # state independently while splitting on top-level commas.
+      source = ~S([oidc.roles]
+      owner = ["a\"b", "c"]
+      )
+
+      assert {:ok, map} = Toml.parse(source)
+      assert map["oidc"]["roles"]["owner"] == ["a\"b", "c"]
+    end
+
+    test "honours \\n and \\t escapes in strings" do
+      source = ~S([oidc]
+      issuer = "line1\nline2\ttab"
+      )
+
+      assert {:ok, map} = Toml.parse(source)
+      assert map["oidc"]["issuer"] == "line1\nline2\ttab"
+    end
+
+    test "rejects extra characters after a closing quote" do
+      assert {:error, {:malformed, 2, _}} = Toml.parse("[oidc]\nissuer = \"abc\"junk\n")
+    end
+  end
 end

--- a/editors/liveview/test/bt_attach_web/class_modals_test.exs
+++ b/editors/liveview/test/bt_attach_web/class_modals_test.exs
@@ -20,6 +20,44 @@ defmodule BtAttachWeb.Live.ClassModalsTest do
   alias BtAttachWeb.StubWorkspaceClient
   alias BtAttachWeb.WorkspaceLive
 
+  # ── one-off workspace-client overrides (BT-3311) ────────────────────────
+  #
+  # `BtAttachWeb.StubClientOverrides` fills in every callback the module below
+  # does not define with a delegate to `StubWorkspaceClient`, so each of these
+  # models exactly one degraded server response instead of restating the
+  # whole stub surface (CLAUDE.md no-duplicate-implementations) — the same
+  # pattern `MethodEditorTest`/`WorkspaceLivePanesTest` use.
+
+  # `eval` fails with the structured 4-tuple shape (`{:error, reason, output,
+  # warnings}`), distinct from a plain 2-tuple `{:error, reason}` —
+  # `remove_method_eval/6`/`remove_class_eval/4`/`rename_class_eval/4`/
+  # `rename_method_eval/6` render each through a different helper
+  # (`Workspace.render_error/1` vs `facade_error/1`).
+  defmodule Eval4TupleErrorClient do
+    @moduledoc false
+    use BtAttachWeb.StubClientOverrides
+
+    def eval(_pid, _code), do: {:error, :compile_failed, "output", ["a warning"]}
+  end
+
+  # `eval` fails with a plain 2-tuple (a down workspace, a malformed reply) —
+  # distinct from the 4-tuple structured-error shape above.
+  defmodule Eval2TupleErrorClient do
+    @moduledoc false
+    use BtAttachWeb.StubClientOverrides
+
+    def eval(_pid, _code), do: {:error, :unreachable}
+  end
+
+  # `new_class/2` fails — `dispatch_new_class/5`'s error branch, kept
+  # in-modal (never the method-editor's shared `save_error`).
+  defmodule NewClassErrorClient do
+    @moduledoc false
+    use BtAttachWeb.StubClientOverrides
+
+    def new_class(_source, _path), do: {:error, :disk_full}
+  end
+
   setup do
     Application.put_env(:bt_attach, :workspace_client, StubWorkspaceClient)
     {:ok, _} = StubWorkspaceClient.start_state()
@@ -611,6 +649,244 @@ defmodule BtAttachWeb.Live.ClassModalsTest do
       refute ClassModals.valid_class_name?("greeter")
       refute ClassModals.valid_class_name?("")
       refute ClassModals.valid_class_name?("Foo. Session current clear")
+    end
+  end
+
+  # ── dispatch error branches (BT-3311) ───────────────────────────────────
+  #
+  # `remove_method`/`remove_class`/`open_rename`/`rename_submit` all gate on
+  # `socket.assigns.role` in their own `handle_event/3` clause head (unlike
+  # e.g. `MethodEditor`'s `save_method`), so a non-owner role never reaches
+  # `Facade.dispatch/3` here at all — an RBAC-denial trick can't reach these
+  # branches. Instead each one is driven by a genuine dispatch failure: no
+  # session pid, or a one-off workspace client answering a structured 4-tuple
+  # or plain 2-tuple eval error.
+  describe "Remove Method dispatch error branches" do
+    test "reports 'not attached to workspace' when there is no session pid" do
+      tabs = [method_tab("method:Counter:instance:increment", "Counter", "increment")]
+
+      socket =
+        base_socket(%{
+          tabs: tabs,
+          active_tab: "method:Counter:instance:increment",
+          session_pid: nil
+        })
+
+      {:noreply, socket} = ClassModals.handle_event("remove_method", %{}, socket)
+
+      assert socket.assigns.save_error == "not attached to workspace"
+    end
+
+    test "renders Workspace.render_error/1 on a structured 4-tuple eval error" do
+      Application.put_env(:bt_attach, :workspace_client, Eval4TupleErrorClient)
+      tabs = [method_tab("method:Counter:instance:increment", "Counter", "increment")]
+      socket = base_socket(%{tabs: tabs, active_tab: "method:Counter:instance:increment"})
+
+      {:noreply, socket} = ClassModals.handle_event("remove_method", %{}, socket)
+
+      assert socket.assigns.save_error == StubWorkspaceClient.render_error(:compile_failed)
+    end
+
+    test "renders the facade error on a plain 2-tuple eval error" do
+      Application.put_env(:bt_attach, :workspace_client, Eval2TupleErrorClient)
+      tabs = [method_tab("method:Counter:instance:increment", "Counter", "increment")]
+      socket = base_socket(%{tabs: tabs, active_tab: "method:Counter:instance:increment"})
+
+      {:noreply, socket} = ClassModals.handle_event("remove_method", %{}, socket)
+
+      assert socket.assigns.save_error == BtAttach.Workspace.render_error(:unreachable)
+    end
+  end
+
+  describe "Remove Class dispatch error branches" do
+    test "reports 'not attached to workspace' when there is no session pid" do
+      tabs = [def_tab("def:Counter", "Counter")]
+      socket = base_socket(%{tabs: tabs, active_tab: "def:Counter", session_pid: nil})
+
+      {:noreply, socket} = ClassModals.handle_event("remove_class", %{}, socket)
+
+      assert socket.assigns.save_error == "not attached to workspace"
+    end
+
+    test "renders Workspace.render_error/1 on a structured 4-tuple eval error" do
+      Application.put_env(:bt_attach, :workspace_client, Eval4TupleErrorClient)
+      tabs = [def_tab("def:Counter", "Counter")]
+      socket = base_socket(%{tabs: tabs, active_tab: "def:Counter"})
+
+      {:noreply, socket} = ClassModals.handle_event("remove_class", %{}, socket)
+
+      assert socket.assigns.save_error == StubWorkspaceClient.render_error(:compile_failed)
+    end
+
+    test "renders the facade error on a plain 2-tuple eval error" do
+      Application.put_env(:bt_attach, :workspace_client, Eval2TupleErrorClient)
+      tabs = [def_tab("def:Counter", "Counter")]
+      socket = base_socket(%{tabs: tabs, active_tab: "def:Counter"})
+
+      {:noreply, socket} = ClassModals.handle_event("remove_class", %{}, socket)
+
+      assert socket.assigns.save_error == BtAttach.Workspace.render_error(:unreachable)
+    end
+  end
+
+  describe "rename_submit with no rename kind in flight" do
+    test "is a graceful no-op that just closes the modal" do
+      # `rename_kind` defaults to `nil` in `base_socket/1` — a modal opened
+      # without a captured target (shouldn't happen via `open_rename/1`, but
+      # kept explicit rather than assumed, mirroring `close_active_tab_if/2`'s
+      # own defensive-but-real catch-all below).
+      socket = base_socket(%{rename_open: true, rename_error: "stale"})
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => "Whatever"}, socket)
+
+      assert socket.assigns.rename_open == false
+      assert socket.assigns.rename_error == nil
+    end
+  end
+
+  describe "class rename: unrelated tree selection + dispatch errors" do
+    test "leaves an unrelated System Browser tree selection untouched" do
+      tabs = [def_tab("def:Counter", "Counter")]
+
+      socket =
+        base_socket(%{
+          tabs: tabs,
+          active_tab: "def:Counter",
+          rename_open: true,
+          rename_kind: :class,
+          rename_class: "Counter",
+          selected_class: "SomethingElse"
+        })
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => "Accumulator"}, socket)
+
+      assert socket.assigns.rename_open == false
+      # The tree's selection was on an unrelated class, so the rename doesn't
+      # follow it (only a selection on the renamed class itself — or none —
+      # would move).
+      assert socket.assigns.selected_class == "SomethingElse"
+    end
+
+    test "renders Workspace.render_error/1 on a structured 4-tuple eval error" do
+      Application.put_env(:bt_attach, :workspace_client, Eval4TupleErrorClient)
+
+      socket =
+        base_socket(%{rename_open: true, rename_kind: :class, rename_class: "Counter"})
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => "Accumulator"}, socket)
+
+      assert socket.assigns.rename_open == true
+      assert socket.assigns.rename_error == StubWorkspaceClient.render_error(:compile_failed)
+    end
+
+    test "renders the facade error on a plain 2-tuple eval error" do
+      Application.put_env(:bt_attach, :workspace_client, Eval2TupleErrorClient)
+
+      socket =
+        base_socket(%{rename_open: true, rename_kind: :class, rename_class: "Counter"})
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => "Accumulator"}, socket)
+
+      assert socket.assigns.rename_open == true
+      assert socket.assigns.rename_error == BtAttach.Workspace.render_error(:unreachable)
+    end
+  end
+
+  describe "method rename: no session, no active tab, and dispatch errors" do
+    test "reports 'not attached to workspace' when there is no session pid" do
+      socket =
+        base_socket(%{
+          session_pid: nil,
+          rename_open: true,
+          rename_kind: :method,
+          rename_class: "Counter",
+          rename_side: "instance",
+          rename_old_selector: "increment"
+        })
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => "incrementBy"}, socket)
+
+      assert socket.assigns.rename_open == true
+      assert socket.assigns.rename_error == "not attached to workspace"
+    end
+
+    test "renders Workspace.render_error/1 on a structured 4-tuple eval error" do
+      Application.put_env(:bt_attach, :workspace_client, Eval4TupleErrorClient)
+
+      socket =
+        base_socket(%{
+          rename_open: true,
+          rename_kind: :method,
+          rename_class: "Counter",
+          rename_side: "instance",
+          rename_old_selector: "increment"
+        })
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => "incrementBy"}, socket)
+
+      assert socket.assigns.rename_open == true
+      assert socket.assigns.rename_error == StubWorkspaceClient.render_error(:compile_failed)
+    end
+
+    test "renders the facade error on a plain 2-tuple eval error" do
+      Application.put_env(:bt_attach, :workspace_client, Eval2TupleErrorClient)
+
+      socket =
+        base_socket(%{
+          rename_open: true,
+          rename_kind: :method,
+          rename_class: "Counter",
+          rename_side: "instance",
+          rename_old_selector: "increment"
+        })
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => "incrementBy"}, socket)
+
+      assert socket.assigns.rename_open == true
+      assert socket.assigns.rename_error == BtAttach.Workspace.render_error(:unreachable)
+    end
+
+    test "a successful rename with no active tab leaves the (empty) tab strip untouched" do
+      # `close_active_tab_if/2`'s own catch-all (BT-3311): `open_rename/1`
+      # always targets the active tab, so this path isn't reachable through
+      # the modal's own open flow — kept explicit rather than assumed, same
+      # as the comment on `close_active_tab_if/2` itself.
+      socket =
+        base_socket(%{
+          active_tab: nil,
+          rename_open: true,
+          rename_kind: :method,
+          rename_class: "Counter",
+          rename_side: "instance",
+          rename_old_selector: "increment"
+        })
+
+      {:noreply, socket} =
+        ClassModals.handle_event("rename_submit", %{"new_name" => "incrementBy"}, socket)
+
+      assert socket.assigns.rename_open == false
+      assert socket.assigns.tabs == []
+      assert socket.assigns.save_result =~ "Renamed Counter increment to incrementBy"
+    end
+  end
+
+  describe "New Class modal dispatch error (BT-3311)" do
+    test "a failed create keeps the modal open with an in-modal facade error" do
+      Application.put_env(:bt_attach, :workspace_client, NewClassErrorClient)
+
+      {:noreply, socket} =
+        ClassModals.handle_event("new_class", %{"name" => "Greeter"}, base_socket())
+
+      assert socket.assigns.new_class_open == true
+      assert socket.assigns.new_class_name == "Greeter"
+      assert socket.assigns.new_class_error == BtAttach.Workspace.render_error(:disk_full)
     end
   end
 end

--- a/editors/liveview/test/bt_attach_web/oidc_flow_test.exs
+++ b/editors/liveview/test/bt_attach_web/oidc_flow_test.exs
@@ -34,6 +34,20 @@ defmodule BtAttachWeb.OidcFlowTest do
     def callback(_config, _params, _session_params), do: {:error, :invalid_grant}
   end
 
+  # A provider whose `authorize_url/1` itself fails (IdP unreachable / a
+  # metadata-discovery error) — distinct from `FakeProvider`'s callback-time
+  # failures above (BT-3311, `OidcController.auth/2`'s `{:error, reason}`
+  # branch).
+  defmodule UnreachableProvider do
+    @behaviour BtAttach.Oidc
+
+    @impl true
+    def authorize_url(_config), do: {:error, :metadata_discovery_failed}
+
+    @impl true
+    def callback(_config, _params, _session_params), do: {:error, :invalid_grant}
+  end
+
   @oidc_config %{
     issuer: "https://idp.test",
     client_id: "beamtalk-ide",
@@ -59,6 +73,20 @@ defmodule BtAttachWeb.OidcFlowTest do
       conn = get(conn, ~p"/")
       assert html_response(conn, 200) =~ "Beamtalk Workspace"
     end
+
+    # BT-3311: a misconfigured front (OIDC disabled but these routes hit
+    # directly) responds via a redirect home rather than leaking a stack
+    # trace — `auth/2`'s and `callback/2`'s own `nil`/`is_nil(config)`
+    # branches, reachable independent of the router's `require_oidc` plug.
+    test "GET /oidc/auth redirects home rather than starting a flow", %{conn: conn} do
+      conn = get(conn, ~p"/oidc/auth")
+      assert redirected_to(conn) == ~p"/"
+    end
+
+    test "GET /oidc/callback redirects home rather than exchanging a code", %{conn: conn} do
+      conn = get(conn, ~p"/oidc/callback?code=good")
+      assert redirected_to(conn) == ~p"/"
+    end
   end
 
   describe "OIDC enabled" do
@@ -82,6 +110,15 @@ defmodule BtAttachWeb.OidcFlowTest do
       assert handshake.same_site == "Lax"
       assert handshake.path == "/oidc"
       assert handshake.http_only
+    end
+
+    test "GET /oidc/auth reports a 502 when the provider's authorize_url fails", %{conn: conn} do
+      # BT-3311: `UnreachableProvider` fails building the authorization URL
+      # itself (IdP unreachable / metadata discovery) — distinct from
+      # `FakeProvider`'s callback-time failures below.
+      Application.put_env(:bt_attach, :oidc_provider, UnreachableProvider)
+      conn = get(conn, ~p"/oidc/auth")
+      assert text_response(conn, 502) =~ "OIDC provider unavailable"
     end
 
     test "a valid callback mints a session and lands authenticated in the IDE", %{conn: conn} do

--- a/editors/liveview/test/bt_attach_web/test_runner_test.exs
+++ b/editors/liveview/test/bt_attach_web/test_runner_test.exs
@@ -196,6 +196,69 @@ defmodule BtAttachWeb.Live.TestRunnerTest do
       socket = base_socket()
       assert {:noreply, ^socket} = TestRunner.handle_event("dismiss_notice", %{}, socket)
     end
+
+    # BT-3311: `dismiss_key_to_assign/1`'s whitelist covers scalar status
+    # assigns owned by several OTHER panes (not just this one's own
+    # `tests_error`) — the cross-pane utility the moduledoc describes.
+    test "dismisses the cross-pane \"browser_error\" key" do
+      socket = base_socket(%{browser_error: "boom"})
+
+      {:noreply, socket} =
+        TestRunner.handle_event("dismiss_notice", %{"key" => "browser_error"}, socket)
+
+      assert socket.assigns.browser_error == nil
+    end
+
+    test "dismisses the cross-pane \"output\" key" do
+      socket = base_socket(%{output: "boom"})
+      {:noreply, socket} = TestRunner.handle_event("dismiss_notice", %{"key" => "output"}, socket)
+      assert socket.assigns.output == nil
+    end
+
+    test "dismisses the cross-pane \"changes_error\" key" do
+      socket = base_socket(%{changes_error: "boom"})
+
+      {:noreply, socket} =
+        TestRunner.handle_event("dismiss_notice", %{"key" => "changes_error"}, socket)
+
+      assert socket.assigns.changes_error == nil
+    end
+
+    test "dismisses the cross-pane \"git_error\" key" do
+      socket = base_socket(%{git_error: "boom"})
+
+      {:noreply, socket} =
+        TestRunner.handle_event("dismiss_notice", %{"key" => "git_error"}, socket)
+
+      assert socket.assigns.git_error == nil
+    end
+
+    test "dismisses the cross-pane \"flush_error\" key" do
+      socket = base_socket(%{flush_error: "boom"})
+
+      {:noreply, socket} =
+        TestRunner.handle_event("dismiss_notice", %{"key" => "flush_error"}, socket)
+
+      assert socket.assigns.flush_error == nil
+    end
+
+    test "dismisses the cross-pane \"bindings_error\" key" do
+      socket = base_socket(%{bindings_error: "boom"})
+
+      {:noreply, socket} =
+        TestRunner.handle_event("dismiss_notice", %{"key" => "bindings_error"}, socket)
+
+      assert socket.assigns.bindings_error == nil
+    end
+
+    test "dismisses the cross-pane \"inspect_error\" key" do
+      socket = base_socket(%{inspect_error: "boom"})
+
+      {:noreply, socket} =
+        TestRunner.handle_event("dismiss_notice", %{"key" => "inspect_error"}, socket)
+
+      assert socket.assigns.inspect_error == nil
+    end
   end
 
   describe "handle_async(:test_discover, …) — test discovery failure handling (BT-2599)" do
@@ -396,9 +459,19 @@ defmodule BtAttachWeb.Live.TestRunnerTest do
       assert TestRunner.test_class_tally(nil, "Counter") == nil
     end
 
+    test "test_class_tally/2 returns nil when the class had no cases in the last run" do
+      results = %{"tests" => [%{"class" => "Other", "status" => "pass"}]}
+
+      assert TestRunner.test_class_tally(results, "Counter") == nil
+    end
+
     test "test_status_label/1 and test_status_class/1 cover pass/fail/skip and an unknown status" do
       assert TestRunner.test_status_label("pass") == "✓ pass"
       assert TestRunner.test_status_class("pass") == "st-pass"
+      assert TestRunner.test_status_label("fail") == "✗ fail"
+      assert TestRunner.test_status_class("fail") == "st-fail"
+      assert TestRunner.test_status_label("skip") == "○ skip"
+      assert TestRunner.test_status_class("skip") == "st-skip"
       assert TestRunner.test_status_label("weird") == "? weird"
       assert TestRunner.test_status_class("weird") == "st-skip"
     end


### PR DESCRIPTION
## Summary
Adds 40 tests across 5 files, closing out the remaining sub-90% small modules:

| Module | Before | After |
|---|---|---|
| `BtAttachWeb.Live.ClassModals` | 88.36% | **99.31%** |
| `BtAttach.SessionRegistry` | already ≥90% at pickup | untouched |
| `BtAttach.IdeConfig` | 80.28% | **100.00%** |
| `BtAttachWeb.Live.TestRunner` | 86.84% | **98.65%** |
| `BtAttach.Toml` | 86.30% | **100.00%** |
| `BtAttachWeb.OidcController` | 81.82% | **100.00%** |
| `BtAttachWeb.Router` | 88.89% | 88.89% (see below) |

No production code changed — tests only. Suite total: 95.84% → **97.19%** (1199 tests, up from 1159; all passing).

## One genuinely unreachable line, documented not chased
`BtAttachWeb.Router` line 24, `pipeline :api do` — declared but referenced by no route (confirmed via grep). Dead code, not something a test can reach without either using it in a route or deleting the pipeline, both out of scope for a test-only PR. Filing a quick follow-up to remove it.

## Note on the issue's framing
Consistent with every sibling issue in this epic: none of the "RBAC-guarded fallback" framing held up. Every gap in `ClassModals`/`TestRunner` was a genuine dispatch-error path (no session pid, structured 4-tuple vs. plain 2-tuple eval error, unrelated tree selection, no-active-tab defensive branch) or a plain params/parser edge case — not a role check.

No other bugs found.

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix test --cover` — 1199 passed
- [x] All target modules ≥90% except the one documented dead-code line in Router

Part of Epic BT-3304 ("Close editors/liveview Elixir coverage gap to 90%, stretch 95%") — with this PR, the suite total clears the 95% stretch goal.

---
_Generated by [Claude Code](https://claude.ai/code/session_017EEfqFa7rmuhhXqXyZg7nn)_