### PR TITLE
Extract shared eval-error-rendering helper (BT-3318)

### DIFF
--- a/editors/liveview/lib/bt_attach_web/live/class_modals.ex
+++ b/editors/liveview/lib/bt_attach_web/live/class_modals.ex
@@ -74,7 +74,6 @@ defmodule BtAttachWeb.Live.ClassModals do
   use BtAttachWeb, :html
 
   alias BtAttach.Facade
-  alias BtAttach.Workspace
   alias BtAttachWeb.Live.FacadeError
   alias BtAttachWeb.Live.MethodEditor
   alias BtAttachWeb.Live.RequestContext
@@ -313,11 +312,11 @@ defmodule BtAttachWeb.Live.ClassModals do
         )
         |> WorkspaceLive.assign_changes()
 
-      {:error, reason, _output, _warnings} ->
-        WorkspaceLive.status_error(socket, Workspace.render_error(reason))
+      {:error, _, _, _} = err ->
+        WorkspaceLive.status_error(socket, FacadeError.render_eval_error(err))
 
-      {:error, reason} ->
-        WorkspaceLive.status_error(socket, FacadeError.render(reason))
+      {:error, _} = err ->
+        WorkspaceLive.status_error(socket, FacadeError.render_eval_error(err))
     end
   end
 
@@ -377,11 +376,11 @@ defmodule BtAttachWeb.Live.ClassModals do
         )
         |> WorkspaceLive.assign_changes()
 
-      {:error, reason, _output, _warnings} ->
-        WorkspaceLive.status_error(socket, Workspace.render_error(reason))
+      {:error, _, _, _} = err ->
+        WorkspaceLive.status_error(socket, FacadeError.render_eval_error(err))
 
-      {:error, reason} ->
-        WorkspaceLive.status_error(socket, FacadeError.render(reason))
+      {:error, _} = err ->
+        WorkspaceLive.status_error(socket, FacadeError.render_eval_error(err))
     end
   end
 
@@ -561,18 +560,18 @@ defmodule BtAttachWeb.Live.ClassModals do
           flush_error: nil
         )
 
-      {:error, reason, _output, _warnings} ->
+      {:error, _, _, _} = err ->
         assign(socket,
           rename_open: true,
           rename_new_name: new_name,
-          rename_error: Workspace.render_error(reason)
+          rename_error: FacadeError.render_eval_error(err)
         )
 
-      {:error, reason} ->
+      {:error, _} = err ->
         assign(socket,
           rename_open: true,
           rename_new_name: new_name,
-          rename_error: FacadeError.render(reason)
+          rename_error: FacadeError.render_eval_error(err)
         )
     end
   end
@@ -667,18 +666,18 @@ defmodule BtAttachWeb.Live.ClassModals do
         )
         |> WorkspaceLive.assign_changes()
 
-      {:error, reason, _output, _warnings} ->
+      {:error, _, _, _} = err ->
         assign(socket,
           rename_open: true,
           rename_new_name: new_selector,
-          rename_error: Workspace.render_error(reason)
+          rename_error: FacadeError.render_eval_error(err)
         )
 
-      {:error, reason} ->
+      {:error, _} = err ->
         assign(socket,
           rename_open: true,
           rename_new_name: new_selector,
-          rename_error: FacadeError.render(reason)
+          rename_error: FacadeError.render_eval_error(err)
         )
     end
   end

--- a/editors/liveview/lib/bt_attach_web/live/dock.ex
+++ b/editors/liveview/lib/bt_attach_web/live/dock.ex
@@ -295,14 +295,15 @@ defmodule BtAttachWeb.Live.Dock do
             {:ok, term, _output, _warnings} ->
               socket |> repl_append_ok(expr, term) |> repl_help_followup(expr)
 
-            {:error, reason, _output, _warnings} ->
-              repl_append_error(socket, expr, Workspace.render_error(reason))
+            # The 2-tuple shape is a facade short-circuit (RBAC denial /
+            # off-vocabulary op) the eval contract never produces on its
+            # own; `render_eval_error/1` renders it as the entry's response
+            # rather than crashing the LiveView.
+            {:error, _, _, _} = err ->
+              repl_append_error(socket, expr, FacadeError.render_eval_error(err))
 
-            # Facade short-circuit (RBAC denial / off-vocabulary op) — a
-            # 2-tuple the eval contract never produces; render it as the
-            # entry's response rather than crashing the LiveView.
-            {:error, reason} ->
-              repl_append_error(socket, expr, FacadeError.render(reason))
+            {:error, _} = err ->
+              repl_append_error(socket, expr, FacadeError.render_eval_error(err))
           end
 
         {:noreply, socket |> repl_record_history(expr) |> repl_clear_input()}
@@ -1446,11 +1447,11 @@ defmodule BtAttachWeb.Live.Dock do
         # "Save All to Disk" flush.
         |> WorkspaceLive.maybe_refresh_git()
 
-      {:error, reason, _output, _warnings} ->
-        WorkspaceLive.status_error(socket, Workspace.render_error(reason))
+      {:error, _, _, _} = err ->
+        WorkspaceLive.status_error(socket, FacadeError.render_eval_error(err))
 
-      {:error, reason} ->
-        WorkspaceLive.status_error(socket, FacadeError.render(reason))
+      {:error, _} = err ->
+        WorkspaceLive.status_error(socket, FacadeError.render_eval_error(err))
     end
   end
 

--- a/editors/liveview/lib/bt_attach_web/live/facade_error.ex
+++ b/editors/liveview/lib/bt_attach_web/live/facade_error.ex
@@ -22,4 +22,17 @@ defmodule BtAttachWeb.Live.FacadeError do
 
   def render(:forbidden_op), do: "Operation not permitted."
   def render(reason), do: Workspace.render_error(reason)
+
+  @doc """
+  Renders the error branch of an `eval` (`Facade.dispatch(:eval, ...)`)
+  result, whichever of its two error shapes it took: a 4-tuple
+  (`{:error, reason, output, warnings}`) from the eval contract itself, or
+  a 2-tuple (`{:error, reason}`) from a facade short-circuit (RBAC denial /
+  off-vocabulary op) that never reaches eval. Collapses the same
+  two-clause dispatch that was duplicated at 9 call sites across the Live
+  panes (BT-3318) into one shared helper.
+  """
+  @spec render_eval_error({:error, term(), term(), term()} | {:error, term()}) :: String.t()
+  def render_eval_error({:error, reason, _output, _warnings}), do: Workspace.render_error(reason)
+  def render_eval_error({:error, reason}), do: render(reason)
 end

--- a/editors/liveview/lib/bt_attach_web/live/inspector.ex
+++ b/editors/liveview/lib/bt_attach_web/live/inspector.ex
@@ -1193,11 +1193,11 @@ defmodule BtAttachWeb.Live.Inspector do
             w
         end
 
-      {:error, reason, _output, _warnings} ->
-        %{w | poke_result: nil, poke_error: Workspace.render_error(reason)}
+      {:error, _, _, _} = err ->
+        %{w | poke_result: nil, poke_error: FacadeError.render_eval_error(err)}
 
-      {:error, reason} ->
-        %{w | poke_result: nil, poke_error: FacadeError.render(reason)}
+      {:error, _} = err ->
+        %{w | poke_result: nil, poke_error: FacadeError.render_eval_error(err)}
     end
   end
 
@@ -1415,11 +1415,11 @@ defmodule BtAttachWeb.Live.Inspector do
         # watched.
         |> refresh_poked_inspector()
 
-      {:error, reason, _output, _warnings} ->
-        assign(socket, poke_result: nil, poke_error: Workspace.render_error(reason))
+      {:error, _, _, _} = err ->
+        assign(socket, poke_result: nil, poke_error: FacadeError.render_eval_error(err))
 
-      {:error, reason} ->
-        assign(socket, poke_result: nil, poke_error: FacadeError.render(reason))
+      {:error, _} = err ->
+        assign(socket, poke_result: nil, poke_error: FacadeError.render_eval_error(err))
     end
   end
 

--- a/editors/liveview/lib/bt_attach_web/live/method_editor.ex
+++ b/editors/liveview/lib/bt_attach_web/live/method_editor.ex
@@ -79,7 +79,6 @@ defmodule BtAttachWeb.Live.MethodEditor do
 
   alias BtAttach.Facade
   alias BtAttach.SessionRegistry
-  alias BtAttach.Workspace
   alias BtAttachWeb.Live.FacadeError
   alias BtAttachWeb.Live.RequestContext
   alias BtAttachWeb.Live.SystemBrowser
@@ -419,11 +418,11 @@ defmodule BtAttachWeb.Live.MethodEditor do
         # (no redundant refresh).
         |> WorkspaceLive.maybe_refresh_git_after_save()
 
-      {:error, reason, _output, _warnings} ->
-        assign(socket, save_result: nil, save_error: Workspace.render_error(reason))
+      {:error, _, _, _} = err ->
+        assign(socket, save_result: nil, save_error: FacadeError.render_eval_error(err))
 
-      {:error, reason} ->
-        assign(socket, save_result: nil, save_error: FacadeError.render(reason))
+      {:error, _} = err ->
+        assign(socket, save_result: nil, save_error: FacadeError.render_eval_error(err))
     end
   end
 


### PR DESCRIPTION
## Summary
- Adds `BtAttachWeb.Live.FacadeError.render_eval_error/1`, matching both the 4-tuple (`{:error, reason, _output, _warnings}` → `Workspace.render_error/1`) and 2-tuple (`{:error, reason}` → `render/1`) error shapes.
- Collapses the same duplicated two-clause error-branch pair at 9 call sites across `dock.ex` (2), `class_modals.ex` (4), `method_editor.ex` (1), `inspector.ex` (2) into a single call each.
- Removed the now-unused `alias BtAttach.Workspace` from `class_modals.ex` and `method_editor.ex` (no longer referenced directly elsewhere in those files — `warnings_as_errors: true` requires this).
- No behavioral change — same message-rendering logic, centralized.

## Verification
Coverage hit/miss line counts (not just displayed %) before/after:

| Module | Before | After |
|---|---|---|
| Dock | 253/1 | 253/1 (unchanged) |
| ClassModals | 128/16 | 128/16 (unchanged) |
| MethodEditor | 346/3 | 346/3 (unchanged) |
| Inspector | 419/1 | 419/1 (unchanged) |
| FacadeError | 3/0 | 5/0 (improved — 2 new fully-covered lines) |

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test --cover` — 1159 passed (identical test count to baseline); one flaky run reproduced the already-tracked BT-3315 async-mount race in `workspace_modifier_badge_test.exs`, confirmed unrelated (same-seed baseline also intermittently hits it)

Part of Epic BT-3304 ("Close editors/liveview Elixir coverage gap to 90%, stretch 95%") — this closes out the production-code duplication audit's mechanical fixes (BT-3317, BT-3318). BT-3319 (Inspector docked/floating unification) remains parked as `needs-spec` — real design risk, not auto-assigned.

---
_Generated by [Claude Code](https://claude.ai/code/session_017EEfqFa7rmuhhXqXyZg7nn)_