### PR TITLE
Ratchet editors/liveview mix.exs coverage threshold to 92 (BT-3313)

### DIFF
--- a/editors/liveview/mix.exs
+++ b/editors/liveview/mix.exs
@@ -33,12 +33,12 @@ defmodule BtAttach.MixProject do
         ],
         # :threshold only takes effect nested under :summary — Mix.Tasks.Test.Coverage
         # reads it from the :summary opts, not the top-level test_coverage opts.
-        # Floor below the current ~82.7% baseline (BT-3299, after the
-        # WorkspaceLive decomposition landed — was ~60%/55 pre-BT-3290) so CI
-        # has headroom to fluctuate without going red; raise as coverage
-        # improves. Mirrors the Rust/Erlang coverage-job thresholds in
-        # .github/workflows/ci.yml.
-        summary: [threshold: 78]
+        # Floor below the current ~97.7% baseline (BT-3304 epic, module-by-module
+        # coverage pass across every Live pane + Workspace/Toml/IdeConfig/etc. —
+        # was ~82.7%/78 pre-BT-3304, ~60%/55 pre-BT-3290) so CI has headroom to
+        # fluctuate without going red; raise as coverage improves. Mirrors the
+        # Rust/Erlang coverage-job thresholds in .github/workflows/ci.yml.
+        summary: [threshold: 92]
       ],
       # Warnings-as-errors for our own code only — deps compile with their
       # upstream settings and routinely warn under newer Elixir releases.


### PR DESCRIPTION
## Summary
Raises `editors/liveview/mix.exs`'s `test_coverage.summary.threshold` from 78 to **92**, and updates the explanatory comment to reflect the new baseline.

Measured on current `main` (post BT-3305–3312, BT-3316, BT-3317, BT-3318): `mix test --cover` → **97.67%** total, 1199 tests passing. Threshold set with the same headroom convention as BT-3299's 55→78 ratchet — a few points below the measured baseline so CI has room to fluctuate without going red.

This is the final issue in Epic BT-3304 ("Close editors/liveview Elixir coverage gap to 90%, stretch 95%") — the epic's floor target was ≥90 with a stretch of ≥95; actual measured coverage landed at 97.67%, comfortably past both.

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix test --cover` — 1199 passed, 97.67% total, comfortably above the new 92 threshold

Closes out Epic BT-3304.

---
_Generated by [Claude Code](https://claude.ai/code/session_017EEfqFa7rmuhhXqXyZg7nn)_